### PR TITLE
refactor(chain)!: make UnminedTx fields private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8365,7 +8365,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "bech32",
  "bitflags",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "5.0.0"
+version = "6.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/src/block/merkle.rs
+++ b/crates/zakura-chain/src/block/merkle.rs
@@ -177,7 +177,7 @@ impl std::iter::FromIterator<UnminedTx> for Root {
     {
         transactions
             .into_iter()
-            .map(|tx| tx.id.mined_id())
+            .map(|tx| tx.id().mined_id())
             .collect()
     }
 }
@@ -198,7 +198,7 @@ impl std::iter::FromIterator<VerifiedUnminedTx> for Root {
     {
         transactions
             .into_iter()
-            .map(|tx| tx.transaction.id.mined_id())
+            .map(|tx| tx.transaction.id().mined_id())
             .collect()
     }
 }
@@ -337,7 +337,7 @@ impl std::iter::FromIterator<UnminedTx> for AuthDataRoot {
     {
         transactions
             .into_iter()
-            .map(|tx| tx.id.auth_digest().unwrap_or(AUTH_DIGEST_PLACEHOLDER))
+            .map(|tx| tx.id().auth_digest().unwrap_or(AUTH_DIGEST_PLACEHOLDER))
             .collect()
     }
 }
@@ -351,7 +351,7 @@ impl std::iter::FromIterator<VerifiedUnminedTx> for AuthDataRoot {
             .into_iter()
             .map(|tx| {
                 tx.transaction
-                    .id
+                    .id()
                     .auth_digest()
                     .unwrap_or(AUTH_DIGEST_PLACEHOLDER)
             })

--- a/crates/zakura-chain/src/serialization/tests/prop.rs
+++ b/crates/zakura-chain/src/serialization/tests/prop.rs
@@ -9,7 +9,7 @@ use crate::{
         CompactSize64, CompactSizeMessage, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
         MAX_PROTOCOL_MESSAGE_LEN,
     },
-    transaction::UnminedTx,
+    transaction::{zip317, UnminedTx},
 };
 
 proptest! {
@@ -110,6 +110,14 @@ proptest! {
     fn transaction_serialized_size(transaction in any::<UnminedTx>()) {
         let _init_guard = zakura_test::init();
 
-        prop_assert_eq!(transaction.transaction.zcash_serialized_size(), transaction.size);
+        prop_assert_eq!(
+            transaction.transaction().zcash_serialized_size(),
+            transaction.size()
+        );
+        prop_assert_eq!(transaction.transaction().unmined_id(), transaction.id());
+        prop_assert_eq!(
+            zip317::conventional_fee(transaction.transaction()),
+            transaction.conventional_fee()
+        );
     }
 }

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -2803,8 +2803,8 @@ fn native_zip244_hashes_invalid_lazy_sapling_points_before_semantic_rejection() 
 
         let unmined = UnminedTx::from(parsed.clone());
         let (txid, auth_digest) = parsed.txid_and_auth_digest();
-        assert_eq!(unmined.id.mined_id(), txid);
-        assert_eq!(unmined.id.auth_digest(), auth_digest);
+        assert_eq!(unmined.id().mined_id(), txid);
+        assert_eq!(unmined.id().auth_digest(), auth_digest);
         assert_ne!(
             txid,
             changed_parsed.hash(),

--- a/crates/zakura-chain/src/transaction/unmined.rs
+++ b/crates/zakura-chain/src/transaction/unmined.rs
@@ -228,21 +228,25 @@ impl UnminedTxId {
 ///
 /// This transaction has been structurally verified.
 /// (But it might still need semantic or contextual verification.)
+///
+/// Its fields are private so the ID, serialized size, and conventional fee
+/// cannot diverge from the transaction. Construct values using the available
+/// [`From`] implementations.
 #[derive(Clone, Eq, PartialEq)]
 pub struct UnminedTx {
     /// The unmined transaction itself.
-    pub transaction: Arc<Transaction>,
+    transaction: Arc<Transaction>,
 
     /// A unique identifier for this unmined transaction.
-    pub id: UnminedTxId,
+    id: UnminedTxId,
 
     /// The size in bytes of the serialized transaction data
-    pub size: usize,
+    size: usize,
 
     /// The conventional fee for this transaction, as defined by [ZIP-317].
     ///
     /// [ZIP-317]: https://zips.z.cash/zip-0317#fee-calculation
-    pub conventional_fee: Amount<NonNegative>,
+    conventional_fee: Amount<NonNegative>,
 }
 
 impl fmt::Debug for UnminedTx {
@@ -256,6 +260,36 @@ impl fmt::Debug for UnminedTx {
 impl fmt::Display for UnminedTx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("UnminedTx").field(&"private").finish()
+    }
+}
+
+impl UnminedTx {
+    /// Returns the unmined transaction.
+    pub fn transaction(&self) -> &Arc<Transaction> {
+        &self.transaction
+    }
+
+    /// Returns the unmined transaction, consuming this wrapper.
+    pub fn into_transaction(self) -> Arc<Transaction> {
+        self.transaction
+    }
+
+    /// Returns the unique identifier for this unmined transaction.
+    pub fn id(&self) -> UnminedTxId {
+        self.id
+    }
+
+    /// Returns the size in bytes of the serialized transaction data.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Returns the conventional fee for this transaction, as defined by
+    /// [ZIP-317].
+    ///
+    /// [ZIP-317]: https://zips.z.cash/zip-0317#fee-calculation
+    pub fn conventional_fee(&self) -> Amount<NonNegative> {
+        self.conventional_fee
     }
 }
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -71,7 +71,7 @@ tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower
 zakura-script = { path = "../zakura-script", version = "3.2.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 
 zcash_protocol.workspace = true
@@ -98,7 +98,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -264,7 +264,7 @@ impl Request {
     pub fn transaction(&self) -> Arc<Transaction> {
         match self {
             Request::Block { transaction, .. } => transaction.clone(),
-            Request::Mempool { transaction, .. } => transaction.transaction.clone(),
+            Request::Mempool { transaction, .. } => transaction.transaction().clone(),
         }
     }
 
@@ -281,7 +281,7 @@ impl Request {
         match self {
             // TODO: get the precalculated ID from the block verifier
             Request::Block { transaction, .. } => transaction.unmined_id(),
-            Request::Mempool { transaction, .. } => transaction.id,
+            Request::Mempool { transaction, .. } => transaction.id(),
         }
     }
 
@@ -291,7 +291,7 @@ impl Request {
             Request::Block {
                 transaction_hash, ..
             } => *transaction_hash,
-            Request::Mempool { transaction, .. } => transaction.id.mined_id(),
+            Request::Mempool { transaction, .. } => transaction.id().mined_id(),
         }
     }
 
@@ -360,7 +360,7 @@ impl Response {
     pub fn tx_id(&self) -> UnminedTxId {
         match self {
             Response::Block { tx_id, .. } => *tx_id,
-            Response::Mempool { transaction, .. } => transaction.transaction.id,
+            Response::Mempool { transaction, .. } => transaction.transaction.id(),
         }
     }
 
@@ -565,7 +565,7 @@ where
                 let fee = Self::miner_fee(tx.as_ref(), &spent_utxos)?;
                 let unpaid_actions = transaction::zip317::unpaid_actions(unmined_tx, fee);
 
-                transaction::zip317::mempool_checks(unpaid_actions, fee, unmined_tx.size)?;
+                transaction::zip317::mempool_checks(unpaid_actions, fee, unmined_tx.size())?;
                 miner_fee = Some(fee);
             }
 

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -93,7 +93,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
@@ -109,7 +109,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/src/peer/connection.rs
+++ b/crates/zakura-network/src/peer/connection.rs
@@ -202,7 +202,7 @@ impl Handler {
                 //   - the transaction messages are sent in a single continuous batch
                 //   - missing transactions are silently skipped
                 //     (there is no `notfound` message at the end of the batch)
-                if pending_ids.remove(&transaction.id) {
+                if pending_ids.remove(&transaction.id()) {
                     // we are in the middle of the continuous transaction messages
                     transactions.push(transaction);
                 } else {

--- a/crates/zakura-network/src/protocol/external/codec.rs
+++ b/crates/zakura-network/src/protocol/external/codec.rs
@@ -358,7 +358,7 @@ impl Codec {
             Message::Inv(hashes) => hashes.zcash_serialize(&mut writer)?,
             Message::GetData(hashes) => hashes.zcash_serialize(&mut writer)?,
             Message::NotFound(hashes) => hashes.zcash_serialize(&mut writer)?,
-            Message::Tx(transaction) => transaction.transaction.zcash_serialize(&mut writer)?,
+            Message::Tx(transaction) => transaction.transaction().zcash_serialize(&mut writer)?,
             Message::Mempool => { /* Empty payload -- no-op */ }
             Message::FilterLoad {
                 filter,

--- a/crates/zakura-network/src/zakura/legacy_gossip.rs
+++ b/crates/zakura-network/src/zakura/legacy_gossip.rs
@@ -365,7 +365,7 @@ impl LegacyRequestFrame {
             Self::PushTransaction(transaction) => Ok(Frame {
                 message_type: MSG_REQUEST_PUSH_TRANSACTION,
                 flags: 0,
-                payload: transaction.transaction.zcash_serialize_to_vec()?,
+                payload: transaction.transaction().zcash_serialize_to_vec()?,
             }),
         }
     }
@@ -548,7 +548,7 @@ impl LegacyResponseCodec {
                                 request_id,
                                 max_frame_bytes,
                                 max_message_bytes,
-                                transaction.transaction.zcash_serialize_to_vec()?,
+                                transaction.transaction().zcash_serialize_to_vec()?,
                             )?;
                         }
                         InventoryResponse::Missing(id) => missing.push(id),
@@ -3234,7 +3234,7 @@ mod tests {
                     Response::Transactions(
                         ids.into_iter()
                             .map(|id| {
-                                if id == self.transaction.id {
+                                if id == self.transaction.id() {
                                     InventoryResponse::Available((self.transaction.clone(), None))
                                 } else {
                                     InventoryResponse::Missing(id)
@@ -3410,7 +3410,7 @@ mod tests {
                     Response::Transactions(
                         ids.into_iter()
                             .map(|id| match &self.transaction {
-                                Some(transaction) if id == transaction.id => {
+                                Some(transaction) if id == transaction.id() => {
                                     InventoryResponse::Available((transaction.clone(), None))
                                 }
                                 _ => InventoryResponse::Missing(id),
@@ -3458,7 +3458,7 @@ mod tests {
                 Request::FindBlocks { .. } => Response::BlockHashes(vec![self.block.hash()]),
                 Request::FindHeaders { .. } => Response::BlockHeaders(vec![self.header()]),
                 Request::MempoolTransactionIds => {
-                    Response::TransactionIds(vec![self.transaction.id])
+                    Response::TransactionIds(vec![self.transaction.id()])
                 }
                 Request::BlocksByHash(hashes) | Request::BlocksByHashFrom { hashes, .. } => {
                     Response::Blocks(
@@ -3475,7 +3475,7 @@ mod tests {
                     )
                 }
                 Request::PushTransaction(transaction, _) => {
-                    if let Err(error) = self.pushed_tx.send(transaction.id) {
+                    if let Err(error) = self.pushed_tx.send(transaction.id()) {
                         return std::future::ready(Err(Box::new(error)));
                     }
                     Response::Nil
@@ -3890,7 +3890,7 @@ mod tests {
     async fn request_adapter_fetches_available_and_missing_transactions() -> Result<(), BoxError> {
         let _guard = zakura_test::init();
         let transaction = UnminedTx::from(empty_v5_transaction(2));
-        let available_id = transaction.id;
+        let available_id = transaction.id();
         let missing_id = witnessed_tx_id(99);
         let node_a = inventory_node(63, transaction.clone()).await?;
         let node_b = ZakuraTestNode::builder(64).spawn().await?;
@@ -3911,7 +3911,7 @@ mod tests {
         assert!(transactions.iter().any(|response| {
             matches!(
                 response,
-                InventoryResponse::Available((tx, None)) if tx.id == transaction.id
+                InventoryResponse::Available((tx, None)) if tx.id() == transaction.id()
             )
         }));
         assert!(transactions.iter().any(
@@ -4105,7 +4105,7 @@ mod tests {
         )?);
         let transaction = UnminedTx::from(empty_v5_transaction(5));
         let pushed_transaction = UnminedTx::from(empty_v5_transaction(6));
-        let pushed_id = pushed_transaction.id;
+        let pushed_id = pushed_transaction.id();
         let (node_a, mut pushed_rx) = normal_network_node(83, block, transaction.clone()).await?;
         let node_b = ZakuraTestNode::builder(84).spawn().await?;
         node_b.connect_native(&node_a, TEST_NET_TIMEOUT).await?;
@@ -4118,7 +4118,7 @@ mod tests {
                 Some(PeerSource::Zakura(a_peer_id.clone())),
             )
             .await?;
-        assert_eq!(mempool, Response::TransactionIds(vec![transaction.id]));
+        assert_eq!(mempool, Response::TransactionIds(vec![transaction.id()]));
 
         let ping = adapter
             .request_from_source(
@@ -4250,7 +4250,7 @@ mod tests {
     ) -> Result<(), BoxError> {
         let _guard = zakura_test::init();
         let transaction = UnminedTx::from(empty_v5_transaction(3));
-        let txid = transaction.id;
+        let txid = transaction.id();
         let (advertiser, mut advertiser_rx) = recording_inventory_node(65, None).await?;
         let (fallback, mut fallback_rx) =
             recording_inventory_node(66, Some(transaction.clone())).await?;
@@ -4294,7 +4294,7 @@ mod tests {
         };
         assert!(matches!(
             transactions.as_slice(),
-            [InventoryResponse::Available((tx, None))] if tx.id == transaction.id
+            [InventoryResponse::Available((tx, None))] if tx.id() == transaction.id()
         ));
 
         advertiser.shutdown().await;
@@ -5878,7 +5878,7 @@ mod tests {
                         StubInventory::Available(tx) => Response::Transactions(
                             ids.into_iter()
                                 .map(|id| {
-                                    if id == tx.id {
+                                    if id == tx.id() {
                                         InventoryResponse::Available((tx.clone(), None))
                                     } else {
                                         InventoryResponse::Missing(id)
@@ -5969,7 +5969,7 @@ mod tests {
         let response = composite
             .ready()
             .await?
-            .call(Request::TransactionsById(HashSet::from([transaction.id])))
+            .call(Request::TransactionsById(HashSet::from([transaction.id()])))
             .await?;
         match response {
             Response::Transactions(items) => {
@@ -6005,7 +6005,7 @@ mod tests {
         let response = composite
             .ready()
             .await?
-            .call(Request::TransactionsById(HashSet::from([transaction.id])))
+            .call(Request::TransactionsById(HashSet::from([transaction.id()])))
             .await?;
         match response {
             Response::Transactions(items) => {
@@ -6042,7 +6042,7 @@ mod tests {
         let response = composite
             .ready()
             .await?
-            .call(Request::TransactionsById(HashSet::from([transaction.id])))
+            .call(Request::TransactionsById(HashSet::from([transaction.id()])))
             .await?;
         match response {
             Response::Transactions(items) => {
@@ -6119,7 +6119,7 @@ mod tests {
             .call(Request::MempoolTransactionIds)
             .await?;
         assert!(
-            matches!(mempool_ids, Response::TransactionIds(ref ids) if *ids == vec![transaction.id]),
+            matches!(mempool_ids, Response::TransactionIds(ref ids) if *ids == vec![transaction.id()]),
             "MempoolTransactionIds should be served over Zakura, got {mempool_ids:?}",
         );
 
@@ -6132,7 +6132,7 @@ mod tests {
             .recv()
             .await
             .expect("transaction pushed over Zakura");
-        assert_eq!(pushed, transaction.id);
+        assert_eq!(pushed, transaction.id());
 
         // None of these requests consulted the legacy peer set.
         assert!(

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "6.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 tower = { workspace = true }
 

--- a/crates/zakura-node-services/src/mempool/gossip.rs
+++ b/crates/zakura-node-services/src/mempool/gossip.rs
@@ -17,7 +17,7 @@ impl Gossip {
     pub fn id(&self) -> UnminedTxId {
         match self {
             Gossip::Id(txid) => *txid,
-            Gossip::Tx(tx) => tx.id,
+            Gossip::Tx(tx) => tx.id(),
         }
     }
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -112,7 +112,7 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
@@ -142,7 +142,7 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
     "proptest-impl",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = [

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -1797,13 +1797,13 @@ where
                 if verbose {
                     let transactions_by_id = transactions
                         .iter()
-                        .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
+                        .map(|unmined_tx| (unmined_tx.transaction.id().mined_id(), unmined_tx))
                         .collect::<HashMap<_, _>>();
                     let map = transactions
                         .iter()
                         .map(|unmined_tx| {
                             (
-                                unmined_tx.transaction.id.mined_id().encode_hex(),
+                                unmined_tx.transaction.id().mined_id().encode_hex(),
                                 get_raw_mempool::MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
                                     &transactions_by_id,
@@ -1823,14 +1823,14 @@ where
                         // support prioritizing transactions
                         cmp::Reverse((
                             i64::from(tx.miner_fee) as u128 * MAX_BLOCK_BYTES as u128
-                                / tx.transaction.size as u128,
+                                / tx.transaction.size() as u128,
                             // transaction hashes are compared in their serialized byte-order.
-                            tx.transaction.id.mined_id(),
+                            tx.transaction.id().mined_id(),
                         ))
                     });
                     let tx_ids: Vec<String> = transactions
                         .iter()
-                        .map(|unmined_tx| unmined_tx.transaction.id.mined_id().encode_hex())
+                        .map(|unmined_tx| unmined_tx.transaction.id().mined_id().encode_hex())
                         .collect();
 
                     Ok(GetRawMempoolResponse::TxIds(tx_ids))
@@ -1882,7 +1882,7 @@ where
                         return Ok(if verbose {
                             GetRawTransactionResponse::Object(Box::new(
                                 TransactionObject::from_transaction(
-                                    tx.transaction.clone(),
+                                    tx.transaction().clone(),
                                     None,
                                     None,
                                     &self.network,
@@ -1893,7 +1893,7 @@ where
                                 ),
                             ))
                         } else {
-                            let hex = tx.transaction.clone().into();
+                            let hex = tx.transaction().clone().into();
                             GetRawTransactionResponse::Raw(hex)
                         });
                     }
@@ -2529,7 +2529,7 @@ where
                 tip_height,
                 tip_hash,
                 max_time,
-                mempool_txs.iter().map(|tx| tx.transaction.id),
+                mempool_txs.iter().map(|tx| tx.transaction.id()),
             )
             .generate_id();
 
@@ -2709,7 +2709,7 @@ where
         tracing::debug!(
             mempool_tx_hashes = ?mempool_txs
                 .iter()
-                .map(|tx| tx.transaction.id.mined_id())
+                .map(|tx| tx.transaction.id().mined_id())
                 .collect::<Vec<_>>(),
             "selecting transactions for the template from the mempool"
         );
@@ -2728,7 +2728,7 @@ where
         tracing::debug!(
             selected_mempool_tx_hashes = ?mempool_txs
                 .iter()
-                .map(|#[cfg(not(test))] tx, #[cfg(test)] (_, tx)| tx.transaction.id.mined_id())
+                .map(|#[cfg(not(test))] tx, #[cfg(test)] (_, tx)| tx.transaction.id().mined_id())
                 .collect::<Vec<_>>(),
             "selected transactions for the template from the mempool"
         );

--- a/crates/zakura-rpc/src/methods/tests/prop.rs
+++ b/crates/zakura-rpc/src/methods/tests/prop.rs
@@ -259,14 +259,14 @@ proptest! {
                 let (expected_response, mempool_query) = {
                     let transactions_by_id = transactions
                         .iter()
-                        .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
+                        .map(|unmined_tx| (unmined_tx.transaction.id().mined_id(), unmined_tx))
                         .collect::<HashMap<_, _>>();
                     let transaction_dependencies = Default::default();
                     let txs = transactions
                         .iter()
                         .map(|unmined_tx| {
                             (
-                                unmined_tx.transaction.id.mined_id().encode_hex(),
+                                unmined_tx.transaction.id().mined_id().encode_hex(),
                                 MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
                                     &transactions_by_id,
@@ -292,14 +292,14 @@ proptest! {
                 let (expected_rsp, mempool_query) = {
                     let mut tx_ids = transactions
                         .iter()
-                        .map(|tx| tx.transaction.id.mined_id().encode_hex::<String>())
+                        .map(|tx| tx.transaction.id().mined_id().encode_hex::<String>())
                         .collect::<Vec<_>>();
 
                     tx_ids.sort();
 
                     let mempool_rsp = transactions
                         .iter()
-                        .map(|tx| tx.transaction.id)
+                        .map(|tx| tx.transaction.id())
                         .collect::<HashSet<_>>();
 
                     let mempool_query = mempool.expect_request(mempool::Request::TransactionIds)
@@ -841,7 +841,7 @@ proptest! {
 
             // the runner will made a new call to TransactionsById
             let mut transactions_hash_set = HashSet::new();
-            transactions_hash_set.insert(tx_unmined.id);
+            transactions_hash_set.insert(tx_unmined.id());
             let expected_request = mempool::Request::TransactionsById(transactions_hash_set);
             let response = mempool::Response::Transactions(vec![]);
 
@@ -907,7 +907,7 @@ proptest! {
                 let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
 
                 // insert to hs we will use later
-                transactions_hash_set.insert(tx_unmined.id);
+                transactions_hash_set.insert(tx_unmined.id());
 
                 // fail the mempool insertion
                 mempool

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -23,7 +23,7 @@ use zakura_chain::{
         NetworkKind, POST_BLOSSOM_POW_TARGET_SPACING,
     },
     serialization::{DateTime32, ZcashDeserializeInto, ZcashSerialize},
-    transaction::{zip317, UnminedTxId, VerifiedUnminedTx},
+    transaction::{zip317, VerifiedUnminedTx},
     work::difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty, U256},
 };
 use zakura_consensus::MAX_BLOCK_SIGOPS;
@@ -2083,12 +2083,7 @@ async fn rpc_getrawtransaction() {
                     }
                 })
                 .map(|responder| {
-                    responder.respond(mempool::Response::Transactions(vec![UnminedTx {
-                        id: UnminedTxId::Legacy(tx.hash()),
-                        transaction: tx.clone(),
-                        size: 0,
-                        conventional_fee: Amount::zero(),
-                    }]));
+                    responder.respond(mempool::Response::Transactions(vec![tx.clone().into()]));
                 });
 
             let rpc_req = rpc.get_raw_transaction(tx.hash().encode_hex(), Some(0u8), None);
@@ -3325,14 +3320,9 @@ async fn gbt_with(net: Network, addr: ZcashAddress) {
         lock_time: transaction::LockTime::unlocked(),
     });
 
-    let unmined_tx = UnminedTx {
-        transaction: tx.clone(),
-        id: tx.unmined_id(),
-        size: tx.zcash_serialized_size(),
-        conventional_fee: 0.try_into().unwrap(),
-    };
+    let unmined_tx: UnminedTx = tx.clone().into();
 
-    let conventional_actions = zip317::conventional_actions(&unmined_tx.transaction);
+    let conventional_actions = zip317::conventional_actions(unmined_tx.transaction());
 
     let verified_unmined_tx = VerifiedUnminedTx {
         transaction: unmined_tx,

--- a/crates/zakura-rpc/src/methods/types/default_roots.rs
+++ b/crates/zakura-rpc/src/methods/types/default_roots.rs
@@ -76,7 +76,7 @@ impl DefaultRoots {
         let auth_data_root = iter::once(coinbase.auth_digest)
             .chain(mempool_txs.iter().map(|tx| {
                 tx.transaction
-                    .id
+                    .id()
                     .auth_digest()
                     .unwrap_or(AUTH_DIGEST_PLACEHOLDER)
             }))
@@ -84,7 +84,7 @@ impl DefaultRoots {
 
         Self {
             merkle_root: iter::once(coinbase.hash)
-                .chain(mempool_txs.iter().map(|tx| tx.transaction.id.mined_id()))
+                .chain(mempool_txs.iter().map(|tx| tx.transaction.id().mined_id()))
                 .collect(),
             chain_history_root,
             auth_data_root,

--- a/crates/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template.rs
@@ -353,7 +353,7 @@ impl BlockTemplateResponse {
         tracing::debug!(
             selected_txs = ?mempool_txs
                 .iter()
-                .map(|tx| (tx.transaction.id.mined_id(), tx.unpaid_actions))
+                .map(|tx| (tx.transaction.id().mined_id(), tx.unpaid_actions))
                 .collect::<Vec<_>>(),
             "creating template ... "
         );

--- a/crates/zakura-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/zip317.rs
@@ -120,7 +120,7 @@ pub fn select_mempool_transactions(
     let (independent_mempool_txs, mut dependent_mempool_txs): (HashMap<_, _>, HashMap<_, _>) =
         mempool_txs
             .into_iter()
-            .map(|tx| (tx.transaction.id.mined_id(), tx))
+            .map(|tx| (tx.transaction.id().mined_id(), tx))
             .partition(|(tx_id, _tx)| !tx_dependencies.contains_key(tx_id));
 
     // Setup the transaction lists.
@@ -215,7 +215,7 @@ fn has_direct_dependencies(
     for tx in selected_txs {
         #[cfg(test)]
         let (_, tx) = tx;
-        if deps.contains(&tx.transaction.id.mined_id()) {
+        if deps.contains(&tx.transaction.id().mined_id()) {
             num_available_deps += 1;
         } else {
             continue;
@@ -285,7 +285,7 @@ fn checked_add_transaction_weighted_random(
     }
 
     let tx_dependencies = mempool_tx_deps.dependencies();
-    let selected_tx_id = &candidate_tx.transaction.id.mined_id();
+    let selected_tx_id = &candidate_tx.transaction.id().mined_id();
     debug_assert!(
         !tx_dependencies.contains_key(selected_tx_id),
         "all candidate transactions should be independent"
@@ -379,11 +379,11 @@ impl TryUpdateBlockLimits for VerifiedUnminedTx {
         // count (legacy + P2SH) so template selection cannot produce blocks that the block verifier
         // would reject for exceeding `MAX_BLOCK_SIGOPS`.
         let tx_block_sigops = self.block_sigop_count();
-        if self.transaction.size <= *remaining_block_bytes
+        if self.transaction.size() <= *remaining_block_bytes
             && tx_block_sigops <= *remaining_block_sigops
             && self.unpaid_actions <= *remaining_block_unpaid_actions
         {
-            *remaining_block_bytes -= self.transaction.size;
+            *remaining_block_bytes -= self.transaction.size();
             *remaining_block_sigops -= tx_block_sigops;
 
             // Unpaid actions are always zero for transactions that pay the conventional fee,

--- a/crates/zakura-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -9,14 +9,51 @@ use zakura_chain::{
     amount::Amount,
     block::{Height, MAX_BLOCK_BYTES},
     parameters::Network,
+    serialization::ZcashSerialize,
     transaction,
-    transparent::OutPoint,
+    transparent::{OutPoint, Output, Script},
 };
 use zakura_node_services::mempool::TransactionDependencies;
 
 use crate::methods::types::{get_block_template::MinerParams, transaction::TransactionTemplate};
 
 use super::{block_template_overhead_bytes, max_coinbase_bytes, select_mempool_transactions};
+
+/// Replaces `transaction`'s inner transaction with one that has exactly
+/// `target_size` serialized bytes.
+fn with_serialized_size(
+    mut transaction: transaction::VerifiedUnminedTx,
+    target_size: usize,
+) -> transaction::VerifiedUnminedTx {
+    let mut inner = transaction.transaction.transaction().as_ref().clone();
+    inner
+        .outputs_mut()
+        .push(Output::new(Amount::zero(), Script::new(&[])));
+
+    let base_size = inner.zcash_serialized_size();
+    let mut script_size = target_size
+        .checked_sub(base_size)
+        .expect("the target size is larger than the test transaction");
+
+    loop {
+        inner
+            .outputs_mut()
+            .last_mut()
+            .expect("the test added an output")
+            .lock_script = Script::new(&vec![0; script_size]);
+
+        let actual_size = inner.zcash_serialized_size();
+        match actual_size.cmp(&target_size) {
+            std::cmp::Ordering::Less => script_size += target_size - actual_size,
+            std::cmp::Ordering::Greater => script_size -= actual_size - target_size,
+            std::cmp::Ordering::Equal => break,
+        }
+    }
+
+    transaction.transaction = inner.into();
+    assert_eq!(transaction.transaction.size(), target_size);
+    transaction
+}
 
 #[test]
 fn reserves_network_specific_header_and_transaction_count_sizes() {
@@ -45,11 +82,11 @@ fn reserves_serialized_block_and_pool_tag_overhead() {
         - max_coinbase_bytes(&fake_coinbase);
 
     let template_transactions = |transaction_size| {
-        let mut transaction = network
+        let transaction = network
             .unmined_transactions_in_blocks(..)
             .next()
             .expect("test network has an unmined transaction");
-        transaction.transaction.size = transaction_size;
+        let transaction = with_serialized_size(transaction, transaction_size);
 
         select_mempool_transactions(
             &network,
@@ -82,7 +119,7 @@ fn excludes_tx_with_unselected_dependencies() {
         .expect("should not be empty");
 
     mempool_tx_deps.add(
-        unmined_tx.transaction.id.mined_id(),
+        unmined_tx.transaction.id().mined_id(),
         vec![OutPoint::from_usize(transaction::Hash([0; 32]), 0)],
     );
 
@@ -110,16 +147,16 @@ fn includes_tx_with_selected_dependencies() {
         .get(2)
         .expect("should have 3 txns")
         .transaction
-        .id
+        .id()
         .mined_id();
 
     let mut mempool_tx_deps = TransactionDependencies::default();
     mempool_tx_deps.add(
-        dependent_tx1.transaction.id.mined_id(),
+        dependent_tx1.transaction.id().mined_id(),
         vec![OutPoint::from_usize(independent_tx_id, 0)],
     );
     mempool_tx_deps.add(
-        dependent_tx2.transaction.id.mined_id(),
+        dependent_tx2.transaction.id().mined_id(),
         vec![
             OutPoint::from_usize(independent_tx_id, 0),
             OutPoint::from_usize(transaction::Hash([0; 32]), 0),
@@ -143,7 +180,7 @@ fn includes_tx_with_selected_dependencies() {
     let selected_tx_by_id = |id| {
         selected_txs
             .iter()
-            .find(|(_, tx)| tx.transaction.id.mined_id() == id)
+            .find(|(_, tx)| tx.transaction.id().mined_id() == id)
     };
 
     let (dependency_depth, _) =
@@ -154,7 +191,7 @@ fn includes_tx_with_selected_dependencies() {
         "should return a dependency depth of 0 for the independent tx"
     );
 
-    let (dependency_depth, _) = selected_tx_by_id(dependent_tx1.transaction.id.mined_id())
+    let (dependency_depth, _) = selected_tx_by_id(dependent_tx1.transaction.id().mined_id())
         .expect("should select dependent_tx1");
 
     assert_eq!(

--- a/crates/zakura-rpc/src/methods/types/get_raw_mempool.rs
+++ b/crates/zakura-rpc/src/methods/types/get_raw_mempool.rs
@@ -69,7 +69,7 @@ impl MempoolObject {
         let empty_set = HashSet::new();
         let deps = transaction_dependencies
             .dependents()
-            .get(&unmined_tx.transaction.id.mined_id())
+            .get(&unmined_tx.transaction.id().mined_id())
             .unwrap_or(&empty_set);
         let deps_len = deps.len();
 
@@ -78,7 +78,7 @@ impl MempoolObject {
         let (deps_size, deps_fees) = deps
             .iter()
             .filter_map(|id| transactions_by_id.get(id))
-            .map(|unmined_tx| (unmined_tx.transaction.size, unmined_tx.miner_fee))
+            .map(|unmined_tx| (unmined_tx.transaction.size(), unmined_tx.miner_fee))
             .reduce(|(size1, fee1), (size2, fee2)| {
                 (size1 + size2, (fee1 + fee2).unwrap_or_default())
             })
@@ -86,7 +86,7 @@ impl MempoolObject {
 
         // Create the MempoolObject from the information we have gathered
         let mempool_object = MempoolObject {
-            size: unmined_tx.transaction.size as u64,
+            size: unmined_tx.transaction.size() as u64,
             fee: unmined_tx.miner_fee.into(),
             // Change this if we ever support fee deltas (prioritisetransaction call)
             modified_fee: unmined_tx.miner_fee.into(),
@@ -97,14 +97,14 @@ impl MempoolObject {
             height: unmined_tx.height.unwrap_or(Height(0)),
             // Note that the following three count this transaction itself
             descendantcount: deps_len as u64 + 1,
-            descendantsize: (deps_size + unmined_tx.transaction.size) as u64,
+            descendantsize: (deps_size + unmined_tx.transaction.size()) as u64,
             descendantfees: (deps_fees + unmined_tx.miner_fee)
                 .unwrap_or_default()
                 .into(),
             // Get dependencies as a txid vector
             depends: transaction_dependencies
                 .dependencies()
-                .get(&unmined_tx.transaction.id.mined_id())
+                .get(&unmined_tx.transaction.id().mined_id())
                 .cloned()
                 .unwrap_or_else(HashSet::new)
                 .iter()

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -88,16 +88,16 @@ where
 impl From<&VerifiedUnminedTx> for TransactionTemplate<NonNegative> {
     fn from(tx: &VerifiedUnminedTx) -> Self {
         assert!(
-            !tx.transaction.transaction.is_coinbase(),
+            !tx.transaction.transaction().is_coinbase(),
             "unexpected coinbase transaction in mempool"
         );
 
         Self {
-            data: tx.transaction.transaction.as_ref().into(),
-            hash: tx.transaction.id.mined_id(),
+            data: tx.transaction.transaction().as_ref().into(),
+            hash: tx.transaction.id().mined_id(),
             auth_digest: tx
                 .transaction
-                .id
+                .id()
                 .auth_digest()
                 .unwrap_or(AUTH_DIGEST_PLACEHOLDER),
 

--- a/crates/zakura-rpc/src/queue.rs
+++ b/crates/zakura-rpc/src/queue.rs
@@ -84,8 +84,10 @@ impl Queue {
 
     /// Insert a transaction to the queue.
     pub fn insert(&mut self, unmined_tx: UnminedTx) {
-        self.transactions
-            .insert(unmined_tx.id, (unmined_tx.transaction, Instant::now()));
+        let id = unmined_tx.id();
+        let transaction = unmined_tx.into_transaction();
+
+        self.transactions.insert(id, (transaction, Instant::now()));
 
         // remove if queue is over capacity
         if self.transactions.len() > CHANNEL_AND_QUEUE_CAPACITY {
@@ -262,7 +264,7 @@ impl Runner {
             let mempool_response = mempool.oneshot(request).await;
             if let Ok(Response::Transactions(txs)) = mempool_response {
                 for tx in txs {
-                    response.insert(tx.id);
+                    response.insert(tx.id());
                 }
             }
         }
@@ -321,7 +323,7 @@ impl Runner {
 
             // return what we retried but don't delete from the queue,
             // we might retry again in a next call.
-            retried.insert(unmined.id);
+            retried.insert(unmined.id());
         }
         retried
     }

--- a/crates/zakura-rpc/src/queue/tests/prop.rs
+++ b/crates/zakura-rpc/src/queue/tests/prop.rs
@@ -44,7 +44,7 @@ proptest! {
         prop_assert_eq!(1, queue_transactions.len());
 
         // remove transaction from the queue
-        runner.queue.remove(transaction.id);
+        runner.queue.remove(transaction.id());
 
         // transaction was removed from queue
         prop_assert_eq!(runner.queue.transactions().len(), 0);

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-script/src/lib.rs
+++ b/crates/zakura-script/src/lib.rs
@@ -319,7 +319,7 @@ impl Sigops for zakura_chain::transaction::Transaction {
 
 impl Sigops for zakura_chain::transaction::UnminedTx {
     fn scripts(&self) -> impl Iterator<Item = Vec<u8>> {
-        self.transaction.scripts()
+        self.transaction().scripts()
     }
 }
 

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -76,7 +76,7 @@ tracing = { workspace = true }
 sapling-crypto = { workspace = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 
 # prod feature progress-bar
@@ -110,7 +110,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -2479,7 +2479,7 @@ impl Service<ReadRequest> for ReadStateService {
                 check::nullifier::tx_no_duplicates_in_chain(
                     &state.db,
                     latest_non_finalized_best_chain.as_ref(),
-                    &unmined_tx.transaction,
+                    unmined_tx.transaction(),
                 )?;
 
                 check::anchors::tx_anchors_refer_to_final_treestates(

--- a/crates/zakura-state/src/service/check/anchors.rs
+++ b/crates/zakura-state/src/service/check/anchors.rs
@@ -481,21 +481,21 @@ pub(crate) fn tx_anchors_refer_to_final_treestates(
     sapling_orchard_ironwood_anchors_refer_to_final_treestates(
         finalized_state,
         parent_chain,
-        &unmined_tx.transaction,
-        unmined_tx.id.mined_id(),
+        unmined_tx.transaction(),
+        unmined_tx.id().mined_id(),
         None,
         None,
     )?;
 
     // If there are no sprout transactions in the block, avoid running a rayon scope
-    if unmined_tx.transaction.has_sprout_joinsplit_data() {
+    if unmined_tx.transaction().has_sprout_joinsplit_data() {
         let mut sprout_final_treestates = HashMap::new();
 
         fetch_sprout_final_treestates(
             &mut sprout_final_treestates,
             finalized_state,
             parent_chain,
-            &unmined_tx.transaction,
+            unmined_tx.transaction(),
             None,
             None,
         );
@@ -515,8 +515,8 @@ pub(crate) fn tx_anchors_refer_to_final_treestates(
 
                 sprout_anchors_result = Some(sprout_anchors_refer_to_treestates(
                     &sprout_final_treestates,
-                    &unmined_tx.transaction,
-                    unmined_tx.id.mined_id(),
+                    unmined_tx.transaction(),
+                    unmined_tx.id().mined_id(),
                     None,
                     None,
                 ));

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
-zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -168,7 +168,7 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "5.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
@@ -323,7 +323,7 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "5.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = ["proptest-impl"] }
 zakura-network = { path = "../zakura-network", version = "7.0.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }

--- a/crates/zakurad/src/components/inbound.rs
+++ b/crates/zakurad/src/components/inbound.rs
@@ -672,7 +672,8 @@ impl Service<zn::Request> for Inbound {
                     };
 
                     // Work out which transaction IDs were missing.
-                    let available_tx_ids: HashSet<UnminedTxId> = transactions.iter().map(|tx| tx.id).collect();
+                    let available_tx_ids: HashSet<UnminedTxId> =
+                        transactions.iter().map(|tx| tx.id()).collect();
                     // We don't need to limit the size of the missing transaction IDs list,
                     // because it is already limited to the size of the getdata request
                     // sent by the peer. (Their content and encodings are the same.)
@@ -687,7 +688,7 @@ impl Service<zn::Request> for Inbound {
                         // (but only one at a time)
                         let within_limit = total_size < GETDATA_SENT_BYTES_LIMIT;
 
-                        total_size += tx.size;
+                        total_size += tx.size();
 
                         within_limit
                     }).map(|tx| Available((tx, None)));

--- a/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -80,7 +80,8 @@ async fn mempool_requests_for_transactions() {
         .iter()
         .map(|t| t.transaction.clone())
         .collect();
-    let added_transaction_ids: Vec<UnminedTxId> = added_transactions.iter().map(|t| t.id).collect();
+    let added_transaction_ids: Vec<UnminedTxId> =
+        added_transactions.iter().map(UnminedTx::id).collect();
 
     // Test `Request::MempoolTransactionIds`
     let response = inbound_service

--- a/crates/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/crates/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -806,7 +806,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
 
     let missing_tx_id = UnminedTxId::from_legacy_id(TxHash([0x22; 32]));
 
-    let txs = [missing_tx_id, repeated_tx.id];
+    let txs = [missing_tx_id, repeated_tx.id()];
 
     // Send a request via the peer set, via a local TCP connection,
     // to the isolated peer's `repeated_response` inbound service

--- a/crates/zakurad/src/components/mempool.rs
+++ b/crates/zakurad/src/components/mempool.rs
@@ -693,7 +693,7 @@ impl Service<Request> for Mempool {
                         // the best chain changes (which is the only way to stay at the same height), and the
                         // mempool re-verifies all pending tx_downloads when there's a `TipAction::Reset`.
                         if best_tip_height == expected_tip_height {
-                            let tx_id = tx.transaction.id;
+                            let tx_id = tx.transaction.id();
                             let (insert_result, evicted_ids) = storage.insert_with_evicted_ids(
                                 tx,
                                 spent_mempool_outpoints,
@@ -1132,7 +1132,7 @@ impl Service<Request> for Mempool {
                     if let Some((tx_version, output)) = storage
                         .transactions()
                         .get(&outpoint.hash)
-                        .map(|tx| tx.transaction.transaction.clone())
+                        .map(|tx| tx.transaction.transaction().clone())
                         .and_then(|tx| {
                             tx.outputs()
                                 .get(outpoint.index as usize)

--- a/crates/zakurad/src/components/mempool/downloads.rs
+++ b/crates/zakurad/src/components/mempool/downloads.rs
@@ -274,7 +274,7 @@ where
             let result = join_result.expect("transaction download and verify tasks must not panic");
             let (result, completed_txid) = match result {
                 Ok(Ok((tx, spent_mempool_outpoints, tip_height, rsp_tx))) => {
-                    let hash = tx.transaction.id;
+                    let hash = tx.transaction.id();
                     (
                         Ok(Ok((tx, spent_mempool_outpoints, tip_height, rsp_tx))),
                         Some(hash),
@@ -492,7 +492,7 @@ where
 
                     metrics::counter!(
                         "mempool.downloaded.transactions.total",
-                        "version" => format!("{}",tx.transaction.version()),
+                        "version" => format!("{}",tx.transaction().version()),
                     ).increment(1);
                     Self::check_transaction_size(&tx, max_transaction_bytes)?;
                     (tx, advertiser_addr)
@@ -500,7 +500,7 @@ where
                 Gossip::Tx(tx) => {
                     metrics::counter!(
                         "mempool.pushed.transactions.total",
-                        "version" => format!("{}",tx.transaction.version()),
+                        "version" => format!("{}",tx.transaction().version()),
                     ).increment(1);
                     (tx, pushed_advertiser_addr)
                 }
@@ -530,7 +530,7 @@ where
         .map_ok(|(tx, spent_mempool_outpoints, tip_height)| {
             metrics::counter!(
                 "mempool.verified.transactions.total",
-                "version" => format!("{}", tx.transaction.transaction.version()),
+                "version" => format!("{}", tx.transaction.transaction().version()),
             ).increment(1);
             (tx, spent_mempool_outpoints, tip_height)
         })
@@ -683,11 +683,11 @@ where
         max_transaction_bytes: u64,
     ) -> Result<(), TransactionDownloadVerifyError> {
         if usize::try_from(max_transaction_bytes)
-            .is_ok_and(|max_transaction_bytes| transaction.size > max_transaction_bytes)
+            .is_ok_and(|max_transaction_bytes| transaction.size() > max_transaction_bytes)
         {
             return Err(TransactionDownloadVerifyError::PolicyRejected(
                 NonStandardTransactionError::TransactionTooLarge {
-                    actual_bytes: transaction.size,
+                    actual_bytes: transaction.size(),
                     max_bytes: max_transaction_bytes,
                 },
             ));
@@ -932,7 +932,7 @@ mod tests {
     #[tokio::test]
     async fn pushed_transaction_at_size_limit_is_verified() {
         let transaction = empty_v5_transaction(1);
-        let max_transaction_bytes = u64::try_from(transaction.size)
+        let max_transaction_bytes = u64::try_from(transaction.size())
             .expect("serialized transaction sizes fit in u64 on supported platforms");
         let verifier_calls = Arc::new(AtomicUsize::new(0));
         let verifier_calls_for_service = verifier_calls.clone();
@@ -948,7 +948,7 @@ mod tests {
                     let tx::Request::Mempool { transaction, .. } = request else {
                         panic!("unexpected transaction verifier request: {request:?}");
                     };
-                    let miner_fee = transaction.conventional_fee;
+                    let miner_fee = transaction.conventional_fee();
                     let transaction =
                         VerifiedUnminedTx::new(transaction, miner_fee, 0, 0, Arc::new(Vec::new()))
                             .expect("test transaction pays its conventional fee");
@@ -987,7 +987,7 @@ mod tests {
     #[tokio::test]
     async fn pushed_transaction_over_size_limit_skips_state_and_verifier() {
         let transaction = empty_v5_transaction(1);
-        let actual_bytes = transaction.size;
+        let actual_bytes = transaction.size();
         let max_bytes = u64::try_from(
             actual_bytes
                 .checked_sub(1)
@@ -1067,8 +1067,8 @@ mod tests {
     #[tokio::test]
     async fn downloaded_transaction_over_size_limit_skips_verifier() {
         let transaction = empty_v5_transaction(1);
-        let txid = transaction.id;
-        let actual_bytes = transaction.size;
+        let txid = transaction.id();
+        let actual_bytes = transaction.size();
         let max_bytes = u64::try_from(
             actual_bytes
                 .checked_sub(1)

--- a/crates/zakurad/src/components/mempool/storage.rs
+++ b/crates/zakurad/src/components/mempool/storage.rs
@@ -999,12 +999,12 @@ impl Storage {
     ///
     /// Must be called every time the rejected lists change.
     fn update_rejected_metrics(&mut self) {
-        metrics::gauge!("mempool.rejected.transaction.id()s",)
+        metrics::gauge!("mempool.rejected.transaction.ids",)
             .set(self.rejected_transaction_count() as f64);
         // This is just an approximation.
         // TODO: make it more accurate #2869
         let item_size = size_of::<(transaction::Hash, SameEffectsTipRejectionError)>();
-        metrics::gauge!("mempool.rejected.transaction.id()s.bytes",)
+        metrics::gauge!("mempool.rejected.transaction.ids.bytes",)
             .set((self.rejected_transaction_count() * item_size) as f64);
     }
 }

--- a/crates/zakurad/src/components/mempool/storage.rs
+++ b/crates/zakurad/src/components/mempool/storage.rs
@@ -283,7 +283,7 @@ impl Storage {
     fn reject_if_non_standard_tx(&mut self, tx: &VerifiedUnminedTx) -> Result<(), MempoolError> {
         use zcash_script::script::{self, Evaluable as _};
 
-        let transaction = tx.transaction.transaction.as_ref();
+        let transaction = tx.transaction.transaction().as_ref();
         let spent_outputs = &tx.spent_outputs;
 
         for input in transaction.inputs() {
@@ -410,7 +410,7 @@ impl Storage {
         tx: &VerifiedUnminedTx,
         rejection_error: NonStandardTransactionError,
     ) -> Result<(), MempoolError> {
-        self.reject(tx.transaction.id, rejection_error.clone().into());
+        self.reject(tx.transaction.id(), rejection_error.clone().into());
         Err(MempoolError::NonStandardTransaction(rejection_error))
     }
 
@@ -452,7 +452,7 @@ impl Storage {
         // # Security
         //
         // This method must call `reject`, rather than modifying the rejection lists directly.
-        let unmined_tx_id = tx.transaction.id;
+        let unmined_tx_id = tx.transaction.id();
         let tx_id = unmined_tx_id.mined_id();
 
         // First, check if we have a cached rejection for this transaction.
@@ -535,7 +535,7 @@ impl Storage {
                 .last()
                 .expect("eviction removes at least the selected transaction")
                 .transaction
-                .id;
+                .id();
 
             self.reject(
                 victim_tx_id,
@@ -547,7 +547,7 @@ impl Storage {
                 result = Err(SameEffectsChainRejectionError::RandomlyEvicted.into());
             }
 
-            evicted_ids.extend(victim_txs.into_iter().map(|tx| tx.transaction.id));
+            evicted_ids.extend(victim_txs.into_iter().map(|tx| tx.transaction.id()));
         }
 
         (result, evicted_ids)
@@ -570,7 +570,7 @@ impl Storage {
     #[allow(dead_code)]
     pub fn remove_exact(&mut self, exact_wtxids: &HashSet<UnminedTxId>) -> usize {
         self.verified
-            .remove_all_that(|tx| exact_wtxids.contains(&tx.transaction.id))
+            .remove_all_that(|tx| exact_wtxids.contains(&tx.transaction.id()))
             .len()
     }
 
@@ -600,7 +600,7 @@ impl Storage {
     ) -> RemovedTransactionIds {
         let removed_mined = self
             .verified
-            .remove_all_that(|tx| mined_ids.contains(&tx.transaction.id.mined_id()));
+            .remove_all_that(|tx| mined_ids.contains(&tx.transaction.id().mined_id()));
 
         let spent_outpoints: HashSet<_> = transactions
             .iter()
@@ -627,7 +627,7 @@ impl Storage {
             .verified
             .transactions()
             .values()
-            .map(|tx| (tx.transaction.id, &tx.transaction.transaction))
+            .map(|tx| (tx.transaction.id(), tx.transaction.transaction()))
             .filter_map(|(tx_id, tx)| {
                 (tx.spent_outpoints()
                     .any(|outpoint| spent_outpoints.contains(&outpoint))
@@ -649,7 +649,7 @@ impl Storage {
 
         let removed_duplicate_spend = self
             .verified
-            .remove_all_that(|tx| duplicate_spend_ids.contains(&tx.transaction.id));
+            .remove_all_that(|tx| duplicate_spend_ids.contains(&tx.transaction.id()));
 
         for &mined_id in mined_ids {
             self.reject(
@@ -713,7 +713,7 @@ impl Storage {
 
     /// Returns the set of [`UnminedTxId`]s in the mempool.
     pub fn tx_ids(&self) -> impl Iterator<Item = UnminedTxId> + '_ {
-        self.transactions().values().map(|tx| tx.transaction.id)
+        self.transactions().values().map(|tx| tx.transaction.id())
     }
 
     /// Returns a reference to the [`HashMap`] of [`VerifiedUnminedTx`]s in the verified set.
@@ -955,7 +955,7 @@ impl Storage {
         let mut tx_ids = HashSet::new();
 
         for (&tx_id, tx) in self.transactions() {
-            if let Some(expiry_height) = tx.transaction.transaction.expiry_height() {
+            if let Some(expiry_height) = tx.transaction.transaction().expiry_height() {
                 if tip_height >= expiry_height {
                     tx_ids.insert(tx_id);
                 }
@@ -965,7 +965,7 @@ impl Storage {
         // expiry height is effecting data, so we match by non-malleable TXID
         let removed_tx_ids = self
             .verified
-            .remove_all_that(|tx| tx_ids.contains(&tx.transaction.id.mined_id()));
+            .remove_all_that(|tx| tx_ids.contains(&tx.transaction.id().mined_id()));
 
         // also reject it
         for id in tx_ids {
@@ -999,12 +999,12 @@ impl Storage {
     ///
     /// Must be called every time the rejected lists change.
     fn update_rejected_metrics(&mut self) {
-        metrics::gauge!("mempool.rejected.transaction.ids",)
+        metrics::gauge!("mempool.rejected.transaction.id()s",)
             .set(self.rejected_transaction_count() as f64);
         // This is just an approximation.
         // TODO: make it more accurate #2869
         let item_size = size_of::<(transaction::Hash, SameEffectsTipRejectionError)>();
-        metrics::gauge!("mempool.rejected.transaction.ids.bytes",)
+        metrics::gauge!("mempool.rejected.transaction.id()s.bytes",)
             .set((self.rejected_transaction_count() * item_size) as f64);
     }
 }

--- a/crates/zakurad/src/components/mempool/storage/tests/prop.rs
+++ b/crates/zakurad/src/components/mempool/storage/tests/prop.rs
@@ -140,7 +140,7 @@ proptest! {
         ];
 
         for (transaction_to_accept, transaction_to_reject) in input_permutations {
-            let id_to_accept = transaction_to_accept.transaction.id;
+            let id_to_accept = transaction_to_accept.transaction.id();
 
             prop_assert_eq!(storage.insert(transaction_to_accept, Vec::new(), None), Ok(id_to_accept));
 
@@ -212,7 +212,7 @@ proptest! {
         );
 
         for (i, transaction) in transactions.iter().enumerate() {
-            let tx_id = transaction.transaction.id;
+            let tx_id = transaction.transaction.id();
 
             if i < transactions.len() - 1 {
                 // The initial transactions should be successful
@@ -356,8 +356,8 @@ proptest! {
         ];
 
         for (transaction_to_accept, transaction_to_reject) in input_permutations {
-            let id_to_accept = transaction_to_accept.transaction.id;
-            let id_to_reject = transaction_to_reject.transaction.id;
+            let id_to_accept = transaction_to_accept.transaction.id();
+            let id_to_reject = transaction_to_reject.transaction.id();
 
             prop_assert_eq!(storage.insert(transaction_to_accept, Vec::new(), None), Ok(id_to_accept));
 
@@ -405,9 +405,9 @@ proptest! {
         for (first_transaction_to_accept, transaction_to_reject, second_transaction_to_accept) in
             input_permutations
         {
-            let first_id_to_accept = first_transaction_to_accept.transaction.id;
-            let second_id_to_accept = second_transaction_to_accept.transaction.id;
-            let id_to_reject = transaction_to_reject.transaction.id;
+            let first_id_to_accept = first_transaction_to_accept.transaction.id();
+            let second_id_to_accept = second_transaction_to_accept.transaction.id();
+            let id_to_reject = transaction_to_reject.transaction.id();
 
             prop_assert_eq!(
                 storage.insert(first_transaction_to_accept, Vec::new(), None),
@@ -447,7 +447,7 @@ proptest! {
         let inserted_transactions: HashSet<_> = input
             .transactions()
             .filter_map(|transaction| {
-                let id = transaction.transaction.id;
+                let id = transaction.transaction.id();
 
                 storage.insert(transaction.clone(), Vec::new(), None).ok().map(|_| id)
             })
@@ -1092,7 +1092,7 @@ impl Arbitrary for MultipleTransactionRemovalTestInput {
             .prop_flat_map(|(transactions, indices_to_remove)| {
                 let wtx_ids_to_remove: HashSet<_> = indices_to_remove
                     .iter()
-                    .map(|&index| transactions[index].transaction.id)
+                    .map(|&index| transactions[index].transaction.id())
                     .collect();
 
                 let mined_ids_to_remove: HashSet<transaction::Hash> = wtx_ids_to_remove
@@ -1139,7 +1139,7 @@ impl MultipleTransactionRemovalTestInput {
                 mined_ids_to_remove,
             } => transactions
                 .iter()
-                .map(|transaction| transaction.transaction.id)
+                .map(|transaction| transaction.transaction.id())
                 .filter(|id| mined_ids_to_remove.contains(&id.mined_id()))
                 .collect(),
         }

--- a/crates/zakurad/src/components/mempool/storage/tests/vectors.rs
+++ b/crates/zakurad/src/components/mempool/storage/tests/vectors.rs
@@ -93,9 +93,9 @@ fn oversized_policy_rejection_is_cached_by_exact_id() {
     let mut storage = Storage::new(&config::Config::default());
     let transaction = Network::Mainnet
         .unmined_transactions_in_blocks(..)
-        .find(|transaction| transaction.transaction.id.auth_digest().is_some())
+        .find(|transaction| transaction.transaction.id().auth_digest().is_some())
         .expect("mainnet test vectors contain a witnessed transaction");
-    let tx_id = transaction.transaction.id;
+    let tx_id = transaction.transaction.id();
     let rejection = NonStandardTransactionError::TransactionTooLarge {
         actual_bytes: 250_001,
         max_bytes: 250_000,
@@ -145,14 +145,14 @@ fn mempool_storage_crud_exact_mainnet() {
     let _ = storage.insert(unmined_tx.clone(), Vec::new(), None);
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains_transaction_exact(&unmined_tx.transaction.id.mined_id()));
+    assert!(storage.contains_transaction_exact(&unmined_tx.transaction.id().mined_id()));
 
     // Remove tx
-    let removal_count = storage.remove_exact(&iter::once(unmined_tx.transaction.id).collect());
+    let removal_count = storage.remove_exact(&iter::once(unmined_tx.transaction.id()).collect());
 
     // Check that it is /not/ in the mempool.
     assert_eq!(removal_count, 1);
-    assert!(!storage.contains_transaction_exact(&unmined_tx.transaction.id.mined_id()));
+    assert!(!storage.contains_transaction_exact(&unmined_tx.transaction.id().mined_id()));
 }
 
 #[test]
@@ -226,13 +226,13 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
 
     // Test if rejected transactions were actually rejected.
     for tx in some_rejected_transactions.iter() {
-        assert!(!storage.contains_transaction_exact(&tx.transaction.id.mined_id()));
+        assert!(!storage.contains_transaction_exact(&tx.transaction.id().mined_id()));
     }
 
     // Query all the ids we have for rejected, get back `total - MEMPOOL_SIZE`
     let all_ids: HashSet<UnminedTxId> = unmined_transactions
         .iter()
-        .map(|tx| tx.transaction.id)
+        .map(|tx| tx.transaction.id())
         .collect();
 
     // Convert response to a `HashSet`, because the order of the response doesn't matter.
@@ -240,7 +240,7 @@ fn mempool_storage_basic_for_network(network: Network) -> Result<()> {
 
     let some_rejected_ids = some_rejected_transactions
         .iter()
-        .map(|tx| tx.transaction.id)
+        .map(|tx| tx.transaction.id())
         .collect::<HashSet<_>>();
 
     // Test if the rejected transactions we have are a subset of the actually
@@ -273,23 +273,23 @@ fn mempool_storage_crud_same_effects_mainnet() {
     let _ = storage.insert(unmined_tx_1.clone(), Vec::new(), None);
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains_transaction_exact(&unmined_tx_1.transaction.id.mined_id()));
+    assert!(storage.contains_transaction_exact(&unmined_tx_1.transaction.id().mined_id()));
 
     // Reject and remove mined tx
     let removal_count = storage
         .reject_and_remove_same_effects(
-            &iter::once(unmined_tx_1.transaction.id.mined_id()).collect(),
-            vec![unmined_tx_1.transaction.transaction.clone()],
+            &iter::once(unmined_tx_1.transaction.id().mined_id()).collect(),
+            vec![unmined_tx_1.transaction.transaction().clone()],
         )
         .total_len();
 
     // Check that it is /not/ in the mempool as a verified transaction.
     assert_eq!(removal_count, 1);
-    assert!(!storage.contains_transaction_exact(&unmined_tx_1.transaction.id.mined_id()));
+    assert!(!storage.contains_transaction_exact(&unmined_tx_1.transaction.id().mined_id()));
 
     // Check that it's rejection is cached in the chain_rejected_same_effects' `Mined` eviction list.
     assert_eq!(
-        storage.rejection_error(&unmined_tx_1.transaction.id),
+        storage.rejection_error(&unmined_tx_1.transaction.id()),
         Some(SameEffectsChainRejectionError::Mined.into())
     );
     assert_eq!(
@@ -302,7 +302,7 @@ fn mempool_storage_crud_same_effects_mainnet() {
         .unmined_transactions_in_blocks(1..)
         .find(|tx| {
             tx.transaction
-                .transaction
+                .transaction()
                 .spent_outpoints()
                 .next()
                 .is_some()
@@ -312,27 +312,27 @@ fn mempool_storage_crud_same_effects_mainnet() {
     // Insert unmined tx into the mempool.
     assert_eq!(
         storage.insert(unmined_tx_2.clone(), Vec::new(), None),
-        Ok(unmined_tx_2.transaction.id)
+        Ok(unmined_tx_2.transaction.id())
     );
 
     // Check that it is in the mempool, and not rejected.
-    assert!(storage.contains_transaction_exact(&unmined_tx_2.transaction.id.mined_id()));
+    assert!(storage.contains_transaction_exact(&unmined_tx_2.transaction.id().mined_id()));
 
     // Reject and remove duplicate spend tx
     let removal_count = storage
         .reject_and_remove_same_effects(
             &HashSet::new(),
-            vec![unmined_tx_2.transaction.transaction.clone()],
+            vec![unmined_tx_2.transaction.transaction().clone()],
         )
         .total_len();
 
     // Check that it is /not/ in the mempool as a verified transaction.
     assert_eq!(removal_count, 1);
-    assert!(!storage.contains_transaction_exact(&unmined_tx_2.transaction.id.mined_id()));
+    assert!(!storage.contains_transaction_exact(&unmined_tx_2.transaction.id().mined_id()));
 
     // Check that it's rejection is cached in the chain_rejected_same_effects' `SpendConflict` eviction list.
     assert_eq!(
-        storage.rejection_error(&unmined_tx_2.transaction.id),
+        storage.rejection_error(&unmined_tx_2.transaction.id()),
         Some(SameEffectsChainRejectionError::DuplicateSpend.into())
     );
     assert_eq!(
@@ -353,7 +353,7 @@ fn mempool_removes_ironwood_duplicate_spends() {
 
     let action = ironwood_action();
     let mempool_tx = verified_ironwood_v6_tx(Height(1), action.clone());
-    let mempool_id = mempool_tx.transaction.id;
+    let mempool_id = mempool_tx.transaction.id();
 
     assert_eq!(
         storage.insert(mempool_tx.clone(), Vec::new(), None),
@@ -391,8 +391,8 @@ fn mempool_rejects_ironwood_conflict_on_insert() {
     let first_mempool_tx = verified_ironwood_v6_tx(Height(1), action.clone());
     let second_mempool_tx = verified_ironwood_v6_tx(Height(2), action);
 
-    let first_mempool_id = first_mempool_tx.transaction.id;
-    let second_mempool_id = second_mempool_tx.transaction.id;
+    let first_mempool_id = first_mempool_tx.transaction.id();
+    let second_mempool_id = second_mempool_tx.transaction.id();
 
     assert_eq!(
         storage.insert(first_mempool_tx, Vec::new(), None),
@@ -538,10 +538,10 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
             // treat outputs < 100 zatoshis as "dust" for these tests, we want them out
             let dust_threshold: Amount<NonNegative> =
                 Amount::try_from(100u64).expect("valid amount");
-            !tx.transaction.transaction.outputs().is_empty()
+            !tx.transaction.transaction().outputs().is_empty()
                 && tx
                     .transaction
-                    .transaction
+                    .transaction()
                     .outputs()
                     .iter()
                     .all(|out| out.value >= dust_threshold)
@@ -552,8 +552,8 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
     let mut expected_transaction_dependencies = HashMap::new();
     let mut expected_transaction_dependents = HashMap::new();
     for unmined_tx in unmined_txs_with_transparent_outputs() {
-        let tx_id = unmined_tx.transaction.id.mined_id();
-        let num_outputs = unmined_tx.transaction.transaction.outputs().len();
+        let tx_id = unmined_tx.transaction.id().mined_id();
+        let num_outputs = unmined_tx.transaction.transaction().outputs().len();
 
         if let Some(&fake_spent_outpoint) = fake_spent_outpoints.first() {
             expected_transaction_dependencies
@@ -599,7 +599,7 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
         .expect("at least one unmined transaction with transparent outputs");
 
     let expected_num_removed = storage.transaction_count();
-    let num_removed = storage.remove_exact(&[first_tx.transaction.id].into_iter().collect());
+    let num_removed = storage.remove_exact(&[first_tx.transaction.id()].into_iter().collect());
 
     assert_eq!(
         num_removed, expected_num_removed,

--- a/crates/zakurad/src/components/mempool/storage/verified_set.rs
+++ b/crates/zakurad/src/components/mempool/storage/verified_set.rs
@@ -174,12 +174,12 @@ impl VerifiedSet {
             }
         }
 
-        let tx_id = transaction.transaction.id.mined_id();
+        let tx_id = transaction.transaction.id().mined_id();
         self.transaction_dependencies
             .add(tx_id, spent_mempool_outpoints);
 
         // Inserts the transaction's outputs into the internal caches and responds to pending output requests.
-        let tx = &transaction.transaction.transaction;
+        let tx = &transaction.transaction.transaction();
         for (index, output) in tx.outputs().iter().cloned().enumerate() {
             let outpoint = transparent::OutPoint::from_usize(tx_id, index);
             self.created_outputs.insert(outpoint, output.clone());
@@ -191,7 +191,7 @@ impl VerifiedSet {
         self.orchard_nullifiers.extend(tx.orchard_nullifiers());
         self.ironwood_nullifiers.extend(tx.ironwood_nullifiers());
 
-        self.transactions_serialized_size += transaction.transaction.size;
+        self.transactions_serialized_size += transaction.transaction.size();
         self.total_cost += transaction.cost();
         transaction.time = Some(chrono::Utc::now());
         transaction.height = height;
@@ -278,7 +278,7 @@ impl VerifiedSet {
             removed_transactions.extend(
                 self.remove(&key_to_remove)
                     .into_iter()
-                    .map(|tx| tx.transaction.id),
+                    .map(|tx| tx.transaction.id()),
             );
         }
 
@@ -306,7 +306,7 @@ impl VerifiedSet {
                     return None;
                 };
 
-                self.transactions_serialized_size -= removed_tx.transaction.size;
+                self.transactions_serialized_size -= removed_tx.transaction.size();
                 self.total_cost -= removed_tx.cost();
                 self.metrics.remove_transaction(&removed_tx);
                 self.remove_outputs(&removed_tx.transaction);
@@ -325,7 +325,7 @@ impl VerifiedSet {
     /// Two transactions have a spend conflict if they spend the same UTXO or if they reveal the
     /// same nullifier.
     fn has_spend_conflicts(&self, unmined_tx: &UnminedTx) -> bool {
-        let tx = &unmined_tx.transaction;
+        let tx = unmined_tx.transaction();
 
         Self::has_conflicts(&self.spent_outpoints, tx.spent_outpoints())
             || Self::has_conflicts(&self.sprout_nullifiers, tx.sprout_nullifiers().copied())
@@ -336,12 +336,12 @@ impl VerifiedSet {
 
     /// Removes the tracked transaction outputs from the mempool.
     fn remove_outputs(&mut self, unmined_tx: &UnminedTx) {
-        let tx = &unmined_tx.transaction;
+        let tx = unmined_tx.transaction();
 
         for index in 0..tx.outputs().len() {
             self.created_outputs
                 .remove(&transparent::OutPoint::from_usize(
-                    unmined_tx.id.mined_id(),
+                    unmined_tx.id().mined_id(),
                     index,
                 ));
         }
@@ -472,7 +472,7 @@ impl MempoolMetrics {
             transaction.fee_weight_ratio,
             transaction.conventional_actions,
             transaction.unpaid_actions,
-            transaction.transaction.size,
+            transaction.transaction.size(),
         )
     }
 

--- a/crates/zakurad/src/components/mempool/tests.rs
+++ b/crates/zakurad/src/components/mempool/tests.rs
@@ -143,7 +143,7 @@ pub fn standard_verified_unmined_tx_strategy() -> BoxedStrategy<VerifiedUnminedT
             standardize_transaction(&mut transaction);
 
             let unmined_tx = UnminedTx::from(transaction);
-            let miner_fee = unmined_tx.conventional_fee;
+            let miner_fee = unmined_tx.conventional_fee();
 
             VerifiedUnminedTx::new(unmined_tx, miner_fee, 0, 0, std::sync::Arc::new(vec![]))
                 .expect("standardized transaction should pass ZIP-317 checks")

--- a/crates/zakurad/src/components/mempool/tests/prop.rs
+++ b/crates/zakurad/src/components/mempool/tests/prop.rs
@@ -144,9 +144,13 @@ proptest! {
                 // Adjust the transaction expiry height based on the new chain
                 // tip height so that the mempool does not evict the transaction
                 // when there is a chain growth.
-                if let Some(expiry_height) = transaction.transaction.transaction.expiry_height() {
+                if let Some(expiry_height) = transaction.transaction.transaction().expiry_height() {
                     if chain_tip.height >= expiry_height {
-                        let mut tmp_tx = (*transaction.transaction.transaction).clone();
+                        let mut tmp_tx = transaction
+                            .transaction
+                            .transaction()
+                            .as_ref()
+                            .clone();
 
                         // Set a new expiry height that is greater than the
                         // height of the current chain tip.

--- a/crates/zakurad/src/components/mempool/tests/vector.rs
+++ b/crates/zakurad/src/components/mempool/tests/vector.rs
@@ -88,7 +88,7 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
         .unmined_transactions_in_blocks(2..)
         .map(|transaction| transaction.transaction.clone())
         .collect::<Vec<_>>();
-    transactions.sort_by_key(|transaction| transaction.size);
+    transactions.sort_by_key(|transaction| transaction.size());
 
     let at_limit_transaction = transactions
         .first()
@@ -99,11 +99,11 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
         .expect("mainnet test vectors contain an unmined transaction")
         .clone();
     assert!(
-        at_limit_transaction.size < oversized_transaction.size,
+        at_limit_transaction.size() < oversized_transaction.size(),
         "test transactions must have different serialized sizes"
     );
 
-    let max_transaction_bytes = u64::try_from(at_limit_transaction.size)
+    let max_transaction_bytes = u64::try_from(at_limit_transaction.size())
         .expect("serialized transaction sizes fit in u64 on supported platforms");
     let mempool_config = mempool::Config {
         max_transaction_bytes,
@@ -130,7 +130,7 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
     .await;
     mempool.enable(&mut recent_syncs).await;
 
-    let oversized_id = oversized_transaction.id;
+    let oversized_id = oversized_transaction.id();
     let response = mempool
         .ready()
         .await
@@ -170,7 +170,7 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
                     max_bytes,
                 }
             )
-        )) if actual_bytes == oversized_transaction.size && max_bytes == max_transaction_bytes
+        )) if actual_bytes == oversized_transaction.size() && max_bytes == max_transaction_bytes
     ));
     assert_eq!(mempool.storage().transaction_count(), 0);
     tx_verifier.expect_no_requests().await;
@@ -179,7 +179,7 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
         Err(tokio::sync::mpsc::error::TryRecvError::Empty)
     ));
 
-    let at_limit_id = at_limit_transaction.id;
+    let at_limit_id = at_limit_transaction.id();
     let response = mempool
         .ready()
         .await
@@ -204,7 +204,7 @@ async fn oversized_peer_transaction_is_rejected_without_misbehavior() -> Result<
         .expect_request_that(|request| {
             matches!(
                 request,
-                tx::Request::Mempool { transaction, .. } if transaction.id == at_limit_id
+                tx::Request::Mempool { transaction, .. } if transaction.id() == at_limit_id
             )
         })
         .await
@@ -238,7 +238,7 @@ async fn cached_size_policy_rejection_is_a_transaction_result() -> Result<(), Re
         .expect("mainnet test vectors contain an unmined transaction")
         .transaction
         .clone();
-    let transaction_id = transaction.id;
+    let transaction_id = transaction.id();
     let mempool_config = mempool::Config {
         max_transaction_bytes: 1,
         ..Default::default()
@@ -349,7 +349,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
     service
         .storage()
         .insert(genesis_transaction.clone(), Vec::new(), None)?;
-    inserted_ids.insert(genesis_transaction.transaction.id);
+    inserted_ids.insert(genesis_transaction.transaction.id());
 
     // Test `Request::TransactionIds`
     let response = service
@@ -415,7 +415,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
     // This will cause the genesis transaction to be moved into rejected.
     // Skip the last (will be used later)
     for tx in more_transactions {
-        inserted_ids.insert(tx.transaction.id);
+        inserted_ids.insert(tx.transaction.id());
         // Error must be ignored because a insert can trigger an eviction and
         // an error is returned if the transaction being inserted in chosen.
         let _ = service.storage().insert(tx.clone(), Vec::new(), None);
@@ -444,7 +444,10 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
         .ready()
         .await
         .unwrap()
-        .call(Request::Queue(vec![last_transaction.transaction.id.into()]))
+        .call(Request::Queue(vec![last_transaction
+            .transaction
+            .id()
+            .into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -480,7 +483,7 @@ async fn mempool_service_basic_single() -> Result<(), Report> {
         .storage()
         .transactions()
         .values()
-        .map(|tx| tx.transaction.size)
+        .map(|tx| tx.transaction.size())
         .sum();
 
     // TODO: Derive memory usage when available
@@ -549,7 +552,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
         .ready()
         .await
         .unwrap()
-        .call(Request::Queue(vec![new_tx.transaction.id.into()]))
+        .call(Request::Queue(vec![new_tx.transaction.id().into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -569,7 +572,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
         .call(Request::Queue(
             transactions
                 .iter()
-                .map(|tx| tx.transaction.id.into())
+                .map(|tx| tx.transaction.id().into())
                 .collect(),
         ))
         .await
@@ -649,7 +652,7 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
 
     // Queue a transaction for download
     // Use the ID of the last transaction in the list
-    let txid = more_transactions.last().unwrap().transaction.id;
+    let txid = more_transactions.last().unwrap().transaction.id();
     let response = service
         .ready()
         .await
@@ -1194,7 +1197,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
         .ready()
         .await
         .unwrap()
-        .call(Request::Queue(vec![rejected_tx.transaction.id.into()]))
+        .call(Request::Queue(vec![rejected_tx.transaction.id().into()]))
         .await
         .unwrap();
     let queued_responses = match response {
@@ -1218,7 +1221,7 @@ async fn mempool_failed_verification_is_rejected() -> Result<(), Report> {
 
     assert_eq!(
         mempool_change,
-        MempoolChange::invalidated([rejected_tx.transaction.id].into_iter().collect())
+        MempoolChange::invalidated([rejected_tx.transaction.id()].into_iter().collect())
     );
 
     Ok(())
@@ -1254,7 +1257,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx
             .transaction
-            .id
+            .id()
             .into()]));
     // Make the mock peer set return that the download failed.
     let verification = peer_set
@@ -1286,7 +1289,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
         .unwrap()
         .call(Request::Queue(vec![rejected_valid_tx
             .transaction
-            .id
+            .id()
             .into()]))
         .await
         .unwrap();
@@ -1304,7 +1307,7 @@ async fn mempool_failed_download_is_not_rejected() -> Result<(), Report> {
 
     assert_eq!(
         mempool_change,
-        MempoolChange::invalidated([rejected_valid_tx.transaction.id].into_iter().collect())
+        MempoolChange::invalidated([rejected_valid_tx.transaction.id()].into_iter().collect())
     );
 
     Ok(())
@@ -1515,15 +1518,15 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
 
     let verified_unmined_tx = network
         .unmined_transactions_in_blocks(1..=10)
-        .find(|tx| !tx.transaction.transaction.outputs().is_empty())
+        .find(|tx| !tx.transaction.transaction().outputs().is_empty())
         .expect("should have at least 1 tx with transparent outputs");
 
     let unmined_tx = verified_unmined_tx.transaction.clone();
-    let unmined_tx_id = unmined_tx.id;
+    let unmined_tx_id = unmined_tx.id();
     let output_index = 0;
-    let outpoint = OutPoint::from_usize(unmined_tx.id.mined_id(), output_index);
+    let outpoint = OutPoint::from_usize(unmined_tx.id().mined_id(), output_index);
     let expected_output = unmined_tx
-        .transaction
+        .transaction()
         .outputs()
         .get(output_index)
         .expect("already checked that tx has outputs")
@@ -1781,8 +1784,8 @@ async fn evicted_transaction_ids_are_removed_from_pending_gossip() -> Result<(),
     let second_tx = transactions
         .next()
         .expect("at least two unmined transactions");
-    let first_tx_id = first_tx.transaction.id;
-    let second_tx_id = second_tx.transaction.id;
+    let first_tx_id = first_tx.transaction.id();
+    let second_tx_id = second_tx.transaction.id();
     let tx_cost_limit = first_tx.cost().max(second_tx.cost());
 
     let (
@@ -1816,7 +1819,7 @@ async fn evicted_transaction_ids_are_removed_from_pending_gossip() -> Result<(),
                         .expect("unexpected non-mempool request");
                     let verified_tx = verified_txs
                         .iter()
-                        .find(|tx| tx.transaction.id == requested_tx.id)
+                        .find(|tx| tx.transaction.id() == requested_tx.id())
                         .expect("unexpected transaction verification request")
                         .clone();
 
@@ -1958,13 +1961,13 @@ async fn mempool_reject_non_standard() -> Result<(), Report> {
 
     // Modify the transaction to make it non-standard.
     // This is done by replacing its outputs with a dust output.
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(10), // this is below the dust threshold
         lock_script: p2pkh_script([0u8; 20]),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     // Set cost limit to the cost of the transaction we will try to insert.
     let cost_limit = last_transaction.cost();
@@ -2009,13 +2012,13 @@ async fn mempool_accept_standard_op_return() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(0),
         lock_script: op_return_script(&[0x01]),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2050,13 +2053,13 @@ async fn mempool_reject_op_return_too_large() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(0),
         lock_script: op_return_script(&[0x03]),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
     // Shrink the OP_RETURN size limit to trigger the oversized rejection path.
@@ -2105,7 +2108,7 @@ async fn mempool_reject_multi_op_return() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![
         transparent::Output {
@@ -2117,7 +2120,7 @@ async fn mempool_reject_multi_op_return() -> Result<(), Report> {
             lock_script: op_return_script(&[0x05]),
         },
     ];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2158,13 +2161,13 @@ async fn mempool_reject_non_standard_scriptpubkey() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(1000),
         lock_script: transparent::Script::new(&[0x00]),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2207,13 +2210,13 @@ async fn mempool_reject_bare_multisig() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(1000),
         lock_script: multisig_script(1, 1),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2254,13 +2257,13 @@ async fn mempool_reject_large_multisig() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     *tx_mut.outputs_mut() = vec![transparent::Output {
         value: Amount::new(1000),
         lock_script: multisig_script(1, 4),
     }];
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2300,10 +2303,10 @@ async fn mempool_reject_large_scriptsig() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     set_first_prevout_unlock_script(tx_mut, transparent::Script::new(&vec![0u8; 1651]));
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2343,10 +2346,10 @@ async fn mempool_reject_non_push_only_scriptsig() -> Result<(), Report> {
 
     last_transaction.height = Some(Height(100_000));
 
-    let mut tx = last_transaction.transaction.transaction.clone();
+    let mut tx = last_transaction.transaction.transaction().clone();
     let tx_mut = Arc::make_mut(&mut tx);
     set_first_prevout_unlock_script(tx_mut, transparent::Script::new(&[0xac]));
-    last_transaction.transaction.transaction = tx;
+    last_transaction.transaction = tx.into();
 
     let cost_limit = last_transaction.cost();
 
@@ -2439,7 +2442,7 @@ async fn mempool_reject_non_standard_inputs() -> Result<(), Report> {
     };
     // Provide one spent output per transparent input (including coinbase inputs in the count,
     // since are_inputs_standard expects spent_outputs.len() == tx.inputs().len()).
-    let input_count = last_transaction.transaction.transaction.inputs().len();
+    let input_count = last_transaction.transaction.transaction().inputs().len();
     last_transaction.spent_outputs = std::sync::Arc::new(vec![non_standard_output; input_count]);
 
     let cost_limit = last_transaction.cost();
@@ -2540,7 +2543,7 @@ fn pick_transaction_with_prevout(network: &Network) -> VerifiedUnminedTx {
         .find(|transaction| {
             transaction
                 .transaction
-                .transaction
+                .transaction()
                 .inputs()
                 .iter()
                 .any(|input| matches!(input, transparent::Input::PrevOut { .. }))

--- a/docs/changelog/unreleased/686.md
+++ b/docs/changelog/unreleased/686.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR makes derived unmined transaction metadata immutable through the
+`zakura-chain` API and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

`UnminedTx` exposes its transaction and precomputed ID, serialized size, and
conventional fee as independent public fields. Downstream callers can therefore
construct or mutate values whose derived metadata does not match the transaction.

## Solution

Make all `UnminedTx` fields private and expose read-only accessors. Add a
consuming transaction accessor for call sites that already own the wrapper.
Update workspace callers to use those accessors, and rebuild test transactions
through the existing `From<Transaction>` conversions whenever the transaction
changes so all derived metadata is recomputed together.

Because removing public fields is a breaking library API change, bump
`zakura-chain` from 5.0.0 to 6.0.0 and update every workspace dependency
requirement.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo semver-checks --package zakura-chain --default-features`
- `cargo clippy -p zakura-chain -p zakura-consensus -p zakura-rpc -p
  zakura-state -p zakura-node-services -p zakura-script -p zakura-utils -p
  zakura --all-targets -- -D warnings`
- `cargo clippy -p zakura-network --lib -- -D warnings`
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/686.md
  --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `git diff --check`

`cargo test --workspace --no-fail-fast --quiet` passed every package except
`zakura-network`, where seven unrelated network/environment-sensitive tests
failed (three could not bind loopback source addresses and four block-sync fuzz
tests stalled before issuing requests). Workspace clippy is likewise blocked by
an existing duplicate `#[cfg(test)]` attribute in
`zakura-network/src/zakura/discovery/service.rs`; the affected crates and the
non-test network library pass separately as listed above.

## Changelog

`docs/changelog/unreleased/686.md` records this as an internal-only API change.

### Specifications & References

- Follow-up to the cache-key review in
  [#613](https://github.com/zakura-core/zakura/pull/613).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-crate refactor touching mempool, consensus, and RPC paths; behavior should be equivalent but any missed direct field access would fail at compile time. Breaking library API requires coordinated dependency bumps.
> 
> **Overview**
> **Breaking `zakura-chain` 6.0.0:** `UnminedTx` no longer exposes public `transaction`, `id`, `size`, or `conventional_fee` fields. Callers must use `transaction()`, `id()`, `size()`, `conventional_fee()`, and `into_transaction()` so ID, serialized size, and ZIP-317 fee stay tied to the wrapped transaction.
> 
> The workspace is updated end-to-end (consensus, network, RPC, mempool, state, tests) to use those accessors. Tests that used to build `UnminedTx` manually now use `From<Transaction>` / `into()` so derived metadata is recomputed when the transaction changes.
> 
> Changelog notes this as an internal API change with no operator-visible effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9b070f0438629ddb568150b6fe6e0cf9eca323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->