### PR TITLE
feat(mining): harden testnet pool infrastructure

### DIFF
--- a/docker/mining/.env.example
+++ b/docker/mining/.env.example
@@ -7,7 +7,7 @@ MINER_ADDRESS=
 
 # === OPTIONAL COINBASE DATA ===
 # Data included in coinbase transaction (max 94 bytes). Hex or UTF-8 encoded.
-# MINER_DATA=
+MINER_DATA=valargroup
 # Shielded memo in coinbase output (max 512 bytes). Only for shielded addresses.
 # MINER_MEMO=
 
@@ -19,7 +19,14 @@ NETWORK=Testnet
 # Uncomment and modify to override defaults
 # RPC_PORT=18232      # 18232 Testnet, 8232 Mainnet (internal, not exposed)
 # PEER_PORT=18233     # 18233 Testnet, 8233 Mainnet (P2P network)
-# STRATUM_PORT=3333   # Miners connect to this port
+# STRATUM_PORT=3333       # ASIC miners connect to this port
+# CPU_STRATUM_PORT=3334   # CPU miners connect to this low-difficulty port
+
+# === SHARE DIFFICULTY ===
+# S-NOMP difficulty must be at least 0.000125.
+# Mining Rig Rentals reports Equihash difficulty at approximately 8192x this value.
+ASIC_DIFFICULTY=64
+CPU_DIFFICULTY=0.000125
 
 # === NHEQMINER (optional, use --profile miner) ===
 # Worker name suffix (address.WORKER_NAME)
@@ -34,5 +41,5 @@ NETWORK=Testnet
 # 4. Check sync:          docker compose logs -f zebra
 # 5. Once synced, either:
 #    a) Start built-in miner:  docker compose --profile miner up -d nheqminer
-#    b) Connect external miner: nheqminer -l <host>:3333 -u <address>.worker1 -t <threads>
+#    b) Connect external CPU miner: nheqminer -l <host>:3334 -u <address>.worker1 -t <threads>
 # 6. Web UI:              http://<host>:8080

--- a/docker/mining/README.md
+++ b/docker/mining/README.md
@@ -28,6 +28,11 @@ peer port published by the Compose configuration.
 
 All block rewards go to the address configured in `MINER_ADDRESS`.
 
+The S-NOMP image pins a Valargroup `node-stratum-pool` revision that uses the
+Merkle root and block commitments supplied in Zakura's `defaultroots`. This is
+required for templates containing Ironwood v6 transactions; recalculating those
+roots with pre-Ironwood transaction hashing produces invalid blocks.
+
 ## Quick Start
 
 ```bash
@@ -57,12 +62,30 @@ Edit `.env` to configure:
 | Variable        | Default    | Description                                  |
 |-----------------|------------|----------------------------------------------|
 | `MINER_ADDRESS` | (required) | Transparent address for block rewards        |
+| `MINER_DATA`    | `valargroup` | UTF-8 data included in mined coinbase transactions |
 | `NETWORK`       | `Testnet`  | `Mainnet` or `Testnet`                       |
 | `RPC_PORT`      | `18232`    | Zebra RPC port (18232 Testnet, 8232 Mainnet) |
 | `PEER_PORT`     | `18233`    | P2P port (18233 Testnet, 8233 Mainnet)       |
-| `STRATUM_PORT`  | `3333`     | Port miners connect to                       |
+| `STRATUM_PORT`  | `3333`     | Fixed-difficulty ASIC Stratum port            |
+| `CPU_STRATUM_PORT` | `3334`  | Low-difficulty CPU Stratum port               |
+| `ASIC_DIFFICULTY` | `64`     | S-NOMP share difficulty for ASIC miners       |
+| `CPU_DIFFICULTY` | `0.000125` | S-NOMP share difficulty for CPU miners       |
 | `WORKER_NAME`   | `docker`   | Worker name suffix (for nheqminer container) |
 | `CPU_THREADS`   | `1`        | CPU threads for nheqminer                    |
+
+### Share Difficulty
+
+Both Stratum ports use fixed share difficulty. Values lower than `0.000125`
+are rejected because S-NOMP cannot represent their mining target.
+
+Mining Rig Rentals reports Equihash difficulty at approximately 8192 times
+the S-NOMP value. The default `ASIC_DIFFICULTY=64` therefore appears as
+`524288`, within its recommended 500k–3M range. After changing either value,
+recreate S-NOMP:
+
+```bash
+docker compose up -d --force-recreate s-nomp
+```
 
 ## Checking Sync Status
 
@@ -86,7 +109,9 @@ docker exec zebra curl -s -H "Content-Type: application/json" \
 
 ### Built-in nheqminer Container
 
-The setup includes an optional nheqminer container for CPU mining. It uses a Docker Compose profile, so it won't start by default.
+The setup includes an optional nheqminer container for CPU mining. It uses the
+low-difficulty CPU Stratum port and a Docker Compose profile, so it won't start
+by default.
 
 ```bash
 # Start the miner (after Zebra is synced)
@@ -102,14 +127,14 @@ docker compose --profile miner stop nheqminer
 CPU_THREADS=4
 ```
 
-### External nheqminer (CPU/GPU)
+### External nheqminer (CPU)
 
 ```bash
 # CPU mining
-./nheqminer -l <pool-host>:3333 -u <your-address>.worker1 -t <threads>
+./nheqminer -l <pool-host>:3334 -u <your-address>.worker1 -t <threads>
 
 # Example
-./nheqminer -l 192.168.1.100:3333 -u t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v.rig1 -t 4
+./nheqminer -l 192.168.1.100:3334 -u t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v.rig1 -t 4
 ```
 
 ### Antminer Z15
@@ -136,7 +161,8 @@ API endpoint: `http://<host>:8080/api/stats`
 
 | Port       | Service | Purpose                       |
 |------------|---------|-------------------------------|
-| 3333       | S-NOMP  | Stratum (miners connect here) |
+| 3333       | S-NOMP  | Fixed-difficulty ASIC Stratum |
+| 3334       | S-NOMP  | Low-difficulty CPU Stratum    |
 | 8080       | S-NOMP  | Web UI and API                |
 | 18233/8233 | Zebra   | P2P network (Testnet/Mainnet) |
 
@@ -209,6 +235,15 @@ Check logs for errors:
 
 ```bash
 docker compose logs s-nomp | tail -50
+```
+
+### Zakura rejects submitted blocks with `BadMerkleRoot`
+
+Rebuild the pinned Valargroup S-NOMP image, then force-recreate the service:
+
+```bash
+docker compose build --no-cache s-nomp
+docker compose up -d --force-recreate s-nomp
 ```
 
 ### Miners can't connect

--- a/docker/mining/docker-compose.yml
+++ b/docker/mining/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       - ZAKURA_NETWORK__P2P_STACK=legacy
       - ZAKURA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT:-18232}
       - ZAKURA_RPC__ENABLE_COOKIE_AUTH=false
+      - ZAKURA_HEALTH__LISTEN_ADDR=0.0.0.0:8080
+      - ZAKURA_HEALTH__ENFORCE_ON_TEST_NETWORKS=true
       - ZAKURA_SYNC__PARALLEL_CPU_THREADS=12
       - ZAKURA_MINING__MINER_ADDRESS=${MINER_ADDRESS:?MINER_ADDRESS is required}
-      - ZAKURA_MINING__MINER_DATA=${MINER_DATA:-}
+      - ZAKURA_MINING__EXTRA_COINBASE_DATA=${MINER_DATA:-}
       - ZAKURA_MINING__MINER_MEMO=${MINER_MEMO:-}
     volumes:
       - zebra-data:/home/zebra/.cache/zakura
@@ -24,7 +26,7 @@ services:
     restart: unless-stopped
     tty: true
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8080/healthy || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8080/ready || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -39,7 +41,7 @@ services:
 
   s-nomp:
     build:
-      context: https://github.com/ZcashFoundation/s-nomp.git
+      context: https://github.com/valargroup/s-nomp.git#749658d21f30a96358f202eba4e01dd752a11f02
       dockerfile: Dockerfile.arch
     container_name: s-nomp
     environment:
@@ -47,10 +49,14 @@ services:
       - ZEBRA_RPC_PORT=${RPC_PORT:-18232}
       - REDIS_HOST=redis
       - STRATUM_PORT=${STRATUM_PORT:-3333}
+      - CPU_STRATUM_PORT=${CPU_STRATUM_PORT:-3334}
+      - ASIC_DIFFICULTY=${ASIC_DIFFICULTY:-64}
+      - CPU_DIFFICULTY=${CPU_DIFFICULTY:-0.000125}
       - NETWORK=${NETWORK:-Testnet}
       - POOL_ADDRESS=${MINER_ADDRESS}
     ports:
       - "${STRATUM_PORT:-3333}:${STRATUM_PORT:-3333}"
+      - "${CPU_STRATUM_PORT:-3334}:${CPU_STRATUM_PORT:-3334}"
       - "8080:8080"
     depends_on:
       zakura:
@@ -71,12 +77,12 @@ services:
     container_name: nheqminer
     environment:
       - POOL_HOST=s-nomp
-      - POOL_PORT=${STRATUM_PORT:-3333}
+      - POOL_PORT=${CPU_STRATUM_PORT:-3334}
       - WORKER_ADDRESS=${MINER_ADDRESS}
       - WORKER_NAME=${WORKER_NAME:-docker}
       - CPU_THREADS=${CPU_THREADS:-1}
     command: >
-      -l ${POOL_HOST:-s-nomp}:${STRATUM_PORT:-3333}
+      -l ${POOL_HOST:-s-nomp}:${CPU_STRATUM_PORT:-3334}
       -u ${MINER_ADDRESS}.${WORKER_NAME:-docker}
       -t ${CPU_THREADS:-1}
     depends_on:

--- a/docker/mining/s-nomp-entrypoint.sh
+++ b/docker/mining/s-nomp-entrypoint.sh
@@ -4,7 +4,39 @@ set -euo pipefail
 /app/docker-entrypoint.sh true
 
 sed -i 's/}$/,"switching":{}}/g' /app/config.json
-sed -i 's/"diff": 0.05/"tls": false, "diff": 0.05/g' /app/pool_configs/zcash.json
+node <<'NODE'
+const fs = require("fs");
+
+const configPath = "/app/pool_configs/zcash.json";
+const config = JSON.parse(fs.readFileSync(configPath));
+const asicPort = process.env.STRATUM_PORT || "3333";
+const cpuPort = process.env.CPU_STRATUM_PORT || "3334";
+const minimumDifficulty = 0.000125;
+
+function parseDifficulty(name, fallback) {
+    const value = Number(process.env[name] || fallback);
+    if (!Number.isFinite(value) || value < minimumDifficulty) {
+        throw new Error(`${name} must be a number greater than or equal to ${minimumDifficulty}`);
+    }
+    return value;
+}
+
+const asicDifficulty = parseDifficulty("ASIC_DIFFICULTY", "64");
+const cpuDifficulty = parseDifficulty("CPU_DIFFICULTY", "0.000125");
+
+config.ports = {
+    [asicPort]: {
+        tls: false,
+        diff: asicDifficulty,
+    },
+    [cpuPort]: {
+        tls: false,
+        diff: cpuDifficulty,
+    },
+};
+
+fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+NODE
 
 if [ "$NETWORK" = "Mainnet" ]; then
     sed -i 's|tmRGc4CD1UyUdbSJmTUzcB6oDqk4qUaHnnh|t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs|g' /app/pool_configs/zcash.json


### PR DESCRIPTION
## Motivation

The testnet mining Compose stack could not reliably serve current Ironwood templates or miners with substantially different hashrates. Its stale Zakura mining and health settings also prevented correct coinbase configuration and dependable service startup.

## Solution

- pin S-NOMP to Valargroup forks with native support for Zakura's `defaultroots`, avoiding legacy Merkle-root recalculation for Ironwood v6 transactions
- correct Zakura health and extra coinbase data settings
- expose separate fixed-difficulty ASIC and CPU Stratum ports
- make both share difficulties configurable and reject values below S-NOMP's representable minimum
- document the Mining Rig Rentals difficulty scale, CPU miner setup, and recovery procedure

## Testing

- `markdownlint docker/mining/README.md --config .github/.markdownlint.yaml`
- `bash -n docker/mining/s-nomp-entrypoint.sh`
- `MINER_ADDRESS=tmTestAddress docker compose -f docker/mining/docker-compose.yml config --quiet`
- `MINER_ADDRESS=tmTestAddress ASIC_DIFFICULTY=128 CPU_DIFFICULTY=0.001 docker compose -f docker/mining/docker-compose.yml config --quiet`
- `npm test` in the pinned Valargroup `node-stratum-pool` fork
- `git diff --check`

Local Rust compilation was skipped because this PR only changes mining configuration, shell setup, and documentation.

## Changelog

No fragment is required because this PR does not change Rust source or Cargo manifests.

### Specifications & References

- https://github.com/valargroup/node-stratum-pool/commit/c1ef172f9db594552b0cfb5bbbfeb1cd3e90dfe1
- https://github.com/valargroup/s-nomp/commit/749658d21f30a96358f202eba4e01dd752a11f02

### Follow-up Work

Rebuild and deploy the pinned S-NOMP image to the live testnet mining host.