### PR TITLE
fix(state): migrate legacy header overlay atomically

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -213,9 +213,9 @@ fn finalized_anchor(
     if bootstrap.height > finalized.height {
         return Err(HeaderChainInitializationError::AnchorMismatch);
     }
-    let (stored_bootstrap_hash, stored_bootstrap) = source
-        .header_by_height(bootstrap.height)
-        .ok_or(HeaderChainInitializationError::AnchorMismatch)?;
+    let (stored_bootstrap_hash, stored_bootstrap) =
+        finalized_header_by_height(source, bootstrap.height)
+            .ok_or(HeaderChainInitializationError::AnchorMismatch)?;
     if stored_bootstrap_hash != bootstrap.hash
         || stored_bootstrap.as_ref() != config.bootstrap_anchor().header.as_ref()
     {
@@ -232,8 +232,7 @@ fn finalized_anchor(
         height = height
             .next()
             .map_err(|_| HeaderChainInitializationError::Work)?;
-        let (hash, next) = source
-            .header_by_height(height)
+        let (hash, next) = finalized_header_by_height(source, height)
             .ok_or(HeaderChainInitializationError::AnchorMismatch)?;
         if next.hash() != hash || next.previous_block_hash != header.hash() {
             return Err(HeaderChainInitializationError::AnchorMismatch);
@@ -259,8 +258,17 @@ fn validation_context(
     expected_hash: block::Hash,
 ) -> Result<Vec<HeaderValidationContextDisk>, HeaderChainInitializationError> {
     linked_validation_context(anchor, expected_hash, |height| {
-        source.header_by_height(height)
+        finalized_header_by_height(source, height)
     })
+}
+
+fn finalized_header_by_height(
+    source: &ZakuraDb,
+    height: block::Height,
+) -> Option<(block::Hash, Arc<block::Header>)> {
+    let hash = source.hash(height)?;
+    let header = source.block_header(height.into())?;
+    Some((hash, header))
 }
 
 fn linked_validation_context(

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -14,6 +14,7 @@ use zakura_header_chain::{
 
 use super::{HeaderChainRuntime, HeaderChainStore, HeaderChainStoreError, StartupReport};
 use crate::service::finalized_state::{
+    disk_db::{ReadDisk, WriteDisk},
     disk_format::{header_chain_values::HeaderValidationContextDisk, RawBytes},
     zakura_db::{
         block::{
@@ -41,11 +42,6 @@ pub enum HeaderChainInitializationError {
     /// The new schema already has its format-complete metadata marker.
     #[error("fork-aware header-chain schema is already initialized")]
     AlreadyInitialized,
-    /// Predecessor overlay rows require an explicit database resync.
-    #[error(
-        "incompatible predecessor header overlay found; resync this database before starting Zakura"
-    )]
-    IncompatibleLegacyOverlay,
     /// Full state has no finalized tip to authenticate initialization.
     #[error("header-chain initialization requires a finalized full-state anchor")]
     MissingFinalizedAnchor,
@@ -61,15 +57,15 @@ pub enum HeaderChainInitializationError {
     /// The durable initialization or mandatory startup audit failed.
     #[error(transparent)]
     Store(#[from] HeaderChainStoreError),
-    /// RocksDB failed while checking predecessor columns.
-    #[error("predecessor header overlay check failed: {0}")]
+    /// RocksDB rejected the atomic legacy-overlay replacement.
+    #[error("header-chain initialization database write failed: {0}")]
     RocksDb(#[from] rocksdb::Error),
 }
 
 /// Initialize an absent DAG only from authenticated full-state facts.
 ///
-/// Initialization checks the predecessor overlay before it writes any DAG row.
-/// Initialization never decodes, deletes, or reinterprets predecessor overlay rows.
+/// Initialization discards obsolete predecessor overlay rows in the same atomic
+/// batch that publishes the replacement DAG.
 pub(in crate::service) fn initialize_header_chain_reconciled(
     source: &ZakuraDb,
     config: &EngineConfig,
@@ -78,9 +74,6 @@ pub(in crate::service) fn initialize_header_chain_reconciled(
     let store = HeaderChainStore::new(source.header_chain_disk_db());
     if store.metadata_row()?.is_some() {
         return Err(HeaderChainInitializationError::AlreadyInitialized);
-    }
-    if legacy_overlay_has_rows(source)? {
-        return Err(HeaderChainInitializationError::IncompatibleLegacyOverlay);
     }
 
     let (anchor_height, anchor_hash) = source
@@ -167,6 +160,7 @@ pub(in crate::service) fn initialize_header_chain_reconciled(
     };
     let contexts = validation_context(source, anchor, anchor_header.previous_block_hash)?;
     let mut base_batch = super::super::DiskWriteBatch::new();
+    clear_legacy_overlay(source, &mut base_batch);
     for context in &contexts {
         store.put_value(
             &mut base_batch,
@@ -189,7 +183,7 @@ pub(in crate::service) fn initialize_header_chain_reconciled(
     ))
 }
 
-fn legacy_overlay_has_rows(source: &ZakuraDb) -> Result<bool, HeaderChainInitializationError> {
+fn clear_legacy_overlay(source: &ZakuraDb, batch: &mut super::super::DiskWriteBatch) {
     let db = source.header_chain_disk_db();
     for family in [
         ZAKURA_HEADER_BY_HEIGHT,
@@ -199,15 +193,15 @@ fn legacy_overlay_has_rows(source: &ZakuraDb) -> Result<bool, HeaderChainInitial
         let Some(cf) = db.cf_handle(family) else {
             continue;
         };
-        if db
-            .zs_forward_range_iter::<_, RawBytes, RawBytes, _>(&cf, ..)
-            .next()
-            .is_some()
-        {
-            return Ok(true);
-        }
+        let Some((first, _)) = db.zs_first_key_value::<_, RawBytes, RawBytes>(&cf) else {
+            continue;
+        };
+        let (last, _) = db
+            .zs_last_key_value::<_, RawBytes, RawBytes>(&cf)
+            .expect("last legacy overlay row exists because the first row exists");
+        batch.zs_delete_range(&cf, &first, &last);
+        batch.zs_delete(&cf, &last);
     }
-    Ok(false)
 }
 
 fn finalized_anchor(

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
@@ -12,7 +12,7 @@ use zakura_header_chain::{
 };
 
 use super::{
-    super::ZAKURA_HEADER_BY_HEIGHT,
+    super::{ZAKURA_HEADER_BY_HEIGHT, ZAKURA_HEADER_HASH_BY_HEIGHT, ZAKURA_HEADER_HEIGHT_BY_HASH},
     common::{mainnet_block, state_with_genesis_config, write_full_block_header_and_transactions},
 };
 use crate::{
@@ -86,12 +86,88 @@ fn clean_store_initializes_only_from_finalized_full_state() {
 }
 
 #[test]
-fn predecessor_overlay_fails_closed_without_mutation_or_publication() {
+fn predecessor_overlay_is_atomically_replaced_from_finalized_state() {
     let _init_guard = zakura_test::init();
     let network = Network::Mainnet;
     let genesis = mainnet_block(0);
     let block1 = mainnet_block(1);
+    let block2 = mainnet_block(2);
     let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    write_full_block_header_and_transactions(&state, block1.clone());
+    let header_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_BY_HEIGHT)
+        .expect("the obsolete column remains physically present");
+    let hash_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT)
+        .expect("the obsolete column remains physically present");
+    let height_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH)
+        .expect("the obsolete column remains physically present");
+    let mut legacy = DiskWriteBatch::new();
+    legacy.zs_insert(&header_cf, Height(2), &block2.header);
+    legacy.zs_insert(&hash_cf, Height(2), block2.hash());
+    legacy.zs_insert(&height_cf, block2.hash(), Height(2));
+    state
+        .db
+        .write(legacy)
+        .expect("the legacy fixture row writes");
+    let config = engine_config(network, &genesis);
+
+    let (runtime, report) = initialize_header_chain_reconciled(&state, &config, Vec::new())
+        .expect("obsolete overlay rows are replaced from authenticated full state");
+    let anchor = Frontier::new(Height(1), block1.hash());
+    assert_eq!(report.anchor, anchor);
+    assert_eq!(report.startup.current.frontiers.header_best, anchor);
+    assert_eq!(runtime.publisher().snapshot(), report.startup.current);
+    assert_eq!(
+        StoreAuditRead::selected_projection(&HeaderChainStore::new(state.header_chain_disk_db()))
+            .expect("the initialized selection decodes"),
+        vec![anchor]
+    );
+    for family in [
+        ZAKURA_HEADER_BY_HEIGHT,
+        ZAKURA_HEADER_HASH_BY_HEIGHT,
+        ZAKURA_HEADER_HEIGHT_BY_HASH,
+    ] {
+        let cf = state
+            .db
+            .cf_handle(family)
+            .expect("the obsolete column remains physically present");
+        assert!(
+            state
+                .db
+                .raw_range_cf(&cf, &[], None)
+                .expect("the obsolete column remains readable")
+                .is_empty(),
+            "{family} is empty after migration"
+        );
+    }
+    assert!(matches!(
+        initialize_header_chain_reconciled(&state, &config, Vec::new()),
+        Err(HeaderChainInitializationError::AlreadyInitialized)
+    ));
+    assert_eq!(
+        runtime
+            .reader()
+            .validation_context(anchor.hash)
+            .expect("the authenticated context read succeeds")
+            .expect("the finalized anchor is retained")
+            .predecessors()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn predecessor_overlay_is_preserved_when_full_state_authentication_fails() {
+    let _init_guard = zakura_test::init();
+    let network = Network::Mainnet;
+    let genesis = mainnet_block(0);
+    let block1 = mainnet_block(1);
+    let state = state_with_genesis_config(&network, genesis, Config::ephemeral());
     let header_cf = state
         .db
         .cf_handle(ZAKURA_HEADER_BY_HEIGHT)
@@ -106,11 +182,20 @@ fn predecessor_overlay_fails_closed_without_mutation_or_publication() {
         .db
         .raw_range_cf(&header_cf, &[], None)
         .expect("the predecessor row can be observed without decoding it");
-    let config = engine_config(network, &genesis);
+    let config = EngineConfig::new(
+        EngineMode::Integrated,
+        network,
+        TrustedAnchor {
+            frontier: Frontier::new(Height(1), block1.hash()),
+            header: block1.header.clone(),
+        },
+        CheckpointSet::default(),
+    )
+    .expect("the fixture has an authenticated but unavailable anchor");
 
     assert!(matches!(
         initialize_header_chain_reconciled(&state, &config, Vec::new()),
-        Err(HeaderChainInitializationError::IncompatibleLegacyOverlay)
+        Err(HeaderChainInitializationError::AnchorMismatch)
     ));
     assert!(
         StoreAuditRead::metadata(&HeaderChainStore::new(state.header_chain_disk_db())).is_err()

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
@@ -12,12 +12,16 @@ use zakura_header_chain::{
 };
 
 use super::{
-    super::{ZAKURA_HEADER_BY_HEIGHT, ZAKURA_HEADER_HASH_BY_HEIGHT, ZAKURA_HEADER_HEIGHT_BY_HASH},
+    super::{
+        ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT, ZAKURA_HEADER_BY_HEIGHT, ZAKURA_HEADER_HASH_BY_HEIGHT,
+        ZAKURA_HEADER_HEIGHT_BY_HASH,
+    },
     common::{mainnet_block, state_with_genesis_config, write_full_block_header_and_transactions},
 };
 use crate::{
     service::finalized_state::{
         disk_db::{DiskWriteBatch, WriteDisk},
+        disk_format::RawBytes,
         header_chain::{
             migration::{initialize_header_chain_reconciled, HeaderChainInitializationError},
             HeaderChainStore,
@@ -92,6 +96,7 @@ fn predecessor_overlay_is_atomically_replaced_from_finalized_state() {
     let genesis = mainnet_block(0);
     let block1 = mainnet_block(1);
     let block2 = mainnet_block(2);
+    let block3 = mainnet_block(3);
     let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
     write_full_block_header_and_transactions(&state, block1.clone());
     let header_cf = state
@@ -106,10 +111,22 @@ fn predecessor_overlay_is_atomically_replaced_from_finalized_state() {
         .db
         .cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH)
         .expect("the obsolete column remains physically present");
+    let body_size_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_BODY_SIZE_BY_HEIGHT)
+        .expect("the advisory body-size column remains physically present");
     let mut legacy = DiskWriteBatch::new();
     legacy.zs_insert(&header_cf, Height(2), &block2.header);
+    legacy.zs_insert(&header_cf, Height(3), &block3.header);
     legacy.zs_insert(&hash_cf, Height(2), block2.hash());
+    legacy.zs_insert(&hash_cf, Height(3), block3.hash());
     legacy.zs_insert(&height_cf, block2.hash(), Height(2));
+    legacy.zs_insert(&height_cf, block3.hash(), Height(3));
+    legacy.zs_insert(
+        &body_size_cf,
+        Height(2),
+        RawBytes::new_raw_bytes(1_u32.to_be_bytes().to_vec()),
+    );
     state
         .db
         .write(legacy)
@@ -122,6 +139,7 @@ fn predecessor_overlay_is_atomically_replaced_from_finalized_state() {
     assert_eq!(report.anchor, anchor);
     assert_eq!(report.startup.current.frontiers.header_best, anchor);
     assert_eq!(runtime.publisher().snapshot(), report.startup.current);
+    assert_eq!(state.hash(Height(1)), Some(block1.hash()));
     assert_eq!(
         StoreAuditRead::selected_projection(&HeaderChainStore::new(state.header_chain_disk_db()))
             .expect("the initialized selection decodes"),
@@ -145,6 +163,15 @@ fn predecessor_overlay_is_atomically_replaced_from_finalized_state() {
             "{family} is empty after migration"
         );
     }
+    assert_eq!(
+        state
+            .db
+            .raw_range_cf(&body_size_cf, &[], None)
+            .expect("the advisory body-size column remains readable")
+            .len(),
+        1,
+        "migration preserves the advisory body-size column"
+    );
     assert!(matches!(
         initialize_header_chain_reconciled(&state, &config, Vec::new()),
         Err(HeaderChainInitializationError::AlreadyInitialized)
@@ -207,4 +234,83 @@ fn predecessor_overlay_is_preserved_when_full_state_authentication_fails() {
             .expect("the rejected startup leaves the predecessor row untouched"),
         before
     );
+}
+
+#[test]
+fn initialization_does_not_fill_finalized_gaps_from_legacy_overlay() {
+    let _init_guard = zakura_test::init();
+    let network = Network::Mainnet;
+    let genesis = mainnet_block(0);
+    let block1 = mainnet_block(1);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    write_full_block_header_and_transactions(&state, block1);
+    let finalized_hash_cf = state
+        .db
+        .cf_handle("hash_by_height")
+        .expect("the finalized hash column exists");
+    let header_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_BY_HEIGHT)
+        .expect("the obsolete column remains physically present");
+    let hash_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_HASH_BY_HEIGHT)
+        .expect("the obsolete column remains physically present");
+    let height_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_HEIGHT_BY_HASH)
+        .expect("the obsolete column remains physically present");
+    let mut corrupted = DiskWriteBatch::new();
+    corrupted.zs_delete(&finalized_hash_cf, Height(0));
+    corrupted.zs_insert(&header_cf, Height(0), &genesis.header);
+    corrupted.zs_insert(&hash_cf, Height(0), genesis.hash());
+    corrupted.zs_insert(&height_cf, genesis.hash(), Height(0));
+    state
+        .db
+        .write(corrupted)
+        .expect("the finalized gap and legacy fallback fixture write");
+    let legacy_before = [
+        ZAKURA_HEADER_BY_HEIGHT,
+        ZAKURA_HEADER_HASH_BY_HEIGHT,
+        ZAKURA_HEADER_HEIGHT_BY_HASH,
+    ]
+    .map(|family| {
+        let cf = state
+            .db
+            .cf_handle(family)
+            .expect("the obsolete column remains physically present");
+        state
+            .db
+            .raw_range_cf(&cf, &[], None)
+            .expect("the predecessor rows can be observed without decoding them")
+    });
+    let config = engine_config(network, &genesis);
+
+    assert!(matches!(
+        initialize_header_chain_reconciled(&state, &config, Vec::new()),
+        Err(HeaderChainInitializationError::AnchorMismatch)
+    ));
+    assert!(
+        StoreAuditRead::metadata(&HeaderChainStore::new(state.header_chain_disk_db())).is_err()
+    );
+    for (family, before) in [
+        ZAKURA_HEADER_BY_HEIGHT,
+        ZAKURA_HEADER_HASH_BY_HEIGHT,
+        ZAKURA_HEADER_HEIGHT_BY_HASH,
+    ]
+    .into_iter()
+    .zip(legacy_before)
+    {
+        let cf = state
+            .db
+            .cf_handle(family)
+            .expect("the obsolete column remains physically present");
+        assert_eq!(
+            state
+                .db
+                .raw_range_cf(&cf, &[], None)
+                .expect("the rejected startup leaves predecessor rows untouched"),
+            before
+        );
+    }
 }

--- a/docs/changelog/unreleased/688.md
+++ b/docs/changelog/unreleased/688.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed fork-aware header-chain upgrades so nodes atomically discard obsolete
+  header-overlay indexes instead of requiring a state resync
+  ([#688](https://github.com/zakura-core/zakura/pull/688)).

--- a/docs/header-chain-v1.4-migration.md
+++ b/docs/header-chain-v1.4-migration.md
@@ -3,11 +3,10 @@
 Header-chain v1.4 is a protocol and storage cutover, not a backward-compatible
 upgrade of the predecessor header overlay.
 
-- A database containing predecessor header-overlay rows is rejected before the
-  new header DAG is initialized or published. Zakura does not decode, import,
-  reinterpret, or delete those rows. Start with a fresh state database and
-  resynchronize.
-- A clean database initializes the header DAG from authenticated finalized and
+- The three obsolete canonical predecessor-overlay indexes are discarded.
+  Zakura does not decode, trust, or import those rows. Their deletion and the
+  initial header DAG write commit atomically.
+- The header DAG initializes exclusively from authenticated finalized and
   reconstructed full-state facts. Headers above the verified block tip are
   downloaded again.
 - `network.zakura.header_sync.accept_new_blocks` no longer exists because header


### PR DESCRIPTION
## Motivation

The fork-aware header-chain cutover rejected databases containing predecessor overlay rows with `IncompatibleLegacyOverlay`, forcing an unnecessary full state resync. This left upgraded nodes unable to start even though the legacy rows are obsolete and the finalized full state can authenticate the replacement DAG.

## Solution

- Discard the three obsolete canonical header-overlay indexes in the same RocksDB batch that initializes the replacement DAG.
- Build every DAG fact exclusively from finalized full-state accessors so legacy rows cannot mask an authenticated-state gap.
- Preserve the advisory header body-size index and leave legacy rows untouched when initialization fails before commit.
- Update the v1.4 migration documentation to describe the atomic cutover.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state --lib migration`
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- `./scripts/changelog.py check`
- Markdown lint for both changed documentation files
- IDE diagnostics for the changed Rust files
- Deployed to `canada-0`; the node completed migration, recovered RPC health, and resumed advancing.

The migration tests cover atomic replacement, preservation on authentication failure, exclusion of legacy fallback data, finalized-state preservation, and retention of the advisory body-size index.

## Changelog

- Added `docs/changelog/unreleased/688.md`.

### Specifications & References

- `docs/header-chain-v1.4-migration.md`

### Follow-up Work

- Rebase initial work coordinates at the finalized tip so first startup reads only the validation context instead of scanning the complete finalized chain.