### PR TITLE
perf(state): rebase header migration at finalized tip

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use zakura_chain::block;
+use zakura_chain::{block, work::difficulty::U256};
 use zakura_header_chain::{
     AlarmSet, BodyValidationState, ChainScore, ChangeSet, EngineConfig, EngineMetadata, EngineMode,
     EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier, FrontierSet,
@@ -45,11 +45,11 @@ pub enum HeaderChainInitializationError {
     /// Full state has no finalized tip to authenticate initialization.
     #[error("header-chain initialization requires a finalized full-state anchor")]
     MissingFinalizedAnchor,
-    /// The engine bootstrap is not an exact full-state ancestor of the finalized tip.
-    #[error("engine bootstrap anchor is not an exact finalized full-state ancestor")]
+    /// The engine bootstrap is above the finalized tip, or the finalized anchor is incoherent.
+    #[error("engine bootstrap or finalized full-state anchor is incoherent")]
     AnchorMismatch,
-    /// Exact work construction failed.
-    #[error("authenticated full-state path could not form an exact work coordinate")]
+    /// Exact finalized-anchor work construction failed.
+    #[error("authenticated finalized anchor could not form an exact work coordinate")]
     Work,
     /// Authenticated full-state context is missing or incoherent.
     #[error("authenticated full-state header context is incoherent: {0}")]
@@ -119,7 +119,7 @@ pub(in crate::service) fn initialize_header_chain_reconciled(
         mode: config.mode,
         network_id: config.network.kind(),
         anchor_manifest_digest: config.trust_anchor_digest(),
-        work_origin: config.bootstrap_anchor().frontier,
+        work_origin: anchor,
         state_version: StateVersion::new(1),
         header_generation: HeaderGeneration::new(1),
         verified_generation: VerifiedGeneration::new(1),
@@ -221,34 +221,15 @@ fn finalized_anchor(
     {
         return Err(HeaderChainInitializationError::AnchorMismatch);
     }
-    let bootstrap_work = stored_bootstrap
-        .difficulty_threshold
-        .to_work()
-        .ok_or(HeaderChainInitializationError::Work)?;
-    let mut coordinate = WorkCoordinate::new(bootstrap.hash, bootstrap_work.as_u256());
-    let mut header = stored_bootstrap;
-    let mut height = bootstrap.height;
-    while height < finalized.height {
-        height = height
-            .next()
-            .map_err(|_| HeaderChainInitializationError::Work)?;
-        let (hash, next) = finalized_header_by_height(source, height)
-            .ok_or(HeaderChainInitializationError::AnchorMismatch)?;
-        if next.hash() != hash || next.previous_block_hash != header.hash() {
-            return Err(HeaderChainInitializationError::AnchorMismatch);
-        }
-        let work = next
-            .difficulty_threshold
-            .to_work()
-            .ok_or(HeaderChainInitializationError::Work)?;
-        coordinate = coordinate
-            .checked_add(work)
-            .map_err(|_| HeaderChainInitializationError::Work)?;
-        header = next;
-    }
+    let header = source
+        .block_header(finalized.height.into())
+        .ok_or(HeaderChainInitializationError::AnchorMismatch)?;
     if header.hash() != finalized.hash {
         return Err(HeaderChainInitializationError::AnchorMismatch);
     }
+    // Every selectable branch descends from finality, so pre-finality work is a
+    // shared constant. Rebasing here avoids rescanning the complete finalized chain.
+    let coordinate = WorkCoordinate::new(finalized.hash, U256::zero());
     Ok((header, coordinate))
 }
 

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/migration.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use zakura_chain::{
     block::{self, Height},
     parameters::Network,
+    work::difficulty::U256,
 };
 use zakura_header_chain::{
     prepare_headers, CheckpointSet, EngineConfig, EngineMode, Frontier, HeaderBatchInput,
@@ -62,9 +63,15 @@ fn clean_store_initializes_only_from_finalized_full_state() {
     assert_eq!(report.validation_context_rows, 1);
     assert_eq!(report.startup.current.frontiers.header_best, anchor);
     assert_eq!(runtime.publisher().snapshot(), report.startup.current);
+    let store = HeaderChainStore::new(state.header_chain_disk_db());
+    let metadata = StoreAuditRead::metadata(&store).expect("the initialized metadata decodes");
+    assert_eq!(metadata.work_origin, anchor);
+    let nodes = StoreAuditRead::all_header_nodes(&store).expect("the initialized node decodes");
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0].work_coordinate().origin_hash(), anchor.hash);
+    assert_eq!(nodes[0].work_coordinate().cumulative_work(), U256::zero());
     assert_eq!(
-        StoreAuditRead::selected_projection(&HeaderChainStore::new(state.header_chain_disk_db()))
-            .expect("the initialized selection decodes"),
+        StoreAuditRead::selected_projection(&store).expect("the initialized selection decodes"),
         vec![anchor]
     );
 
@@ -233,6 +240,52 @@ fn predecessor_overlay_is_preserved_when_full_state_authentication_fails() {
             .raw_range_cf(&header_cf, &[], None)
             .expect("the rejected startup leaves the predecessor row untouched"),
         before
+    );
+}
+
+#[test]
+fn initialization_rejects_finalized_tip_header_mismatch_before_cleanup() {
+    let _init_guard = zakura_test::init();
+    let network = Network::Mainnet;
+    let genesis = mainnet_block(0);
+    let block1 = mainnet_block(1);
+    let block2 = mainnet_block(2);
+    let state = state_with_genesis_config(&network, genesis.clone(), Config::ephemeral());
+    write_full_block_header_and_transactions(&state, block1);
+    let finalized_header_cf = state
+        .db
+        .cf_handle("block_header_by_height")
+        .expect("the finalized header column exists");
+    let legacy_header_cf = state
+        .db
+        .cf_handle(ZAKURA_HEADER_BY_HEIGHT)
+        .expect("the obsolete column remains physically present");
+    let mut corrupted = DiskWriteBatch::new();
+    corrupted.zs_insert(&finalized_header_cf, Height(1), &genesis.header);
+    corrupted.zs_insert(&legacy_header_cf, Height(2), &block2.header);
+    state
+        .db
+        .write(corrupted)
+        .expect("the mismatched tip and legacy fixture write");
+    let legacy_before = state
+        .db
+        .raw_range_cf(&legacy_header_cf, &[], None)
+        .expect("the predecessor row can be observed without decoding it");
+    let config = engine_config(network, &genesis);
+
+    assert!(matches!(
+        initialize_header_chain_reconciled(&state, &config, Vec::new()),
+        Err(HeaderChainInitializationError::AnchorMismatch)
+    ));
+    assert!(
+        StoreAuditRead::metadata(&HeaderChainStore::new(state.header_chain_disk_db())).is_err()
+    );
+    assert_eq!(
+        state
+            .db
+            .raw_range_cf(&legacy_header_cf, &[], None)
+            .expect("the rejected startup leaves the predecessor row untouched"),
+        legacy_before
     );
 }
 

--- a/docs/changelog/unreleased/689.md
+++ b/docs/changelog/unreleased/689.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed initial header DAG migration startup so it does not rescan every
+  historical finalized header
+  ([#689](https://github.com/zakura-core/zakura/pull/689)).

--- a/docs/header-chain-v1.4-migration.md
+++ b/docs/header-chain-v1.4-migration.md
@@ -6,9 +6,10 @@ upgrade of the predecessor header overlay.
 - The three obsolete canonical predecessor-overlay indexes are discarded.
   Zakura does not decode, trust, or import those rows. Their deletion and the
   initial header DAG write commit atomically.
-- The header DAG initializes exclusively from authenticated finalized and
-  reconstructed full-state facts. Headers above the verified block tip are
-  downloaded again.
+- The header DAG initializes exclusively from the authenticated finalized tip
+  and its bounded predecessor context. Work coordinates are rebased at that
+  tip, so historical finalized headers are not rescanned. Headers above the
+  verified block tip are downloaded again.
 - `network.zakura.header_sync.accept_new_blocks` no longer exists because header
   sync does not relay blocks. Configuration parsing rejects the stale field;
   remove it before starting the upgraded node.


### PR DESCRIPTION
## Motivation

The migration introduced by [#688](https://github.com/zakura-core/zakura/pull/688) preserves the bootstrap anchor as the DAG work origin. Constructing the finalized tip's absolute work coordinate therefore scans and sums every historical finalized header. On `canada-0`, that one-time scan delayed RPC readiness by approximately 21 minutes and 46 seconds.

## Solution

- Rebase the initial DAG work origin at the authenticated finalized tip with zero suffix work.
- Retain constant-time authentication of the configured bootstrap and finalized tip.
- Continue loading and validating the bounded 27-header predecessor context required for future header validation.
- Keep legacy-overlay cleanup and DAG initialization in the existing atomic RocksDB batch.

All selectable future branches descend from the finalized tip, so pre-finality work is a shared constant and cannot affect branch comparison. The header engine already uses this rebase model when finality advances.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-state --lib migration` (10 passed)
- `cargo clippy -p zakura-state --all-targets -- -D warnings`
- `./scripts/changelog.py check`
- Markdown lint for changed documentation
- IDE diagnostics for the changed Rust files

Tests verify the persisted work origin and zero coordinate, successful startup audit/publication, bounded predecessor context, and failure before cleanup when the finalized tip header disagrees with its canonical hash.

## Changelog

- Added `docs/changelog/unreleased/689.md`.

### Specifications & References

- Stacked on [#688](https://github.com/zakura-core/zakura/pull/688).
- `docs/header-chain-v1.4-migration.md`