### PR TITLE
feat(network): trace testnet block propagation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -49,7 +49,7 @@ These workflows run on pull requests, pushes to `main` / `feat/**` / `release/**
 
 Deploys are manual, SSH-based, and run from self-hosted deployer runners; there are no cloud-managed instance groups.
 
-- **`zakura-mainnet-deploy.yml`** — manual, binary-only deploy across the mainnet fleet. Builds `zakurad` natively on the `zakura-mainnet-deployer` runner, then installs it host-by-host with `deploy/deployer/deploy.py`. Node configs, identities, and chain state are deliberately left untouched; the previous binary is kept as `.bak`.
+- **`zakura-mainnet-deploy.yml`** — manual, binary-only deploy across the mainnet fleet. Builds `zakurad` natively on the `zakura-mainnet-deployer` runner, then installs it host-by-host with `deploy/deployer/deploy.py`. Node configs, identities, and chain state are deliberately left untouched; the previous binary is kept as `.bak`. An opt-in workflow-owned systemd drop-in enables narrow block propagation tracing without rewriting node configs.
 - **`zakura-testnet-deploy.yml`** — the same for the testnet fleet, from the `zakura-testnet-deployer` runner.
 - **`zakura-mainnet-rollback.yml`** — emergency rollback for a single mainnet node: captures diagnostics, restores `<bin_path>.bak`, restarts the service.
 - **`zakura-continuous-sync.yml`** — twice-hourly audit (plus manual deploy/status/resume actions) of the continuous genesis-sync fleet, which permanently re-syncs from genesis to catch sync regressions.

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -12,10 +12,11 @@ name: Deploy Zakura mainnet fleet
 # per-node configs (external_addr, an inline zakura_node_secret_key that pins
 # each node's iroh identity, custom peers, and mempool/sync tuning) and their
 # state DB at /root/.cache/zebra. To avoid changing node identities or resyncing,
-# this deploy sets manage_config = false: it only swaps /usr/local/bin/zakurad and
-# restarts the existing `zakurad` service, leaving the config, unit, and cache
-# untouched. Rebuilding those configs into the deployer's managed model is
-# separate future work.
+# this deploy sets manage_config = false: it swaps /usr/local/bin/zakurad and
+# restarts the existing `zakurad` service, leaving the config, base unit, and
+# cache untouched. The optional propagation trace input owns one narrow systemd
+# drop-in. Rebuilding the hand-managed configs into the deployer's managed model
+# is separate future work.
 #
 # After PR #21, hand configs should use network.p2p_stack (legacy|zakura|dual|
 # default) rather than the deprecated v2_p2p/legacy_p2p bools. This workflow does
@@ -36,6 +37,11 @@ on:
         default: false
       no_restart:
         description: "Stage the binary without restarting the node"
+        type: boolean
+        required: false
+        default: false
+      block_propagation_trace:
+        description: "Write narrow block propagation traces on every selected node"
         type: boolean
         required: false
         default: false
@@ -100,9 +106,10 @@ jobs:
         run: |
           set -euo pipefail
           if ! grep -q 'manage_config' deploy/deployer/deploy.py ||
-             ! grep -q 'container_name' deploy/deployer/deploy.py; then
-            echo "::error::deploy.py at ref '${REF}' lacks binary-only Docker support." \
-                 "Deploy from a ref whose deploy.py supports manage_config and container_name."
+             ! grep -q 'container_name' deploy/deployer/deploy.py ||
+             ! grep -q 'block_propagation_trace_dir' deploy/deployer/deploy.py; then
+            echo "::error::deploy.py at ref '${REF}' lacks required binary-only deploy support." \
+                 "Deploy from a ref with managed propagation trace drop-ins."
             exit 1
           fi
 
@@ -167,14 +174,21 @@ jobs:
       - name: Generate deployer fleet config
         working-directory: deploy/deployer
         env:
+          BLOCK_PROPAGATION_TRACE: ${{ inputs.block_propagation_trace }}
           REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
 
+          block_propagation_trace_dir=""
+          if [ "${BLOCK_PROPAGATION_TRACE}" = "true" ]; then
+            block_propagation_trace_dir="/mnt/data/traces/block-propagation"
+          fi
+
           cat > nodes.ci.toml <<EOF
           [defaults]
           # Binary-only: swap the binary and restart the existing service; leave
-          # the hand-tuned config, unit, and /root/.cache/zebra state untouched.
+          # the hand-tuned config, base unit, and state untouched. The deployer
+          # may manage its own propagation-trace systemd drop-in.
           deploy_kind     = "systemd"
           manage_config   = false
           service_name    = "zakurad"
@@ -190,6 +204,7 @@ jobs:
           # Verified on the fleet: the nine regional nodes keep state here, the
           # compat host does not. Used only for the dashboard's disk probe.
           state_cache_dir = "/mnt/data/zakura-cache"
+          block_propagation_trace_dir = "${block_propagation_trace_dir}"
 
           # Public mainnet node ids (crates/zakura-network/src/zakura/handler.rs). Used by
           # the dashboard to label each host; not deployed to the nodes.

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -36,6 +36,11 @@ on:
         type: boolean
         required: false
         default: false
+      block_propagation_trace:
+        description: "Write block propagation traces on every selected node"
+        type: boolean
+        required: false
+        default: false
       node:
         description: "Optional single deployer node name; blank deploys the whole fleet"
         required: false
@@ -135,6 +140,7 @@ jobs:
       - name: Generate deployer fleet config
         working-directory: deploy/deployer
         env:
+          BLOCK_PROPAGATION_TRACE: ${{ inputs.block_propagation_trace }}
           HEADER_SYNC_TRACE: ${{ inputs.header_sync_trace }}
           NODE: ${{ inputs.node }}
           P2P_STACK: ${{ inputs.p2p_stack }}
@@ -160,7 +166,9 @@ jobs:
           fi
 
           zakura_trace_line=""
-          if [ "${HEADER_SYNC_TRACE}" = "true" ]; then
+          if [ "${BLOCK_PROPAGATION_TRACE}" = "true" ]; then
+            zakura_trace_line='trace_dir = "/mnt/data/traces/block-propagation"'
+          elif [ "${HEADER_SYNC_TRACE}" = "true" ]; then
             zakura_trace_line='trace_dir = "/mnt/data/traces/header-chain-canary"'
           fi
 

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -164,10 +164,15 @@ jobs:
             echo "header_sync_trace requires one explicit node" >&2
             exit 1
           fi
+          if [ "${BLOCK_PROPAGATION_TRACE}" = "true" ] \
+            && [ "${HEADER_SYNC_TRACE}" = "true" ]; then
+            echo "block_propagation_trace and header_sync_trace are mutually exclusive" >&2
+            exit 1
+          fi
 
           zakura_trace_line=""
           if [ "${BLOCK_PROPAGATION_TRACE}" = "true" ]; then
-            zakura_trace_line='trace_dir = "/mnt/data/traces/block-propagation"'
+            zakura_trace_line='block_propagation_trace_dir = "/mnt/data/traces/block-propagation"'
           elif [ "${HEADER_SYNC_TRACE}" = "true" ]; then
             zakura_trace_line='trace_dir = "/mnt/data/traces/header-chain-canary"'
           fi

--- a/crates/zakura-jsonl-trace/src/lib.rs
+++ b/crates/zakura-jsonl-trace/src/lib.rs
@@ -46,7 +46,10 @@ pub const DEFAULT_BUFFER_FLUSH_BYTES: usize = 256 * 1024;
 pub const DEFAULT_FILE_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Env var used to label every JSONL trace record with a stable node identifier.
-pub const NODE_ID_ENV: &str = "ZEBRA_NODE_ID";
+pub const NODE_ID_ENV: &str = "ZAKURA_NODE_ID";
+
+/// Legacy env var retained for deployments that still use Zebra naming.
+pub const LEGACY_NODE_ID_ENV: &str = "ZEBRA_NODE_ID";
 
 /// A logical JSONL trace table and its output file.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -171,6 +174,7 @@ impl JsonlEventEmitter {
         let event = build();
         let row = JsonlEventEnvelope {
             ts: elapsed_micros(self.started.elapsed()),
+            wall_ts_unix_us: unix_time_micros(),
             node: &self.node,
             process_trace_id: process_trace_id(),
             event: &event,
@@ -195,6 +199,10 @@ impl JsonlEventEmitter {
         row.insert(
             "ts".to_string(),
             Value::from(elapsed_micros(self.started.elapsed())),
+        );
+        row.insert(
+            "wall_ts_unix_us".to_string(),
+            Value::from(unix_time_micros()),
         );
         row.insert("node".to_string(), Value::String(self.node.to_string()));
         row.insert(
@@ -222,6 +230,7 @@ impl Default for JsonlEventEmitter {
 #[derive(Serialize)]
 struct JsonlEventEnvelope<'a, E> {
     ts: u64,
+    wall_ts_unix_us: u64,
     node: &'a str,
     process_trace_id: &'static str,
     #[serde(flatten)]
@@ -232,19 +241,36 @@ fn elapsed_micros(elapsed: Duration) -> u64 {
     saturating_micros(elapsed)
 }
 
+fn unix_time_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(saturating_micros)
+        .unwrap_or_default()
+}
+
 /// Returns the process-wide node identifier used to tag JSONL trace records.
 ///
-/// Resolution order: `ZEBRA_NODE_ID`, `HOSTNAME`, `/etc/hostname`, then
-/// `"unknown"`. The value is resolved once on first call and cached for the
-/// lifetime of the process so every trace record from this node reports the
-/// same id.
+/// Resolution order: `ZAKURA_NODE_ID`, `ZEBRA_NODE_ID`, `HOSTNAME`,
+/// `/etc/hostname`, then `"unknown"`. The value is resolved once on first call
+/// and cached for the lifetime of the process so every trace record from this
+/// node reports the same id.
 pub fn node_id() -> &'static str {
     static NODE_ID: OnceLock<String> = OnceLock::new();
     NODE_ID
         .get_or_init(|| {
             std::env::var(NODE_ID_ENV)
                 .ok()
-                .or_else(|| std::env::var("HOSTNAME").ok())
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| {
+                    std::env::var(LEGACY_NODE_ID_ENV)
+                        .ok()
+                        .filter(|value| !value.trim().is_empty())
+                })
+                .or_else(|| {
+                    std::env::var("HOSTNAME")
+                        .ok()
+                        .filter(|value| !value.trim().is_empty())
+                })
                 .or_else(|| std::fs::read_to_string("/etc/hostname").ok())
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
@@ -863,6 +889,7 @@ mod tests {
         assert_eq!(row["value"], 7);
         assert_eq!(row["optional"], Value::Null);
         assert!(row["ts"].is_u64());
+        assert!(row["wall_ts_unix_us"].is_u64());
     }
 
     #[test]
@@ -880,6 +907,23 @@ mod tests {
         assert_eq!(row["process_trace_id"], process_trace_id());
         assert_eq!(row["event"], "raw_event");
         assert!(row["ts"].is_u64());
+        assert!(row["wall_ts_unix_us"].is_u64());
+    }
+
+    #[test]
+    fn unix_wall_timestamp_is_bounded_by_observation_times() {
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(saturating_micros)
+            .expect("current time is after the Unix epoch");
+        let observed = unix_time_micros();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(saturating_micros)
+            .expect("current time is after the Unix epoch");
+
+        assert!(before <= observed);
+        assert!(observed <= after);
     }
 
     #[test]

--- a/crates/zakura-network/src/config.rs
+++ b/crates/zakura-network/src/config.rs
@@ -1248,6 +1248,12 @@ impl<'de> Deserialize<'de> for Config {
 
         // Clamp too-small budgets rather than rejecting existing configurations.
         let mut zakura = zakura;
+        if zakura.trace_dir.is_some() && zakura.block_propagation_trace_dir.is_some() {
+            return Err(de::Error::custom(
+                "network.zakura.trace_dir and \
+                 network.zakura.block_propagation_trace_dir are mutually exclusive",
+            ));
+        }
         zakura.apply_network_defaults(&network);
         let default_zakura_bootstrap_peers =
             ZakuraConfig::default_bootstrap_peers_for_network(&network);

--- a/crates/zakura-network/src/config/tests/vectors.rs
+++ b/crates/zakura-network/src/config/tests/vectors.rs
@@ -625,6 +625,35 @@ fn p2p_v2_config_roundtrip_keeps_dconfig_zakura_fields() {
 }
 
 #[test]
+fn block_propagation_trace_dir_is_narrow_and_mutually_exclusive() {
+    let narrow: Config = toml::from_str(
+        r#"
+        [zakura]
+        block_propagation_trace_dir = "target/block-propagation"
+        "#,
+    )
+    .expect("dedicated propagation tracing is valid");
+    assert_eq!(
+        narrow.zakura.block_propagation_trace_dir,
+        Some("target/block-propagation".into())
+    );
+    assert!(narrow.zakura.trace_dir.is_none());
+
+    let error = toml::from_str::<Config>(
+        r#"
+        [zakura]
+        trace_dir = "target/general"
+        block_propagation_trace_dir = "target/block-propagation"
+        "#,
+    )
+    .expect_err("general and dedicated tracing must fail closed");
+    assert!(
+        error.to_string().contains("mutually exclusive"),
+        "unexpected trace directory conflict error: {error}"
+    );
+}
+
+#[test]
 fn configured_regtest_checkpoints_preserve_regtest_identity() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-network/src/lib.rs
+++ b/crates/zakura-network/src/lib.rs
@@ -194,7 +194,9 @@ pub use crate::{
         Client, ConnectedAddr, ConnectionInfo, HandshakeError, NotFoundClass, PeerError,
         SharedPeerError,
     },
-    peer_set::{init, init_with_zakura_header_sync},
+    peer_set::{
+        init, init_with_zakura_header_sync, init_with_zakura_header_sync_and_block_propagation,
+    },
     policies::RetryLimit,
     protocol::{
         external::{Version, VersionMessage, MAX_TX_INV_IN_SENT_MESSAGE},

--- a/crates/zakura-network/src/peer_set.rs
+++ b/crates/zakura-network/src/peer_set.rs
@@ -14,4 +14,6 @@ pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker};
 use inventory_registry::InventoryRegistry;
 pub(crate) use set::PeerSet;
 
-pub use initialize::{init, init_with_zakura_header_sync};
+pub use initialize::{
+    init, init_with_zakura_header_sync, init_with_zakura_header_sync_and_block_propagation,
+};

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -191,6 +191,44 @@ where
     S::Future: Send + 'static,
     C: ChainTip + Clone + Send + Sync + 'static,
 {
+    let block_propagation = crate::zakura::BlockPropagationTrace::from_config(&config);
+    init_with_zakura_header_sync_and_block_propagation(
+        config,
+        inbound_service,
+        latest_chain_tip,
+        user_agent,
+        advertised_services,
+        block_gossip_peer_ips,
+        (header_sync_driver_startup, block_propagation),
+    )
+    .await
+}
+
+/// Initialize a peer set with real-driver Zakura sync and propagation tracing.
+#[doc(hidden)]
+pub async fn init_with_zakura_header_sync_and_block_propagation<S, C>(
+    config: Config,
+    inbound_service: S,
+    latest_chain_tip: C,
+    user_agent: String,
+    advertised_services: PeerServices,
+    block_gossip_peer_ips: Vec<IpAddr>,
+    driver_tracing: (
+        Option<crate::zakura::ZakuraHeaderSyncDriverStartup>,
+        crate::zakura::BlockPropagationTrace,
+    ),
+) -> (
+    Buffer<BoxService<Request, Response, BoxError>, Request>,
+    Arc<std::sync::Mutex<AddressBook>>,
+    mpsc::Sender<(PeerSocketAddr, u32)>,
+    Option<crate::zakura::ZakuraEndpoint>,
+)
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + Sync + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
+    let (header_sync_driver_startup, block_propagation) = driver_tracing;
     let (tcp_listener, listen_addr) = if config.legacy_p2p() {
         let (tcp_listener, listen_addr) = open_listener(&config.clone()).await;
         (Some(tcp_listener), listen_addr)
@@ -202,7 +240,7 @@ where
     // handshake builder consumes the original below. The factory only runs when
     // `v2_p2p` is enabled; otherwise the endpoint is `None` and the clone drops.
     let inbound_for_zakura_sink = inbound_service.clone();
-    let zakura_endpoint = crate::zakura::spawn_zakura_endpoint_with_header_sync_driver(
+    let zakura_endpoint = crate::zakura::spawn_zakura_endpoint_with_traces(
         &config,
         move |supervisor, trace| {
             Arc::new(crate::zakura::LegacyGossipSink::spawn_with_trace(
@@ -212,6 +250,7 @@ where
             )) as Arc<dyn crate::zakura::Service>
         },
         header_sync_driver_startup,
+        block_propagation,
     )
     .await
     .expect("Zakura endpoint should start when P2P v2 is enabled");

--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -15,6 +15,7 @@ use crate::{
     PeerSocketAddr,
 };
 
+mod block_propagation_trace;
 mod block_sync;
 mod discovery;
 mod handler;
@@ -27,6 +28,7 @@ pub mod testkit;
 mod trace;
 pub mod transport;
 
+pub use block_propagation_trace::BlockPropagationTrace;
 pub use block_sync::*;
 pub use discovery::*;
 pub use handler::*;

--- a/crates/zakura-network/src/zakura/block_propagation_trace.rs
+++ b/crates/zakura-network/src/zakura/block_propagation_trace.rs
@@ -1,6 +1,6 @@
 //! Hash-correlated diagnostics for near-tip block propagation.
 
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use serde::Serialize;
 use zakura_chain::block;
@@ -8,39 +8,54 @@ use zakura_jsonl_trace::{
     saturating_millis, JsonlDisplay, JsonlEventEmitter, JsonlTraceEvent, JsonlTraceTable,
     JsonlTracer,
 };
-use zakura_network::{self as zn, PeerSocketAddr};
+
+use super::{zakura_trace_peer_label, BlockApplyResult, ZakuraPeerId};
+use crate::{Config, PeerSocketAddr, PeerSource};
 
 const TABLE: JsonlTraceTable = JsonlTraceTable::new("block_propagation", "block_propagation.jsonl");
 
 /// Non-blocking block propagation event emitter.
 #[derive(Clone, Debug)]
-pub(crate) struct BlockPropagationTrace {
+pub struct BlockPropagationTrace {
     emitter: JsonlEventEmitter,
     expose_peer_addresses: bool,
+    emit_native_events: bool,
 }
 
 impl BlockPropagationTrace {
-    /// Create a propagation trace writing into `trace_dir`, or a no-op trace when disabled.
-    pub(crate) fn new(trace_dir: Option<PathBuf>, expose_peer_addresses: bool) -> Self {
+    /// Create a propagation trace from the network tracing configuration.
+    ///
+    /// The dedicated directory takes the narrow native event path. The general
+    /// directory keeps the previous behavior, where native events come from the
+    /// broader header, block, and commit trace tables.
+    pub fn from_config(config: &Config) -> Self {
+        let emit_native_events = config.zakura.block_propagation_trace_dir.is_some();
+        let trace_dir = config
+            .zakura
+            .block_propagation_trace_dir
+            .clone()
+            .or_else(|| config.zakura.trace_dir.clone());
         let tracer = trace_dir
             .map(JsonlTracer::spawn)
             .unwrap_or_else(JsonlTracer::noop);
         Self {
             emitter: JsonlEventEmitter::new(tracer, zakura_jsonl_trace::node_id()),
-            expose_peer_addresses,
+            expose_peer_addresses: config.expose_peer_addresses,
+            emit_native_events,
         }
     }
 
     /// Create a disabled propagation trace.
-    pub(crate) fn noop() -> Self {
+    pub fn noop() -> Self {
         Self {
             emitter: JsonlEventEmitter::noop(),
             expose_peer_addresses: false,
+            emit_native_events: false,
         }
     }
 
     /// Record the point where a locally submitted block starts network broadcast.
-    pub(crate) fn mined_block_broadcast_started(&self, hash: block::Hash, height: block::Height) {
+    pub fn mined_block_broadcast_started(&self, hash: block::Hash, height: block::Height) {
         self.emitter
             .emit_event(|| BlockPropagationEvent::MinedBlockBroadcastStarted {
                 hash: JsonlDisplay(&hash),
@@ -49,7 +64,7 @@ impl BlockPropagationTrace {
     }
 
     /// Record completion of the local peer-set broadcast request.
-    pub(crate) fn mined_block_broadcast_finished(
+    pub fn mined_block_broadcast_finished(
         &self,
         hash: block::Hash,
         height: block::Height,
@@ -66,10 +81,10 @@ impl BlockPropagationTrace {
     }
 
     /// Record a legacy-compatible block advertisement and its local admission result.
-    pub(crate) fn block_announced(
+    pub fn block_announced(
         &self,
         hash: block::Hash,
-        source: Option<&zn::PeerSource>,
+        source: Option<&PeerSource>,
         transport: &'static str,
         disposition: &'static str,
     ) {
@@ -83,7 +98,7 @@ impl BlockPropagationTrace {
     }
 
     /// Record a complete legacy block body returned by the network service.
-    pub(crate) fn legacy_block_downloaded(
+    pub fn legacy_block_downloaded(
         &self,
         hash: block::Hash,
         height: block::Height,
@@ -100,7 +115,7 @@ impl BlockPropagationTrace {
     }
 
     /// Record the terminal result of legacy gossip download and verification.
-    pub(crate) fn legacy_block_finished(
+    pub fn legacy_block_finished(
         &self,
         hash: block::Hash,
         height: Option<block::Height>,
@@ -118,11 +133,65 @@ impl BlockPropagationTrace {
             });
     }
 
-    fn source_label(&self, source: &zn::PeerSource) -> String {
+    /// Record a valid native status that announces a selected tip.
+    pub fn native_header_status_received(
+        &self,
+        peer: &ZakuraPeerId,
+        hash: block::Hash,
+        height: block::Height,
+    ) {
+        if !self.emit_native_events {
+            return;
+        }
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::HeaderStatusReceived {
+                peer: zakura_trace_peer_label(peer),
+                selected_tip_hash: JsonlDisplay(&hash),
+                selected_tip_height: height.0,
+            });
+    }
+
+    /// Record a complete native block body.
+    pub fn native_block_body_received(
+        &self,
+        peer: &ZakuraPeerId,
+        hash: block::Hash,
+        height: block::Height,
+    ) {
+        if !self.emit_native_events {
+            return;
+        }
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::BlockBodyReceived {
+                peer: zakura_trace_peer_label(peer),
+                hash: JsonlDisplay(&hash),
+                height: height.0,
+            });
+    }
+
+    /// Record the terminal result of a native block commit.
+    pub fn native_commit_finished(
+        &self,
+        hash: block::Hash,
+        height: block::Height,
+        result: BlockApplyResult,
+    ) {
+        if !self.emit_native_events {
+            return;
+        }
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::CommitFinish {
+                hash: JsonlDisplay(&hash),
+                height: height.0,
+                result: block_apply_result_label(result),
+            });
+    }
+
+    fn source_label(&self, source: &PeerSource) -> String {
         match source {
-            zn::PeerSource::LegacySocket(peer) => self.legacy_peer_label(*peer),
-            zn::PeerSource::Zakura(peer) => {
-                format!("native:{}", zn::zakura::zakura_trace_peer_label(peer))
+            PeerSource::LegacySocket(peer) => self.legacy_peer_label(*peer),
+            PeerSource::Zakura(peer) => {
+                format!("native:{}", zakura_trace_peer_label(peer))
             }
         }
     }
@@ -178,10 +247,35 @@ enum BlockPropagationEvent<'a> {
         reason: Option<String>,
         elapsed_ms: u64,
     },
+    HeaderStatusReceived {
+        peer: String,
+        selected_tip_hash: JsonlDisplay<'a, block::Hash>,
+        selected_tip_height: u32,
+    },
+    BlockBodyReceived {
+        peer: String,
+        hash: JsonlDisplay<'a, block::Hash>,
+        height: u32,
+    },
+    CommitFinish {
+        hash: JsonlDisplay<'a, block::Hash>,
+        height: u32,
+        result: &'static str,
+    },
 }
 
 impl JsonlTraceEvent for BlockPropagationEvent<'_> {
     const TABLE: JsonlTraceTable = TABLE;
+}
+
+fn block_apply_result_label(result: BlockApplyResult) -> &'static str {
+    match result {
+        BlockApplyResult::Committed => "committed",
+        BlockApplyResult::Duplicate => "duplicate",
+        BlockApplyResult::Rejected => "rejected",
+        BlockApplyResult::Unavailable => "unavailable",
+        BlockApplyResult::TimedOut => "timed_out",
+    }
 }
 
 fn bounded_reason(reason: &str) -> String {
@@ -203,12 +297,62 @@ mod tests {
             disposition: "queued",
         };
 
-        let value = serde_json::to_value(event).expect("propagation event serializes");
+        let value = serde_json::to_value(event).expect("body event serializes");
         assert_eq!(value["event"], "block_announced");
         assert_eq!(value["hash"], hash.to_string());
         assert_eq!(value["transport"], "legacy");
         assert_eq!(value["source"], "legacy:peer:1234");
         assert_eq!(value["disposition"], "queued");
+    }
+
+    #[test]
+    fn native_events_keep_report_compatible_names() {
+        let hash = block::Hash([0x2a; 32]);
+        let event = BlockPropagationEvent::CommitFinish {
+            hash: JsonlDisplay(&hash),
+            height: 42,
+            result: block_apply_result_label(BlockApplyResult::Committed),
+        };
+
+        let value = serde_json::to_value(event).expect("commit event serializes");
+        assert_eq!(value["event"], "commit_finish");
+        assert_eq!(value["hash"], hash.to_string());
+        assert_eq!(value["height"], 42);
+        assert_eq!(value["result"], "committed");
+    }
+
+    #[tokio::test]
+    async fn dedicated_native_commit_writes_only_propagation_table() {
+        let directory = tempfile::tempdir().expect("temporary trace directory is created");
+        let guard = JsonlTracer::spawn_guard(directory.path().to_path_buf());
+        let trace = BlockPropagationTrace {
+            emitter: JsonlEventEmitter::new(guard.tracer(), "observer"),
+            expose_peer_addresses: false,
+            emit_native_events: true,
+        };
+        let hash = block::Hash([0x2a; 32]);
+
+        trace.native_commit_finished(hash, block::Height(42), BlockApplyResult::Committed);
+        guard.shutdown().await;
+
+        let files: Vec<_> = std::fs::read_dir(directory.path())
+            .expect("trace directory is readable")
+            .map(|entry| {
+                entry
+                    .expect("trace file entry is readable")
+                    .file_name()
+                    .into_string()
+                    .expect("trace file name is UTF-8")
+            })
+            .collect();
+        assert_eq!(files, ["block_propagation.jsonl"]);
+        let row: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(directory.path().join("block_propagation.jsonl"))
+                .expect("propagation trace is readable"),
+        )
+        .expect("propagation row is valid JSON");
+        assert_eq!(row["event"], "commit_finish");
+        assert_eq!(row["hash"], hash.to_string());
     }
 
     #[test]
@@ -218,6 +362,7 @@ mod tests {
         let public_trace = BlockPropagationTrace {
             emitter: JsonlEventEmitter::noop(),
             expose_peer_addresses: true,
+            emit_native_events: false,
         };
 
         assert_eq!(private_trace.legacy_peer_label(peer), "legacy:redacted");

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -51,6 +51,7 @@ use tokio::time;
 use zakura_chain::{block, serialization::ZcashSerialize};
 
 mod trace;
+use trace::ReceivedBodyTrace;
 
 /// How long a routine avoids a height after returning it because of a failure.
 /// The delay lets another routine take the height first on the single-threaded
@@ -1524,14 +1525,15 @@ impl PeerRoutine {
         };
         let decoded_attributed_memory_size_bytes =
             record_decoded_memory_size(&block, body_wire_bytes);
-        self.trace_body_received(
+        self.trace_body_received(ReceivedBodyTrace {
             height,
+            hash: block.hash(),
             serialized_bytes,
             decoded_attributed_memory_size_bytes,
-            Some(request_start_height),
-            Some(request_range_count),
-            Some(request_elapsed_ms),
-        );
+            request_start_height: Some(request_start_height),
+            request_range_count: Some(request_range_count),
+            request_elapsed_ms: Some(request_elapsed_ms),
+        });
 
         self.window
             .note_block_progress(Instant::now(), self.config.effective_liveness_timeout());
@@ -1734,14 +1736,15 @@ impl PeerRoutine {
         let decoded_attributed_memory_size_bytes =
             record_decoded_memory_size(&block, body_wire_bytes);
         self.record_received(serialized_bytes);
-        self.trace_body_received(
+        self.trace_body_received(ReceivedBodyTrace {
             height,
+            hash: block.hash(),
             serialized_bytes,
             decoded_attributed_memory_size_bytes,
-            None,
-            None,
-            None,
-        );
+            request_start_height: None,
+            request_range_count: None,
+            request_elapsed_ms: None,
+        });
 
         // A real, wanted body that no longer matches an outstanding request (typically
         // arrived just after its request timed out). Count it as block progress: resets

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine/trace.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine/trace.rs
@@ -157,6 +157,11 @@ impl PeerRoutine {
     }
 
     pub(super) fn trace_body_received(&self, received: ReceivedBodyTrace) {
+        self.trace.block_propagation().native_block_body_received(
+            &self.peer,
+            received.hash,
+            received.height,
+        );
         self.emit(bs_trace::BLOCK_BODY_RECEIVED, |row| {
             row.peer = Some(trace_peer(&self.peer));
             row.height = Some(trace_height(received.height));

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine/trace.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine/trace.rs
@@ -5,6 +5,16 @@ use super::super::trace::{
 use super::*;
 use crate::zakura::trace::block_sync_trace as bs_trace;
 
+pub(super) struct ReceivedBodyTrace {
+    pub height: block::Height,
+    pub hash: block::Hash,
+    pub serialized_bytes: u64,
+    pub decoded_attributed_memory_size_bytes: u64,
+    pub request_start_height: Option<block::Height>,
+    pub request_range_count: Option<u32>,
+    pub request_elapsed_ms: Option<u64>,
+}
+
 impl PeerRoutine {
     pub(super) fn emit(&self, event: &'static str, build: impl FnOnce(&mut BlockTraceFields)) {
         self.trace
@@ -146,31 +156,25 @@ impl PeerRoutine {
         });
     }
 
-    pub(super) fn trace_body_received(
-        &self,
-        height: block::Height,
-        serialized_bytes: u64,
-        decoded_attributed_memory_size_bytes: u64,
-        request_start_height: Option<block::Height>,
-        request_range_count: Option<u32>,
-        request_elapsed_ms: Option<u64>,
-    ) {
+    pub(super) fn trace_body_received(&self, received: ReceivedBodyTrace) {
         self.emit(bs_trace::BLOCK_BODY_RECEIVED, |row| {
             row.peer = Some(trace_peer(&self.peer));
-            row.height = Some(trace_height(height));
-            row.serialized_bytes = Some(serialized_bytes);
-            row.decoded_attributed_memory_size_bytes = Some(decoded_attributed_memory_size_bytes);
+            row.height = Some(trace_height(received.height));
+            row.hash = Some(received.hash.to_string());
+            row.serialized_bytes = Some(received.serialized_bytes);
+            row.decoded_attributed_memory_size_bytes =
+                Some(received.decoded_attributed_memory_size_bytes);
             row.budget_reserved_after = Some(self.budget.reserved());
             row.sequencer_input_capacity = Some(saturating_usize(self.sequencer_input.capacity()));
             row.sequencer_input_max_capacity =
                 Some(saturating_usize(self.sequencer_input.max_capacity()));
-            if let Some(request_start_height) = request_start_height {
+            if let Some(request_start_height) = received.request_start_height {
                 row.request_start = Some(trace_height(request_start_height));
             }
-            if let Some(request_range_count) = request_range_count {
+            if let Some(request_range_count) = received.request_range_count {
                 row.request_range_count = Some(u64::from(request_range_count));
             }
-            if let Some(request_elapsed_ms) = request_elapsed_ms {
+            if let Some(request_elapsed_ms) = received.request_elapsed_ms {
                 row.request_elapsed_ms = Some(request_elapsed_ms);
             }
             self.insert_bbr_fields(row);

--- a/crates/zakura-network/src/zakura/block_sync/trace.rs
+++ b/crates/zakura-network/src/zakura/block_sync/trace.rs
@@ -791,6 +791,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn received_body_schema_carries_block_hash() {
+        let mut event = BlockTraceEvent::new("block_body_received");
+        event.fields.height = Some(42);
+        event.fields.hash = Some("abcd".to_string());
+        event.fields.peer = Some("peer:1234".to_string());
+
+        assert_eq!(
+            serde_json::to_value(event).expect("body event serializes"),
+            json!({
+                "event": "block_body_received",
+                "peer": "peer:1234",
+                "height": 42,
+                "hash": "abcd",
+            })
+        );
+    }
+
+    #[test]
     fn block_sync_core_avoids_legacy_trace_builders() {
         for (name, source) in [
             ("reactor", include_str!("reactor.rs")),

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -52,19 +52,20 @@ use crate::{
     protocol::external::InventoryHash,
     zakura::{
         canonical_ip, direct_endpoint_builder, spawn_block_sync_reactor, spawn_header_sync_reactor,
-        BlockSyncAction, BlockSyncFrontiers, BlockSyncHandle, BlockSyncService, BlockSyncStartup,
-        BoxRunFuture, Clock, CloseCause, Frame, FramedRecv, FramedSend, FullStateFrontiers,
-        HeaderSyncPassthroughService, HeaderSyncService, HeaderSyncStartup, OrderedSessionDemand,
-        OrderedStreamOpening, OrderedStreamPolicy, Peer, RealClock, Service, ServicePeerDirection,
-        ServiceRegistry, ServiceStream, SinkReject, Stream, StreamMode, StreamPrelude,
-        ZakuraAcceptedLimits, ZakuraBlockSyncConfig, ZakuraConnId, ZakuraControlAck,
-        ZakuraControlHello, ZakuraControlRole, ZakuraControlValidation, ZakuraHandshakeConfig,
-        ZakuraHandshakePath, ZakuraHeaderSyncConfig, ZakuraInitialLimits, ZakuraLimits,
-        ZakuraPeerId, ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRejectReason,
-        ZakuraUpgradeOutcome, CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC, CONTROL_VERSION,
-        FRAME_HEADER_BYTES, MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN, STREAM_PRELUDE_MAGIC,
-        TRANSCRIPT_HASH_BYTES, ZAKURA_CAP_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION,
-        ZAKURA_PROTOCOL_VERSION_1, ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_HEADER_SYNC,
+        BlockPropagationTrace, BlockSyncAction, BlockSyncFrontiers, BlockSyncHandle,
+        BlockSyncService, BlockSyncStartup, BoxRunFuture, Clock, CloseCause, Frame, FramedRecv,
+        FramedSend, FullStateFrontiers, HeaderSyncPassthroughService, HeaderSyncService,
+        HeaderSyncStartup, OrderedSessionDemand, OrderedStreamOpening, OrderedStreamPolicy, Peer,
+        RealClock, Service, ServicePeerDirection, ServiceRegistry, ServiceStream, SinkReject,
+        Stream, StreamMode, StreamPrelude, ZakuraAcceptedLimits, ZakuraBlockSyncConfig,
+        ZakuraConnId, ZakuraControlAck, ZakuraControlHello, ZakuraControlRole,
+        ZakuraControlValidation, ZakuraHandshakeConfig, ZakuraHandshakePath,
+        ZakuraHeaderSyncConfig, ZakuraInitialLimits, ZakuraLimits, ZakuraPeerId,
+        ZakuraPeerSupervisor, ZakuraProtocolError, ZakuraRejectReason, ZakuraUpgradeOutcome,
+        CONTROL_ACK_MAGIC, CONTROL_HELLO_MAGIC, CONTROL_VERSION, FRAME_HEADER_BYTES,
+        MAX_CONTROL_PAYLOAD_BYTES, P2P_V2_ALPN, STREAM_PRELUDE_MAGIC, TRANSCRIPT_HASH_BYTES,
+        ZAKURA_CAP_HEADER_SYNC, ZAKURA_HEADER_SYNC_STREAM_VERSION, ZAKURA_PROTOCOL_VERSION_1,
+        ZAKURA_STREAM_BLOCK_SYNC, ZAKURA_STREAM_HEADER_SYNC,
     },
 };
 use crate::{BoxError, Config, MAX_TX_INV_IN_SENT_MESSAGE};
@@ -298,6 +299,11 @@ pub struct ZakuraConfig {
     /// this directory. Legacy peer fields in `legacy_sync.jsonl` follow
     /// [`Config::expose_peer_addresses`](crate::config::Config::expose_peer_addresses).
     pub trace_dir: Option<PathBuf>,
+    /// Optional directory for the narrow block propagation JSONL trace.
+    ///
+    /// When set, only `block_propagation.jsonl` is written. This setting is
+    /// mutually exclusive with [`Self::trace_dir`].
+    pub block_propagation_trace_dir: Option<PathBuf>,
     /// Native header-sync wire settings.
     pub header_sync: ZakuraHeaderSyncConfig,
     /// Native stream-6 block-sync wire, scheduling, serving, and rollout settings.
@@ -331,6 +337,7 @@ impl Default for ZakuraConfig {
             stream_open_rate_per_second: DEFAULT_ZAKURA_STREAM_OPEN_RATE_PER_SECOND,
             message_rate_per_second: DEFAULT_ZAKURA_MESSAGE_RATE_PER_SECOND,
             trace_dir: None,
+            block_propagation_trace_dir: None,
             header_sync: ZakuraHeaderSyncConfig::default(),
             block_sync: ZakuraBlockSyncConfig::default(),
             dev_network: None,
@@ -3258,6 +3265,22 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
     sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
     header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
 ) -> Result<Option<ZakuraEndpoint>, BoxError> {
+    let block_propagation = BlockPropagationTrace::from_config(config);
+    spawn_zakura_endpoint_with_traces(
+        config,
+        sink_factory,
+        header_sync_driver_startup,
+        block_propagation,
+    )
+    .await
+}
+
+pub(crate) async fn spawn_zakura_endpoint_with_traces(
+    config: &Config,
+    sink_factory: impl FnOnce(ZakuraSupervisorHandle, ZakuraTrace) -> Arc<dyn Service>,
+    header_sync_driver_startup: Option<ZakuraHeaderSyncDriverStartup>,
+    block_propagation: BlockPropagationTrace,
+) -> Result<Option<ZakuraEndpoint>, BoxError> {
     if !config.v2_p2p() {
         return Ok(None);
     }
@@ -3280,7 +3303,8 @@ pub async fn spawn_zakura_endpoint_with_header_sync_driver(
         .clone()
         .map(zakura_jsonl_trace::JsonlTracer::spawn)
         .unwrap_or_else(zakura_jsonl_trace::JsonlTracer::noop);
-    let trace = ZakuraTrace::new(tracer, zakura_jsonl_trace::node_id());
+    let trace = ZakuraTrace::new(tracer, zakura_jsonl_trace::node_id())
+        .with_block_propagation(block_propagation);
     let handshake_config = ZakuraHandshakeConfig::for_network_with_dev_cohort(
         &config.network,
         config.zakura.dev_network.as_deref(),

--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -800,6 +800,14 @@ impl HeaderSyncReactor {
             self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage);
             return;
         }
+        self.startup
+            .trace
+            .block_propagation()
+            .native_header_status_received(
+                &peer,
+                status.selected_tip_hash,
+                status.selected_tip_height,
+            );
         if let Some(state) = self.peer_state.get_mut(&peer) {
             state.last_status = Some(status.clone());
         }

--- a/crates/zakura-network/src/zakura/trace.rs
+++ b/crates/zakura-network/src/zakura/trace.rs
@@ -14,6 +14,7 @@ use blake2b_simd::Params as Blake2bParams;
 use serde_json::{Map, Number, Value};
 use zakura_jsonl_trace::{JsonlEventEmitter, JsonlTraceEvent, JsonlTracer};
 
+use super::block_propagation_trace::BlockPropagationTrace;
 use super::{ZakuraPeerId, ZakuraRejectReason};
 
 /// A Zakura JSONL trace table.
@@ -470,6 +471,7 @@ pub mod commit_state_trace {
 #[derive(Clone, Debug)]
 pub struct ZakuraTrace {
     emitter: JsonlEventEmitter,
+    block_propagation: BlockPropagationTrace,
 }
 
 impl ZakuraTrace {
@@ -482,7 +484,19 @@ impl ZakuraTrace {
     pub fn new(tracer: JsonlTracer, node: impl Into<Arc<str>>) -> Self {
         Self {
             emitter: JsonlEventEmitter::new(tracer, node),
+            block_propagation: BlockPropagationTrace::noop(),
         }
+    }
+
+    /// Attach the narrow block propagation trace sink.
+    pub fn with_block_propagation(mut self, block_propagation: BlockPropagationTrace) -> Self {
+        self.block_propagation = block_propagation;
+        self
+    }
+
+    /// Return the narrow block propagation trace sink.
+    pub fn block_propagation(&self) -> &BlockPropagationTrace {
+        &self.block_propagation
     }
 
     /// Return the underlying JSONL tracer.

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -467,10 +467,7 @@ impl StartCmd {
         // See `zakura_network::Connection::drive_peer_request()` for details.
         let (setup_tx, setup_rx) = oneshot::channel();
         let block_propagation_trace =
-            crate::components::block_propagation_trace::BlockPropagationTrace::new(
-                config.network.zakura.trace_dir.clone(),
-                config.network.expose_peer_addresses,
-            );
+            zakura_network::zakura::BlockPropagationTrace::from_config(&config.network);
         let zcashd_compat_pruning_retention = config
             .zcashd_compat
             .enabled
@@ -495,14 +492,17 @@ impl StartCmd {
         let advertised_services = Self::advertised_services(&config);
 
         let (peer_set, address_book, misbehavior_sender, zakura_endpoint) =
-            zakura_network::init_with_zakura_header_sync(
+            zakura_network::init_with_zakura_header_sync_and_block_propagation(
                 config.network.clone(),
                 inbound,
                 latest_chain_tip.clone(),
                 user_agent(),
                 advertised_services,
                 zcashd_compat_block_gossip_peer_ips,
-                zakura_header_sync_driver_startup,
+                (
+                    zakura_header_sync_driver_startup,
+                    block_propagation_trace.clone(),
+                ),
             )
             .await;
 

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -466,6 +466,11 @@ impl StartCmd {
         //
         // See `zakura_network::Connection::drive_peer_request()` for details.
         let (setup_tx, setup_rx) = oneshot::channel();
+        let block_propagation_trace =
+            crate::components::block_propagation_trace::BlockPropagationTrace::new(
+                config.network.zakura.trace_dir.clone(),
+                config.network.expose_peer_addresses,
+            );
         let zcashd_compat_pruning_retention = config
             .zcashd_compat
             .enabled
@@ -476,13 +481,16 @@ impl StartCmd {
             .load_shed()
             .buffer(inbound::downloads::MAX_INBOUND_CONCURRENCY)
             .timeout(MAX_INBOUND_RESPONSE_TIME)
-            .service(Inbound::new(
-                config.sync.full_verify_concurrency_limit,
-                config.network.expose_peer_addresses,
-                zcashd_compat_pruning_retention,
-                zcashd_compat_block_gossip_peer_ips.clone(),
-                setup_rx,
-            ));
+            .service(
+                Inbound::new(
+                    config.sync.full_verify_concurrency_limit,
+                    config.network.expose_peer_addresses,
+                    zcashd_compat_pruning_retention,
+                    zcashd_compat_block_gossip_peer_ips.clone(),
+                    setup_rx,
+                )
+                .with_block_propagation_trace(block_propagation_trace.clone()),
+            );
 
         let advertised_services = Self::advertised_services(&config);
 
@@ -682,11 +690,12 @@ impl StartCmd {
         // Start concurrent tasks which don't add load to other tasks
         info!("spawning block gossip task");
         let block_gossip_task_handle = tokio::spawn(
-            sync::gossip_best_tip_block_hashes(
+            sync::gossip_best_tip_block_hashes_with_trace(
                 sync_status.clone(),
                 chain_tip_change.clone(),
                 peer_set.clone(),
                 Some(submit_block_channel.receiver()),
+                block_propagation_trace,
             )
             .in_current_span(),
         );

--- a/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
@@ -1349,6 +1349,9 @@ where
         }
     };
     let result = outcome.result();
+    trace
+        .block_propagation()
+        .native_commit_finished(expected_hash, height, result);
     trace.trace_block_commit_finished(token, class, height, expected_hash, result, started);
     let _ = block_sync.send_control(BlockSyncEvent::BlockApplyFinished {
         owner,

--- a/crates/zakurad/src/components.rs
+++ b/crates/zakurad/src/components.rs
@@ -6,7 +6,6 @@
 //! don't fit the async context well.
 
 pub(crate) mod auth_download_height;
-pub(crate) mod block_propagation_trace;
 pub mod health;
 pub mod inbound;
 #[allow(missing_docs)]

--- a/crates/zakurad/src/components.rs
+++ b/crates/zakurad/src/components.rs
@@ -6,6 +6,7 @@
 //! don't fit the async context well.
 
 pub(crate) mod auth_download_height;
+pub(crate) mod block_propagation_trace;
 pub mod health;
 pub mod inbound;
 #[allow(missing_docs)]

--- a/crates/zakurad/src/components/block_propagation_trace.rs
+++ b/crates/zakurad/src/components/block_propagation_trace.rs
@@ -1,0 +1,235 @@
+//! Hash-correlated diagnostics for near-tip block propagation.
+
+use std::{path::PathBuf, time::Duration};
+
+use serde::Serialize;
+use zakura_chain::block;
+use zakura_jsonl_trace::{
+    saturating_millis, JsonlDisplay, JsonlEventEmitter, JsonlTraceEvent, JsonlTraceTable,
+    JsonlTracer,
+};
+use zakura_network::{self as zn, PeerSocketAddr};
+
+const TABLE: JsonlTraceTable = JsonlTraceTable::new("block_propagation", "block_propagation.jsonl");
+
+/// Non-blocking block propagation event emitter.
+#[derive(Clone, Debug)]
+pub(crate) struct BlockPropagationTrace {
+    emitter: JsonlEventEmitter,
+    expose_peer_addresses: bool,
+}
+
+impl BlockPropagationTrace {
+    /// Create a propagation trace writing into `trace_dir`, or a no-op trace when disabled.
+    pub(crate) fn new(trace_dir: Option<PathBuf>, expose_peer_addresses: bool) -> Self {
+        let tracer = trace_dir
+            .map(JsonlTracer::spawn)
+            .unwrap_or_else(JsonlTracer::noop);
+        Self {
+            emitter: JsonlEventEmitter::new(tracer, zakura_jsonl_trace::node_id()),
+            expose_peer_addresses,
+        }
+    }
+
+    /// Create a disabled propagation trace.
+    pub(crate) fn noop() -> Self {
+        Self {
+            emitter: JsonlEventEmitter::noop(),
+            expose_peer_addresses: false,
+        }
+    }
+
+    /// Record the point where a locally submitted block starts network broadcast.
+    pub(crate) fn mined_block_broadcast_started(&self, hash: block::Hash, height: block::Height) {
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::MinedBlockBroadcastStarted {
+                hash: JsonlDisplay(&hash),
+                height: height.0,
+            });
+    }
+
+    /// Record completion of the local peer-set broadcast request.
+    pub(crate) fn mined_block_broadcast_finished(
+        &self,
+        hash: block::Hash,
+        height: block::Height,
+        result: &'static str,
+        elapsed: Duration,
+    ) {
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::MinedBlockBroadcastFinished {
+                hash: JsonlDisplay(&hash),
+                height: height.0,
+                result,
+                elapsed_ms: saturating_millis(elapsed),
+            });
+    }
+
+    /// Record a legacy-compatible block advertisement and its local admission result.
+    pub(crate) fn block_announced(
+        &self,
+        hash: block::Hash,
+        source: Option<&zn::PeerSource>,
+        transport: &'static str,
+        disposition: &'static str,
+    ) {
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::BlockAnnounced {
+                hash: JsonlDisplay(&hash),
+                transport,
+                source: source.map(|source| self.source_label(source)),
+                disposition,
+            });
+    }
+
+    /// Record a complete legacy block body returned by the network service.
+    pub(crate) fn legacy_block_downloaded(
+        &self,
+        hash: block::Hash,
+        height: block::Height,
+        peer: Option<PeerSocketAddr>,
+        elapsed: Duration,
+    ) {
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::LegacyBlockDownloaded {
+                hash: JsonlDisplay(&hash),
+                height: height.0,
+                source: peer.map(|peer| self.legacy_peer_label(peer)),
+                elapsed_ms: saturating_millis(elapsed),
+            });
+    }
+
+    /// Record the terminal result of legacy gossip download and verification.
+    pub(crate) fn legacy_block_finished(
+        &self,
+        hash: block::Hash,
+        height: Option<block::Height>,
+        result: &'static str,
+        reason: Option<&str>,
+        elapsed: Duration,
+    ) {
+        self.emitter
+            .emit_event(|| BlockPropagationEvent::LegacyBlockFinished {
+                hash: JsonlDisplay(&hash),
+                height: height.map(|height| height.0),
+                result,
+                reason: reason.map(bounded_reason),
+                elapsed_ms: saturating_millis(elapsed),
+            });
+    }
+
+    fn source_label(&self, source: &zn::PeerSource) -> String {
+        match source {
+            zn::PeerSource::LegacySocket(peer) => self.legacy_peer_label(*peer),
+            zn::PeerSource::Zakura(peer) => {
+                format!("native:{}", zn::zakura::zakura_trace_peer_label(peer))
+            }
+        }
+    }
+
+    fn legacy_peer_label(&self, peer: PeerSocketAddr) -> String {
+        if self.expose_peer_addresses {
+            format!("legacy:{}", peer.remove_socket_addr_privacy())
+        } else {
+            "legacy:redacted".to_string()
+        }
+    }
+}
+
+impl Default for BlockPropagationTrace {
+    fn default() -> Self {
+        Self::noop()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+enum BlockPropagationEvent<'a> {
+    MinedBlockBroadcastStarted {
+        hash: JsonlDisplay<'a, block::Hash>,
+        height: u32,
+    },
+    MinedBlockBroadcastFinished {
+        hash: JsonlDisplay<'a, block::Hash>,
+        height: u32,
+        result: &'static str,
+        elapsed_ms: u64,
+    },
+    BlockAnnounced {
+        hash: JsonlDisplay<'a, block::Hash>,
+        transport: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        disposition: &'static str,
+    },
+    LegacyBlockDownloaded {
+        hash: JsonlDisplay<'a, block::Hash>,
+        height: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        elapsed_ms: u64,
+    },
+    LegacyBlockFinished {
+        hash: JsonlDisplay<'a, block::Hash>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        height: Option<u32>,
+        result: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        elapsed_ms: u64,
+    },
+}
+
+impl JsonlTraceEvent for BlockPropagationEvent<'_> {
+    const TABLE: JsonlTraceTable = TABLE;
+}
+
+fn bounded_reason(reason: &str) -> String {
+    const MAX_REASON_CHARS: usize = 256;
+    reason.chars().take(MAX_REASON_CHARS).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn propagation_events_have_hash_correlated_schema() {
+        let hash = block::Hash([0x2a; 32]);
+        let event = BlockPropagationEvent::BlockAnnounced {
+            hash: JsonlDisplay(&hash),
+            transport: "legacy",
+            source: Some("legacy:peer:1234".to_string()),
+            disposition: "queued",
+        };
+
+        let value = serde_json::to_value(event).expect("propagation event serializes");
+        assert_eq!(value["event"], "block_announced");
+        assert_eq!(value["hash"], hash.to_string());
+        assert_eq!(value["transport"], "legacy");
+        assert_eq!(value["source"], "legacy:peer:1234");
+        assert_eq!(value["disposition"], "queued");
+    }
+
+    #[test]
+    fn legacy_peer_labels_follow_address_privacy_policy() {
+        let peer = PeerSocketAddr::from(([203, 0, 113, 7], 18233));
+        let private_trace = BlockPropagationTrace::noop();
+        let public_trace = BlockPropagationTrace {
+            emitter: JsonlEventEmitter::noop(),
+            expose_peer_addresses: true,
+        };
+
+        assert_eq!(private_trace.legacy_peer_label(peer), "legacy:redacted");
+        assert_eq!(
+            public_trace.legacy_peer_label(peer),
+            "legacy:203.0.113.7:18233"
+        );
+    }
+
+    #[test]
+    fn failure_reasons_are_bounded() {
+        let reason = "x".repeat(300);
+        assert_eq!(bounded_reason(&reason).len(), 256);
+    }
+}

--- a/crates/zakurad/src/components/inbound.rs
+++ b/crates/zakurad/src/components/inbound.rs
@@ -34,7 +34,7 @@ use zakura_consensus::{router::RouterError, VerifyBlockError};
 use zakura_network::{AddressBook, InventoryResponse};
 use zakura_node_services::mempool;
 
-use crate::BoxError;
+use crate::{components::block_propagation_trace::BlockPropagationTrace, BoxError};
 
 // Re-use the syncer timeouts for consistency.
 use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
@@ -336,6 +336,9 @@ pub struct Inbound {
     /// Whether legacy peer address labels in logs are unredacted.
     expose_peer_addresses: bool,
 
+    /// Hash-correlated diagnostics for block gossip handled by this service.
+    block_propagation_trace: BlockPropagationTrace,
+
     /// Diagnostics for zcashd-compat requests that need pruned block bodies.
     pruned_block_not_found_logger: Arc<PrunedBlockNotFoundLogger>,
 }
@@ -357,11 +360,21 @@ impl Inbound {
                 setup,
             },
             expose_peer_addresses,
+            block_propagation_trace: BlockPropagationTrace::noop(),
             pruned_block_not_found_logger: Arc::new(PrunedBlockNotFoundLogger::new(
                 zcashd_compat_pruning_retention,
                 zcashd_compat_peer_ips,
             )),
         }
+    }
+
+    /// Attach an opt-in block propagation trace to this inbound service.
+    pub(crate) fn with_block_propagation_trace(
+        mut self,
+        block_propagation_trace: BlockPropagationTrace,
+    ) -> Self {
+        self.block_propagation_trace = block_propagation_trace;
+        self
     }
 
     /// Remove `self.setup`, temporarily replacing it with an invalid state.
@@ -406,14 +419,17 @@ impl Service<zn::Request> for Inbound {
 
                     let cached_peer_addr_response = CachedPeerAddrResponse::new(address_book);
 
-                    let block_downloads = Box::pin(BlockDownloads::new(
-                        full_verify_concurrency_limit,
-                        self.expose_peer_addresses,
-                        Timeout::new(block_download_peer_set, BLOCK_DOWNLOAD_TIMEOUT),
-                        Timeout::new(block_verifier, BLOCK_VERIFY_TIMEOUT),
-                        state.clone(),
-                        latest_chain_tip,
-                    ));
+                    let block_downloads = Box::pin(
+                        BlockDownloads::new(
+                            full_verify_concurrency_limit,
+                            self.expose_peer_addresses,
+                            Timeout::new(block_download_peer_set, BLOCK_DOWNLOAD_TIMEOUT),
+                            Timeout::new(block_verifier, BLOCK_VERIFY_TIMEOUT),
+                            state.clone(),
+                            latest_chain_tip,
+                        )
+                        .with_block_propagation_trace(self.block_propagation_trace.clone()),
+                    );
 
                     result = Ok(());
                     Setup::Initialized {
@@ -536,6 +552,7 @@ impl Service<zn::Request> for Inbound {
     #[instrument(name = "inbound", skip(self, req))]
     fn call(&mut self, req: zn::Request) -> Self::Future {
         let pruned_block_not_found_logger = self.pruned_block_not_found_logger.clone();
+        let block_propagation_trace = self.block_propagation_trace.clone();
         let (cached_peer_addr_response, block_downloads, mempool, state) = match &mut self.setup {
             Setup::Initialized {
                 cached_peer_addr_response,
@@ -754,6 +771,13 @@ impl Service<zn::Request> for Inbound {
                     .boxed()
             }
             zn::Request::AdvertiseBlock(hash, Some(zn::PeerSource::Zakura(peer_id))) => {
+                let source = zn::PeerSource::Zakura(peer_id.clone());
+                block_propagation_trace.block_announced(
+                    hash,
+                    Some(&source),
+                    "native_compat",
+                    "ignored_native_sync",
+                );
                 debug!(
                     ?hash,
                     ?peer_id,

--- a/crates/zakurad/src/components/inbound.rs
+++ b/crates/zakurad/src/components/inbound.rs
@@ -22,7 +22,7 @@ use futures::{
 use tokio::sync::oneshot::{self, error::TryRecvError};
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};
 
-use zakura_network::{self as zn, PeerSocketAddr};
+use zakura_network::{self as zn, zakura::BlockPropagationTrace, PeerSocketAddr};
 use zakura_state::{self as zs};
 
 use zakura_chain::{
@@ -34,7 +34,7 @@ use zakura_consensus::{router::RouterError, VerifyBlockError};
 use zakura_network::{AddressBook, InventoryResponse};
 use zakura_node_services::mempool;
 
-use crate::{components::block_propagation_trace::BlockPropagationTrace, BoxError};
+use crate::BoxError;
 
 // Re-use the syncer timeouts for consistency.
 use super::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};

--- a/crates/zakurad/src/components/inbound/downloads.rs
+++ b/crates/zakurad/src/components/inbound/downloads.rs
@@ -26,13 +26,10 @@ use zakura_chain::{
     block::{self, HeightDiff},
     chain_tip::ChainTip,
 };
-use zakura_network::{self as zn, PeerSocketAddr};
+use zakura_network::{self as zn, zakura::BlockPropagationTrace, PeerSocketAddr};
 use zakura_state as zs;
 
-use crate::components::{
-    auth_download_height::tip_child_mismatch, block_propagation_trace::BlockPropagationTrace,
-    sync::MIN_CONCURRENCY_LIMIT,
-};
+use crate::components::{auth_download_height::tip_child_mismatch, sync::MIN_CONCURRENCY_LIMIT};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 

--- a/crates/zakurad/src/components/inbound/downloads.rs
+++ b/crates/zakurad/src/components/inbound/downloads.rs
@@ -6,6 +6,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Instant,
 };
 
 use futures::{
@@ -28,7 +29,10 @@ use zakura_chain::{
 use zakura_network::{self as zn, PeerSocketAddr};
 use zakura_state as zs;
 
-use crate::components::{auth_download_height::tip_child_mismatch, sync::MIN_CONCURRENCY_LIMIT};
+use crate::components::{
+    auth_download_height::tip_child_mismatch, block_propagation_trace::BlockPropagationTrace,
+    sync::MIN_CONCURRENCY_LIMIT,
+};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -269,6 +273,9 @@ where
     /// Allows efficient access to the best tip of the blockchain.
     latest_chain_tip: zs::LatestChainTip,
 
+    /// Hash-correlated diagnostics for gossip-path block propagation.
+    block_propagation_trace: BlockPropagationTrace,
+
     // Internal downloads state
     //
     /// Active block download and verify tasks.
@@ -392,12 +399,22 @@ where
             verifier,
             state,
             latest_chain_tip,
+            block_propagation_trace: BlockPropagationTrace::noop(),
             pending: FuturesUnordered::new(),
             cancel_handles: HashMap::new(),
             source_locks: HashMap::new(),
             source_counts: HashMap::new(),
             poisoned_retries: PoisonedRetryBudgets::default(),
         }
+    }
+
+    /// Attach an opt-in block propagation trace to this download stream.
+    pub(crate) fn with_block_propagation_trace(
+        mut self,
+        block_propagation_trace: BlockPropagationTrace,
+    ) -> Self {
+        self.block_propagation_trace = block_propagation_trace;
+        self
     }
 
     /// Re-request a gossiped block whose body was rejected as poisoned, from any peer.
@@ -454,7 +471,7 @@ where
 
         // Report what actually happened, not what was attempted: the replacement can be refused
         // by the queue bounds, which spends the budget without dispatching anything.
-        let action = self.download_and_verify(hash, None);
+        let action = self.download_and_verify_inner(hash, None, false);
 
         match action {
             DownloadAction::AddedToQueue => {
@@ -497,6 +514,15 @@ where
         hash: block::Hash,
         download_source: Option<zn::PeerSource>,
     ) -> DownloadAction {
+        self.download_and_verify_inner(hash, download_source, true)
+    }
+
+    fn download_and_verify_inner(
+        &mut self,
+        hash: block::Hash,
+        download_source: Option<zn::PeerSource>,
+        trace_announcement: bool,
+    ) -> DownloadAction {
         let source_label = download_source
             .as_ref()
             .map(|source| peer_source_log_label(source, self.expose_peer_addresses))
@@ -513,6 +539,14 @@ where
 
             metrics::gauge!("gossip.queued.block.count").set(self.queue_len() as f64);
             metrics::counter!("gossip.already.queued.dropped.block.hash.count").increment(1);
+            if trace_announcement {
+                self.block_propagation_trace.block_announced(
+                    hash,
+                    download_source.as_ref(),
+                    "legacy",
+                    "already_queued",
+                );
+            }
 
             return DownloadAction::AlreadyQueued;
         }
@@ -527,6 +561,14 @@ where
 
             metrics::gauge!("gossip.queued.block.count").set(self.queue_len() as f64);
             metrics::counter!("gossip.full.queue.dropped.block.hash.count").increment(1);
+            if trace_announcement {
+                self.block_propagation_trace.block_announced(
+                    hash,
+                    download_source.as_ref(),
+                    "legacy",
+                    "queue_full",
+                );
+            }
 
             return DownloadAction::FullQueue;
         }
@@ -547,6 +589,14 @@ where
 
                 metrics::gauge!("gossip.queued.block.count").set(self.queue_len() as f64);
                 metrics::counter!("gossip.source.queue.dropped.block.hash.count").increment(1);
+                if trace_announcement {
+                    self.block_propagation_trace.block_announced(
+                        hash,
+                        download_source.as_ref(),
+                        "legacy",
+                        "source_queue_full",
+                    );
+                }
 
                 return DownloadAction::FullQueue;
             }
@@ -558,6 +608,14 @@ where
             download_source,
         };
 
+        if trace_announcement {
+            self.block_propagation_trace.block_announced(
+                hash,
+                download.download_source.as_ref(),
+                "legacy",
+                "queued",
+            );
+        }
         self.spawn_download_task(download);
 
         debug!(
@@ -598,6 +656,8 @@ where
         let state = self.state.clone();
         let latest_chain_tip = self.latest_chain_tip.clone();
         let full_verify_concurrency_limit = self.full_verify_concurrency_limit;
+        let block_propagation_trace = self.block_propagation_trace.clone();
+        let download_started = Instant::now();
 
         let fut = async move {
             // Check if the full block body is already in the state. `KnownBlock`
@@ -721,6 +781,12 @@ where
                     BoxError::from("gossiped block with no height")
                 })
                 .map_err(|e| (e, None))?;
+            block_propagation_trace.legacy_block_downloaded(
+                hash,
+                block_height,
+                advertiser_addr,
+                download_started.elapsed(),
+            );
 
             // Security: authenticate the claimed coinbase height against our own tip before the
             // height policies below run. See `crate::components::auth_download_height`.
@@ -791,14 +857,36 @@ where
                 .map(|hash| (hash, block_height))
                 .map_err(|e| (e, advertiser_addr))
         }
-        .map_ok(|(hash, height)| {
-            info!(?height, "downloaded and verified gossiped block");
-            metrics::counter!("gossip.verified.block.count").increment(1);
-            hash
+        .map_ok({
+            let block_propagation_trace = self.block_propagation_trace.clone();
+            move |(hash, height)| {
+                block_propagation_trace.legacy_block_finished(
+                    hash,
+                    Some(height),
+                    "committed",
+                    None,
+                    download_started.elapsed(),
+                );
+                info!(?height, "downloaded and verified gossiped block");
+                metrics::counter!("gossip.verified.block.count").increment(1);
+                hash
+            }
         })
         // Tack the hash onto the error so poll_next can look up the cancel
         // handle and advertising IP on failure as well as success.
-        .map_err(move |(e, advertiser_addr)| (e, hash, advertiser_addr))
+        .map_err({
+            let block_propagation_trace = self.block_propagation_trace.clone();
+            move |(e, advertiser_addr)| {
+                block_propagation_trace.legacy_block_finished(
+                    hash,
+                    None,
+                    "error",
+                    Some(&e.to_string()),
+                    download_started.elapsed(),
+                );
+                (e, hash, advertiser_addr)
+            }
+        })
         .in_current_span();
 
         let task = tokio::spawn(async move {

--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -55,6 +55,7 @@ use downloads::{AlwaysHedge, Downloads, NotFoundKind};
 use legacy_trace::{peer_addr_label, LegacySyncTrace};
 
 pub use downloads::VERIFICATION_PIPELINE_SCALING_MULTIPLIER;
+pub(crate) use gossip::gossip_best_tip_block_hashes_with_trace;
 pub use gossip::{gossip_best_tip_block_hashes, BlockGossipError};
 pub use progress::show_block_chain_progress;
 pub use recent_sync_lengths::RecentSyncLengths;

--- a/crates/zakurad/src/components/sync/gossip.rs
+++ b/crates/zakurad/src/components/sync/gossip.rs
@@ -14,14 +14,11 @@ use tower::{timeout::Timeout, Service, ServiceExt};
 use tracing::Instrument;
 
 use zakura_chain::block;
-use zakura_network as zn;
+use zakura_network::{self as zn, zakura::BlockPropagationTrace};
 use zakura_state::ChainTipChange;
 
 use crate::{
-    components::{
-        block_propagation_trace::BlockPropagationTrace,
-        sync::{SyncStatus, PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT},
-    },
+    components::sync::{SyncStatus, PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT},
     BoxError,
 };
 

--- a/crates/zakurad/src/components/sync/gossip.rs
+++ b/crates/zakurad/src/components/sync/gossip.rs
@@ -2,7 +2,10 @@
 //!
 //! [`block::Hash`]: zakura_chain::block::Hash
 
-use std::{future::Future, time::Duration};
+use std::{
+    future::Future,
+    time::{Duration, Instant},
+};
 
 use futures::TryFutureExt;
 use thiserror::Error;
@@ -15,7 +18,10 @@ use zakura_network as zn;
 use zakura_state::ChainTipChange;
 
 use crate::{
-    components::sync::{SyncStatus, PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT},
+    components::{
+        block_propagation_trace::BlockPropagationTrace,
+        sync::{SyncStatus, PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT},
+    },
     BoxError,
 };
 
@@ -100,9 +106,31 @@ pub enum BlockGossipError {
 /// [`block::Hash`]: zakura_chain::block::Hash
 pub async fn gossip_best_tip_block_hashes<ZN>(
     sync_status: SyncStatus,
+    chain_state: ChainTipChange,
+    broadcast_network: ZN,
+    mined_block_receiver: Option<mpsc::Receiver<(block::Hash, block::Height)>>,
+) -> Result<(), BlockGossipError>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
+    ZN::Future: Send,
+{
+    gossip_best_tip_block_hashes_with_trace(
+        sync_status,
+        chain_state,
+        broadcast_network,
+        mined_block_receiver,
+        BlockPropagationTrace::noop(),
+    )
+    .await
+}
+
+/// Run block gossip with hash-correlated propagation diagnostics.
+pub(crate) async fn gossip_best_tip_block_hashes_with_trace<ZN>(
+    sync_status: SyncStatus,
     mut chain_state: ChainTipChange,
     broadcast_network: ZN,
     mut mined_block_receiver: Option<mpsc::Receiver<(block::Hash, block::Height)>>,
+    block_propagation_trace: BlockPropagationTrace,
 ) -> Result<(), BlockGossipError>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
@@ -211,11 +239,12 @@ where
         };
 
         info!(?height, ?request, log_msg);
-        let broadcast_fut = broadcast_network
-            .ready()
-            .await
-            .map_err(PeerSetReadiness)?
-            .call(request);
+        let ready_network = broadcast_network.ready().await.map_err(PeerSetReadiness)?;
+        let broadcast_started = Instant::now();
+        if is_block_submission {
+            block_propagation_trace.mined_block_broadcast_started(hash, height);
+        }
+        let broadcast_fut = ready_network.call(request);
 
         // Await the broadcast future in a spawned task to avoid waiting on
         // `AdvertiseBlockToAll` requests when there are unready peers.
@@ -223,8 +252,16 @@ where
         if is_block_submission {
             let mark_tx = mined_block_mark_sender.clone();
             let submission_hash = hash;
+            let block_propagation_trace = block_propagation_trace.clone();
             tokio::spawn(async move {
-                if broadcast_fut.await.is_ok() {
+                let result = broadcast_fut.await;
+                block_propagation_trace.mined_block_broadcast_finished(
+                    submission_hash,
+                    height,
+                    if result.is_ok() { "ok" } else { "error" },
+                    broadcast_started.elapsed(),
+                );
+                if result.is_ok() {
                     let _ = mark_tx.send(submission_hash).await;
                 }
             });

--- a/crates/zakurad/src/config.rs
+++ b/crates/zakurad/src/config.rs
@@ -197,6 +197,12 @@ fn filtered_env_vars(env_prefix: &str) -> Result<HashMap<String, String>, config
 
     for (key, value) in std::env::vars() {
         if let Some(without_prefix) = key.strip_prefix(&required_prefix) {
+            // This process metadata is consumed by `zakura-jsonl-trace`, not by
+            // the serde configuration tree.
+            if is_process_metadata_env_key(without_prefix) {
+                continue;
+            }
+
             // Check for sensitive keys on the stripped key.
             let parts: Vec<&str> = without_prefix.split("__").collect();
             if let Some(leaf) = parts.last() {
@@ -217,6 +223,10 @@ fn filtered_env_vars(env_prefix: &str) -> Result<HashMap<String, String>, config
     Ok(filtered_env)
 }
 
+fn is_process_metadata_env_key(key: &str) -> bool {
+    key.eq_ignore_ascii_case("NODE_ID")
+}
+
 impl With<MinerAddressType> for ZakuradConfig {
     fn with(mut self, miner_address_type: MinerAddressType) -> Self {
         self.mining.miner_address = Some(
@@ -226,5 +236,17 @@ impl With<MinerAddressType> for ZakuradConfig {
         );
 
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_process_metadata_env_key;
+
+    #[test]
+    fn trace_node_id_is_not_deserialized_as_application_config() {
+        assert!(is_process_metadata_env_key("NODE_ID"));
+        assert!(is_process_metadata_env_key("node_id"));
+        assert!(!is_process_metadata_env_key("NETWORK__NETWORK"));
     }
 }

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -103,12 +103,14 @@ The workflow is manual (`workflow_dispatch`). Inputs:
   `/mnt/data/traces/header-chain-canary`; defaults to `false`.
 - `block_propagation_trace` — write hash-correlated block propagation traces
   under `/mnt/data/traces/block-propagation` on every selected node; defaults
-  to `false`. See [`docs/block-propagation-tracing.md`](../../docs/block-propagation-tracing.md).
+  to `false`. This enables only `block_propagation.jsonl`; see
+  [`docs/block-propagation-tracing.md`](../../docs/block-propagation-tracing.md).
 - `node` — optional deployer node name; blank deploys the whole fleet.
 
 Explicit `p2p_stack` overrides and `header_sync_trace = true` require an
 explicit `node`, preventing canary settings from being applied fleet-wide.
 `block_propagation_trace` may be enabled for the whole selected fleet.
+The two trace inputs are mutually exclusive.
 
 The generated CI config uses Testnet ports, public RPC at `0.0.0.0:18232`, and
 explicitly sets `vct_fast_sync = false`, which keeps checkpoint sync available
@@ -219,8 +221,9 @@ cd deploy/deployer
 ./mainnet/bootstrap-zakura-mainnet-runner.sh
 ```
 
-The workflow is manual (`workflow_dispatch`) with the same inputs as testnet
-(`ref` defaults to `main`, plus `force_rebuild`, `no_restart`, `node`).
+The workflow is manual (`workflow_dispatch`). In addition to `ref`,
+`force_rebuild`, `no_restart`, and `node`, `block_propagation_trace` enables
+the narrow trace across every selected node.
 
 **Binary-only deploy (`manage_config = false`).** The mainnet nodes were
 provisioned by hand with rich, per-node configs — `external_addr`, custom peers,
@@ -237,6 +240,13 @@ dashboard's SSH probe, not deployed to nodes. On-node configs should use
 `network.p2p_stack` (not the deprecated `v2_p2p` /
 `legacy_p2p` bools). Reproducing these configs in the deployer's managed model
 is separate future work.
+
+When `block_propagation_trace` is enabled, the deployer manages only
+`50-zakura-block-propagation-trace.conf` under the service's systemd drop-in
+directory. It sets the dedicated trace environment variable and stable node
+label without rewriting the base unit or TOML. A deployment with the input
+disabled removes that owned drop-in. Failed restarts restore both the previous
+binary and previous drop-in.
 
 The workflow refreshes a fleet status dashboard on `us-east-0`:
 

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -101,10 +101,14 @@ The workflow is manual (`workflow_dispatch`). Inputs:
   `legacy`. The default `auto` preserves the fleet's dual-stack role.
 - `header_sync_trace` — write structured canary traces under
   `/mnt/data/traces/header-chain-canary`; defaults to `false`.
+- `block_propagation_trace` — write hash-correlated block propagation traces
+  under `/mnt/data/traces/block-propagation` on every selected node; defaults
+  to `false`. See [`docs/block-propagation-tracing.md`](../../docs/block-propagation-tracing.md).
 - `node` — optional deployer node name; blank deploys the whole fleet.
 
 Explicit `p2p_stack` overrides and `header_sync_trace = true` require an
 explicit `node`, preventing canary settings from being applied fleet-wide.
+`block_propagation_trace` may be enabled for the whole selected fleet.
 
 The generated CI config uses Testnet ports, public RPC at `0.0.0.0:18232`, and
 explicitly sets `vct_fast_sync = false`, which keeps checkpoint sync available

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -72,8 +72,11 @@ DEFAULTS = {
     "checkpoint_sync": True,
     # Setting this false keeps checkpoint sync on while selecting the legacy non-VCT path.
     "vct_fast_sync": True,
+    # Binary-only systemd deploys manage this through an owned drop-in.
+    # Empty removes the owned override without touching the hand-managed unit.
+    "block_propagation_trace_dir": "",
     # Optional fleet-wide [defaults.zakura] table -> rendered [network.zakura].
-    # Keys: dev_network, listen_addr, bootstrap_peers. Absent -> no section.
+    # Common keys: dev_network, listen_addr, bootstrap_peers, and trace dirs.
     "zakura": None,
     # Process deploys are for manually supervised nodes, like the testnet
     # zcashd-compat Zakura sidecar, where systemd would fight the local runbook.
@@ -115,6 +118,7 @@ class Node:
     tracing_filter: str
     checkpoint_sync: bool
     vct_fast_sync: bool
+    block_propagation_trace_dir: str
     zakura: object  # dict | None: fleet-wide [network.zakura] settings
     working_dir: str
     start_command: str
@@ -216,6 +220,32 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
         seen.add(name)
         merged = dict(defaults)
         merged.update(raw)
+        block_propagation_trace_dir = merged["block_propagation_trace_dir"]
+        if not isinstance(block_propagation_trace_dir, str):
+            raise DeployError(
+                f"[[nodes]] {name}: block_propagation_trace_dir must be a string"
+            )
+        if block_propagation_trace_dir:
+            trace_path = Path(block_propagation_trace_dir)
+            if (
+                not trace_path.is_absolute()
+                or trace_path != DATA_MOUNT
+                and DATA_MOUNT not in trace_path.parents
+            ):
+                raise DeployError(
+                    f"[[nodes]] {name}: block_propagation_trace_dir must be under "
+                    f"{DATA_MOUNT}"
+                )
+            if any(char in block_propagation_trace_dir for char in '"\\\n\r'):
+                raise DeployError(
+                    f"[[nodes]] {name}: block_propagation_trace_dir contains "
+                    "unsupported characters"
+                )
+            if merged["manage_config"] or merged["deploy_kind"] != "systemd":
+                raise DeployError(
+                    f"[[nodes]] {name}: block_propagation_trace_dir requires "
+                    "manage_config=false and deploy_kind=systemd"
+                )
         nodes.append(Node(
             name=name,
             ssh_string=merged["ssh_string"],
@@ -242,6 +272,7 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             tracing_filter=merged["tracing_filter"],
             checkpoint_sync=merged["checkpoint_sync"],
             vct_fast_sync=merged["vct_fast_sync"],
+            block_propagation_trace_dir=block_propagation_trace_dir,
             zakura=merged.get("zakura"),
             working_dir=merged["working_dir"],
             start_command=merged["start_command"],
@@ -701,25 +732,52 @@ fi
 
 
 # Binary-only deploy (manage_config = false): swap the binary in place and
-# restart the existing service, leaving the node's config, unit, and state cache
-# untouched. Used for fleets provisioned outside the deployer.
+# restart the existing service, leaving the node's config, base unit, and state
+# cache untouched. It may manage one owned propagation-trace drop-in.
 BINARY_ONLY_INSTALL_SCRIPT = r"""
 set -euo pipefail
 
 BIN_PATH={bin_path}
 SERVICE={service}
 NO_RESTART={no_restart}
+TRACE_DIR={block_propagation_trace_dir}
+NODE_ID={node_id}
+DROP_IN_DIR="/etc/systemd/system/${{SERVICE}}.service.d"
+DROP_IN="${{DROP_IN_DIR}}/50-zakura-block-propagation-trace.conf"
+DROP_IN_BACKUP="/tmp/zakurad-block-propagation-trace.conf.bak"
+HAD_DROP_IN=0
 
 mkdir -p "$(dirname "$BIN_PATH")"
 
 if [ -x "$BIN_PATH" ]; then
     cp -a "$BIN_PATH" "${{BIN_PATH}}.bak"
 fi
+if [ -f "$DROP_IN" ]; then
+    cp -a "$DROP_IN" "$DROP_IN_BACKUP"
+    HAD_DROP_IN=1
+else
+    rm -f "$DROP_IN_BACKUP"
+fi
 install -m 755 /tmp/zakurad-deploy.new "$BIN_PATH"
 rm -f /tmp/zakurad-deploy.new
 
+if [ -n "$TRACE_DIR" ]; then
+    install -d -m 755 "$TRACE_DIR" "$DROP_IN_DIR"
+    {{
+        printf '%s\n' '[Service]'
+        printf 'Environment="ZAKURA_NETWORK__ZAKURA__BLOCK_PROPAGATION_TRACE_DIR=%s"\n' "$TRACE_DIR"
+        printf 'Environment="ZAKURA_NODE_ID=%s"\n' "$NODE_ID"
+    }} > "${{DROP_IN}}.new"
+    install -m 644 "${{DROP_IN}}.new" "$DROP_IN"
+    rm -f "${{DROP_IN}}.new"
+else
+    rm -f "$DROP_IN"
+fi
+systemctl daemon-reload
+
 if [ "$NO_RESTART" = "1" ]; then
-    echo "installed binary (restart skipped)"
+    rm -f "$DROP_IN_BACKUP"
+    echo "installed binary and propagation trace override (restart skipped)"
     exit 0
 fi
 
@@ -736,14 +794,22 @@ restart_service() {{
 }}
 
 if ! restart_service; then
-    echo "service unhealthy after deploy; rolling back to ${{BIN_PATH}}.bak" >&2
+    echo "service unhealthy after deploy; rolling back binary and trace override" >&2
     if [ -x "${{BIN_PATH}}.bak" ]; then
         install -m 755 "${{BIN_PATH}}.bak" "$BIN_PATH"
-        restart_service || true
     fi
+    if [ "$HAD_DROP_IN" = "1" ]; then
+        install -m 644 "$DROP_IN_BACKUP" "$DROP_IN"
+    else
+        rm -f "$DROP_IN"
+    fi
+    rm -f "$DROP_IN_BACKUP"
+    systemctl daemon-reload
+    restart_service || true
     exit 1
 fi
 
+rm -f "$DROP_IN_BACKUP"
 systemctl is-active "$SERVICE"
 "$BIN_PATH" --version || true
 """
@@ -857,6 +923,10 @@ def cmd_deploy(args) -> int:
                         bin_path=shlex.quote(node.bin_path),
                         service=shlex.quote(node.service_name),
                         no_restart="1" if args.no_restart else "0",
+                        block_propagation_trace_dir=shlex.quote(
+                            node.block_propagation_trace_dir
+                        ),
+                        node_id=shlex.quote(node.name),
                     )
                 proc = ssh_with_stdin(node, script)
                 if proc.returncode != 0:

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -506,6 +506,7 @@ def render_service(node: Node) -> str:
             f"AssertPathIsMountPoint={DATA_MOUNT}\n"
         )
     return render_template("zakurad.service", {
+        "NODE_NAME": node.name,
         "SERVICE_NAME": node.service_name,
         "BIN_PATH": node.bin_path,
         "CONFIG_PATH": node.config_path,

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -11,6 +11,8 @@ log_file        = "/var/log/zakura/zakura.log"   # deterministic log path
 state_cache_dir = "/var/lib/zakura"
 # manage_config = true                       # false = only swap the binary + restart the existing
 #                                            # service, leaving config/unit/cache untouched (systemd only)
+# block_propagation_trace_dir = "/mnt/data/traces/block-propagation"
+#                                            # binary-only systemd drop-in; empty removes it
 network         = "Mainnet"
 listen_addr     = "[::]:8233"
 # identity_dir  = "/root/.zakura"           # empty = zakurad default; pins the iroh node_id

--- a/deploy/deployer/templates/zakurad.service
+++ b/deploy/deployer/templates/zakurad.service
@@ -9,6 +9,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=ZAKURA_NODE_ID={{NODE_NAME}}
 ExecStart={{BIN_PATH}} -c {{CONFIG_PATH}} start
 Restart=always
 RestartSec=5

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -172,6 +172,11 @@ class MountRenderingTests(NodeBuilder, unittest.TestCase):
         self.assertNotIn("RequiresMountsFor=/mnt/data", service)
         self.assertNotIn("AssertPathIsMountPoint=/mnt/data", service)
 
+    def test_render_service_sets_stable_trace_node_id(self):
+        service = deploy.render_service(self.node(name="testnet-observer-eu"))
+
+        self.assertIn("Environment=ZAKURA_NODE_ID=testnet-observer-eu", service)
+
 
 class ObservabilityRenderingTests(NodeBuilder, unittest.TestCase):
     """The [metrics] and [health] sections are opt-in and must round-trip as TOML."""

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -146,6 +146,7 @@ class NodeBuilder:
             "tracing_filter": "",
             "checkpoint_sync": True,
             "vct_fast_sync": True,
+            "block_propagation_trace_dir": "",
             "zakura": None,
             "working_dir": "",
             "start_command": "",
@@ -204,6 +205,18 @@ class ObservabilityRenderingTests(NodeBuilder, unittest.TestCase):
         self.assertNotIn("metrics", config)
         self.assertEqual(config["health"], {"listen_addr": "127.0.0.1:8080"})
 
+    def test_dedicated_propagation_directory_renders_in_zakura_section(self):
+        config = tomllib.loads(deploy.render_node_config(self.node(
+            zakura={
+                "block_propagation_trace_dir": "/mnt/data/traces/block-propagation",
+            },
+        )))
+
+        self.assertEqual(
+            config["network"]["zakura"]["block_propagation_trace_dir"],
+            "/mnt/data/traces/block-propagation",
+        )
+
 
 class ConfigKeyTests(unittest.TestCase):
     def write_config(self, tmp: str, body: str) -> Path:
@@ -241,6 +254,95 @@ class ConfigKeyTests(unittest.TestCase):
 
             with self.assertRaises(deploy.DeployError):
                 deploy.load_nodes(path, None)
+
+    def test_binary_only_block_propagation_trace_dir_is_loaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, """
+                [defaults]
+                manage_config = false
+                block_propagation_trace_dir = "/mnt/data/traces/block-propagation"
+
+                [[nodes]]
+                name = "node-a"
+                ssh_string = "root@example"
+                commit = "main"
+            """.replace("                ", ""))
+
+            nodes = deploy.load_nodes(path, None)
+
+            self.assertEqual(
+                nodes[0].block_propagation_trace_dir,
+                "/mnt/data/traces/block-propagation",
+            )
+
+    def test_block_propagation_trace_dir_rejects_managed_or_external_paths(self):
+        for defaults in (
+            'block_propagation_trace_dir = "/mnt/data/traces/block-propagation"',
+            'manage_config = false\nblock_propagation_trace_dir = "/tmp/traces"',
+        ):
+            with self.subTest(defaults=defaults), tempfile.TemporaryDirectory() as tmp:
+                path = self.write_config(tmp, f"""
+                    [defaults]
+                    {defaults}
+
+                    [[nodes]]
+                    name = "node-a"
+                    ssh_string = "root@example"
+                    commit = "main"
+                """.replace("                    ", ""))
+
+                with self.assertRaises(deploy.DeployError):
+                    deploy.load_nodes(path, None)
+
+
+class BinaryOnlyTraceOverrideTests(unittest.TestCase):
+    def render_script(self, trace_dir, no_restart="0"):
+        return deploy.BINARY_ONLY_INSTALL_SCRIPT.format(
+            bin_path="'/usr/local/bin/zakurad'",
+            service="'zakurad'",
+            no_restart=no_restart,
+            block_propagation_trace_dir=f"'{trace_dir}'",
+            node_id="'us-east-0'",
+        )
+
+    def test_enable_stages_narrow_environment_override(self):
+        script = self.render_script("/mnt/data/traces/block-propagation")
+
+        self.assertIn(
+            "ZAKURA_NETWORK__ZAKURA__BLOCK_PROPAGATION_TRACE_DIR=%s",
+            script,
+        )
+        self.assertIn('Environment="ZAKURA_NODE_ID=%s"', script)
+        self.assertIn('install -d -m 755 "$TRACE_DIR" "$DROP_IN_DIR"', script)
+        self.assertIn("systemctl daemon-reload", script)
+
+    def test_disable_removes_only_owned_drop_in(self):
+        script = self.render_script("")
+
+        self.assertIn('DROP_IN="${DROP_IN_DIR}/50-zakura-block-propagation-trace.conf"', script)
+        self.assertIn('rm -f "$DROP_IN"', script)
+
+    def test_failure_restores_binary_and_previous_drop_in(self):
+        script = self.render_script("/mnt/data/traces/block-propagation")
+
+        self.assertIn('install -m 755 "${BIN_PATH}.bak" "$BIN_PATH"', script)
+        self.assertIn('install -m 644 "$DROP_IN_BACKUP" "$DROP_IN"', script)
+        self.assertIn("rolling back binary and trace override", script)
+
+    def test_no_restart_stages_drop_in_before_exiting(self):
+        script = self.render_script(
+            "/mnt/data/traces/block-propagation",
+            no_restart="1",
+        )
+
+        self.assertLess(
+            script.index('install -m 644 "${DROP_IN}.new" "$DROP_IN"'),
+            script.index('if [ "$NO_RESTART" = "1" ]'),
+        )
+        self.assertIn(
+            "installed binary and propagation trace override (restart skipped)",
+            script,
+        )
 
 
 if __name__ == "__main__":

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -87,6 +87,8 @@ create_owned_directory() {
 [[ -n ${ZAKURA_ZCASHD_COMPAT__ZCASHD_DATADIR:-} ]] && create_owned_directory "${ZAKURA_ZCASHD_COMPAT__ZCASHD_DATADIR}"
 [[ -n ${ZAKURA_TRACING__LOG_FILE:-} ]] && create_owned_directory "$(dirname "${ZAKURA_TRACING__LOG_FILE}")"
 [[ -n ${ZAKURA_NETWORK__ZAKURA__TRACE_DIR:-} ]] && create_owned_directory "${ZAKURA_NETWORK__ZAKURA__TRACE_DIR}"
+[[ -n ${ZAKURA_NETWORK__ZAKURA__BLOCK_PROPAGATION_TRACE_DIR:-} ]] && \
+  create_owned_directory "${ZAKURA_NETWORK__ZAKURA__BLOCK_PROPAGATION_TRACE_DIR}"
 
 # --- Optional config file support ---
 # If provided, pass a config file path through to zakurad via CONFIG_FILE_PATH.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,6 +86,7 @@ create_owned_directory() {
 [[ -n ${ZAKURA_RPC__COOKIE_DIR} ]] && create_owned_directory "${ZAKURA_RPC__COOKIE_DIR}"
 [[ -n ${ZAKURA_ZCASHD_COMPAT__ZCASHD_DATADIR:-} ]] && create_owned_directory "${ZAKURA_ZCASHD_COMPAT__ZCASHD_DATADIR}"
 [[ -n ${ZAKURA_TRACING__LOG_FILE:-} ]] && create_owned_directory "$(dirname "${ZAKURA_TRACING__LOG_FILE}")"
+[[ -n ${ZAKURA_NETWORK__ZAKURA__TRACE_DIR:-} ]] && create_owned_directory "${ZAKURA_NETWORK__ZAKURA__TRACE_DIR}"
 
 # --- Optional config file support ---
 # If provided, pass a config file path through to zakurad via CONFIG_FILE_PATH.

--- a/docker/mining/.env.example
+++ b/docker/mining/.env.example
@@ -28,6 +28,11 @@ NETWORK=Testnet
 ASIC_DIFFICULTY=64
 CPU_DIFFICULTY=0.000125
 
+# === BLOCK PROPAGATION TRACE (optional Compose override) ===
+# Used by docker-compose.trace.yml. The trace directory is a named Docker volume.
+ZAKURA_NODE_ID=zakura-testnet-miner
+# BLOCK_PROPAGATION_TRACE_DIR=/var/lib/zakura-traces
+
 # === NHEQMINER (optional, use --profile miner) ===
 # Worker name suffix (address.WORKER_NAME)
 # WORKER_NAME=docker

--- a/docker/mining/README.md
+++ b/docker/mining/README.md
@@ -89,8 +89,9 @@ docker compose up -d --force-recreate s-nomp
 
 ## Block Propagation Tracing
 
-The optional Compose override enables hash-correlated JSONL traces on the mining
-node without exposing another host port:
+The optional Compose override enables the narrow, hash-correlated
+`block_propagation.jsonl` trace on the mining node without enabling the general
+Zakura trace tables or exposing another host port:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.trace.yml up -d

--- a/docker/mining/README.md
+++ b/docker/mining/README.md
@@ -87,6 +87,29 @@ recreate S-NOMP:
 docker compose up -d --force-recreate s-nomp
 ```
 
+## Block Propagation Tracing
+
+The optional Compose override enables hash-correlated JSONL traces on the mining
+node without exposing another host port:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.trace.yml up -d
+```
+
+The trace rows use `ZAKURA_NODE_ID` (default `zakura-testnet-miner`) and are
+stored in the `block-propagation-traces` Docker volume. Export them after a
+canary block:
+
+```bash
+mkdir -p propagation-artifacts/miner
+docker compose -f docker-compose.yml -f docker-compose.trace.yml \
+  cp zakura:/var/lib/zakura-traces/. propagation-artifacts/miner/
+```
+
+Use the base Compose file by itself to run without propagation tracing. See
+[`../../docs/block-propagation-tracing.md`](../../docs/block-propagation-tracing.md)
+for the fleet rollout, collection, and report workflow.
+
 ## Checking Sync Status
 
 Zebra must fully sync before mining can begin.

--- a/docker/mining/docker-compose.trace.yml
+++ b/docker/mining/docker-compose.trace.yml
@@ -1,0 +1,10 @@
+services:
+  zakura:
+    environment:
+      - ZAKURA_NODE_ID=${ZAKURA_NODE_ID:-zakura-testnet-miner}
+      - ZAKURA_NETWORK__ZAKURA__TRACE_DIR=${BLOCK_PROPAGATION_TRACE_DIR:-/var/lib/zakura-traces}
+    volumes:
+      - block-propagation-traces:${BLOCK_PROPAGATION_TRACE_DIR:-/var/lib/zakura-traces}
+
+volumes:
+  block-propagation-traces:

--- a/docker/mining/docker-compose.trace.yml
+++ b/docker/mining/docker-compose.trace.yml
@@ -2,7 +2,7 @@ services:
   zakura:
     environment:
       - ZAKURA_NODE_ID=${ZAKURA_NODE_ID:-zakura-testnet-miner}
-      - ZAKURA_NETWORK__ZAKURA__TRACE_DIR=${BLOCK_PROPAGATION_TRACE_DIR:-/var/lib/zakura-traces}
+      - ZAKURA_NETWORK__ZAKURA__BLOCK_PROPAGATION_TRACE_DIR=${BLOCK_PROPAGATION_TRACE_DIR:-/var/lib/zakura-traces}
     volumes:
       - block-propagation-traces:${BLOCK_PROPAGATION_TRACE_DIR:-/var/lib/zakura-traces}
 

--- a/docs/block-propagation-tracing.md
+++ b/docs/block-propagation-tracing.md
@@ -40,9 +40,17 @@ is enabled for that run. Native peer labels stay pseudonymous (`peer:<hex>`).
 
 ## Enable tracing
 
-Tracing is off until `network.zakura.trace_dir` is set. The same directory
-receives `block_propagation.jsonl` plus the existing `block_sync.jsonl` and
-`commit_state.jsonl` tables used for the native path.
+Tracing is off by default. There are two mutually exclusive settings:
+
+```toml
+[network.zakura]
+block_propagation_trace_dir = "/mnt/data/traces/block-propagation"
+```
+
+The dedicated setting writes only `block_propagation.jsonl`. The existing
+general `trace_dir` remains available for full Zakura diagnostics and also
+contains propagation data for backward compatibility. Zakura rejects startup
+if both settings are configured.
 
 ### Testnet observers
 
@@ -67,35 +75,29 @@ older `header_sync_trace` input remains restricted to one explicit node.
 
 ### Mainnet observers
 
-The Mainnet deploy is binary-only and deliberately leaves each node's
-hand-managed configuration and systemd unit unchanged. Enable tracing manually
-on each observer for a short measurement window.
+The Mainnet deploy is binary-only, so the workflow enables narrow tracing with
+an owned systemd drop-in rather than rewriting the hand-managed node config or
+base unit:
 
-Add a trace directory to the existing node configuration:
-
-```toml
-[network.zakura]
-trace_dir = "/mnt/data/traces/block-propagation"
+```bash
+gh workflow run zakura-mainnet-deploy.yml \
+  --ref REF \
+  -f ref=REF \
+  -f block_propagation_trace=true
 ```
 
-Set a stable node label in the `zakurad` systemd service or a service drop-in,
-then restart the service:
+Leave `node` blank to select the whole fleet, or pass `-f node=NAME` for one
+observer. The drop-in sets the dedicated trace directory and a stable
+`ZAKURA_NODE_ID`, and writes traces under:
 
-```ini
-[Service]
-Environment=ZAKURA_NODE_ID=us-east-0
+```text
+/mnt/data/traces/block-propagation
 ```
 
-The label must match the `NAME` supplied in `--trace-dir NAME=PATH`. If
-`ZAKURA_NODE_ID` is unset, use the resolved hostname as `NAME`; the report
-rejects rows whose embedded node label belongs to a different observer.
-
-Repeat this on the desired managed observers: `asia-0`, `us-0`, `us-east-0`,
-`us-west-0`, `canada-0`, `europe-west-0`, `europe-central-0`, `asia-south-0`,
-and `asia-pacific-0`. Their current host addresses are listed in the
+The managed observers are `asia-0`, `us-0`, `us-east-0`, `us-west-0`,
+`canada-0`, `europe-west-0`, `europe-central-0`, `asia-south-0`, and
+`asia-pacific-0`. Their current host addresses are listed in the
 [deployer documentation](../deploy/deployer/README.md#github-actions-mainnet-fleet-deploy).
-Keep the window short because native `block_sync.jsonl` can grow quickly at
-Mainnet head.
 
 Confirm the observers are synchronized and their clocks are synchronized
 before the measurement. After a new block is committed, obtain its hash from
@@ -257,9 +259,9 @@ docker compose -f docker-compose.yml -f docker-compose.trace.yml down
 docker compose up -d
 ```
 
-On Mainnet, remove `trace_dir` from each hand-managed configuration and restart
-the service. Remove the temporary `ZAKURA_NODE_ID` drop-in too if it was added
-only for this measurement.
+On Mainnet, rerun the deploy workflow with
+`block_propagation_trace=false`. This removes only the workflow-owned drop-in
+and leaves the hand-managed configuration and base unit untouched.
 
 Keep the exported run directory with the report, exact ref, node
 configuration, and clock preflight results. Remove remote or Docker-volume

--- a/docs/block-propagation-tracing.md
+++ b/docs/block-propagation-tracing.md
@@ -1,0 +1,266 @@
+# Block Propagation Tracing
+
+Opt-in JSONL tracing that measures how a block moves through first
+announcement, full-body receipt, and durable commit across a group of nodes. It
+covers both legacy TCP gossip and native Zakura sync.
+
+The block hash is the correlation key. The report supports two origins:
+
+- `broadcast` starts `t0` at `mined_block_broadcast_started` on a controlled
+  mining node, after `submitblock` has validated and committed the block. It
+  does not measure the interval from the physical miner finding a solution to
+  S-NOMP submitting it.
+- `first-discovery` starts `t0` at the earliest announcement, body receipt, or
+  commit across the supplied observer traces. Use this on Mainnet when the
+  mining node is not observable.
+
+Enable it only for a bounded measurement window. Trace files append across
+restarts, and wall-clock timestamps are only comparable when node clocks are
+synchronized.
+
+## What it records
+
+Every JSONL row includes a Unix wall-clock timestamp (`wall_ts_unix_us`) and a
+stable node identity (`ZAKURA_NODE_ID`, then `ZEBRA_NODE_ID`, then hostname).
+Do not treat cross-node differences below the known clock uncertainty as
+network latency. The report defaults to ±100 ms.
+
+| Phase | Legacy TCP | Native Zakura |
+| --- | --- | --- |
+| Broadcast origin | `mined_block_broadcast_started` / `_finished` | same local events |
+| Announcement | `block_announced` | `header_status_received` |
+| Body received | `legacy_block_downloaded` | `block_body_received` |
+| Commit | `legacy_block_finished` | `commit_finish` |
+
+An observer may receive the same block through both transports. Duplicate
+events are retained so the report can show which path arrived first.
+
+Legacy peer addresses stay redacted unless `network.expose_peer_addresses`
+is enabled for that run. Native peer labels stay pseudonymous (`peer:<hex>`).
+
+## Enable tracing
+
+Tracing is off until `network.zakura.trace_dir` is set. The same directory
+receives `block_propagation.jsonl` plus the existing `block_sync.jsonl` and
+`commit_state.jsonl` tables used for the native path.
+
+### Testnet observers
+
+Deploy with propagation tracing enabled on the selected fleet:
+
+```bash
+gh workflow run zakura-testnet-deploy.yml \
+  --ref REF \
+  -f ref=REF \
+  -f p2p_stack=auto \
+  -f block_propagation_trace=true
+```
+
+The workflow writes each node's traces to:
+
+```text
+/mnt/data/traces/block-propagation
+```
+
+`block_propagation_trace` can be enabled for the entire selected fleet. The
+older `header_sync_trace` input remains restricted to one explicit node.
+
+### Mainnet observers
+
+The Mainnet deploy is binary-only and deliberately leaves each node's
+hand-managed configuration and systemd unit unchanged. Enable tracing manually
+on each observer for a short measurement window.
+
+Add a trace directory to the existing node configuration:
+
+```toml
+[network.zakura]
+trace_dir = "/mnt/data/traces/block-propagation"
+```
+
+Set a stable node label in the `zakurad` systemd service or a service drop-in,
+then restart the service:
+
+```ini
+[Service]
+Environment=ZAKURA_NODE_ID=us-east-0
+```
+
+The label must match the `NAME` supplied in `--trace-dir NAME=PATH`. If
+`ZAKURA_NODE_ID` is unset, use the resolved hostname as `NAME`; the report
+rejects rows whose embedded node label belongs to a different observer.
+
+Repeat this on the desired managed observers: `asia-0`, `us-0`, `us-east-0`,
+`us-west-0`, `canada-0`, `europe-west-0`, `europe-central-0`, `asia-south-0`,
+and `asia-pacific-0`. Their current host addresses are listed in the
+[deployer documentation](../deploy/deployer/README.md#github-actions-mainnet-fleet-deploy).
+Keep the window short because native `block_sync.jsonl` can grow quickly at
+Mainnet head.
+
+Confirm the observers are synchronized and their clocks are synchronized
+before the measurement. After a new block is committed, obtain its hash from
+`getbestblockhash`, the Zakura logs, or a Mainnet explorer. Copy each
+observer's trace directory into a separate local directory, then run:
+
+```bash
+python3 scripts/zakura-block-propagation-report.py \
+  --origin first-discovery \
+  --hash BLOCK_HASH \
+  --trace-dir us-east-0="$run_dir/us-east-0" \
+  --trace-dir europe-west-0="$run_dir/europe-west-0" \
+  --trace-dir asia-pacific-0="$run_dir/asia-pacific-0" \
+  --clock-uncertainty-ms 100 \
+  --json-out "$run_dir/report.json" \
+  --markdown-out "$run_dir/report.md"
+```
+
+Here, `t0` is the first time any supplied observer recorded an announcement,
+body, or commit. The offsets measure spread within the observed fleet, not time
+from the miner. They are a lower bound on true network propagation delay
+because the miner and unobserved peers are outside the measurement.
+
+### Testnet mining node
+
+On the mining host, use the opt-in Compose override:
+
+```bash
+cd docker/mining
+docker compose -f docker-compose.yml -f docker-compose.trace.yml up -d
+```
+
+The mining node remains legacy TCP-only. Its trace directory is stored in the
+`block-propagation-traces` Docker volume and its default trace label is
+`zakura-testnet-miner`.
+
+Verify the trace file appears after startup:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.trace.yml \
+  exec zakura sh -c 'ls -l /var/lib/zakura-traces'
+```
+
+## Capture a block
+
+Before mining:
+
+1. Confirm the mining node and observers are synchronized at the same tip.
+2. Confirm each Linux host reports synchronized time:
+
+   ```bash
+   timedatectl show -p NTPSynchronized --value
+   ```
+
+3. Record the exact Zakura ref deployed to the mining node and observers.
+4. Confirm sufficient free space under `/mnt/data` on observers and in Docker's
+   storage directory on the mining host.
+
+Then mine one block:
+
+1. Start the smallest practical Mining Rig Rentals worker.
+2. Confirm accepted shares and low reject/stale rates.
+3. Stop or redirect the rental after one accepted block.
+4. Record the accepted block hash from S-NOMP, the Zakura log, or a Testnet
+   explorer.
+5. Wait until all observers report the block at their committed tip.
+
+To force a live native-path measurement when natural propagation only
+exercises legacy TCP, redeploy one explicit observer with `p2p_stack=zakura`
+and `block_propagation_trace=true`, capture one block, then restore that node
+with `p2p_stack=auto`.
+
+## Collect traces
+
+Create one local directory per node:
+
+```bash
+run_dir="propagation-artifacts/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p \
+  "$run_dir/zakura-testnet-miner" \
+  "$run_dir/zakura-testnet-1" \
+  "$run_dir/zakura-testnet-eu" \
+  "$run_dir/zakura-testnet-as"
+```
+
+Export the mining trace:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.trace.yml \
+  cp zakura:/var/lib/zakura-traces/. \
+  "$run_dir/zakura-testnet-miner/"
+```
+
+Copy observer traces from their managed hosts:
+
+```bash
+scp -r root@167.99.103.111:/mnt/data/traces/block-propagation/. \
+  "$run_dir/zakura-testnet-1/"
+scp -r root@164.92.209.78:/mnt/data/traces/block-propagation/. \
+  "$run_dir/zakura-testnet-eu/"
+scp -r root@206.189.148.0:/mnt/data/traces/block-propagation/. \
+  "$run_dir/zakura-testnet-as/"
+```
+
+The report partitions warnings by `process_trace_id` and filters events by
+block hash, so prior runs can remain in the directory.
+
+## Generate the report
+
+Run the stdlib-only report tool from the repository root:
+
+```bash
+python3 scripts/zakura-block-propagation-report.py \
+  --hash BLOCK_HASH \
+  --trace-dir zakura-testnet-miner="$run_dir/zakura-testnet-miner" \
+  --trace-dir zakura-testnet-1="$run_dir/zakura-testnet-1" \
+  --trace-dir zakura-testnet-eu="$run_dir/zakura-testnet-eu" \
+  --trace-dir zakura-testnet-as="$run_dir/zakura-testnet-as" \
+  --native-node zakura-testnet-1=57ad39fad4f0bca46cf1ea831772a99d5027b372fef2be5a0ea68e1b5bb4da49 \
+  --native-node zakura-testnet-eu=2bbb907b5d90598ef49f2e637066586b311a64587479be6ed43e8388587fcd2a \
+  --native-node zakura-testnet-as=50999835f48f4a048c0e9042e5332844c9673943d7fab1f7e993bae698c27ea3 \
+  --clock-uncertainty-ms 100 \
+  --json-out "$run_dir/report.json" \
+  --markdown-out "$run_dir/report.md"
+```
+
+`--legacy-node NAME=IP` resolves legacy edges only for a run that already has
+`network.expose_peer_addresses = true`. Do not enable address exposure for
+ordinary retained traces. Native peer labels can be resolved with the public
+node IDs shown above.
+
+The report contains:
+
+- a globally ordered event timeline in JSON
+- first announcement, body receipt, and commit offset per node
+- per-node discovery-to-body and discovery-to-commit duration
+- first-to-last observer spread for each phase
+- inferred managed-node edges when peer labels can be resolved
+- duplicate transport paths, missing phases, process restarts, and clock
+  warnings
+
+Before using a controlled-miner report for optimization, confirm:
+
+- the mining trace contains `mined_block_broadcast_started` for the hash
+- every observer has at least a body-receive and commit event for that hash
+- native `block_body_received` and legacy `legacy_block_downloaded` rows
+  include the same hash
+- no observer reports an unexpected rejection, reorg, or sustained tip
+  divergence
+- missing or negative offsets are explained by a known path or clock issue
+
+## Disable tracing
+
+On Testnet, redeploy observers with `block_propagation_trace=false`. On the
+mining host, restart with only the base Compose file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.trace.yml down
+docker compose up -d
+```
+
+On Mainnet, remove `trace_dir` from each hand-managed configuration and restart
+the service. Remove the temporary `ZAKURA_NODE_ID` drop-in too if it was added
+only for this measurement.
+
+Keep the exported run directory with the report, exact ref, node
+configuration, and clock preflight results. Remove remote or Docker-volume
+traces only after confirming the export is complete.

--- a/docs/changelog/unreleased/690.md
+++ b/docs/changelog/unreleased/690.md
@@ -1,0 +1,11 @@
+## Added
+
+- Added opt-in, hash-correlated block propagation traces and reporting for
+  controlled Testnet mining runs
+  ([#690](https://github.com/zakura-core/zakura/pull/690)).
+
+## Fixed
+
+- Fixed Docker trace-directory ownership so containerized nodes persist
+  propagation events after dropping privileges
+  ([#690](https://github.com/zakura-core/zakura/pull/690)).

--- a/docs/changelog/unreleased/690.md
+++ b/docs/changelog/unreleased/690.md
@@ -1,7 +1,8 @@
 ## Added
 
 - Added opt-in, hash-correlated block propagation traces and reporting for
-  controlled Testnet mining runs
+  controlled Testnet mining runs and observer-only Mainnet measurements. The
+  dedicated trace setting writes only propagation events
   ([#690](https://github.com/zakura-core/zakura/pull/690)).
 
 ## Fixed

--- a/scripts/tests/test_zakura_block_propagation_report.py
+++ b/scripts/tests/test_zakura_block_propagation_report.py
@@ -286,6 +286,41 @@ class PropagationReportTests(unittest.TestCase):
             )
             self.assertEqual(report["nodes"]["body-node"]["discovery_to_body_us"], 0)
 
+    def test_dedicated_native_rows_replace_broad_trace_duplicates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            node = Path(temp) / "observer"
+            canonical = {
+                "wall_ts_unix_us": 3_000_000,
+                "event": "block_body_received",
+                "hash": BLOCK_HASH,
+                "height": 42,
+                "peer": "peer:source",
+            }
+            write_rows(node, "block_propagation.jsonl", [canonical])
+            write_rows(
+                node,
+                "block_sync.jsonl",
+                [{**canonical, "wall_ts_unix_us": 3_000_001}],
+            )
+
+            report = reporter.build_report(
+                {"observer": node},
+                BLOCK_HASH,
+                origin="first-discovery",
+            )
+
+            body_events = [
+                event
+                for event in report["events"]
+                if event["raw_event"] == "block_body_received"
+            ]
+            self.assertEqual(len(body_events), 1)
+            self.assertEqual(
+                body_events[0]["trace_file"],
+                "block_propagation.jsonl",
+            )
+            self.assertEqual(report["duplicates"], [])
+
     def test_reports_missing_origin_timestamp_restarts_and_duplicate_paths(self):
         with tempfile.TemporaryDirectory() as temp:
             node = Path(temp) / "observer"

--- a/scripts/tests/test_zakura_block_propagation_report.py
+++ b/scripts/tests/test_zakura_block_propagation_report.py
@@ -1,0 +1,506 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "zakura-block-propagation-report.py"
+SPEC = importlib.util.spec_from_file_location("zakura_block_propagation_report", SCRIPT)
+assert SPEC and SPEC.loader
+reporter = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = reporter
+SPEC.loader.exec_module(reporter)
+
+
+BLOCK_HASH = "2a" * 32
+
+
+def write_rows(directory, file_name, rows):
+    path = Path(directory) / file_name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+
+class PropagationReportTests(unittest.TestCase):
+    def test_correlates_legacy_and_native_paths_from_broadcast_origin(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            miner = root / "miner"
+            node_a = root / "node-a"
+            node_b = root / "node-b"
+            native_a_id = "11" * 32
+            native_a_peer = reporter.native_peer_label(native_a_id)
+
+            write_rows(
+                miner,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_000_000,
+                        "process_trace_id": "miner-1",
+                        "event": "mined_block_broadcast_started",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                    },
+                    {
+                        "wall_ts_unix_us": 1_080_000,
+                        "process_trace_id": "miner-1",
+                        "event": "mined_block_broadcast_finished",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "result": "ok",
+                    },
+                ],
+            )
+            write_rows(
+                node_a,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_010_000,
+                        "process_trace_id": "a-1",
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "legacy",
+                        "source": "legacy:198.51.100.7:18233",
+                        "disposition": "queued",
+                    },
+                    {
+                        "wall_ts_unix_us": 1_020_000,
+                        "process_trace_id": "a-1",
+                        "event": "legacy_block_downloaded",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "source": "legacy:198.51.100.7:18233",
+                    },
+                    {
+                        "wall_ts_unix_us": 1_040_000,
+                        "process_trace_id": "a-1",
+                        "event": "legacy_block_finished",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "result": "committed",
+                    },
+                ],
+            )
+            write_rows(
+                node_b,
+                "header_sync.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_015_000,
+                        "process_trace_id": "b-1",
+                        "event": "header_status_received",
+                        "selected_tip_hash": BLOCK_HASH,
+                        "selected_tip_height": 42,
+                        "peer": native_a_peer,
+                    }
+                ],
+            )
+            write_rows(
+                node_b,
+                "block_sync.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_025_000,
+                        "process_trace_id": "b-1",
+                        "event": "block_body_received",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "peer": native_a_peer,
+                    }
+                ],
+            )
+            write_rows(
+                node_b,
+                "commit_state.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_050_000,
+                        "process_trace_id": "b-1",
+                        "event": "commit_finish",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "result": "committed",
+                    }
+                ],
+            )
+
+            report = reporter.build_report(
+                {"miner": miner, "node-a": node_a, "node-b": node_b},
+                BLOCK_HASH,
+                native_node_ids={"node-a": native_a_id},
+                legacy_node_addresses={"miner": "198.51.100.7"},
+            )
+
+            self.assertEqual(report["origin"]["node"], "miner")
+            self.assertEqual(report["origin_kind"], "broadcast")
+            self.assertEqual(report["nodes"]["node-a"]["commit"]["offset_us"], 40_000)
+            self.assertEqual(report["nodes"]["node-a"]["discovery_to_body_us"], 10_000)
+            self.assertEqual(report["nodes"]["node-a"]["discovery_to_commit_us"], 30_000)
+            self.assertEqual(report["nodes"]["node-b"]["announcement"]["offset_us"], 15_000)
+            self.assertEqual(report["announcement_spread_us"], 5_000)
+            self.assertEqual(report["commit_spread_us"], 10_000)
+            self.assertIn(
+                {
+                    "source": "node-a",
+                    "destination": "node-b",
+                    "transport": "native",
+                    "first_observed_us": 15_000,
+                },
+                report["edges"],
+            )
+            self.assertIn(
+                {
+                    "source": "miner",
+                    "destination": "node-a",
+                    "transport": "legacy",
+                    "first_observed_us": 10_000,
+                },
+                report["edges"],
+            )
+
+    def test_first_discovery_origin_uses_earliest_observer_announcement(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            miner = root / "miner"
+            node_a = root / "node-a"
+            node_b = root / "node-b"
+            write_rows(
+                miner,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_500_000,
+                        "event": "mined_block_broadcast_started",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                    }
+                ],
+            )
+            write_rows(
+                node_a,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 2_000_000,
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "legacy",
+                    },
+                    {
+                        "wall_ts_unix_us": 2_020_000,
+                        "event": "legacy_block_downloaded",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                    },
+                    {
+                        "wall_ts_unix_us": 2_035_000,
+                        "event": "legacy_block_finished",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "result": "committed",
+                    },
+                ],
+            )
+            write_rows(
+                node_b,
+                "block_sync.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 2_010_000,
+                        "event": "block_body_received",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "peer": "peer:source",
+                    }
+                ],
+            )
+
+            report = reporter.build_report(
+                {"miner": miner, "node-a": node_a, "node-b": node_b},
+                BLOCK_HASH,
+                origin="first-discovery",
+            )
+            markdown = reporter.render_markdown(report)
+
+            self.assertEqual(report["origin_kind"], "first_discovery")
+            self.assertEqual(report["origin"]["node"], "node-a")
+            self.assertEqual(report["origin"]["phase"], "announcement")
+            self.assertEqual(report["nodes"]["node-a"]["announcement"]["offset_us"], 0)
+            self.assertEqual(report["nodes"]["node-b"]["body_received"]["offset_us"], 10_000)
+            self.assertEqual(report["nodes"]["node-a"]["discovery_to_body_us"], 20_000)
+            self.assertEqual(report["nodes"]["node-a"]["discovery_to_commit_us"], 35_000)
+            self.assertNotIn("mining-node broadcast origin is missing", report["warnings"])
+            self.assertFalse(any("precedes t0" in warning for warning in report["warnings"]))
+            self.assertIn("first discovery on `node-a` via `legacy`", markdown)
+            self.assertIn("# Block propagation report", markdown)
+
+    def test_first_discovery_origin_uses_body_before_later_announcement(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            body_node = root / "body-node"
+            announcement_node = root / "announcement-node"
+            write_rows(
+                body_node,
+                "block_sync.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 3_000_000,
+                        "event": "block_body_received",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                    }
+                ],
+            )
+            write_rows(
+                announcement_node,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 3_005_000,
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "legacy",
+                    }
+                ],
+            )
+
+            report = reporter.build_report(
+                {
+                    "body-node": body_node,
+                    "announcement-node": announcement_node,
+                },
+                BLOCK_HASH,
+                origin="first-discovery",
+            )
+
+            self.assertEqual(report["origin"]["node"], "body-node")
+            self.assertEqual(report["origin"]["phase"], "body_received")
+            self.assertEqual(report["origin"]["offset_us"], 0)
+            self.assertEqual(
+                report["nodes"]["announcement-node"]["announcement"]["offset_us"],
+                5_000,
+            )
+            self.assertEqual(report["nodes"]["body-node"]["discovery_to_body_us"], 0)
+
+    def test_reports_missing_origin_timestamp_restarts_and_duplicate_paths(self):
+        with tempfile.TemporaryDirectory() as temp:
+            node = Path(temp) / "observer"
+            write_rows(
+                node,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "process_trace_id": "old",
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                    },
+                    {
+                        "wall_ts_unix_us": 2_000_000,
+                        "process_trace_id": "old",
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "legacy",
+                    },
+                    {
+                        "wall_ts_unix_us": 2_001_000,
+                        "process_trace_id": "new",
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "native_compat",
+                    },
+                ],
+            )
+
+            report = reporter.build_report({"observer": node}, BLOCK_HASH)
+
+            self.assertIsNone(report["origin"])
+            self.assertEqual(report["duplicates"][0]["count"], 2)
+            self.assertIn("mining-node broadcast origin is missing", report["warnings"])
+            self.assertTrue(
+                any("lacks wall_ts_unix_us" in warning for warning in report["warnings"])
+            )
+            self.assertTrue(
+                any("2 process instances" in warning for warning in report["warnings"])
+            )
+
+    def test_missing_origin_managed_edge_renders_without_crashing(self):
+        with tempfile.TemporaryDirectory() as temp:
+            node = Path(temp) / "observer"
+            source_id = "22" * 32
+            write_rows(
+                node,
+                "header_sync.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 2_000_000,
+                        "event": "header_status_received",
+                        "selected_tip_hash": BLOCK_HASH,
+                        "peer": reporter.native_peer_label(source_id),
+                    }
+                ],
+            )
+
+            report = reporter.build_report(
+                {"observer": node},
+                BLOCK_HASH,
+                native_node_ids={"source": source_id},
+            )
+            markdown = reporter.render_markdown(report)
+
+            self.assertIn("unknown offset", markdown)
+
+    def test_rejects_invalid_hash_and_non_object_rows(self):
+        with tempfile.TemporaryDirectory() as temp:
+            trace_dir = Path(temp)
+            (trace_dir / "block_propagation.jsonl").write_text("null\n")
+
+            with self.assertRaisesRegex(ValueError, "exactly 32 bytes"):
+                reporter.build_report({"node": trace_dir}, "0x")
+
+            rows, warnings = reporter.load_rows(trace_dir)
+            self.assertEqual(rows, [])
+            self.assertTrue(any("must be an object" in warning for warning in warnings))
+
+    def test_skips_mislabeled_rows_and_surfaces_failures(self):
+        with tempfile.TemporaryDirectory() as temp:
+            trace_dir = Path(temp)
+            write_rows(
+                trace_dir,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "node": "other-node",
+                        "wall_ts_unix_us": 1_000_000,
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                    },
+                    {
+                        "node": "observer",
+                        "wall_ts_unix_us": 1_001_000,
+                        "event": "legacy_block_finished",
+                        "hash": BLOCK_HASH,
+                        "result": "error",
+                        "reason": "verification failed",
+                    },
+                ],
+            )
+
+            report = reporter.build_report({"observer": trace_dir}, BLOCK_HASH)
+            markdown = reporter.render_markdown(report)
+
+            self.assertEqual(len(report["events"]), 1)
+            self.assertTrue(any("different node" in warning for warning in report["warnings"]))
+            self.assertTrue(any("reported error" in warning for warning in report["warnings"]))
+            self.assertIn("verification failed", markdown)
+
+    def test_exposed_legacy_labels_resolve_to_nodes(self):
+        source = "legacy:203.0.113.7:18233"
+        resolved = reporter.source_node(
+            source,
+            {},
+            {
+                "203.0.113.7": "source",
+            },
+        )
+
+        self.assertEqual(resolved, "source")
+
+    def test_classifies_broadcast_drops_and_expected_duplicates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            trace_dir = Path(temp)
+            write_rows(
+                trace_dir,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_000_000,
+                        "event": "mined_block_broadcast_finished",
+                        "hash": BLOCK_HASH,
+                        "result": "error",
+                    },
+                    {
+                        "wall_ts_unix_us": 1_001_000,
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "transport": "legacy",
+                        "disposition": "queue_full",
+                    },
+                ],
+            )
+            write_rows(
+                trace_dir,
+                "commit_state.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_002_000,
+                        "event": "commit_finish",
+                        "hash": BLOCK_HASH,
+                        "result": "duplicate",
+                    }
+                ],
+            )
+
+            report = reporter.build_report({"observer": trace_dir}, BLOCK_HASH)
+
+            self.assertEqual(report["nodes"]["observer"]["commit"]["result"], "duplicate")
+            self.assertTrue(any("broadcast" in warning for warning in report["warnings"]))
+            self.assertTrue(any("queue_full" in warning for warning in report["warnings"]))
+            self.assertFalse(any("commit_finish" in warning for warning in report["warnings"]))
+
+    def test_rejects_non_32_byte_native_node_id(self):
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaisesRegex(ValueError, "exactly 32 bytes"):
+                reporter.build_report(
+                    {"observer": Path(temp)},
+                    BLOCK_HASH,
+                    native_node_ids={"observer": "11"},
+                )
+
+    def test_main_writes_json_and_markdown_outputs(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            trace_dir = root / "observer"
+            write_rows(
+                trace_dir,
+                "block_propagation.jsonl",
+                [
+                    {
+                        "wall_ts_unix_us": 1_000_000,
+                        "event": "block_announced",
+                        "hash": BLOCK_HASH,
+                        "height": 42,
+                        "transport": "legacy",
+                    }
+                ],
+            )
+            json_out = root / "report.json"
+            markdown_out = root / "report.md"
+
+            result = reporter.main(
+                [
+                    "--hash",
+                    BLOCK_HASH,
+                    "--origin",
+                    "first-discovery",
+                    "--trace-dir",
+                    f"observer={trace_dir}",
+                    "--json-out",
+                    str(json_out),
+                    "--markdown-out",
+                    str(markdown_out),
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            output = json.loads(json_out.read_text())
+            self.assertEqual(output["block_hash"], BLOCK_HASH)
+            self.assertEqual(output["origin_kind"], "first_discovery")
+            self.assertIn("Block propagation report", markdown_out.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/zakura-block-propagation-report.py
+++ b/scripts/zakura-block-propagation-report.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+"""Correlate one block across Zakura JSONL trace directories.
+
+The report joins native and legacy observations by block hash. Its origin can be
+the mining node's `mined_block_broadcast_started` event or the earliest discovery
+across the observed nodes. All timestamps are producer wall-clock values, so
+operators must synchronize node clocks before interpreting cross-node offsets.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+TRACE_FILES = {
+    "block_propagation.jsonl",
+    "header_sync.jsonl",
+    "block_sync.jsonl",
+    "commit_state.jsonl",
+    "legacy_sync.jsonl",
+}
+
+PHASE_ORDER = {
+    "broadcast_start": 0,
+    "announcement": 1,
+    "body_received": 2,
+    "commit": 3,
+    "broadcast_finish": 4,
+    "error": 5,
+}
+
+ORIGIN_MODES = ("broadcast", "first-discovery")
+
+
+def parse_named_value(raw):
+    """Parse NAME=VALUE command-line values."""
+    name, separator, value = raw.partition("=")
+    if not separator or not name or not value:
+        raise argparse.ArgumentTypeError("expected NAME=VALUE")
+    return name, value
+
+
+def normalize_hash(value):
+    """Normalize a displayed block hash for case-insensitive matching."""
+    return str(value or "").removeprefix("0x").lower()
+
+
+def validate_block_hash(value):
+    """Return a normalized 32-byte hash or raise a user-facing error."""
+    normalized = normalize_hash(value)
+    if len(normalized) != 64:
+        raise ValueError("block hash must contain exactly 32 bytes of hexadecimal data")
+    try:
+        bytes.fromhex(normalized)
+    except ValueError as error:
+        raise ValueError("block hash must contain exactly 32 bytes of hexadecimal data") from error
+    return normalized
+
+
+def native_peer_label(node_id):
+    """Return the privacy-preserving trace label for a native Zakura node ID."""
+    try:
+        raw = bytes.fromhex(node_id)
+    except ValueError as error:
+        raise ValueError(f"invalid native node ID {node_id!r}") from error
+    if len(raw) != 32:
+        raise ValueError(f"native node ID must contain exactly 32 bytes: {node_id!r}")
+    digest = hashlib.blake2b(
+        raw, digest_size=8, person=b"zakura-peer-lbl"
+    ).hexdigest()
+    return f"peer:{digest}"
+
+
+def load_rows(trace_dir):
+    """Load relevant JSONL rows, retaining malformed-row diagnostics."""
+    rows = []
+    warnings = []
+    path = Path(trace_dir)
+    if not path.exists():
+        return rows, [f"trace directory does not exist: {path}"]
+
+    for trace_file in sorted(
+        candidate for candidate in path.rglob("*.jsonl") if candidate.name in TRACE_FILES
+    ):
+        with trace_file.open(encoding="utf-8") as source:
+            for line_number, line in enumerate(source, 1):
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as error:
+                    warnings.append(f"{trace_file}:{line_number}: invalid JSON: {error}")
+                    continue
+                if not isinstance(row, dict):
+                    warnings.append(
+                        f"{trace_file}:{line_number}: JSON row must be an object"
+                    )
+                    continue
+                row["_trace_file"] = trace_file.name
+                rows.append(row)
+    return rows, warnings
+
+
+def event_for_row(node, row, block_hash):
+    """Project one raw trace row into a propagation event, if relevant."""
+    if normalize_hash(row.get("hash")) != block_hash:
+        if not (
+            row.get("event") == "header_status_received"
+            and normalize_hash(row.get("selected_tip_hash")) == block_hash
+        ):
+            return None
+
+    wall_ts = row.get("wall_ts_unix_us")
+    if not isinstance(wall_ts, int):
+        return {"warning": f"{node}:{row.get('event', 'unknown')} lacks wall_ts_unix_us"}
+
+    event = row.get("event")
+    projected = {
+        "node": node,
+        "wall_ts_unix_us": wall_ts,
+        "process_trace_id": row.get("process_trace_id"),
+        "raw_event": event,
+        "height": row.get("height"),
+        "source": row.get("source") or row.get("peer"),
+        "result": row.get("result"),
+        "reason": row.get("reason") or row.get("error"),
+        "disposition": row.get("disposition"),
+        "trace_file": row["_trace_file"],
+    }
+
+    if event == "mined_block_broadcast_started":
+        projected.update(phase="broadcast_start", transport="local")
+    elif event == "mined_block_broadcast_finished":
+        projected.update(
+            phase="broadcast_finish" if row.get("result") == "ok" else "error",
+            transport="local",
+        )
+    elif event == "block_announced":
+        projected.update(phase="announcement", transport=row.get("transport", "unknown"))
+    elif event == "legacy_block_downloaded":
+        projected.update(phase="body_received", transport="legacy")
+    elif event == "legacy_block_finished":
+        committed = row.get("result") == "committed" or row.get("reason") == "already present"
+        projected.update(
+            phase="commit" if committed else "error",
+            transport="legacy",
+        )
+    elif event == "header_status_received":
+        projected.update(
+            phase="announcement",
+            transport="native",
+            height=row.get("selected_tip_height"),
+            source=row.get("peer"),
+        )
+    elif event == "block_body_received":
+        projected.update(phase="body_received", transport="native")
+    elif event == "commit_finish":
+        projected.update(
+            phase="commit"
+            if row.get("result") in {"committed", "duplicate"}
+            else "error",
+            transport="native",
+        )
+    elif event == "block_downloaded":
+        projected.update(
+            phase="body_received", transport="legacy_sync", source=row.get("peer")
+        )
+    elif event == "block_finish":
+        projected.update(
+            phase="commit" if row.get("result") == "verified" else "error",
+            transport="legacy_sync",
+        )
+    else:
+        return None
+
+    return projected
+
+
+def source_node(source, native_nodes, legacy_nodes):
+    """Resolve a trace peer label to a managed node name when possible."""
+    if not source:
+        return None
+    normalized = str(source)
+    if normalized.startswith("native:"):
+        normalized = normalized.removeprefix("native:")
+    if normalized in native_nodes:
+        return native_nodes[normalized]
+
+    if normalized in legacy_nodes:
+        return legacy_nodes[normalized]
+    legacy_source = normalized.removeprefix("legacy:")
+    for address, node in legacy_nodes.items():
+        if legacy_source == address or legacy_source.startswith(f"{address}:"):
+            return node
+    return None
+
+
+def build_report(
+    trace_dirs,
+    block_hash,
+    native_node_ids=None,
+    legacy_node_addresses=None,
+    clock_uncertainty_us=100_000,
+    origin="broadcast",
+):
+    """Load, correlate, and summarize propagation events for `block_hash`."""
+    if origin not in ORIGIN_MODES:
+        raise ValueError(f"origin must be one of: {', '.join(ORIGIN_MODES)}")
+
+    block_hash = validate_block_hash(block_hash)
+    native_nodes = {
+        native_peer_label(node_id): name
+        for name, node_id in (native_node_ids or {}).items()
+    }
+    legacy_nodes = {
+        address: name for name, address in (legacy_node_addresses or {}).items()
+    }
+
+    events = []
+    warnings = []
+    process_ids = defaultdict(set)
+    for node, trace_dir in trace_dirs.items():
+        rows, load_warnings = load_rows(trace_dir)
+        warnings.extend(load_warnings)
+        for row in rows:
+            embedded_node = row.get("node")
+            if embedded_node and embedded_node != node:
+                warnings.append(
+                    f"{node}: skipped row labeled for different node {embedded_node!r}"
+                )
+                continue
+            event = event_for_row(node, row, block_hash)
+            if event and "warning" in event:
+                if row.get("process_trace_id"):
+                    process_ids[node].add(row["process_trace_id"])
+                warnings.append(event["warning"])
+            elif event:
+                if row.get("process_trace_id"):
+                    process_ids[node].add(row["process_trace_id"])
+                event["source_node"] = source_node(
+                    event.get("source"), native_nodes, legacy_nodes
+                )
+                events.append(event)
+                if event.get("disposition") in {"queue_full", "source_queue_full"}:
+                    warnings.append(
+                        f"{node}: block announcement dropped with "
+                        f"{event['disposition']}"
+                    )
+
+    events.sort(
+        key=lambda event: (
+            event["wall_ts_unix_us"],
+            PHASE_ORDER[event["phase"]],
+            event["node"],
+        )
+    )
+    discovery_phases = {"announcement", "body_received", "commit"}
+    if origin == "broadcast":
+        origins = [event for event in events if event["phase"] == "broadcast_start"]
+        selected_origin = origins[0] if origins else None
+        if not selected_origin:
+            warnings.append("mining-node broadcast origin is missing")
+        if len(origins) > 1:
+            warnings.append(
+                "multiple mining-node broadcast origins were found; using the earliest"
+            )
+    else:
+        selected_origin = next(
+            (event for event in events if event["phase"] in discovery_phases),
+            None,
+        )
+        if not selected_origin:
+            warnings.append("first-discovery origin is missing")
+
+    origin_ts = (
+        selected_origin["wall_ts_unix_us"] if selected_origin is not None else None
+    )
+
+    for node, ids in sorted(process_ids.items()):
+        if len(ids) > 1:
+            warnings.append(f"{node}: trace rows span {len(ids)} process instances")
+
+    for event in events:
+        event["offset_us"] = (
+            event["wall_ts_unix_us"] - origin_ts if origin_ts is not None else None
+        )
+        warn_for_negative_offset = (
+            origin == "broadcast" or event["phase"] in discovery_phases
+        )
+        if (
+            warn_for_negative_offset
+            and event["offset_us"] is not None
+            and event["offset_us"] < -clock_uncertainty_us
+        ):
+            warnings.append(
+                f"{event['node']}:{event['raw_event']} precedes t0 by "
+                f"{-event['offset_us']}us"
+            )
+
+    per_node = {}
+    duplicates = []
+    for node in trace_dirs:
+        node_events = [event for event in events if event["node"] == node]
+        node_summary = {}
+        for phase in ("announcement", "body_received", "commit"):
+            phase_events = [event for event in node_events if event["phase"] == phase]
+            if phase_events:
+                node_summary[phase] = phase_events[0]
+            if len(phase_events) > 1:
+                duplicates.append(
+                    {
+                        "node": node,
+                        "phase": phase,
+                        "count": len(phase_events),
+                        "paths": sorted(
+                            {
+                                f"{event['transport']}:{event.get('source') or 'unknown'}"
+                                for event in phase_events
+                            }
+                        ),
+                    }
+                )
+        node_summary["missing"] = [
+            phase
+            for phase in ("announcement", "body_received", "commit")
+            if phase not in node_summary
+        ]
+        node_summary["errors"] = [
+            event for event in node_events if event["phase"] == "error"
+        ]
+        discovery = next(
+            (
+                event
+                for event in node_events
+                if event["phase"] in {"announcement", "body_received", "commit"}
+            ),
+            None,
+        )
+        node_summary["discovery"] = discovery
+        body_received = node_summary.get("body_received")
+        commit = node_summary.get("commit")
+        node_summary["discovery_to_body_us"] = (
+            body_received["wall_ts_unix_us"] - discovery["wall_ts_unix_us"]
+            if discovery is not None and body_received is not None
+            else None
+        )
+        node_summary["discovery_to_commit_us"] = (
+            commit["wall_ts_unix_us"] - discovery["wall_ts_unix_us"]
+            if discovery is not None and commit is not None
+            else None
+        )
+        for error_event in node_summary["errors"]:
+            warnings.append(
+                f"{node}:{error_event['raw_event']} reported "
+                f"{error_event.get('result') or 'error'}"
+            )
+        per_node[node] = node_summary
+
+    edges = []
+    seen_edges = set()
+    for event in events:
+        source = event.get("source_node")
+        edge = (source, event["node"], event["transport"])
+        if source and source != event["node"] and edge not in seen_edges:
+            seen_edges.add(edge)
+            edges.append(
+                {
+                    "source": source,
+                    "destination": event["node"],
+                    "transport": event["transport"],
+                    "first_observed_us": event["offset_us"],
+                }
+            )
+
+    def spread(phase):
+        timestamps = [
+            summary[phase]["wall_ts_unix_us"]
+            for summary in per_node.values()
+            if phase in summary
+        ]
+        return max(timestamps) - min(timestamps) if len(timestamps) >= 2 else None
+
+    return {
+        "block_hash": block_hash,
+        "clock_uncertainty_us": clock_uncertainty_us,
+        "origin_kind": origin.replace("-", "_"),
+        "origin": selected_origin,
+        "events": events,
+        "nodes": per_node,
+        "edges": edges,
+        "duplicates": duplicates,
+        "announcement_spread_us": spread("announcement"),
+        "body_receive_spread_us": spread("body_received"),
+        "commit_spread_us": spread("commit"),
+        "warnings": sorted(set(warnings)),
+    }
+
+
+def format_offset(event):
+    """Format an event's t0-relative offset for a compact report."""
+    if not event or event.get("offset_us") is None:
+        return "missing"
+    offset_us = event["offset_us"]
+    return f"{offset_us / 1000:.3f} ms"
+
+
+def format_duration(duration_us):
+    """Format an optional duration in microseconds."""
+    if duration_us is None:
+        return "missing"
+    return f"{duration_us / 1000:.3f} ms"
+
+
+def render_markdown(report):
+    """Render a concise human-readable propagation report."""
+    lines = [
+        "# Block propagation report",
+        "",
+        f"- Block: `{report['block_hash']}`",
+        f"- Clock uncertainty assumption: ±{report['clock_uncertainty_us'] / 1000:.3f} ms",
+    ]
+    origin = report["origin"]
+    if origin:
+        if report["origin_kind"] == "first_discovery":
+            lines.append(
+                f"- Origin: first discovery on `{origin['node']}` via "
+                f"`{origin['transport']}` at `{origin['wall_ts_unix_us']}` Unix µs"
+            )
+        else:
+            lines.append(
+                f"- Origin: mining broadcast on `{origin['node']}` at "
+                f"`{origin['wall_ts_unix_us']}` Unix µs"
+            )
+    else:
+        lines.append("- Origin: missing")
+
+    lines.extend(
+        [
+            "",
+            "| Node | First announcement | First body | Commit | "
+            "Local discovery → body | Local discovery → commit | "
+            "First transport/source |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for node, summary in report["nodes"].items():
+        first = summary.get("announcement") or summary.get("body_received")
+        path = (
+            f"{first['transport']} / {first.get('source') or 'unknown'}"
+            if first
+            else "missing"
+        )
+        lines.append(
+            f"| {node} | {format_offset(summary.get('announcement'))} | "
+            f"{format_offset(summary.get('body_received'))} | "
+            f"{format_offset(summary.get('commit'))} | "
+            f"{format_duration(summary['discovery_to_body_us'])} | "
+            f"{format_duration(summary['discovery_to_commit_us'])} | {path} |"
+        )
+
+    lines.extend(["", "## Spread"])
+    for label, field in (
+        ("Announcement", "announcement_spread_us"),
+        ("Body receive", "body_receive_spread_us"),
+        ("Commit", "commit_spread_us"),
+    ):
+        value = report[field]
+        lines.append(f"- {label}: {value / 1000:.3f} ms" if value is not None else f"- {label}: unavailable")
+
+    if report["edges"]:
+        lines.extend(["", "## Inferred managed-node edges"])
+        for edge in report["edges"]:
+            observed = edge["first_observed_us"]
+            observed_label = (
+                f"{observed / 1000:.3f} ms" if observed is not None else "unknown offset"
+            )
+            lines.append(
+                f"- `{edge['source']}` → `{edge['destination']}` via "
+                f"`{edge['transport']}` at {observed_label}"
+            )
+
+    error_events = [
+        error
+        for summary in report["nodes"].values()
+        for error in summary.get("errors", [])
+    ]
+    if error_events:
+        lines.extend(["", "## Propagation errors"])
+        for error in error_events:
+            reason = error.get("reason") or error.get("result") or "unknown"
+            lines.append(
+                f"- `{error['node']}` `{error['raw_event']}`: {reason}"
+            )
+
+    if report["duplicates"]:
+        lines.extend(["", "## Duplicate paths"])
+        for duplicate in report["duplicates"]:
+            lines.append(
+                f"- `{duplicate['node']}` {duplicate['phase']}: "
+                f"{duplicate['count']} events ({', '.join(duplicate['paths'])})"
+            )
+
+    if report["warnings"]:
+        lines.extend(["", "## Warnings"])
+        lines.extend(f"- {warning}" for warning in report["warnings"])
+
+    return "\n".join(lines) + "\n"
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hash", required=True, dest="block_hash")
+    parser.add_argument(
+        "--trace-dir",
+        action="append",
+        required=True,
+        type=parse_named_value,
+        metavar="NODE=PATH",
+    )
+    parser.add_argument(
+        "--native-node",
+        action="append",
+        default=[],
+        type=parse_named_value,
+        metavar="NODE=HEX_ID",
+    )
+    parser.add_argument(
+        "--legacy-node",
+        action="append",
+        default=[],
+        type=parse_named_value,
+        metavar="NODE=IP",
+    )
+    parser.add_argument("--clock-uncertainty-ms", type=float, default=100.0)
+    parser.add_argument("--origin", choices=ORIGIN_MODES, default="broadcast")
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    try:
+        report = build_report(
+            dict(args.trace_dir),
+            args.block_hash,
+            dict(args.native_node),
+            dict(args.legacy_node),
+            max(0, round(args.clock_uncertainty_ms * 1000)),
+            args.origin,
+        )
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    markdown = render_markdown(report)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2) + "\n")
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown)
+    print(markdown, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zakura-block-propagation-report.py
+++ b/scripts/zakura-block-propagation-report.py
@@ -248,6 +248,20 @@ def build_report(
                         f"{event['disposition']}"
                     )
 
+    native_events = {"header_status_received", "block_body_received", "commit_finish"}
+    canonical_native_events = {
+        (event["node"], event["raw_event"])
+        for event in events
+        if event["trace_file"] == "block_propagation.jsonl"
+        and event["raw_event"] in native_events
+    }
+    events = [
+        event
+        for event in events
+        if event["trace_file"] == "block_propagation.jsonl"
+        or (event["node"], event["raw_event"]) not in canonical_native_events
+    ]
+
     events.sort(
         key=lambda event: (
             event["wall_ts_unix_us"],


### PR DESCRIPTION
## Motivation

Controlled Testnet mining needs an empirical view of when each node first learns about a block, receives its body, and durably commits it. Existing JSONL timestamps were process-relative, and legacy gossip lacked a cohesive propagation trace.

Header overlay migration and Ironwood mining-template fixes landed separately in #688 and #687.

## Solution

- add cross-node wall-clock timestamps and stable node identities to JSONL trace envelopes
- trace mined-block broadcast, legacy advertisements/downloads/commits, and native block-body hashes without high-cardinality metrics
- add a stdlib-only report tool that correlates one block across miner and observer trace directories
- deploy opt-in tracing to the managed Testnet fleet and Docker mining stack, including correct trace-volume ownership after privilege drop

## Testing

Automated:

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-jsonl-trace -p zakura-network -p zakura --lib -- -D warnings`
- `cargo test -p zakura-jsonl-trace`
- `cargo test -p zakura-network received_body_schema_carries_block_hash`
- `cargo test -p zakura --lib block_propagation_trace`
- `python3 -m unittest scripts/tests/test_zakura_block_propagation_report.py`
- `python3 -m unittest test_deploy.py` from `deploy/deployer`
- `./scripts/changelog.py check`
- Markdown lint for all changed Markdown
- `bash -n docker/entrypoint.sh`

Manual Testnet validation:

- verified every observer is healthy with zero restarts, matching tips, synchronized clocks, and active JSONL trace output
- verified the miner emits `mined_block_broadcast_started` with a block hash, height, node ID, and Unix timestamp
- collected an 85 MB three-observer dry-run bundle and generated JSON, Markdown, and Canvas reports

Dry-run block `00006c8bae431779aad40098804b66345ac8b74aabfdd991df0e7a62ec335740` showed a 104.4 ms announcement spread, 303.1 ms body-receive spread, and 303.8 ms commit spread. Local body-to-commit processing was consistently 35–37 ms.

## Changelog

- Added `docs/changelog/unreleased/690.md` with operator-visible tracing and Docker trace-directory ownership.

### Specifications & References

- `docs/block-propagation-tracing.md`

### Follow-up Work

- collect a full miner-origin report from a longer controlled run
- add bounded trace retention or per-run rotation before leaving fleet tracing enabled indefinitely