### PR TITLE
ci(release): publish crates from the release tag via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,26 +1,43 @@
-# No-upload proof of concept for crates.io Trusted Publishing.
+# Publish Zakura's crates to crates.io using Trusted Publishing.
 #
-# This workflow performs Cargo dry-run publishing before it requests an OIDC
-# token. The token is never exported to repository code, and there is
-# deliberately no registry upload command.
-name: Dry-run crate publishing
+# Verification and publication are deliberately separate jobs. The packaging
+# and compile checks run before any registry token exists, because they take
+# far longer than the 30-minute Trusted Publishing token lifetime; only the
+# publish job holds a token, and only the single cargo step that needs it sees
+# it. `mode: verify` stops after those checks and proves the OIDC exchange
+# without an upload path, which is the pre-flight to run before a release.
+#
+# This is a dispatched workflow rather than one create-release.yml calls:
+# crates.io matches its Trusted Publisher configuration against the OIDC
+# `workflow_ref` claim, which names the *top-level* workflow file, so a
+# `workflow_call` would present create-release.yml as the publishing identity
+# instead of this file.
+name: Publish crates
 
 on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Published release tag to inspect, for example v1.0.3"
+        description: "Published release tag to publish crates for, for example v1.0.3"
         required: true
         type: string
+      mode:
+        description: "verify: run the checks and prove the OIDC exchange without uploading. publish: upload to crates.io (irreversible)"
+        required: false
+        default: verify
+        type: choice
+        options:
+          - verify
+          - publish
 
 permissions: {}
 
 concurrency:
-  group: publish-crates-poc-${{ inputs.release_tag }}
+  group: publish-crates-${{ inputs.release_tag }}
   cancel-in-progress: false
 
 jobs:
-  dry-run:
+  plan-verify:
     name: Plan and verify crate publication
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -111,26 +128,32 @@ jobs:
           ZAKURA_REPO_ROOT: ${{ github.workspace }}/release
         run: ./scripts/publish-crates.sh verify --output "$RUNNER_TEMP/publish-plan.json"
 
-      - name: Summarize the dry-run
+      - name: Summarize the plan
         if: ${{ !cancelled() }}
         env:
           PLAN: ${{ runner.temp }}/publish-plan.json
           RELEASE_TAG: ${{ inputs.release_tag }}
           TARGET_SHA: ${{ steps.release.outputs.target_sha }}
+          MODE: ${{ inputs.mode }}
         run: |
           if [ ! -f "$PLAN" ]; then
             echo "No publish plan was produced." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           {
-            echo "## Crates.io dry-run"
+            echo "## Crates.io plan (mode: ${MODE})"
             echo
             echo "- Release: \`${RELEASE_TAG}\`"
             echo "- Commit: \`${TARGET_SHA}\`"
             echo
             echo "| Crate | Version | Status |"
             echo "| --- | --- | --- |"
-            jq -r '.packages[] | "| `\(.name)` | `\(.version)` | `\(.status)` |"' "$PLAN"
+            jq -r '
+              .packages[]
+              | "| `\(.name)` | `\(.version)` | `\(.status)`"
+                + (if .below_newest_published then " — below the newest published version" else "" end)
+                + " |"
+            ' "$PLAN"
             echo
             jq -r '
               "Selected: \(.counts.to_publish + .counts.initial_publish_required); " +
@@ -141,7 +164,8 @@ jobs:
 
   oidc-smoke:
     name: Exchange and revoke crates.io OIDC token
-    needs: [dry-run]
+    needs: [plan-verify]
+    if: ${{ inputs.mode == 'verify' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: crates-io
@@ -152,3 +176,168 @@ jobs:
       # short-lived production token returned by the action.
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+  publish:
+    name: Publish crates to crates.io
+    needs: [plan-verify]
+    # The repository guard matches release-binaries.yml: the private staging
+    # repo used for release dress rehearsals must never reach the real
+    # registry. crates.io would reject the exchange there anyway, since the
+    # `repository` claim would match no publisher, but failing before the
+    # attempt keeps the rehearsal's logs honest.
+    if: ${{ inputs.mode == 'publish' && github.repository == 'zakura-core/zakura' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      published_zakura: ${{ steps.plan-facts.outputs.published_zakura }}
+    steps:
+      - name: Checkout publishing tools from the dispatched commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Checkout the release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.plan-verify.outputs.target_sha }}
+          path: release
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          # This job packages crates with --no-verify but never compiles them,
+          # so it needs no build environment and nothing a cache could carry.
+          cache: false
+
+      - name: Confirm the tag matches the zakura package
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ZAKURA_REPO_ROOT: ${{ github.workspace }}/release
+        run: ./scripts/check-release-version.sh "$RELEASE_TAG"
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      # The token is scoped to this step alone, and the action's post step
+      # revokes it when the job ends. Everything slow already ran in
+      # plan-verify, so the token is live for as long as packaging and upload
+      # take rather than for a full workspace build.
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          ZAKURA_REPO_ROOT: ${{ github.workspace }}/release
+        run: ./scripts/publish-crates.sh publish --output "$RUNNER_TEMP/publish-plan.json"
+
+      # The plan is written before the first upload, so it survives a partial
+      # publish and is what the verification job checks against.
+      - name: Upload the publish plan
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: crates-publish-plan
+          path: ${{ runner.temp }}/publish-plan.json
+          if-no-files-found: error
+
+      - name: Record plan facts
+        id: plan-facts
+        if: ${{ !cancelled() }}
+        env:
+          PLAN: ${{ runner.temp }}/publish-plan.json
+        run: |
+          set -euo pipefail
+          published_zakura=false
+          if [ -f "$PLAN" ] && [ "$(
+            jq -r '[.packages[] | select(.name == "zakura" and .status != "already_published")] | length' "$PLAN"
+          )" != "0" ]; then
+            published_zakura=true
+          fi
+          echo "published_zakura=${published_zakura}" >> "$GITHUB_OUTPUT"
+
+  verify-published:
+    name: Verify the published versions
+    needs: [plan-verify, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout publishing tools from the dispatched commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Download the publish plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crates-publish-plan
+          path: ${{ runner.temp }}/plan
+
+      # crates.io records the repository, run ID, and commit behind every
+      # Trusted Publishing upload and serves them publicly. Asserting they name
+      # this run proves the release pipeline published these versions, rather
+      # than only that something with the right version number exists.
+      - name: Confirm every selected version came from this run
+        env:
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          TARGET_SHA: ${{ needs.plan-verify.outputs.target_sha }}
+        run: |
+          ./scripts/verify-published-crates.sh \
+            --plan "$RUNNER_TEMP/plan/publish-plan.json" \
+            --repository "$REPOSITORY" \
+            --run-id "$RUN_ID" \
+            --sha "$TARGET_SHA"
+
+  install-check:
+    name: Install zakurad from crates.io
+    needs: [publish, verify-published]
+    if: ${{ needs.publish.outputs.published_zakura == 'true' }}
+    runs-on: ubuntu-latest
+    # A cold build of the whole node from the registry, which is the point: it
+    # is the only check that the published crates resolve and compile as a
+    # consumer receives them, rather than as this workspace resolves them.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    steps:
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          # The published tag is compiled with a current stable toolchain, so
+          # the action's default `-D warnings` would fail the install on
+          # new-since-the-tag warnings.
+          rustflags: ""
+          cache: false
+
+      - name: Checkout publishing tools from the dispatched commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Install and run the published zakurad
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          cargo install --locked --force --version "$version" zakura
+          "$HOME/.cargo/bin/zakurad" --version | tee "$RUNNER_TEMP/zakurad-version.txt"
+          grep -Fq -- "$version" "$RUNNER_TEMP/zakurad-version.txt"
+          {
+            echo "## Installed from crates.io"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/zakurad-version.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -262,7 +262,9 @@ jobs:
 
   verify-published:
     name: Verify the published versions
-    needs: [plan-verify, publish]
+    # `publish` already depends on plan-verify, and the attestation comes from
+    # the OIDC claims rather than the resolved tag, so nothing here needs it.
+    needs: [publish]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -280,21 +280,22 @@ jobs:
           name: crates-publish-plan
           path: ${{ runner.temp }}/plan
 
-      # crates.io records the repository, run ID, and commit behind every
-      # Trusted Publishing upload and serves them publicly. Asserting they name
-      # this run proves the release pipeline published these versions, rather
-      # than only that something with the right version number exists.
+      # crates.io records the repository, run ID, and OIDC commit claim behind
+      # every Trusted Publishing upload and serves them publicly. Asserting
+      # they name this run proves the release pipeline published these
+      # versions, rather than only that something with the right version number
+      # exists.
       - name: Confirm every selected version came from this run
         env:
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          TARGET_SHA: ${{ needs.plan-verify.outputs.target_sha }}
+          OIDC_SHA: ${{ github.sha }}
         run: |
           ./scripts/verify-published-crates.sh \
             --plan "$RUNNER_TEMP/plan/publish-plan.json" \
             --repository "$REPOSITORY" \
             --run-id "$RUN_ID" \
-            --sha "$TARGET_SHA"
+            --sha "$OIDC_SHA"
 
   install-check:
     name: Install zakurad from crates.io

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -173,6 +173,12 @@ permission:
    workflow run and the dispatch commit on `main` (the OIDC `sha` claim),
    and `Install zakurad from crates.io` installs and runs the published binary.
 
+Both post-publish jobs run after the uploads are already irreversible, so a
+failure there reports a problem rather than preventing one. `Install zakurad
+from crates.io` in particular is a cold release build of the whole node and can
+exhaust its timeout on a slow runner; re-run the job before concluding the
+published crates are broken.
+
 Publishing to crates.io has historically been a separate decision from
 tagging — `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but
 intentionally never published — and the environment reviewer is where that

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -80,66 +80,103 @@ elsewhere. Every release is initially a pre-release; see
 [Promotion and the "Latest" release](#promotion-and-the-latest-release) for
 when and how a release is promoted.
 
-## Crates.io Trusted Publishing Dry Run
+## Crates.io Trusted Publishing
 
 The manually dispatched
-[`Dry-run crate publishing`](../.github/workflows/publish-crates.yml) workflow
-is a no-upload proof of concept. It checks out an existing published release
-tag, computes the exact workspace versions absent from crates.io, and runs
-Cargo's complete dry-run publishing checks. A separate checkout-free job then
-exchanges GitHub's OIDC identity for a short-lived production crates.io token
-and immediately revokes it. The token is never passed to repository code, and
-the workflow contains no registry upload command.
+[`Publish crates`](../.github/workflows/publish-crates.yml) workflow publishes
+Zakura's crates from a published release tag, authenticated by short-lived
+tokens crates.io mints against this repository's GitHub OIDC identity. No
+registry credential is stored anywhere.
 
-One-time setup requires two distinct permission levels:
+The workflow takes a `mode`:
+
+- **`verify`** (default) checks out the release tag, computes the exact
+  workspace versions absent from crates.io, runs the publish-graph check and
+  Cargo's complete dry-run publishing checks, and then exchanges and
+  immediately revokes a real token in a checkout-free job. Nothing is
+  uploaded. This is the pre-flight: run it before a release to confirm the
+  crate selection and that the trusted-publisher configuration still works.
+- **`publish`** repeats the plan and uploads. It is irreversible — a crates.io
+  version can be yanked but never replaced or reused.
+
+Verification and publication are separate jobs on purpose. The verify builds
+take much longer than the 30-minute token lifetime, so they run before any
+token exists; the publish job packages with `--no-verify` and only its single
+`cargo publish` step sees the token, which the action revokes when the job
+ends.
+
+Publishing is resumable. The plan excludes every crate already on the index at
+its workspace version, so a run that fails partway through is recovered by
+dispatching it again: the crates that landed are skipped and the rest are
+published. Fix forward — never try to repair a partial publish by yanking and
+re-uploading the same version.
+
+### One-time setup
+
+This requires two distinct permission levels:
 
 1. A repository administrator creates a GitHub Actions environment named
-   `crates-io`, restricts its deployment branch to `main`, configures a
-   required reviewer, and disables administrator bypass of protection rules.
-   Add no environment secrets or variables. The environment constrains the
-   OIDC identity; manually dispatching the workflow is the POC's only trigger,
-   and the `oidc-smoke` job waits for that reviewer before exchanging a token.
-2. An owner of each existing crate opens that crate's **Settings > Trusted
+   `crates-io`, restricts its deployment branch to `main`, configures required
+   reviewers, and disables administrator bypass of protection rules. Add no
+   environment secrets or variables. The environment constrains the OIDC
+   identity, and its reviewers are the human gate on an irreversible upload.
+2. An owner of **each** crate opens that crate's **Settings > Trusted
    Publishing** page on crates.io and adds a GitHub Actions publisher with:
    - repository owner `zakura-core`
    - repository name `zakura`
    - workflow filename `publish-crates.yml`
    - environment `crates-io`
 
-Only a crates.io owner can configure a crate's trusted publisher. An existing
-owner can grant another maintainer access from the crate's Owners settings or
-with `cargo owner`. A crate that has never been published must first be
-published manually with a narrowly scoped token from a trusted maintainer
-machine; never store that bootstrap token in GitHub.
+Only a crates.io owner can configure a crate's trusted publisher, and Zakura's
+crates do not all share one owner. An existing owner can grant another
+maintainer access from the crate's Owners settings or with `cargo owner`.
 
-After setup, an operator needs repository Write access or higher, but no
-crates.io account permission:
+Configure every publishable crate, and audit the list when adding one. A
+crate missing its entry is not an error at exchange time: crates.io scopes the
+minted token to whichever crates did match, the run starts publishing, and the
+unconfigured crate fails with a permission error partway through — a partial,
+irreversible publish. There is no way to read another owner's configuration,
+so this audit is a checklist, backed by the resumable retry above.
 
-1. Open **Actions > Dry-run crate publishing > Run workflow**.
-2. Select `main`, enter the existing release tag, and dispatch the run.
-3. Ask a `crates-io` environment reviewer to approve the pending
-   `oidc-smoke` deployment.
-4. Review the crate/version/status table in the workflow summary and confirm
-   both jobs pass.
+A crate that has never been published cannot be bootstrapped this way, because
+its trusted-publisher configuration lives on a crate that does not yet exist.
+Reserve the name manually with a narrowly scoped token from a trusted
+maintainer machine, add the configuration, and only then let CI publish it;
+never store that bootstrap token in GitHub. `publish` mode refuses to run when
+the plan contains an unpublished crate name, rather than discovering it
+mid-upload.
 
-A successful OIDC exchange proves that at least one trusted-publisher
-configuration matches; Cargo dry-run does not exercise registry upload
-authorization for every crate. Audit every crate's configuration before adding
-real publication in a later change. Continue to use the manual crates.io
-publishing procedure during this POC.
+The workflow filename is part of the crates.io configuration: it is matched
+against the OIDC `workflow_ref` claim, which names the workflow a run _starts
+from_. A reusable workflow does not change it — `create-release.yml` calling
+this file would present `create-release.yml`. That is why release automation
+dispatches this workflow instead of calling it, and why renaming this file
+means reconfiguring every crate.
 
-The `crates-io` environment has a required reviewer from day one, and
-administrator bypass of protection rules is disabled. Publishing to crates.io
-has historically been a separate decision from tagging — `v1.0.3-rc1`,
-`v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but intentionally never published —
-so the reviewer preserves that decision point once this POC graduates to a
-real upload path. For the dry-run workflow, the `oidc-smoke` job pauses at
-"Review pending deployments" until a reviewer approves; ping a reviewer after
-dispatching. When trusted publishing is folded into the release CI, keep the
-reviewer on `crates-io` and move the trusted publisher's workflow filename to
-whichever workflow actually publishes. Until then the trusted-publisher
-entries grant only what the POC exercises — minting and revoking a token — so
-remove them if this POC is abandoned rather than wired into the release path.
+### Publishing a release
+
+An operator needs repository Write access or higher, but no crates.io account
+permission:
+
+1. Open **Actions > Publish crates > Run workflow**.
+2. Select `main`, enter the published release tag, choose the mode, and
+   dispatch. Always dispatch from `main`, including for a hotfix release: the
+   tag is resolved by name and checked out on its own, so the `crates-io`
+   environment stays restricted to `main`.
+3. Ask a `crates-io` environment reviewer to approve the pending deployment,
+   after reviewing the crate/version/status table in the run summary. Watch
+   for rows flagged as below the newest published version: expected for a
+   hotfix on an older release line, and otherwise a sign the run is publishing
+   from a stale tag.
+4. Confirm every job passes. After a `publish` run, `Verify the published
+   versions` asserts that each new version's crates.io record names this
+   workflow run and the tag's commit, and `Install zakurad from crates.io`
+   installs and runs the published binary.
+
+Publishing to crates.io has historically been a separate decision from
+tagging — `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but
+intentionally never published — and the environment reviewer is where that
+decision is now recorded.
 
 ## Promotion and the "Latest" Release
 

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -170,8 +170,8 @@ permission:
    from a stale tag.
 4. Confirm every job passes. After a `publish` run, `Verify the published
    versions` asserts that each new version's crates.io record names this
-   workflow run and the tag's commit, and `Install zakurad from crates.io`
-   installs and runs the published binary.
+   workflow run and the dispatch commit on `main` (the OIDC `sha` claim),
+   and `Install zakurad from crates.io` installs and runs the published binary.
 
 Publishing to crates.io has historically been a separate decision from
 tagging — `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but

--- a/scripts/lib/crates-index.sh
+++ b/scripts/lib/crates-index.sh
@@ -58,6 +58,15 @@ crates_index_fetch() {
   printf '%s\n' "$cache"
 }
 
+# crates_index_forget NAME — drop NAME's cached response so the next query
+# refetches it. Only polling callers need this: the index is the moving part
+# they are waiting on, while every other caller wants one stable answer for
+# the lifetime of the process.
+crates_index_forget() {
+  [ -n "$_crates_index_cache_dir" ] || return 0
+  rm -f "${_crates_index_cache_dir}/${1}"
+}
+
 # crates_index_versions NAME — echo every published version of NAME, one per
 # line (yanked included: the version number stays taken), or nothing when
 # the crate has never been published. Returns 2 on transport failure.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -64,6 +64,11 @@ done
 #
 # `sort -V` cannot answer this: it orders 1.0.0 before 1.0.0-rc1, the reverse of
 # semver, which would hide exactly the stale-prerelease case this warns about.
+#
+# Zakura's `-rcN` tags are a single alphanumeric identifier, which semver (and
+# so crates.io) compares lexically: 1.0.0-rc10 ranks below 1.0.0-rc2. Past rc9
+# the advisory can fire on a version that is newest by tag order. That matches
+# how the registry itself orders them; `-rc.N` would sort numerically.
 version_precedes() {
   python3 -c '
 import sys

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
-# Plan or fully dry-run the exact Zakura crate set absent from crates.io.
+# Plan, dry-run, or publish the exact Zakura crate set absent from crates.io.
 #
-# This proof of concept deliberately has no publish mode and never accepts or
-# reads a registry token.
+# The publish set is derived from `cargo metadata`, never a hardcoded list, and
+# is filtered against the live sparse index: a crate already published at its
+# workspace version is excluded. That is what makes `publish` resumable — a run
+# that fails partway through republishes nothing when it is dispatched again.
+#
+# `publish` uploads to crates.io and is irreversible (versions can only be
+# yanked, never replaced). It reads CARGO_REGISTRY_TOKEN from the environment —
+# in CI, a short-lived Trusted Publishing token — and never logs it.
 #
 # Usage:
-#   ./scripts/publish-crates.sh plan [--output PATH]
-#   ./scripts/publish-crates.sh verify [--output PATH]
+#   ./scripts/publish-crates.sh plan    [--output PATH]
+#   ./scripts/publish-crates.sh verify  [--output PATH]
+#   ./scripts/publish-crates.sh publish [--output PATH]
 set -euo pipefail
 
 tool_root="$(cd "$(dirname "$0")/.." && pwd)"
@@ -24,9 +31,9 @@ cd "$repo_root"
 mode="${1:-}"
 [ $# -gt 0 ] && shift
 case "$mode" in
-  plan | verify) ;;
+  plan | verify | publish) ;;
   *)
-    echo "Usage: $0 <plan|verify> [--output PATH]" >&2
+    echo "Usage: $0 <plan|verify|publish> [--output PATH]" >&2
     exit 1
     ;;
 esac
@@ -45,12 +52,42 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-for cmd in cargo curl git jq; do
+for cmd in cargo curl git jq python3; do
   command -v "$cmd" >/dev/null || {
     echo "Missing required tool: $cmd" >&2
     exit 1
   }
 done
+
+# version_precedes VERSION — read published versions on stdin and succeed when
+# VERSION sorts below the highest of them under semver precedence.
+#
+# `sort -V` cannot answer this: it orders 1.0.0 before 1.0.0-rc1, the reverse of
+# semver, which would hide exactly the stale-prerelease case this warns about.
+version_precedes() {
+  python3 -c '
+import sys
+
+
+def key(version):
+    core, _, pre = version.split("+")[0].partition("-")
+    nums = [int(part) for part in core.split(".")]
+    if not pre:
+        # A release outranks every prerelease sharing its core version.
+        return (nums, 1, [])
+    ids = [(0, int(p), "") if p.isdigit() else (1, 0, p) for p in pre.split(".")]
+    return (nums, 0, ids)
+
+
+candidate = sys.argv[1]
+published = [line.strip() for line in sys.stdin if line.strip()]
+try:
+    sys.exit(0 if key(candidate) < max(key(v) for v in published) else 1)
+except ValueError:
+    # An unparsable version on the index is not a reason to fail a publish.
+    sys.exit(1)
+' "$1"
+}
 
 metadata="$(cargo metadata --format-version 1 --no-deps --locked)"
 publishable="$(jq -r '
@@ -63,9 +100,10 @@ publishable="$(jq -r '
 packages_json='[]'
 publish_set=()
 initial_publish_required=()
+superseded=()
 exclude_args=()
 
-echo "Crates.io dry-run plan (exact workspace versions):"
+echo "Crates.io publish plan (exact workspace versions):"
 while IFS=$'\t' read -r crate version; do
   [ -n "$crate" ] || continue
   published_versions="$(crates_index_versions "$crate")" || {
@@ -73,6 +111,9 @@ while IFS=$'\t' read -r crate version; do
     exit 1
   }
 
+  # Advisory only: a hotfix on an older release line legitimately publishes
+  # below the newest version, so this informs the approver rather than failing.
+  older=false
   if grep -Fxq -- "$version" <<<"$published_versions"; then
     status="already_published"
     exclude_args+=(--exclude "$crate")
@@ -83,12 +124,18 @@ while IFS=$'\t' read -r crate version; do
   else
     status="to_publish"
     publish_set+=("${crate}@${version}")
+    if version_precedes "$version" <<<"$published_versions"; then
+      older=true
+      superseded+=("${crate}@${version}")
+    fi
   fi
-  printf '  %-30s %-18s %s\n' "$crate" "$version" "$status"
+  printf '  %-30s %-18s %s%s\n' "$crate" "$version" "$status" \
+    "$([ "$older" = true ] && echo ' (below the newest published version)')"
 
   packages_json="$(
     jq --arg name "$crate" --arg version "$version" --arg status "$status" \
-      '. + [{name: $name, version: $version, status: $status}]' \
+      --argjson older "$older" \
+      '. + [{name: $name, version: $version, status: $status, below_newest_published: $older}]' \
       <<<"$packages_json"
   )"
 done <<<"$publishable"
@@ -111,7 +158,7 @@ plan_json="$(
 
 if [ -n "$output_path" ]; then
   printf '%s\n' "$plan_json" > "$output_path"
-  echo "Wrote dry-run plan to ${output_path}."
+  echo "Wrote the publish plan to ${output_path}."
 fi
 
 echo
@@ -121,8 +168,25 @@ jq -r '
   "\(.counts.already_published) already published"
 ' <<<"$plan_json"
 
+if [ "${#superseded[@]}" -gt 0 ]; then
+  echo "WARNING: selected below the newest version already on crates.io: ${superseded[*]}" >&2
+  echo "WARNING: expected for a hotfix on an older release line; otherwise this run is publishing from a stale tag." >&2
+fi
+
 if [ "${#initial_publish_required[@]}" -gt 0 ]; then
-  echo "NOTICE: bootstrap these crate names manually before production automation: ${initial_publish_required[*]}" >&2
+  if [ "$mode" = "publish" ]; then
+    cat >&2 <<EOF
+ERROR: these crate names do not exist on crates.io: ${initial_publish_required[*]}
+
+Trusted Publishing cannot create a crate: its configuration lives on an
+existing crate, so an unknown name has no publisher to authorize this run and
+would fail partway through the publish. Reserve each name manually with a
+narrowly scoped token from a trusted maintainer machine, add the Trusted
+Publishing entry described in docs/release-tag-protection.md, then re-run.
+EOF
+    exit 1
+  fi
+  echo "NOTICE: reserve and configure these crate names before they can be published: ${initial_publish_required[*]}" >&2
 fi
 
 if [ "$mode" = "plan" ]; then
@@ -130,12 +194,12 @@ if [ "$mode" = "plan" ]; then
 fi
 
 if [ "${#publish_set[@]}" -eq 0 ]; then
-  echo "Every publishable workspace version is already on crates.io; verification is a no-op."
+  echo "Every publishable workspace version is already on crates.io; ${mode} is a no-op."
   exit 0
 fi
 
 if ! git diff --quiet HEAD -- Cargo.lock; then
-  echo "Cargo.lock must be clean before dry-run verification." >&2
+  echo "Cargo.lock must be clean before ${mode}." >&2
   exit 1
 fi
 lock_backup="$(mktemp)"
@@ -148,15 +212,34 @@ restore_lock() {
 }
 trap restore_lock EXIT
 
-echo
-echo "Checking the selected crates against the live crates.io dependency graph..."
-ZAKURA_REPO_ROOT="$repo_root" \
-ZAKURA_ALLOW_UNPUBLISHABLE_CRATE_GRAPH=0 \
-  "${tool_root}/scripts/check-crate-publish-graph.sh"
+if [ "$mode" = "verify" ]; then
+  echo
+  echo "Checking the selected crates against the live crates.io dependency graph..."
+  ZAKURA_REPO_ROOT="$repo_root" \
+  ZAKURA_ALLOW_UNPUBLISHABLE_CRATE_GRAPH=0 \
+    "${tool_root}/scripts/check-crate-publish-graph.sh"
+
+  echo
+  echo "Building the selected packaged crates with Cargo dry-run publishing..."
+  cargo publish --workspace --dry-run --locked "${exclude_args[@]}"
+
+  echo
+  echo "Dry-run verification passed: ${publish_set[*]}"
+  exit 0
+fi
+
+if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+  echo "CARGO_REGISTRY_TOKEN is not set; publishing needs a registry token." >&2
+  exit 1
+fi
 
 echo
-echo "Building the selected packaged crates with Cargo dry-run publishing..."
-cargo publish --workspace --dry-run --locked "${exclude_args[@]}"
+echo "Publishing to crates.io: ${publish_set[*]}"
+# --no-verify is required, not a shortcut: the verify mode compiled these exact
+# packages minutes earlier in a token-free job, and repeating those builds here
+# would outlast the 30-minute Trusted Publishing token. Cargo orders the
+# multi-package publish and waits for each crate to reach the index itself.
+cargo publish --workspace --no-verify --locked "${exclude_args[@]}"
 
 echo
-echo "Dry-run verification passed: ${publish_set[*]}"
+echo "Published: ${publish_set[*]}"

--- a/scripts/verify-published-crates.sh
+++ b/scripts/verify-published-crates.sh
@@ -14,6 +14,9 @@
 #   ./scripts/verify-published-crates.sh --plan PATH \
 #     --repository OWNER/NAME --run-id ID --sha COMMIT
 #
+# --timeout SECONDS bounds the wait for each version to reach the index
+# (default 300).
+#
 # Without the attestation triple, this checks only that each selected version
 # exists and is not yanked, which is what an operator wants after a manual
 # publish.
@@ -47,7 +50,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$plan_path" ] || { echo "Usage: $0 --plan PATH [--repository OWNER/NAME --run-id ID --sha COMMIT]" >&2; exit 1; }
+[ -n "$plan_path" ] || { echo "Usage: $0 --plan PATH [--repository OWNER/NAME --run-id ID --sha COMMIT] [--timeout SECONDS]" >&2; exit 1; }
 [ -f "$plan_path" ] || { echo "No publish plan at ${plan_path}." >&2; exit 1; }
 
 attest=false
@@ -95,8 +98,11 @@ while IFS=$'\t' read -r crate version; do
   done
   crates_index_has_version "$crate" "$version" || continue
 
+  # --fail turns an HTTP error into a non-zero exit instead of an error body
+  # that would parse to a null `yanked` and be reported as a yank. This runs
+  # right after an irreversible publish, where a wrong diagnosis is expensive.
   version_json="$(
-    curl -sS --retry 4 --retry-connrefused \
+    curl -sS --fail --retry 4 --retry-connrefused \
       -H 'User-Agent: zakura-release-tooling (https://github.com/zakura-core/zakura)' \
       "${CRATES_API_URL}/crates/${crate}/${version}"
   )" || {

--- a/scripts/verify-published-crates.sh
+++ b/scripts/verify-published-crates.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Confirm that a publish plan actually landed on crates.io, and that each
+# version was uploaded by the workflow run that claims it.
+#
+# crates.io records the GitHub repository, run ID, and commit behind every
+# Trusted Publishing upload and serves them publicly as a version's
+# `trustpub_data`. Asserting those match this run is what distinguishes "the
+# release pipeline published this" from "a version with the right number
+# exists" — the latter is also true of a hand-published crate, or of a version
+# an attacker with a stolen classic token uploaded first.
+#
+# Usage:
+#   ./scripts/verify-published-crates.sh --plan PATH
+#   ./scripts/verify-published-crates.sh --plan PATH \
+#     --repository OWNER/NAME --run-id ID --sha COMMIT
+#
+# Without the attestation triple, this checks only that each selected version
+# exists and is not yanked, which is what an operator wants after a manual
+# publish.
+set -euo pipefail
+
+tool_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+# The library is linted as a standalone shellcheck input in lint.yml.
+# shellcheck source=scripts/lib/crates-index.sh disable=SC1091
+. "${tool_root}/scripts/lib/crates-index.sh"
+
+CRATES_API_URL="${CRATES_API_URL:-https://crates.io/api/v1}"
+
+plan_path=""
+repository=""
+run_id=""
+sha=""
+timeout_seconds=300
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --plan) plan_path="${2:?--plan needs a path}"; shift 2 ;;
+    --repository) repository="${2:?--repository needs OWNER/NAME}"; shift 2 ;;
+    --run-id) run_id="${2:?--run-id needs an ID}"; shift 2 ;;
+    --sha) sha="${2:?--sha needs a commit}"; shift 2 ;;
+    --timeout) timeout_seconds="${2:?--timeout needs seconds}"; shift 2 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+[ -n "$plan_path" ] || { echo "Usage: $0 --plan PATH [--repository OWNER/NAME --run-id ID --sha COMMIT]" >&2; exit 1; }
+[ -f "$plan_path" ] || { echo "No publish plan at ${plan_path}." >&2; exit 1; }
+
+attest=false
+if [ -n "$run_id" ] || [ -n "$sha" ] || [ -n "$repository" ]; then
+  if [ -z "$run_id" ] || [ -z "$sha" ] || [ -z "$repository" ]; then
+    echo "--repository, --run-id, and --sha must be given together." >&2
+    exit 1
+  fi
+  attest=true
+fi
+
+for cmd in curl jq; do
+  command -v "$cmd" >/dev/null || { echo "Missing required tool: $cmd" >&2; exit 1; }
+done
+
+selected="$(jq -r '
+  .packages[]
+  | select(.status != "already_published")
+  | [.name, .version]
+  | @tsv
+' "$plan_path")"
+
+if [ -z "$selected" ]; then
+  echo "The plan selected no crates; nothing to verify."
+  exit 0
+fi
+
+failed=0
+while IFS=$'\t' read -r crate version; do
+  [ -n "$crate" ] || continue
+
+  # cargo already waits for each crate to reach the index before publishing its
+  # dependents, so this normally passes first try; the poll only covers the
+  # window where a final crate's index write has not propagated yet.
+  waited=0
+  until crates_index_has_version "$crate" "$version"; do
+    if [ "$waited" -ge "$timeout_seconds" ]; then
+      echo "ERROR: ${crate}@${version} never appeared on the crates.io index after ${timeout_seconds}s." >&2
+      failed=1
+      break
+    fi
+    sleep 10
+    waited=$((waited + 10))
+    crates_index_forget "$crate"
+  done
+  crates_index_has_version "$crate" "$version" || continue
+
+  version_json="$(
+    curl -sS --retry 4 --retry-connrefused \
+      -H 'User-Agent: zakura-release-tooling (https://github.com/zakura-core/zakura)' \
+      "${CRATES_API_URL}/crates/${crate}/${version}"
+  )" || {
+    echo "ERROR: could not read ${crate}@${version} from the crates.io API." >&2
+    failed=1
+    continue
+  }
+
+  if [ "$(jq -r '.version.yanked' <<<"$version_json")" != "false" ]; then
+    echo "ERROR: ${crate}@${version} is yanked on crates.io." >&2
+    failed=1
+    continue
+  fi
+
+  if [ "$attest" != true ]; then
+    printf '  %-30s %-18s published\n' "$crate" "$version"
+    continue
+  fi
+
+  actual="$(jq -r '
+    .version.trustpub_data
+    | if . == null then "none"
+      else "\(.provider) \(.repository) \(.run_id) \(.sha)"
+      end
+  ' <<<"$version_json")"
+  expected="github ${repository} ${run_id} ${sha}"
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR: ${crate}@${version} was not published by this run." >&2
+    echo "         expected: ${expected}" >&2
+    echo "         recorded: ${actual}" >&2
+    failed=1
+    continue
+  fi
+  printf '  %-30s %-18s published by this run\n' "$crate" "$version"
+done <<<"$selected"
+
+if [ "$failed" -ne 0 ]; then
+  echo >&2
+  echo "ERROR: the publish did not land as planned. crates.io versions cannot be replaced," >&2
+  echo "so recover by re-running the publish (already-published crates are skipped), and" >&2
+  echo "yank anything uploaded in error." >&2
+  exit 1
+fi
+
+echo
+echo "Every selected crate version is live on crates.io."


### PR DESCRIPTION
## Motivation

[#654](https://github.com/zakura-core/zakura/pull/654) proved the plan and the OIDC identity but deliberately had no upload path, so releases still depend on a maintainer running `cargo login` and a hand-ordered publish loop from a laptop. That is the credential and the drift this initiative removes: the rc3 versions were published by hand from a commit that was never tagged.

This PR adds the upload path. It stays manually dispatched; wiring it into `Create release` is the follow-up.

The `oidc-smoke` job of [run 31961981502](https://github.com/zakura-core/zakura/actions/runs/31961981502) has now passed, so the `crates-io` environment and at least one trusted-publisher entry are confirmed working.

## Solution

`scripts/publish-crates.sh` gains a `publish` mode alongside `plan` and `verify`:

- The publish set still comes from `cargo metadata` filtered against the live sparse index, so a crate already published at its workspace version is excluded. That is what makes publishing **resumable**: a run that fails partway through is recovered by dispatching it again, not by yanking.
- **Hard error on an unpublished crate name.** Trusted Publishing cannot create a crate, because the configuration authorizing this workflow lives on a crate that must already exist. Previously a `NOTICE`; discovering this mid-upload would leave a partial, irreversible publish.
- **Advisory when a selected version sits below the newest already published.** This is expected for a hotfix on an older release line, and otherwise means the run is publishing from a stale tag — `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but deliberately never published, and re-dispatching one of those would permanently add stale prereleases. It is an advisory, not an error, precisely because the hotfix case is legitimate.
- `cargo publish --workspace --no-verify --locked` with the computed exclusions. `--no-verify` is required rather than a shortcut: `verify` compiled these exact packages minutes earlier in a token-free job, and repeating those builds would outlast the 30-minute token. Cargo orders the multi-package publish and waits for index availability itself, replacing the hand-ordered loop.

`.github/workflows/publish-crates.yml` splits into `plan-verify` → `publish` → `verify-published` → `install-check`, with a `mode` input. `oidc-smoke` is kept under `mode: verify` as the zero-upload pre-flight.

`scripts/verify-published-crates.sh` is new. crates.io records the repository, run ID, and commit behind every Trusted Publishing upload and serves them publicly as a version's `trustpub_data`; asserting those name this run distinguishes "the release pipeline published this" from "a version with the right number exists".

### Why this workflow keeps the publishing identity

crates.io matches its Trusted Publisher configuration against the OIDC **`workflow_ref`** claim, which names the *top-level* workflow a run starts from — see [`handle_github_token_inner`](https://github.com/rust-lang/crates.io/blob/main/src/controllers/trustpub/tokens/exchange/mod.rs) and [`extract_workflow_filename`](https://github.com/rust-lang/crates.io/blob/main/crates/crates_io_trustpub/src/github/workflows.rs). A `workflow_call` from `create-release.yml` would therefore present `create-release.yml`, requiring every crate to be reconfigured. Release automation must **dispatch** this workflow, which the follow-up PR does. (crates.io also rejects the `workflow_run` event outright, so chaining that way is not available either.)

### Token exposure

The POC kept the token in a checkout-free job. Real publishing cannot: the token and the repo checkout must be in the same job. Mitigations are the step-scoped env var, `persist-credentials: false` on both checkouts, tooling pinned from the dispatched `main` commit, the action's auto-revoke post step, and the `crates-io` environment approval on the exact run.

## Testing

Linters: `shellcheck scripts/*.sh scripts/lib/*.sh`, `actionlint`, `markdownlint --config .github/.markdownlint.yaml`, and `zizmor --min-severity informational` (CI's setting) — all clean.

Behaviour, run against live crates.io:

- `publish-crates.sh plan` on this branch: 14 publishable crates, 5 to publish. `zakura-header-chain 1.0.0-rc0` is correctly classified `to_publish` rather than a new crate, since `0.0.0` is reserved.
- `plan` against the `v1.1.0-rc0` tag, one of the deliberately unpublished ones: all 7 selected crates flagged below the newest published version. This is the exact case the advisory exists for.
- `publish` with no `CARGO_REGISTRY_TOKEN`: fails with the token error, after the plan and before any upload.
- `publish` against an index where no crate resolves: hard-fails with the unreserved-name error, exit 1, never reaching `cargo publish`. The same input under `plan` exits 0 with a notice.
- 11-case unit test of the semver comparator. `sort -V` orders `1.0.0` before `1.0.0-rc1`, the reverse of semver, which would have hidden the stale-prerelease case — hence the small Python key rather than `sort -V`.
- `verify-published-crates.sh` on four paths: existence-only pass; attestation correctly **failing** against hand-published `zakura@1.2.0` (`recorded: none`); attestation **passing** against `cargo-semver-checks@0.50.0`, a real Trusted Publishing upload; and the index-timeout path.

Not exercised: an actual upload. The acceptance test for that is `mode=publish` against `v1.2.0`, where every crate is already published — the token is minted first and the script then no-ops, proving the exchange and the real job shape with zero upload risk. Happy to run that before this is marked ready.

## Changelog

No changelog fragment: this changes release automation only and touches no Rust source or `Cargo.toml`.

### Specifications & References

- [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing)
- Supersedes the in-`create-release` approach of [#157](https://github.com/zakura-core/zakura/pull/157); builds on [#654](https://github.com/zakura-core/zakura/pull/654).

### Follow-up Work

- Stacked on this: `ci/crates-io-publish-wiring` dispatches this workflow from `Create release`.
- **Before merging:** audit that every one of the 14 publishable crates has a trusted-publisher entry for `publish-crates.yml` / `crates-io`. `oidc-smoke` passing proves at least one matched, not all of them. A crate missing its entry is silently absent from the token's `crate_ids` and fails mid-publish. Ownership is split — 13 crates are owned by `ebfull`, `zakura-header-chain` by `p0mvn` — so this needs both.
- The `crates-io` environment currently has a single reviewer. Consider a second so releases do not stall.

### AI Disclosure

- [x] AI tools were used: Claude Code (Claude Opus 5) wrote the scripts, workflow, docs, and this description; the crates.io claim semantics were verified by reading the registry's source rather than assumed, and every behavioural claim above was executed.
