### PR TITLE
ci(release): hand crates.io publishing off from Create release

### DIFF
--- a/.agents/skills/release-zakura/SKILL.md
+++ b/.agents/skills/release-zakura/SKILL.md
@@ -103,6 +103,10 @@ For crates.io publishing:
    runs the same script as the `crates.io publish graph` job in
    `tests-unit.yml` (part of `test success`), so a missing cascade bump
    cannot merge. It is also step 5 of `make pre-release`.
+7. Reserve any crate name the release adds. The same check warns when a
+   selected crate has never been published; CI cannot bootstrap it, because
+   its crates.io Trusted Publishing entry lives on a crate that must already
+   exist. Publish the name manually and configure it before the release.
 
 Partial version graphs are allowed, but all tooling must handle them. Do not
 assume every publishable crate has the `zakura` package version.
@@ -236,6 +240,9 @@ The workflow must:
 5. create the immutable tag and GitHub pre-release
 6. publish the release assets; the tag push then triggers
    `release-binaries.yml`, which publishes the Docker images
+7. dispatch `publish-crates.yml` for the new tag, unless `publish_crates` is
+   `never`, the tag is a release candidate under the default `auto`, or
+   `allow_unpublishable_crate_graph` is set
 
 The documented emergency source-first mode skips the pre-tag VCT crossing and
 asset build. A handoff-canary failure in the normal path blocks release
@@ -257,8 +264,12 @@ still has the previous package version.
 - Verify release checksums.
 - Verify the standard Docker image has amd64 and arm64; verify the
   zcashd-compat image has amd64.
-- Publish only changed crates, preserving dependency order.
-- Install the exact version from crates.io and run `zakurad --version`.
+- Approve the `crates-io` deployment on the dispatched `Publish crates` run
+  after reviewing its plan table; that approval is the crates.io publish, and
+  it is irreversible. Retry a partial publish by dispatching the workflow again
+  for the same tag, never by yanking.
+- Confirm the run's `Verify the published versions` and `Install zakurad from
+  crates.io` jobs passed; they replace publishing and installing by hand.
 - Replace the boilerplate GitHub release body with concrete notes from the final
   changelog or approved release-note draft.
 - Promote stable releases with `./scripts/release-t0.sh promote --tag <tag>`

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -320,20 +320,25 @@ from publication until deletion.
 
 ## Publish Crates
 
-- [ ] [Run `cargo login`](https://github.com/zakura-core/zakura/dev/crate-owners.html#logging-in-to-cratesio)
-- [ ] It is recommended that the following step be run from a fresh checkout of
-      the repo, to avoid accidentally publishing files like e.g. logs that might
-      be lingering around
-- [ ] Publish the crates to crates.io; edit the list to only include the crates that
-      have been changed, but keep their overall order:
+CI publishes the crates from the tagged commit using crates.io Trusted
+Publishing. There is no `cargo login`, no local publish loop, and no crate list
+to edit: the set comes from `cargo metadata` filtered against the live index,
+so only crates whose workspace version is absent are uploaded. See
+[`docs/release-tag-protection.md`](https://github.com/zakura-core/zakura/blob/main/docs/release-tag-protection.md).
 
-```
-for c in zakura-test zakura-tower-fallback zakura-jsonl-trace zakura-chain zakura-header-chain zakura-tower-batch-control zakura-node-services zakura-script zakura-state zakura-consensus zakura-network zakura-rpc zakura-utils zakura; do cargo release publish --verbose --execute -p $c; done
-```
-
-- [ ] Check that Zakura can be installed from `crates.io`:
-      `cargo install --locked --force --version <version> zakura && ~/.cargo/bin/zakurad`
-      and put the output in a comment on the PR.
+- [ ] Confirm `Create release` dispatched `Publish crates` for this tag. It
+      does so automatically for a stable tag; for a release candidate, dispatch
+      it by hand from `main` with `mode: publish` once the decision to publish
+      has been made.
+- [ ] Review the crate/version/status table in that run's summary, then have a
+      `crates-io` environment reviewer approve the deployment. Approving is
+      irreversible — a published version can be yanked, never replaced.
+- [ ] Confirm `Verify the published versions` and `Install zakurad from
+      crates.io` pass, and put the reported `zakurad --version` in a comment on
+      the PR.
+- [ ] If the publish failed partway through, dispatch `Publish crates` again
+      for the same tag: the plan skips whatever landed and publishes the rest.
+      Never repair a partial publish by yanking and re-uploading a version.
 
 ## Publish Docker Images
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,15 @@ on:
         description: "Release tag, matching the zakura package version (for example v1.0.0-rc2)"
         required: true
         type: string
+      publish_crates:
+        description: "Publish to crates.io after tagging: auto publishes stable tags and skips release candidates. A crates-io reviewer still approves the upload"
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - always
+          - never
       allow_bootstrap_release_state:
         description: "Emergency override: accept legacy-bootstrap Mainnet release state (note it in the release PR)"
         required: false
@@ -258,6 +267,11 @@ jobs:
         )
       }}
     environment: release
+    # actions: write is for dispatching crates.io publishing below; the release
+    # itself is created with the GitHub App token, not GITHUB_TOKEN.
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Download staged release assets
         if: ${{ !inputs.source_first_release }}
@@ -480,3 +494,77 @@ jobs:
               --jq '.html_url'
           )"
           echo "Published ${html_url}; tag ${RELEASE_TAG} now points to ${TARGET_SHA}."
+
+      # Dispatched rather than called: crates.io matches its Trusted Publisher
+      # configuration against the OIDC `workflow_ref` claim, which names the
+      # workflow a run starts from, so a `workflow_call` here would present
+      # create-release.yml as the publishing identity instead of
+      # publish-crates.yml.
+      #
+      # Always --ref main, including for a hotfix release: publish-crates.yml
+      # resolves and checks out the tag on its own, so the crates-io
+      # environment stays restricted to main.
+      #
+      # This only queues the upload. A crates-io environment reviewer approves
+      # it, in its own concurrency group, so a release left awaiting that
+      # decision never holds this workflow open.
+      - name: Dispatch crates.io publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          PUBLISH_CRATES: ${{ inputs.publish_crates }}
+          UNPUBLISHABLE_GRAPH: ${{ inputs.allow_unpublishable_crate_graph && 'true' || 'false' }}
+        run: |
+          set -euo pipefail
+
+          skip_reason=""
+          if [ "$UNPUBLISHABLE_GRAPH" = "true" ]; then
+            # This override means the publish graph does not resolve, so the
+            # release is GitHub-only by definition.
+            skip_reason="allow_unpublishable_crate_graph was set, so this release must not publish crates"
+          else
+            case "$PUBLISH_CRATES" in
+              never)
+                skip_reason="publish_crates was set to never"
+                ;;
+              always) ;;
+              auto)
+                case "$RELEASE_TAG" in
+                  # Release candidates decide per release, so auto leaves them
+                  # to an explicit dispatch.
+                  *-*) skip_reason="publish_crates is auto and ${RELEASE_TAG} is a release candidate" ;;
+                esac
+                ;;
+              *)
+                echo "Unexpected publish_crates value: ${PUBLISH_CRATES}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          workflow_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/publish-crates.yml"
+          if [ -n "$skip_reason" ]; then
+            echo "Not dispatching crates.io publishing: ${skip_reason}."
+            {
+              echo "## Crates.io"
+              echo
+              echo "Not dispatched: ${skip_reason}."
+              echo
+              echo "To publish later, run [\`Publish crates\`](${workflow_url}) from \`main\`"
+              echo "with \`mode: publish\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh workflow run publish-crates.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f release_tag="$RELEASE_TAG" \
+            -f mode=publish
+          echo "Dispatched crates.io publishing for ${RELEASE_TAG}."
+          {
+            echo "## Crates.io"
+            echo
+            echo "Dispatched [\`Publish crates\`](${workflow_url}) for \`${RELEASE_TAG}\`."
+            echo "It waits for a \`crates-io\` environment reviewer before uploading."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -60,7 +60,9 @@ ruleset administration must remain limited.
 2. Open **Actions > Create release > Run workflow**.
 3. Select the `main` branch, enter the exact release tag, and set the expected
    tag delay. Dispatching the workflow acknowledges that no release hold is
-   active.
+   active. Leave `publish_crates` on `auto` unless this release departs from
+   the norm: `auto` publishes stable tags to crates.io and leaves release
+   candidates to an explicit dispatch.
 4. The workflow resolves the latest digest-verified Mainnet release-state
    bundle and warns about release-level, committed-state, or
    `ESTIMATED_RELEASE_HEIGHT` readiness problems. Then wait for it to build and
@@ -71,6 +73,9 @@ ruleset administration must remain limited.
 6. Confirm that `Release binaries` starts from the new tag, skips rebuilding
    the existing assets, publishes the Docker images, and opens the installer
    metadata update pull request.
+7. If the run dispatched crates.io publishing, approve the `crates-io`
+   deployment on that run. See
+   [Crates.io Trusted Publishing](#cratesio-trusted-publishing).
 
 The workflow always builds the commit selected when it was dispatched, even if
 `main` advances before approval. It is safe to rerun after a partial failure:
@@ -82,11 +87,29 @@ when and how a release is promoted.
 
 ## Crates.io Trusted Publishing
 
-The manually dispatched
-[`Publish crates`](../.github/workflows/publish-crates.yml) workflow publishes
-Zakura's crates from a published release tag, authenticated by short-lived
-tokens crates.io mints against this repository's GitHub OIDC identity. No
-registry credential is stored anywhere.
+The [`Publish crates`](../.github/workflows/publish-crates.yml) workflow
+publishes Zakura's crates from a published release tag, authenticated by
+short-lived tokens crates.io mints against this repository's GitHub OIDC
+identity. No registry credential is stored anywhere.
+
+`Create release` dispatches it as the last thing it does, once the tag exists,
+subject to its `publish_crates` input:
+
+- **`auto`** (the default) publishes a stable tag and skips a release
+  candidate. Release candidates have gone both ways — `v1.1.0-rc1` and
+  `v1.1.0-rc2` were published while `v1.0.3-rc1`, `v1.1.0-rc0`, and
+  `v1.2.0-rc0` deliberately were not — so `auto` asks for a decision instead
+  of assuming one.
+- **`always`** publishes whatever the tag looks like.
+- **`never`**, and any release using `allow_unpublishable_crate_graph`, does
+  not dispatch. That override means the publish graph does not resolve, so the
+  release is GitHub-only by definition.
+
+Dispatching only queues the upload behind the `crates-io` environment
+reviewer. Because that approval waits in the dispatched run rather than in
+`Create release`, a release left pending a publishing decision does not hold
+the release workflow open. Dispatch `Publish crates` by hand at any later
+point for a tag that was skipped, or to retry one that failed.
 
 The workflow takes a `mode`:
 
@@ -153,25 +176,23 @@ this file would present `create-release.yml`. That is why release automation
 dispatches this workflow instead of calling it, and why renaming this file
 means reconfiguring every crate.
 
-### Publishing a release
+### Approving a publish
 
-An operator needs repository Write access or higher, but no crates.io account
-permission:
+Approving needs no crates.io account permission, only membership in the
+`crates-io` environment's reviewers:
 
-1. Open **Actions > Publish crates > Run workflow**.
-2. Select `main`, enter the published release tag, choose the mode, and
-   dispatch. Always dispatch from `main`, including for a hotfix release: the
-   tag is resolved by name and checked out on its own, so the `crates-io`
-   environment stays restricted to `main`.
-3. Ask a `crates-io` environment reviewer to approve the pending deployment,
-   after reviewing the crate/version/status table in the run summary. Watch
-   for rows flagged as below the newest published version: expected for a
-   hotfix on an older release line, and otherwise a sign the run is publishing
-   from a stale tag.
-4. Confirm every job passes. After a `publish` run, `Verify the published
-   versions` asserts that each new version's crates.io record names this
-   workflow run and the dispatch commit on `main` (the OIDC `sha` claim),
-   and `Install zakurad from crates.io` installs and runs the published binary.
+1. Open the pending `Publish crates` run and read the crate/version/status
+   table in the `Plan and verify crate publication` summary. This is the last
+   point at which the upload can be stopped.
+2. Watch for rows flagged as below the newest published version. That is
+   expected for a hotfix on an older release line, and otherwise means the run
+   is publishing from a stale tag — most likely a tag that was deliberately
+   never published.
+3. Approve the `crates-io` deployment.
+4. Confirm every job passes. `Verify the published versions` asserts that each
+   new version's public crates.io record names this workflow run and the
+   dispatch commit on `main` (the OIDC `sha` claim), and `Install zakurad from
+   crates.io` installs and runs the published binary.
 
 Both post-publish jobs run after the uploads are already irreversible, so a
 failure there reports a problem rather than preventing one. `Install zakurad
@@ -179,10 +200,17 @@ from crates.io` in particular is a cold release build of the whole node and can
 exhaust its timeout on a slow runner; re-run the job before concluding the
 published crates are broken.
 
-Publishing to crates.io has historically been a separate decision from
-tagging — `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` were tagged but
-intentionally never published — and the environment reviewer is where that
-decision is now recorded.
+### Dispatching by hand
+
+An operator needs repository Write access or higher. Open **Actions > Publish
+crates > Run workflow**, select `main`, enter the published release tag, and
+choose the mode. Always dispatch from `main`, including for a hotfix release:
+the workflow resolves the tag by name and checks it out on its own, so the
+`crates-io` environment stays restricted to `main`.
+
+Reach for this to publish a tag `Create release` skipped, to retry a failed or
+partial publish, or — with `mode: verify` — to confirm before a release that
+the crate selection and the trusted-publisher configuration are still good.
 
 ## Promotion and the "Latest" Release
 

--- a/docs/security-hotfix-release.md
+++ b/docs/security-hotfix-release.md
@@ -366,13 +366,16 @@ What Mode B trades, explicitly:
 
 ### Crates publish
 
-From a fresh checkout of the new tag, per the standard checklist: `cargo
-login`, then the publish loop in dependency order (`zakura-test … zakura`),
-edited to the crates that changed. Hotfix notes: crates.io is **public and
-irreversible from the first crate** — it's part of T-0, never earlier;
-`[workspace.metadata.release]` in the root `Cargo.toml` allows publishing
-from `hotfix/v*` checkouts; a mid-loop
-failure is fixed forward by publishing the remainder, not by yanking.
+`Create release` dispatches `Publish crates` once the tag exists, per the
+standard checklist; approving its `crates-io` deployment is the publish.
+Hotfix notes: crates.io is **public and irreversible from the first crate** —
+that approval is part of T-0, never earlier; the dispatch always targets
+`main` and the workflow checks out the tag itself, so publishing works from a
+`hotfix/v*` release without the `crates-io` environment accepting hotfix
+branches; a mid-publish failure is fixed forward by dispatching the workflow
+again for the same tag, which skips what landed, not by yanking. A hotfix on
+an older release line publishes versions below the newest on crates.io, so
+expect the plan to flag those rows — here that is correct.
 
 ### Pre-announcement
 

--- a/scripts/check-crate-publish-graph.sh
+++ b/scripts/check-crate-publish-graph.sh
@@ -127,6 +127,7 @@ local_internal_reqs="$(jq -r '
 publish_set=()
 exclude_args=()
 divergent=0
+unreserved=0
 
 echo "Crates.io publish set (exact workspace versions absent from the index):"
 while IFS=$'\t' read -r crate version; do
@@ -159,6 +160,17 @@ while IFS=$'\t' read -r crate version; do
     1)
       printf '  %s@%s: to publish\n' "$crate" "$version"
       publish_set+=("${crate}@${version}")
+
+      # Advisory: Trusted Publishing cannot create a crate, because the
+      # configuration authorizing the release workflow lives on an existing
+      # crate. Surfacing an unreserved name here puts it in the release PR,
+      # rather than in a half-finished publish at T-0. The index response is
+      # already cached by the query above, so this costs no extra request.
+      if [ -z "$(crates_index_versions "$crate")" ]; then
+        printf '      WARNING: %s has never been published; reserve the name manually and add its crates.io Trusted Publishing entry (docs/release-tag-protection.md) before this release\n' \
+          "$crate"
+        unreserved=1
+      fi
       ;;
     *)
       echo "ERROR: could not query the crates.io index for ${crate}." >&2
@@ -263,5 +275,8 @@ fi
 echo "Publish graph resolves at workspace versions: ${publish_set[*]}"
 if [ "$divergent" = 1 ]; then
   echo "WARNING: published crates with locally diverged requirements were skipped above; review the warnings." >&2
+fi
+if [ "$unreserved" = 1 ]; then
+  echo "WARNING: crate names that do not exist on crates.io were selected above; automated publishing refuses to run until they are reserved and configured." >&2
 fi
 exit 0


### PR DESCRIPTION
## Motivation

With #694 the upload path exists, but it is still a manual dispatch, so the tag and the registry artifacts can drift apart. That is not hypothetical: the rc3 crates were published by hand from a commit that was never tagged, and those registry versions now correspond to no tag at all.

## Solution

`Create release` dispatches `Publish crates` for the tag it just created, as the last step of the `publish` job — after the tag exists.

**Dispatched, not called.** crates.io matches its Trusted Publisher configuration against the OIDC `workflow_ref` claim, which names the workflow a run starts from, so a `workflow_call` would present `create-release.yml` as the publishing identity and require reconfiguring all 14 crates. (`on: workflow_run` is not an option either — crates.io rejects that event.) This reuses the existing `handoff-canary` pattern in the same file: `gh workflow run` with `github.token` and `actions: write`, which is confirmed working in this repo.

**Dispatching also keeps the approval out of `Create release`.** This was [#157](https://github.com/zakura-core/zakura/pull/157)'s open design question 1: a publish job gated inside `create-release.yml` holds the `create-release` concurrency group open while parked on the approval, and GitHub expires an unapproved deployment after 30 days. In its own run, the `crates-io` approval can wait for test/sign/promote without blocking anything.

**New `publish_crates` input**, defaulting to `auto`:

- `auto` publishes a stable tag and leaves a release candidate to an explicit dispatch. RCs have genuinely gone both ways — `v1.1.0-rc1` and `v1.1.0-rc2` were published, `v1.0.3-rc1`, `v1.1.0-rc0`, and `v1.2.0-rc0` deliberately were not — so `auto` asks for a decision rather than assuming one. This is where this PR departs from #157, which hard-blocked every pre-release.
- `always` publishes whatever the tag looks like; `never` skips.
- `allow_unpublishable_crate_graph` forces the skip: that override already means the publish graph does not resolve, so the release is GitHub-only by definition.

**Always `--ref main`,** including for a hotfix release. `Publish crates` resolves and checks out the tag itself, so hotfix releases publish without the `crates-io` environment having to accept `hotfix/v*` branches — it stays `main`-only, unlike the `release` environment.

`check-crate-publish-graph.sh` now warns when a selected crate has never been published. Trusted Publishing cannot bootstrap a crate name, so this belongs in the release PR — it runs as step 5 of `make pre-release`, which `create-release.yml`'s `validate` job already invokes — rather than as a hard failure at T-0.

