### PR TITLE
fix(release): cascade-republish the crates pinning zakura-chain 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -8580,7 +8580,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8649,7 +8649,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "hex",
  "lazy_static",
@@ -8781,7 +8781,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "3.2.0"
+version = "3.2.1"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "3.2.0"
+version = "3.2.1"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "2.2.0"
+version = "2.2.1"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/docs/changelog/unreleased/696.md
+++ b/docs/changelog/unreleased/696.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+This PR only patch-bumps four library crates so they republish with dependency
+requirements that already landed on `main`. It changes no code and no operator-
+visible `zakurad` behavior.


### PR DESCRIPTION
## Motivation

`./scripts/check-crate-publish-graph.sh` fails on `main` today. Publishing the current workspace would put a broken graph on crates.io.

Root cause: `zakura-chain` took a new major on `main` (`5.0.0` → `6.0.0`), along with `zakura-consensus` (`6.1.0` → `7.0.0`), `zakura-network` (`6.1.0` → `7.0.0`), and `zakura-state` (`6.2.0` → `7.0.0`). Four published dependents — `zakura-node-services`, `zakura-script`, `zakura-rpc`, `zakura-utils` — had their requirements rewritten to match but kept their already-published versions. Those rewrites can never ship: a crate that is not republished is resolved from its **index** manifest, and the index copies still pin `zakura-chain ^5.0.0`.

This is the silent-duplicate-major failure, not a resolution error. cargo happily selects `zakura-chain 5.0.0` next to `6.0.0`, the dry-run publish itself succeeds, and consumers get two copies of the crate with mismatched types between them. `check-crate-publish-graph.sh` catches it by asserting on the `Cargo.lock` cargo writes into each packaged archive:

```
ERROR: zakura-consensus-7.0.0 resolves zakura-chain 5.0.0; this workspace publishes zakura-chain 6.0.0.
ERROR: zakura-state-7.0.0 resolves zakura-chain 5.0.0; this workspace publishes zakura-chain 6.0.0.
ERROR: zakura-network-7.0.0 resolves zakura-chain 5.0.0; this workspace publishes zakura-chain 6.0.0.
```

### Why nothing caught this at merge time

`Semver checks` is explicit that bump levels "settle when the change merges, not when the release is being cut" — it exists because v1.0.3 shipped with semver debt discovered on release day. It did not catch this, and correctly so: `cargo semver-checks` compares rustdoc APIs, and these crates' APIs are textually unchanged. The type *names* are identical across the `zakura-chain` major, so nothing in `zakura-node-services`' public surface looks different. It cannot see a dependency's major bump underneath.

`check-crate-publish-graph.sh` is the check that can see it, and it only runs at release time (`make pre-release`, and PRs labelled `A-release`). So the debt accumulated legitimately, which is worth knowing independently of this fix.

## Solution

Patch-bump exactly the four crates whose index manifests do the pinning, which is the documented cascade fix. Nothing else changes: `^3.2.0` still selects `3.2.1`, and `dependent-version = "fix"` only rewrites a requirement that no longer matches, so no dependent manifest is touched.

| Crate | Before | After |
| --- | --- | --- |
| `zakura-node-services` | 3.2.0 | 3.2.1 |
| `zakura-script` | 3.2.0 | 3.2.1 |
| `zakura-rpc` | 7.0.0 | 7.0.1 |
| `zakura-utils` | 2.2.0 | 2.2.1 |

Patch is the right level, not a judgment call I made: `cargo semver-checks --default-features` reports `no semver update required` for these crates against their published baselines. The bump exists to ship the rewritten requirements, which is exactly what a cascade bump is for.

`zakura` is deliberately left at `1.2.0`. It pins the same stale versions, so the graph check still reports it in the advisory list, but nothing depends on `zakura`, so its index manifest cannot corrupt anyone else's resolution — and release preparation sets its version from the release tag. Bumping it here would be pre-deciding the next release version.

## Testing

The fix is verified by the check that was failing, run to completion against the live crates.io index:

- **Before** (`main`): exit 1, the three `resolves zakura-chain 5.0.0` errors above.
- **After**: exit 0 — `Publish graph resolves at workspace versions: zakura-chain@6.0.0 zakura-consensus@7.0.0 zakura-header-chain@1.0.0-rc0 zakura-node-services@3.2.1 zakura-script@3.2.1 zakura-state@7.0.0 zakura-network@7.0.0 zakura-rpc@7.0.1 zakura-utils@2.2.1`.

That check dry-run-publishes the real publish set against the live index and then reads the `Cargo.lock` out of each packaged archive, so it exercises the root cause directly: the assertion that failed is precisely "a packaged crate resolves a workspace crate at a non-workspace version".

- `cargo semver-checks --package <crate> --default-features` on `zakura-node-services` and `zakura-script`: `no semver update required`, confirming patch is correct and that this is a cascade rather than an API break. CI runs the same check on all affected crates.
- The only remaining advisory is `zakura@1.2.0`, which is expected and explained above.

Not run locally: the full workspace build and test suite. This is a version-and-lockfile-only change with no source edits, so it is left to draft CI.

## Changelog

<!-- changelog: none -->

Internal release plumbing: these patch bumps carry no user-visible `zakurad` behaviour change. They exist so the affected crates republish with requirements that already landed.

### Specifications & References

- The cascade rule and both failure shapes are documented in [`scripts/check-crate-publish-graph.sh`](https://github.com/zakura-core/zakura/blob/main/scripts/check-crate-publish-graph.sh) and `.agents/skills/release-zakura/SKILL.md`.
- Surfaced while wiring up automated crates.io publishing (#694, #695); independent of both.

### Follow-up Work

- PR CI for this check is stacked as #698. It cannot land first: the graph is still broken on `main`.
- `scripts/check-crate-version-bumps.sh` reports every crate as "new since v1.2.0", because `v1.2.0` predates the `crates/` move and the script has no fallback for the old layout (`create-release.yml` does have one). That made it useless for diagnosing this, and is worth fixing separately.

### AI Disclosure

- [x] AI tools were used: Claude Code (Claude Opus 5) diagnosed the failure, determined the cascade set, and wrote this description. The cascade set was derived from the workspace dependency graph and confirmed empirically by the before/after check runs above rather than assumed.
