### PR TITLE
fix(network): drop per-connection Prometheus addr labels

### DIFF
--- a/crates/zakura-network/src/config.rs
+++ b/crates/zakura-network/src/config.rs
@@ -337,9 +337,9 @@ pub struct Config {
     /// outbound connections are also limited to a multiple of `peerset_initial_target_size`.
     pub max_connections_per_ip: usize,
 
-    /// Exposes legacy peer IP addresses in peer activity logs, structured trace files, and
-    /// Prometheus metric labels. This includes connected peers and candidate or address book
-    /// entries.
+    /// Exposes legacy peer IP addresses in peer activity logs and structured trace files.
+    /// This includes connected peers and candidate or address book entries.
+    /// Seed and peer-cache Prometheus metrics also use this setting for `remote_ip` labels.
     ///
     /// Literal addresses supplied in the node configuration can appear in startup logs and
     /// `seed` labels regardless of this setting.
@@ -348,9 +348,8 @@ pub struct Config {
     ///
     /// # Security
     ///
-    /// Enabling this setting reveals peer topology in logs and trace files, and can create
-    /// high-cardinality metric series. Restrict access to logs, trace directories, the metrics
-    /// endpoint, and downstream monitoring systems.
+    /// Enabling this setting reveals peer topology in logs and trace files. Restrict access
+    /// to logs, trace directories, and downstream monitoring systems.
     pub expose_peer_addresses: bool,
 }
 

--- a/crates/zakura-network/src/peer/connection.rs
+++ b/crates/zakura-network/src/peer/connection.rs
@@ -604,7 +604,7 @@ where
     #[allow(dead_code)]
     pub(super) connection_tracker: ConnectionTracker,
 
-    /// The configured log and metrics label for this peer. Usually the remote IP and port.
+    /// The configured log label for this peer. Usually the remote IP and port.
     pub(super) addr_label: String,
 
     /// The state for this peer, when the metrics were last updated.
@@ -809,7 +809,6 @@ where
                             metrics::counter!(
                                 "zakura.net.in.responses",
                                 "command" => response.command(),
-                                "addr" => self.addr_label.clone(),
                             )
                             .increment(1);
                         } else {
@@ -993,7 +992,6 @@ where
             metrics::counter!(
                 "zakura.net.out.requests.canceled",
                 "command" => request.command(),
-                "addr" => self.addr_label.clone(),
             )
             .increment(1);
             self.update_state_metrics(format!("Out::Req::Canceled::{}", request.command()));
@@ -1007,7 +1005,6 @@ where
         metrics::counter!(
             "zakura.net.out.requests",
             "command" => request.command(),
-            "addr" => self.addr_label.clone(),
         )
         .increment(1);
         self.update_state_metrics(format!("Out::Req::{}", request.command()));
@@ -1419,7 +1416,6 @@ where
         metrics::counter!(
             "zakura.net.in.requests",
             "command" => req.command(),
-            "addr" => self.addr_label.clone(),
         )
         .increment(1);
         self.update_state_metrics(format!("In::Req::{}", req.command()));
@@ -1490,7 +1486,6 @@ where
         metrics::counter!(
             "zakura.net.out.responses",
             "command" => rsp.command(),
-            "addr" => self.addr_label.clone(),
         )
         .increment(1);
         self.update_state_metrics(format!("In::Rsp::{}", rsp.command()));

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -912,22 +912,16 @@ where
             "disconnecting from peer with obsolete network protocol version",
         );
 
-        // the value is the number of rejected handshakes, by peer IP and protocol version
+        // Handshake rejects by protocol version. Not labeled by peer address or
+        // user-agent: the Prometheus exporter never prunes series.
         metrics::counter!(
             "zcash.net.peers.obsolete",
-            "remote_ip" => addr_label.clone(),
             "remote_version" => remote.version.to_string(),
             "min_version" => min_version.to_string(),
-            "user_agent" => remote.user_agent.clone(),
         )
         .increment(1);
 
-        // the value is the remote version of the most recent rejected handshake from each peer
-        metrics::gauge!(
-            "zcash.net.peers.version.obsolete",
-            "remote_ip" => addr_label.clone(),
-        )
-        .set(remote.version.0 as f64);
+        metrics::gauge!("zcash.net.peers.version.obsolete").set(remote.version.0 as f64);
 
         // Disconnect if peer is using an obsolete version.
         return Err(HandshakeError::ObsoleteVersion(remote.version));
@@ -953,23 +947,18 @@ where
         "negotiated network protocol version with peer",
     );
 
-    // the value is the number of connected handshakes, by peer IP and protocol version
+    // Handshake count by protocol version. Not labeled by peer address or
+    // user-agent: the Prometheus exporter never prunes series.
     metrics::counter!(
         "zcash.net.peers.connected",
-        "remote_ip" => addr_label.clone(),
         "remote_version" => connection_info.remote.version.to_string(),
         "negotiated_version" => negotiated_version.to_string(),
         "min_version" => min_version.to_string(),
-        "user_agent" => connection_info.remote.user_agent.clone(),
     )
     .increment(1);
 
-    // the value is the remote version of the most recent connected handshake from each peer
-    metrics::gauge!(
-        "zcash.net.peers.version.connected",
-        "remote_ip" => addr_label,
-    )
-    .set(connection_info.remote.version.0 as f64);
+    metrics::gauge!("zcash.net.peers.version.connected")
+        .set(connection_info.remote.version.0 as f64);
 
     peer_conn.send(Message::Verack).await?;
 
@@ -1500,10 +1489,7 @@ where
 
             let mut peer_conn = Framed::new(
                 data_stream,
-                Codec::builder()
-                    .for_network(&config.network)
-                    .with_metrics_addr_label(addr_label.clone())
-                    .finish(),
+                Codec::builder().for_network(&config.network).finish(),
             );
             let mut connection_tracker = connection_tracker;
 
@@ -1639,14 +1625,12 @@ where
             // Instrument the peer's rx and tx streams.
 
             let inner_conn_span = connection_span.clone();
-            let outbound_addr_label = addr_label.clone();
             let peer_tx = peer_tx.with(move |msg: Message| {
                 let span = debug_span!(parent: inner_conn_span.clone(), "outbound_metric");
                 // Add a metric for outbound messages.
                 metrics::counter!(
                     "zcash.net.out.messages",
                     "command" => msg.command(),
-                    "addr" => outbound_addr_label.clone(),
                 )
                 .increment(1);
                 // We need to use future::ready rather than an async block here,
@@ -1669,13 +1653,11 @@ where
             let inbound_inv_collector = inv_collector.clone();
             let ts_inner_conn_span = connection_span.clone();
             let inv_inner_conn_span = connection_span.clone();
-            let inbound_addr_label = addr_label.clone();
             let peer_rx = peer_rx
                 .then(move |msg| {
                     // Add a metric for inbound messages and errors.
                     // Fire a timestamp or failure event.
                     let inbound_ts_collector = inbound_ts_collector.clone();
-                    let addr_label = inbound_addr_label.clone();
                     let span =
                         debug_span!(parent: ts_inner_conn_span.clone(), "inbound_ts_collector");
 
@@ -1685,7 +1667,6 @@ where
                                 metrics::counter!(
                                     "zcash.net.in.messages",
                                     "command" => msg.command(),
-                                    "addr" => addr_label.clone(),
                                 )
                                 .increment(1);
 
@@ -1698,7 +1679,6 @@ where
                                 metrics::counter!(
                                     "zakura.net.in.errors",
                                     "error" => err.to_string(),
-                                    "addr" => addr_label.clone(),
                                 )
                                 .increment(1);
 

--- a/crates/zakura-network/src/protocol/external/codec.rs
+++ b/crates/zakura-network/src/protocol/external/codec.rs
@@ -149,15 +149,6 @@ impl Builder {
         self.max_len = len;
         self
     }
-
-    /// Previously attached a peer-address label to byte counters.
-    ///
-    /// This is a no-op: per-addr labels are never pruned by the Prometheus
-    /// exporter and grew without bound on public listeners.
-    #[allow(dead_code)]
-    pub fn with_metrics_addr_label(self, _metrics_addr_label: String) -> Self {
-        self
-    }
 }
 
 // ======== Encoding =========

--- a/crates/zakura-network/src/protocol/external/codec.rs
+++ b/crates/zakura-network/src/protocol/external/codec.rs
@@ -154,6 +154,7 @@ impl Builder {
     ///
     /// This is a no-op: per-addr labels are never pruned by the Prometheus
     /// exporter and grew without bound on public listeners.
+    #[allow(dead_code)]
     pub fn with_metrics_addr_label(self, _metrics_addr_label: String) -> Self {
         self
     }

--- a/crates/zakura-network/src/protocol/external/codec.rs
+++ b/crates/zakura-network/src/protocol/external/codec.rs
@@ -93,8 +93,6 @@ pub struct Builder {
     version: Version,
     /// The maximum allowable message length.
     max_len: usize,
-    /// An optional address label, to use for reporting metrics.
-    metrics_addr_label: Option<String>,
 }
 
 impl Codec {
@@ -104,7 +102,6 @@ impl Codec {
             network: Network::Mainnet,
             version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
             max_len: MAX_HANDSHAKE_BODY_LEN,
-            metrics_addr_label: None,
         }
     }
 
@@ -153,9 +150,11 @@ impl Builder {
         self
     }
 
-    /// Configure the codec with a label corresponding to the peer address.
-    pub fn with_metrics_addr_label(mut self, metrics_addr_label: String) -> Self {
-        self.metrics_addr_label = Some(metrics_addr_label);
+    /// Previously attached a peer-address label to byte counters.
+    ///
+    /// This is a no-op: per-addr labels are never pruned by the Prometheus
+    /// exporter and grew without bound on public listeners.
+    pub fn with_metrics_addr_label(self, _metrics_addr_label: String) -> Self {
         self
     }
 }
@@ -174,11 +173,9 @@ impl Encoder<Message> for Codec {
             return Err(Parse("body length exceeded maximum size"));
         }
 
-        if let Some(addr_label) = self.builder.metrics_addr_label.clone() {
-            metrics::counter!("zcash.net.out.bytes.total",
-                              "addr" => addr_label)
-            .increment((body_length + HEADER_LEN) as u64);
-        }
+        // Aggregate totals only: per-addr labels are never pruned by the Prometheus
+        // exporter and grow without bound on public listeners.
+        metrics::counter!("zcash.net.out.bytes.total").increment((body_length + HEADER_LEN) as u64);
 
         use Message::*;
         // Note: because all match arms must have
@@ -455,10 +452,8 @@ impl Decoder for Codec {
                     return Err(Parse("Zakura p2pv2up payload exceeds the hard prelude cap"));
                 }
 
-                if let Some(label) = self.builder.metrics_addr_label.clone() {
-                    metrics::counter!("zcash.net.in.bytes.total", "addr" =>  label)
-                        .increment((body_len + HEADER_LEN) as u64);
-                }
+                metrics::counter!("zcash.net.in.bytes.total")
+                    .increment((body_len + HEADER_LEN) as u64);
 
                 // Reserve buffer space for the expected body and the following header.
                 src.reserve(body_len + HEADER_LEN);

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -106,7 +106,9 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
 """
 
     def setUp(self):
-        exposition = self.EXPOSITION
+        self.exposition = self.EXPOSITION
+        self.rpc_results = {}
+        outer = self
 
         class StubHandler(BaseHTTPRequestHandler):
             def log_message(self, *args):
@@ -120,12 +122,30 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
 
             def do_GET(self):
                 if self.path == "/metrics":
-                    return self.reply(200, exposition)
+                    return self.reply(200, outer.exposition)
                 if self.path == "/healthy":
                     return self.reply(200, b"ok")
                 if self.path == "/ready":
                     return self.reply(503, b"lag=47 blocks")
                 return self.reply(404, b"nope")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(length).decode())
+                method = payload.get("method")
+                if method in outer.rpc_results:
+                    body = json.dumps({
+                        "jsonrpc": "2.0",
+                        "id": payload.get("id"),
+                        "result": outer.rpc_results[method],
+                    }).encode()
+                    return self.reply(200, body)
+                body = json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": payload.get("id"),
+                    "error": {"code": -32601, "message": method},
+                }).encode()
+                return self.reply(200, body)
 
         self.server = status.ThreadingHTTPServer(("127.0.0.1", 0), StubHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -201,8 +221,8 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
         )
 
     def test_peer_versions_come_from_the_user_agent_label(self):
-        # zakurad's getpeerinfo omits subver, so the exporter label is the only
-        # source for a peer version breakdown.
+        # Legacy fallback: older zakurad omits getpeerinfo.subver, so the
+        # exporter label still fills the panel until that RPC field exists.
         probe = self.run_probe(metrics_endpoint=self.endpoint)
 
         self.assertEqual(
@@ -210,6 +230,40 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
             [["/Zakura:1.1.0/", 42], ["/MagicBean:6.2.0/", 33]],
         )
         self.assertNotIn("zcash_net_peers_connected", probe["metrics"])
+
+    def test_peer_versions_are_absent_without_user_agent_labels(self):
+        self.exposition = b"""zakura_build_info{version="1.1.0-rc1"} 1
+zcash_net_peers 74
+zcash_net_in_bytes_total 12345
+"""
+        probe = self.run_probe(metrics_endpoint=self.endpoint)
+
+        self.assertNotIn("peer_user_agents", probe)
+
+    def test_peer_versions_come_from_getpeerinfo_subver(self):
+        # Durable source: once zakurad exposes subver, the panel restores
+        # from RPC even when the exporter no longer labels by user_agent.
+        self.rpc_results = {
+            "getblockchaininfo": {
+                "blocks": 10,
+                "headers": 10,
+                "bestblockhash": "aa",
+                "chain": "test",
+            },
+            "getpeerinfo": [
+                {"addr": "127.0.0.1:1", "inbound": False, "subver": "/Zakura:1.1.0/"},
+                {"addr": "127.0.0.1:2", "inbound": True, "subver": "/Zakura:1.1.0/"},
+                {"addr": "127.0.0.1:3", "inbound": False, "subver": "/MagicBean:6.2.0/"},
+                {"addr": "127.0.0.1:4", "inbound": False},
+            ],
+        }
+        probe = self.run_probe(rpc_url=f"http://{self.endpoint}/")
+
+        self.assertEqual(
+            probe["peer_subversions"],
+            [["/Zakura:1.1.0/", 2], ["/MagicBean:6.2.0/", 1], ["unknown", 1]],
+        )
+        self.assertNotIn("peer_user_agents", probe)
 
     def test_metrics_scrape_can_be_skipped(self):
         probe = self.run_probe(metrics_endpoint=self.endpoint, want_metrics="")
@@ -300,6 +354,18 @@ class IronwoodStatusTests(unittest.TestCase):
         self.assertIn('blockchain_info.get("headers")', status.REMOTE_PROBE)
         self.assertIn('"getblockhash"', status.REMOTE_PROBE)
         self.assertIn('rpc_call("getblockheader"', status.REMOTE_PROBE)
+
+    def test_peer_version_panel_prefers_rpc_subver(self):
+        # When getpeerinfo.subver is present, the live RPC mix wins over the
+        # legacy exporter user_agent label.
+        self.assertIn(
+            "(row.peer_subversions || []).length",
+            status.PAGE,
+        )
+        self.assertLess(
+            status.PAGE.find("(row.peer_subversions || []).length"),
+            status.PAGE.find("(row.peer_user_agents || [])"),
+        )
 
     def test_success_response_has_the_stable_public_shape(self):
         subject = collector()

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -355,7 +355,8 @@ WANTED_METRICS = frozenset((
 # A live mainnet/testnet exposition runs to ~12 MB because several net counters
 # are labelled per peer address. This is only a runaway guard, not a budget.
 MAX_METRICS_BYTES = 64 * 1024 * 1024
-# Carries the peer version breakdown in a user_agent label.
+# Legacy peer-software breakdown. Newer zakurad omits this label; getpeerinfo
+# subver is the durable source once the node exposes it.
 PEER_AGENT_METRIC = "zcash_net_peers_connected"
 IPV4 = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
 
@@ -432,8 +433,7 @@ def scrape_metrics(endpoint):
             version = labels.split('version="', 1)[1].split('"', 1)[0]
             continue
         if name == PEER_AGENT_METRIC and 'user_agent="' in labels:
-            # zakurad's getpeerinfo has no subver field, so the peer version
-            # breakdown has to come from this label instead of the RPC.
+            # Fallback for older zakurad builds that omit getpeerinfo.subver.
             agent = labels.split('user_agent="', 1)[1].split('"', 1)[0]
             try:
                 agents[agent] = agents.get(agent, 0.0) + float(value)
@@ -878,7 +878,9 @@ if rpc_url:
             subversions[key] = subversions.get(key, 0) + 1
         out["peer_count"] = len(peers)
         out["peer_inbound"] = inbound
-        # zakurad omits subver, so this is only meaningful for the zcashd probe.
+        # Live peer software mix. zakurad omitted subver historically; once the
+        # node exposes it, this restores the dashboard panel without metrics
+        # labels. Until then the exporter user_agent fallback still applies.
         if set(subversions) != {"unknown"}:
             out["peer_subversions"] = sorted(
                 subversions.items(), key=lambda item: (-item[1], item[0])
@@ -3430,11 +3432,11 @@ const PEER_ROWS = [
 function renderNodePeers(data) {
   const row = data.node || {};
   const m = row.metrics || {};
-  // zakurad's getpeerinfo has no subver, so prefer the exporter's user_agent
-  // label and fall back to the RPC breakdown for the zcashd probe.
-  const subversions = (row.peer_user_agents || []).length
-    ? row.peer_user_agents
-    : (row.peer_subversions || []);
+  // Prefer getpeerinfo.subver (live peers). Fall back to the exporter
+  // user_agent label on older zakurad builds that omit subver.
+  const subversions = (row.peer_subversions || []).length
+    ? row.peer_subversions
+    : (row.peer_user_agents || []);
   let html = '<div class="kv">'
     + kvRow('Peers (RPC)', row.peer_count == null ? '—' : num(row.peer_count))
     + kvRow('Inbound', row.peer_inbound == null ? '—' : num(row.peer_inbound));

--- a/docs/changelog/unreleased/697.md
+++ b/docs/changelog/unreleased/697.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Stopped labeling network Prometheus counters by peer address, so `/metrics`
+  stays bounded on long-lived public listeners
+  ([#697](https://github.com/zakura-core/zakura/pull/697)).


### PR DESCRIPTION
## Motivation

Network Prometheus counters were labeled by remote socket address, including the inbound ephemeral port. The exporter never prunes series, so every reconnect and every scanner handshake minted permanent label sets.

On a publicly reachable mainnet node this made `GET /metrics` grow without bound (about 117 MB / 1.4M lines after 7 days, ~34k new series per day). Scrapers with conventional timeouts failed, and the registry contributed to process RSS growth. Cycling P2P connections is a low-rate memory-exhaustion vector.

Root cause: `addr` / `remote_ip` (and attacker-controlled `user_agent`) labels on handshake, byte, message, and request/response metrics, with no unregister path.

## Solution

Drop per-connection address and user-agent labels. Export aggregate totals, keeping bounded `command` and protocol-version labels. Live peer count remains the existing `zcash.net.peers` gauge.

`Codec::with_metrics_addr_label` is kept as a no-op so this is not a `zakura-network` public-API break. Seed and peer-cache `remote_ip` labels are unchanged (bounded by the seed list).

## Testing

- `cargo clippy -p zakura-network --all-targets -- -D warnings` passed.
- `cargo test -p zakura-network --lib -- handshake connection codec` passed (146 tests).
- `./scripts/changelog.py check` passed.
- Protocol behavior is unchanged; cardinality is bounded by construction (no per-addr series). Remaining coverage is draft CI.

## Changelog

- `docs/changelog/unreleased/697.md`