### PR TITLE
fix(ops): distinguish long blocks from fleet stalls

### DIFF
--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -45,8 +45,8 @@ of rendering blanks.
 
 Sparklines come from an in-memory per-node ring buffer sized by
 `--history-window` (default 3h). This history is deliberately not persisted:
-`--state-file` carries the durable orphan-pair and stall timers, and losing
-sparklines across a dashboard restart is acceptable.
+`--state-file` carries the durable orphan-pair history and per-node tip progress,
+and losing sparklines across a dashboard restart is acceptable.
 
 The probe collects a redacted tail of the node's `ERROR`/`WARN` log lines, but
 the page does not serve it unless the dashboard runs with `--expose-logs`. These
@@ -64,15 +64,17 @@ hashes sampled at 1, 2, 5, 10, and 32 blocks back, so an unresolved fork reports
 
 A node whose height drops or whose tip hash changes at the same height records
 an orphan pair: the discarded hash, the new canonical hash, and the depth. Pass
-`--state-file` to persist that history across restarts; the deploy workflows
-point it at `/var/lib/zakura-<network>-dashboard/orphan-pairs.json`. Without the
-flag the history is in-memory only and is lost on every restart.
+`--state-file` to persist that history and the tip baseline across restarts; the
+deploy workflows point it at
+`/var/lib/zakura-<network>-dashboard/orphan-pairs.json`. Without the flag the
+history is in-memory only and is lost on every restart.
 
 ## Fleet Slack Watchdog
 
 `zakura-cluster-watchdog.py` is a small stdlib-only Python service that polls the
 mainnet and testnet cluster status dashboards and posts Slack transition alerts
-when a fleet node remains unhealthy.
+when a fleet node remains unhealthy or the agreeing fleet observes an extended
+block interval.
 
 It is installed by `.github/workflows/zakura-mainnet-deploy.yml` on `us-east-0`:
 
@@ -91,12 +93,68 @@ The default config in `fleet-watchdog.toml` watches:
 Alerts fire only after a sustained condition:
 
 - `health` is `down` or `rpc_error` for at least 10 minutes
-- `seconds_since_advanced` is at least 600 seconds for at least 10 minutes
-- a dashboard endpoint is unreachable for at least 10 minutes
+- no agreed-fleet or individual-node tip change for at least 600 seconds
+- a dashboard fetch fails or its completed poll is stale for at least 10 minutes
+
+When at least two reachable nodes share the freshest majority height and hash,
+the watchdog suppresses duplicate stall alerts for those majority nodes. After
+the threshold it opens one fleet-wide extended-interval incident, including the
+configured target spacing and the client implementations that confirm the tip.
+The incident keeps that height, hash, header time, and start time as an immutable
+anchor. The default fleet config sets the current post-Blossom target of 75
+seconds and the corresponding mainnet or testnet CipherScan block explorer.
+
+The `zcashd-compat` sidecar is pinned to its local Zakura node, so cross-client
+agreement is useful context but not an independent network reference. The first
+fleet alert therefore leaves the interval unclassified. When the agreeing
+majority changes, one resolution message first verifies that the new tip
+descends from the exact alerted hash, then compares that block and its first
+successor's canonical header timestamps. A same-height replacement, rollback,
+or mismatched ancestor resolves as a canonical branch change consistent with an
+orphan/reorg; it is never classified as a Zakura delay. A snapshot whose last
+completed dashboard poll is more than one watchdog interval old is handled as
+one fleet telemetry failure instead of entering chain or per-node
+classification. Per-node sample times can span a full collection cycle without
+invalidating a completed poll.
+
+With the default 600-second alert threshold, 30-second timestamp tolerance, and
+75-second target spacing, same-branch intervals are classified conservatively:
+
+- 600 seconds or more confirms a long canonical interval;
+- 570-599 seconds is consistent with the alert within the timestamp tolerance;
+- 0-150 seconds indicates that the fleet likely observed the successor late;
+- 151-569 seconds, or a negative timestamp delta, remains inconclusive.
+
+Two matching header reports are sufficient when the other reports are missing
+because header data is deterministic for an already agreed block hash. Any
+conflicting report makes the evidence unavailable. Missing or inconsistent
+H+1/H+2 evidence is retried for two watchdog cycles without an intermediate
+Slack message. If the evidence remains missing, or the fleet has already
+advanced beyond the exact header window, the one resolution says progress
+resumed but leaves the cause unclassified.
+
+The classified resolution links the canonical blocks at the alerted height and
+its successor in CipherScan. A long or near-threshold canonical interval means a
+Zakura fleet delay is not needed to explain the alert. Conversely, a canonical
+interval near the 75-second target paired with a long observed interval points
+to a fleet observation delay.
+
+An unchanged height and hash does not confirm or clear the interval. A changed
+hash resets the dashboard's stall timer and resolves an open incident as a
+branch change. Any node behind the freshest majority still gets its own stall
+alert, and if a reference node is already ahead, the older majority is not
+classified as a long block.
+
+The alert and follow-up also count real orphan/reorg observations recorded
+during the interval. They report both the dashboard's observed no-progress
+duration and, when available, the canonical header interval. Header timestamps
+are miner-reported, so this classifies the interval recorded by the canonical
+chain rather than claiming the exact wall-clock instant that mining completed.
 
 Down alerts take precedence over stalled alerts, so each node has at most one
-active alert. The watchdog posts only on transitions: first failure after the
-threshold, then recovery. Persistent failures do not post every poll.
+active alert. Node and dashboard failures post once after the threshold and
+again on recovery. A consolidated interval posts one initial alert and one
+classified resolution; neither repeats on every poll.
 
 Slack delivery is **webhook-only**. Set:
 

--- a/deploy/runner/fleet-watchdog.toml
+++ b/deploy/runner/fleet-watchdog.toml
@@ -2,8 +2,12 @@
 name = "testnet"
 url = "http://167.99.103.111:8090/data"
 dashboard_url = "http://167.99.103.111:8090/"
+target_block_seconds = 75
+block_explorer_url = "https://testnet.cipherscan.app/block"
 
 [[fleets]]
 name = "mainnet"
 url = "http://127.0.0.1:8090/data"
 dashboard_url = "http://159.65.183.89:8090/"
+target_block_seconds = 75
+block_explorer_url = "https://cipherscan.app/block"

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -133,18 +133,47 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
                 length = int(self.headers.get("Content-Length", "0"))
                 payload = json.loads(self.rfile.read(length).decode())
                 method = payload.get("method")
+                params = payload.get("params") or []
+                best_hash = "b" * 64
+                previous_hash = "a" * 64
                 if method in outer.rpc_results:
+                    result = outer.rpc_results[method]
+                elif method == "getblockchaininfo":
+                    result = {
+                        "blocks": 101,
+                        "headers": 101,
+                        "bestblockhash": best_hash,
+                        "chain": "test",
+                        "valuePools": [],
+                    }
+                elif method == "getblockhash":
+                    result = "c" * 64
+                elif method == "getblockheader" and params[0] == best_hash:
+                    result = {
+                        "previousblockhash": previous_hash,
+                        "time": 10_831,
+                    }
+                elif method == "getblockheader" and params[0] == previous_hash:
+                    result = {
+                        "previousblockhash": "9" * 64,
+                        "time": 10_000,
+                    }
+                elif method == "getinfo":
+                    result = {"testnet": True, "build": "stub"}
+                elif method == "getpeerinfo":
+                    result = []
+                elif method == "getmempoolinfo":
+                    result = {"size": 0, "bytes": 0}
+                else:
                     body = json.dumps({
                         "jsonrpc": "2.0",
                         "id": payload.get("id"),
-                        "result": outer.rpc_results[method],
+                        "error": {"code": -32601, "message": method},
                     }).encode()
                     return self.reply(200, body)
-                body = json.dumps({
-                    "jsonrpc": "2.0",
-                    "id": payload.get("id"),
-                    "error": {"code": -32601, "message": method},
-                }).encode()
+                body = json.dumps(
+                    {"result": result, "error": None, "id": payload.get("id")}
+                ).encode()
                 return self.reply(200, body)
 
         self.server = status.ThreadingHTTPServer(("127.0.0.1", 0), StubHandler)
@@ -344,6 +373,16 @@ zcash_net_in_bytes_total 12345
         self.assertIn("metrics_error", probe)
         self.assertNotIn("metrics", probe)
         self.assertIn("host", probe)
+
+    def test_rpc_probe_reports_the_canonical_header_interval(self):
+        probe = self.run_probe(rpc_url=f"http://{self.endpoint}/")
+
+        self.assertNotIn("rpc_error", probe)
+        self.assertEqual(probe["block_time"], 10_831)
+        self.assertEqual(probe["previous_block_time"], 10_000)
+        self.assertEqual(probe["grandparent_hash"], "9" * 64)
+        self.assertEqual(probe["ancestor_hashes"]["1"], "a" * 64)
+        self.assertEqual(probe["ancestor_hashes"]["2"], "9" * 64)
 
 
 class IronwoodStatusTests(unittest.TestCase):
@@ -565,6 +604,8 @@ class TipAgreementTests(unittest.TestCase):
                 "height": 98,
                 "headers": 101,
                 "block_hash": "b" * 64,
+                "block_time": 10_831,
+                "previous_block_time": 10_000,
                 "active_state": "active",
                 "process_running": True,
                 "client_name": "zakurad",
@@ -576,6 +617,10 @@ class TipAgreementTests(unittest.TestCase):
         self.assertEqual(row["tip_event"], "reorg_height_drop")
         self.assertEqual(row["headers"], 101)
         self.assertEqual(row["header_lag"], 3)
+        self.assertEqual(row["block_time"], 10_831)
+        self.assertEqual(row["previous_block_time"], 10_000)
+        self.assertEqual(row["seconds_since_advanced"], 0.0)
+        self.assertEqual(row["health"], "healthy")
         self.assertEqual(len(subject.recent_reorgs), 1)
         self.assertEqual(subject.recent_reorgs[0]["kind"], "reorg_height_drop")
 
@@ -635,6 +680,28 @@ class TipAgreementTests(unittest.TestCase):
             self.assertEqual(event["discarded_hash"], "a" * 64)
             self.assertEqual(event["canonical_hash"], "b" * 64)
 
+    def test_same_height_tip_switch_resets_the_stall_timer(self):
+        subject = collector()
+        subject.last_height["node-a"] = 100
+        subject.last_block_hash["node-a"] = "a" * 64
+        subject.last_advanced_at["node-a"] = 100.0
+
+        row = subject.row_for(
+            node(),
+            {
+                "height": 100,
+                "block_hash": "b" * 64,
+                "active_state": "active",
+                "process_running": True,
+            },
+            now=1_000.0,
+        )
+
+        self.assertEqual(row["tip_event"], "tip_switch")
+        self.assertEqual(row["seconds_since_advanced"], 0.0)
+        self.assertEqual(row["health"], "healthy")
+        self.assertEqual(subject.last_advanced_at["node-a"], 1_000.0)
+
     def test_stall_timer_survives_a_collector_restart(self):
         # A restart used to reseed last_advanced_at to "now", reporting every
         # node as freshly advanced and clearing in-flight stall alerts.
@@ -674,6 +741,48 @@ class TipAgreementTests(unittest.TestCase):
             )
             self.assertEqual(row["seconds_since_advanced"], 3_000.0)
             self.assertEqual(row["health"], "stale")
+
+    def test_tip_switch_is_detected_across_a_collector_restart(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_file = Path(tmp) / "state.json"
+            first = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                network="testnet",
+                state_file=state_file,
+            )
+            first.last_height["node-a"] = 100
+            first.last_block_hash["node-a"] = "a" * 64
+            first.last_ancestors["node-a"] = {"1": "p" * 64}
+            first.last_advanced_at["node-a"] = 1_000.0
+            first.persist_state()
+
+            second = status.ClusterCollector(
+                [node()],
+                interval=10,
+                stale_after=300,
+                network="testnet",
+                state_file=state_file,
+            )
+            self.assertEqual(second.last_block_hash["node-a"], "a" * 64)
+            self.assertEqual(second.last_ancestors["node-a"], {"1": "p" * 64})
+
+            row = second.row_for(
+                node(),
+                {
+                    "height": 100,
+                    "block_hash": "b" * 64,
+                    "ancestor_hashes": {"1": "p" * 64},
+                    "active_state": "active",
+                    "process_running": True,
+                },
+                now=1_100.0,
+            )
+
+            self.assertEqual(row["tip_event"], "tip_switch")
+            self.assertEqual(row["seconds_since_advanced"], 0.0)
+            self.assertEqual(second.recent_reorgs[0]["discarded_hash"], "a" * 64)
 
     def test_progress_state_tolerates_a_missing_or_corrupt_file(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -21,6 +22,11 @@ def make_args(**overrides):
     defaults = {
         "down_after": 600.0,
         "stalled_after": 600.0,
+        "dashboard_down_after": 600.0,
+        "interval": 60.0,
+        "request_timeout": 20.0,
+        "slack_timeout": 20.0,
+        "suppression_file": Path("/tmp/zakura-test-suppression-missing"),
         "starting_grace": 120.0,
         "slack_webhook": None,
         "dry_run": True,
@@ -29,22 +35,50 @@ def make_args(**overrides):
     return argparse.Namespace(**defaults)
 
 
+class FleetConfigTests(unittest.TestCase):
+    def test_non_finite_target_block_intervals_are_rejected(self):
+        for value in ("nan", "inf"):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "fleets.toml"
+                path.write_text(
+                    "[[fleets]]\n"
+                    'name = "mainnet"\n'
+                    'url = "http://dashboard/data"\n'
+                    f"target_block_seconds = {value}\n",
+                    encoding="utf-8",
+                )
+
+                with self.assertRaisesRegex(SystemExit, "finite number greater"):
+                    watchdog.load_fleets(path)
+
+
 class StallRecoveryTests(unittest.TestCase):
     """A stalled node must not be declared recovered at an unchanged height."""
 
     def setUp(self):
         self.posted: list[str] = []
         self._real_post = watchdog.post_slack
+        self._real_fetch = watchdog.fetch_json
+        self._real_time = watchdog.time.time
         watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
 
     def tearDown(self):
         watchdog.post_slack = self._real_post
+        watchdog.fetch_json = self._real_fetch
+        watchdog.time.time = self._real_time
 
-    def fire_stall(self, bucket, key="fleet/node-a", height=4129396, now=1000.0):
+    def fire_stall(
+        self,
+        bucket,
+        key="fleet/node-a",
+        height=4129396,
+        now=1000.0,
+        block_hash=None,
+    ):
         """Drive the alert past its threshold so it latches."""
         watchdog.update_alert_state(
             bucket, key, "stalled", now - 700.0, 600.0,
-            "STALLED", "RECOVERED", now, False, make_args(), height,
+            "STALLED", "RECOVERED", now, False, make_args(), height, block_hash,
         )
 
     def test_stall_alert_records_the_height_it_fired_at(self):
@@ -93,6 +127,47 @@ class StallRecoveryTests(unittest.TestCase):
         )
         self.assertEqual(self.posted, ["RECOVERED"])
         self.assertFalse(bucket["fleet/node-a"]["alerting"])
+
+    def test_same_height_tip_replacement_clears_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket, height=100, block_hash="aa")
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 100, "bb",
+        )
+
+        self.assertEqual(self.posted, ["RECOVERED"])
+        self.assertEqual(
+            bucket["fleet/node-a"],
+            {"condition": "ok", "alerting": False},
+        )
+
+    def test_tip_rollback_clears_the_stall_when_the_hash_changed(self):
+        bucket = {}
+        self.fire_stall(bucket, height=100, block_hash="aa")
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 99, "99",
+        )
+
+        self.assertEqual(self.posted, ["RECOVERED"])
+
+    def test_unchanged_tip_hash_does_not_clear_the_stall(self):
+        bucket = {}
+        self.fire_stall(bucket, height=100, block_hash="aa")
+        self.posted.clear()
+
+        watchdog.update_alert_state(
+            bucket, "fleet/node-a", "ok", 2000.0, 0.0,
+            "STALLED", "RECOVERED", 2000.0, False, make_args(), 100, "aa",
+        )
+
+        self.assertEqual(self.posted, [])
+        self.assertTrue(bucket["fleet/node-a"]["alerting"])
 
     def test_missing_height_does_not_clear_the_stall(self):
         # The "starting" grace window reports ok with no usable height.
@@ -194,6 +269,796 @@ class StallRecoveryTests(unittest.TestCase):
             "STALLED", "RECOVERED", 2000.0, False, make_args(), 4129396,
         )
         self.assertEqual(self.posted, [])
+
+
+class FleetIntervalTests(unittest.TestCase):
+    """Fleet agreement replaces duplicate node stalls with one chain interval."""
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self._real_post = watchdog.post_slack
+        self._real_fetch = watchdog.fetch_json
+        self._real_time = watchdog.time.time
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        self.fleet = watchdog.Fleet(
+            name="mainnet",
+            url="http://dashboard/data",
+            dashboard_url="http://dashboard/",
+            target_block_seconds=75.0,
+            block_explorer_url="https://cipherscan.app/block",
+        )
+        self.subject = watchdog.Watchdog([self.fleet], make_args())
+
+    def tearDown(self):
+        watchdog.post_slack = self._real_post
+        watchdog.fetch_json = self._real_fetch
+        watchdog.time.time = self._real_time
+
+    @staticmethod
+    def row(
+        name: str,
+        client_name: str,
+        *,
+        height: int = 100,
+        block_hash: str = "aa",
+        stalled_for: float = 700.0,
+        health: str = "stale",
+        block_time: int | None = 10_000,
+        previous_block_time: int | None = 9_925,
+        ancestor_hashes=None,
+        previous_hash: str | None = None,
+        grandparent_hash: str | None = None,
+        last_seen_at: float = 995.0,
+    ):
+        ancestors = dict(ancestor_hashes or {})
+        return {
+            "name": name,
+            "client_name": client_name,
+            "height": height,
+            "block_hash": block_hash,
+            "seconds_since_advanced": stalled_for,
+            "health": health,
+            "block_time": block_time,
+            "previous_block_time": previous_block_time,
+            "ancestor_hashes": ancestors,
+            "previous_hash": (
+                previous_hash if previous_hash is not None else ancestors.get("1", "")
+            ),
+            "grandparent_hash": (
+                grandparent_hash
+                if grandparent_hash is not None
+                else ancestors.get("2", "")
+            ),
+            "last_seen_at": last_seen_at,
+        }
+
+    @staticmethod
+    def snapshot(
+        rows,
+        *,
+        majority_height: int = 100,
+        majority_hash: str = "aa",
+        recent_reorgs=None,
+        generated_at: float = 1_000.0,
+        last_poll: float = 995.0,
+    ):
+        return {
+            "generated_at": generated_at,
+            "last_poll": last_poll,
+            "chain": {
+                "majority_height": majority_height,
+                "majority_hash": majority_hash,
+                "recent_reorgs": list(recent_reorgs or []),
+            },
+            "rows": rows,
+        }
+
+    def agreed_snapshot(
+        self,
+        *,
+        height: int = 100,
+        block_hash: str = "aa",
+        stalled_for: float = 700.0,
+        health: str = "stale",
+        block_time: int | None = 10_000,
+        previous_block_time: int | None = 9_925,
+        ancestor_hashes=None,
+        previous_hash: str | None = None,
+        grandparent_hash: str | None = None,
+        recent_reorgs=None,
+    ):
+        common = {
+            "height": height,
+            "block_hash": block_hash,
+            "stalled_for": stalled_for,
+            "health": health,
+            "block_time": block_time,
+            "previous_block_time": previous_block_time,
+            "ancestor_hashes": ancestor_hashes,
+            "previous_hash": previous_hash,
+            "grandparent_hash": grandparent_hash,
+        }
+        return self.snapshot(
+            [
+                self.row("node-a", "zakurad", **common),
+                self.row("node-b", "zcashd", **common),
+            ],
+            majority_height=height,
+            majority_hash=block_hash,
+            recent_reorgs=recent_reorgs,
+        )
+
+    def drive(self, state, snapshot, now):
+        rows = snapshot["rows"]
+        consolidated = self.subject.handle_chain(
+            state, self.fleet, snapshot, rows, now, False
+        )
+        for row in rows:
+            self.subject.handle_node(
+                state,
+                self.fleet,
+                row,
+                now,
+                False,
+                suppress_stall=row["name"] in consolidated,
+            )
+
+    @staticmethod
+    def empty_state():
+        return {"version": 1, "nodes": {}, "fleets": {}, "chains": {}}
+
+    def test_cross_client_agreement_posts_one_chain_interval_alert(self):
+        state = self.empty_state()
+        snapshot = self.agreed_snapshot(
+            recent_reorgs=[
+                {"at": 900.0, "kind": "tip_switch", "demo": False},
+                {"at": 950.0, "kind": "tip_switch", "demo": True},
+            ],
+        )
+
+        self.drive(state, snapshot, now=1_000.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("extended block interval", self.posted[0])
+        self.assertIn("Zakura and its pinned zcashd", self.posted[0])
+        self.assertIn("not an independent network reference", self.posted[0])
+        self.assertIn("stays unclassified", self.posted[0])
+        self.assertIn("9.3× the 75s target", self.posted[0])
+        self.assertIn("orphan/reorg observations during interval: 1", self.posted[0])
+        self.assertNotIn("`node-a` stalled", self.posted[0])
+        self.assertEqual(state["chains"]["mainnet"]["anchor_height"], 100)
+        self.assertEqual(state["chains"]["mainnet"]["anchor_hash"], "aa")
+        self.assertFalse(state["nodes"]["mainnet/node-a"]["alerting"])
+        self.assertFalse(state["nodes"]["mainnet/node-b"]["alerting"])
+
+        self.drive(state, snapshot, now=1_060.0)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_consolidated_alert_retires_an_existing_duplicate_stall(self):
+        state = self.empty_state()
+        state["nodes"]["mainnet/node-a"] = {
+            "condition": "stalled",
+            "alerting": True,
+            "alert_height": 100,
+        }
+        snapshot = self.agreed_snapshot()
+
+        self.drive(state, snapshot, now=1_000.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("extended block interval", self.posted[0])
+        self.assertEqual(
+            state["nodes"]["mainnet/node-a"],
+            {"condition": "ok", "alerting": False},
+        )
+
+    def test_next_agreed_height_confirms_the_observed_interval_once(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+        state["nodes"]["mainnet/node-a"] = {
+            "condition": "stalled",
+            "alerting": True,
+            "alert_height": 100,
+        }
+
+        advanced = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_831,
+            previous_block_time=10_000,
+            ancestor_hashes={"1": "aa"},
+            recent_reorgs=[
+                {"at": 900.0, "kind": "tip_switch", "demo": False},
+                {"at": 1_100.0, "kind": "tip_switch", "demo": False},
+            ],
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("long canonical block interval confirmed", self.posted[0])
+        self.assertIn("observed interval: 13m 51s", self.posted[0])
+        self.assertIn("agreed height 100 → 101", self.posted[0])
+        self.assertIn("canonical header interval 100→101: 13m 51s", self.posted[0])
+        self.assertIn("confirms a long canonical block interval", self.posted[0])
+        self.assertIn("fleet delay is not needed", self.posted[0])
+        self.assertIn(
+            "<https://cipherscan.app/block/100|block 100> → "
+            "<https://cipherscan.app/block/101|block 101>",
+            self.posted[0],
+        )
+        self.assertIn("orphan/reorg observations during interval: 2", self.posted[0])
+        self.assertNotIn("mainnet", state["chains"])
+        self.assertEqual(
+            state["nodes"]["mainnet/node-a"],
+            {"condition": "ok", "alerting": False},
+        )
+
+        self.drive(state, advanced, now=1_191.0)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_short_successor_header_interval_reports_a_shared_fleet_delay(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        advanced = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_090,
+            previous_block_time=10_000,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fleet delay suspected", self.posted[0])
+        self.assertIn("canonical header interval 100→101: 1m 30s", self.posted[0])
+        self.assertIn("did not observe the canonical successor promptly", self.posted[0])
+        self.assertIn("cipherscan.app/block/100", self.posted[0])
+        self.assertEqual(watchdog.format_header_interval(-30), "-30s")
+
+    def test_missing_successor_header_interval_retries_before_unclassified(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        advanced = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=None,
+            previous_block_time=None,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(self.posted, [])
+        self.assertEqual(state["chains"]["mainnet"]["evidence_deadline"], 1_251.0)
+
+        self.drive(state, advanced, now=1_191.0)
+        self.assertEqual(self.posted, [])
+        self.drive(state, advanced, now=1_251.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fleet progress resumed", self.posted[0])
+        self.assertIn("event remains unclassified", self.posted[0])
+        self.assertNotIn("mainnet", state["chains"])
+
+    def test_one_extra_block_still_classifies_the_alerted_successor(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        advanced = self.agreed_snapshot(
+            height=102,
+            block_hash="cc",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_900,
+            previous_block_time=10_831,
+            ancestor_hashes={"2": "aa"},
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("long canonical block interval confirmed", self.posted[0])
+        self.assertIn("agreed height 100 → 102", self.posted[0])
+        self.assertIn("canonical header interval 100→101: 13m 51s", self.posted[0])
+
+    def test_extra_block_on_a_different_branch_reports_branch_change(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        advanced = self.agreed_snapshot(
+            height=102,
+            block_hash="cc",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_900,
+            previous_block_time=10_831,
+            ancestor_hashes={"2": "different-height-100-hash"},
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("canonical branch changed", self.posted[0])
+        self.assertIn("is not the agreed tip's canonical ancestor", self.posted[0])
+        self.assertNotIn("fleet delay suspected", self.posted[0])
+
+    def test_orphan_rollback_resolves_without_reanchoring(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        rolled_back = self.agreed_snapshot(
+            height=99,
+            block_hash="99",
+            block_time=9_900,
+            previous_block_time=9_825,
+            recent_reorgs=[
+                {"at": 1_020.0, "kind": "reorg_height_drop", "demo": False}
+            ],
+        )
+        self.drive(state, rolled_back, now=1_020.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("canonical branch changed", self.posted[0])
+        self.assertIn("rolled back from alerted height 100 to 99", self.posted[0])
+        self.assertIn("orphan/reorg observations during interval: 1", self.posted[0])
+        self.assertNotIn("mainnet", state["chains"])
+
+    def test_timer_reset_at_the_same_height_does_not_confirm_the_interval(self):
+        state = self.empty_state()
+        stalled = self.agreed_snapshot()
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        reset = self.agreed_snapshot(stalled_for=5.0, health="healthy")
+        self.drive(state, reset, now=1_010.0)
+
+        self.assertEqual(self.posted, [])
+        self.assertEqual(state["chains"]["mainnet"]["anchor_hash"], "aa")
+
+    def test_same_height_replacement_resolves_against_the_original_anchor(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        replacement = self.agreed_snapshot(
+            block_hash="bb",
+            block_time=10_050,
+            previous_block_time=9_925,
+            ancestor_hashes={"1": "parent"},
+            recent_reorgs=[{"at": 1_020.0, "kind": "tip_switch", "demo": False}],
+        )
+        self.drive(state, replacement, now=1_020.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("canonical branch changed", self.posted[0])
+        self.assertIn("`aa` at height 100 was replaced by `bb`", self.posted[0])
+        self.assertNotIn("fleet delay suspected", self.posted[0])
+        self.assertNotIn("mainnet", state["chains"])
+
+        successor = self.agreed_snapshot(
+            height=101,
+            block_hash="cc",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_125,
+            previous_block_time=10_050,
+            ancestor_hashes={"1": "bb"},
+        )
+        self.drive(state, successor, now=1_080.0)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_skipped_replacement_cannot_be_called_a_fleet_delay(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        successor = self.agreed_snapshot(
+            height=101,
+            block_hash="cc",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_080,
+            previous_block_time=10_050,
+            ancestor_hashes={"1": "bb"},
+        )
+        self.drive(state, successor, now=1_060.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("canonical branch changed", self.posted[0])
+        self.assertIn("height 100 is now `bb`", self.posted[0])
+        self.assertNotIn("fleet delay suspected", self.posted[0])
+        self.assertIn("orphan/reorg observations during interval: 0", self.posted[0])
+        self.assertIn(
+            "<https://cipherscan.app/block/100|block 100> → "
+            "<https://cipherscan.app/block/101|block 101>",
+            self.posted[0],
+        )
+
+    def test_hash_linked_parent_wins_over_racy_height_lookup(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        successor = self.agreed_snapshot(
+            height=101,
+            block_hash="cc",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_090,
+            previous_block_time=10_000,
+            ancestor_hashes={"1": "aa"},
+            previous_hash="bb",
+        )
+        self.drive(state, successor, now=1_060.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("canonical branch changed", self.posted[0])
+        self.assertIn("height 100 is now `bb`", self.posted[0])
+        self.assertNotIn("fleet delay suspected", self.posted[0])
+
+    def test_two_matching_header_reports_ignore_one_missing_member(self):
+        state = self.empty_state()
+        stalled = self.snapshot(
+            [
+                self.row("node-a", "zakurad"),
+                self.row("node-b", "zcashd"),
+                self.row("node-c", "zakurad"),
+            ]
+        )
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        common = {
+            "height": 101,
+            "block_hash": "bb",
+            "stalled_for": 5.0,
+            "health": "healthy",
+            "block_time": 10_831,
+            "previous_block_time": 10_000,
+            "ancestor_hashes": {"1": "aa"},
+        }
+        advanced = self.snapshot(
+            [
+                self.row("node-a", "zakurad", **common),
+                self.row("node-b", "zcashd", **common),
+                self.row(
+                    "node-c",
+                    "zakurad",
+                    **{
+                        **common,
+                        "block_time": None,
+                        "previous_block_time": None,
+                        "ancestor_hashes": {},
+                    },
+                ),
+            ],
+            majority_height=101,
+            majority_hash="bb",
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("long canonical block interval confirmed", self.posted[0])
+
+    def test_conflicting_header_reports_retry_instead_of_classifying(self):
+        state = self.empty_state()
+        stalled = self.snapshot(
+            [
+                self.row("node-a", "zakurad"),
+                self.row("node-b", "zcashd"),
+                self.row("node-c", "zakurad"),
+            ]
+        )
+        self.drive(state, stalled, now=1_000.0)
+        self.posted.clear()
+
+        common = {
+            "height": 101,
+            "block_hash": "bb",
+            "stalled_for": 5.0,
+            "health": "healthy",
+            "previous_block_time": 10_000,
+            "ancestor_hashes": {"1": "aa"},
+        }
+        advanced = self.snapshot(
+            [
+                self.row("node-a", "zakurad", block_time=10_831, **common),
+                self.row("node-b", "zcashd", block_time=10_831, **common),
+                self.row("node-c", "zakurad", block_time=10_830, **common),
+            ],
+            majority_height=101,
+            majority_hash="bb",
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(self.posted, [])
+        self.assertEqual(state["chains"]["mainnet"]["evidence_deadline"], 1_251.0)
+
+    def test_missing_evidence_can_recover_before_the_deadline(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        missing = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=None,
+            previous_block_time=None,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, missing, now=1_131.0)
+        self.assertEqual(self.posted, [])
+
+        recovered = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=10_831,
+            previous_block_time=10_000,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, recovered, now=1_191.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("long canonical block interval confirmed", self.posted[0])
+        self.assertNotIn("mainnet", state["chains"])
+
+    def test_return_to_anchor_resets_the_evidence_deadline(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+        missing = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=None,
+            previous_block_time=None,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, missing, now=1_131.0)
+        self.assertIn("evidence_deadline", state["chains"]["mainnet"])
+
+        self.drive(
+            state,
+            self.agreed_snapshot(stalled_for=5.0, health="healthy"),
+            now=1_191.0,
+        )
+
+        self.assertNotIn("evidence_deadline", state["chains"]["mainnet"])
+
+    def test_advancing_beyond_header_window_resolves_unclassified(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        advanced = self.agreed_snapshot(
+            height=103,
+            block_hash="dd",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=11_000,
+            previous_block_time=10_900,
+            ancestor_hashes={"3": "aa"},
+        )
+        self.drive(state, advanced, now=1_131.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fleet progress resumed", self.posted[0])
+        self.assertIn("beyond the dashboard's exact H+1 timestamp window", self.posted[0])
+        self.assertIn("event remains unclassified", self.posted[0])
+
+    def test_stale_dashboard_routes_to_one_telemetry_alert(self):
+        state = self.empty_state()
+        stale = self.agreed_snapshot()
+        stale["generated_at"] = 1_000.0
+        stale["last_poll"] = 600.0
+        watchdog.fetch_json = lambda url, timeout: stale
+        watchdog.time.time = lambda: 1_000.0
+
+        self.subject.run_once(state)
+        self.assertEqual(self.posted, [])
+        self.assertEqual(state["fleets"]["mainnet"]["condition"], "unreachable")
+        self.assertEqual(state["nodes"], {})
+        self.assertEqual(state["chains"], {})
+
+        watchdog.time.time = lambda: 1_600.0
+        self.subject.run_once(state)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("dashboard telemetry unavailable", self.posted[0])
+        self.assertIn("last completed poll is 400.0s behind", self.posted[0])
+
+    def test_completed_slow_collection_is_not_treated_as_stale(self):
+        state = self.empty_state()
+        snapshot = self.agreed_snapshot()
+        snapshot["generated_at"] = 1_000.0
+        snapshot["last_poll"] = 995.0
+        snapshot["rows"][0]["last_seen_at"] = 936.0
+        watchdog.fetch_json = lambda url, timeout: snapshot
+        watchdog.time.time = lambda: 1_000.0
+
+        self.subject.run_once(state)
+
+        self.assertEqual(state["fleets"]["mainnet"]["condition"], "ok")
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("extended block interval", self.posted[0])
+
+    def test_interval_classification_bands_are_conservative(self):
+        expected_titles = {
+            -1: "interval cause inconclusive",
+            150: "fleet delay suspected",
+            151: "interval cause inconclusive",
+            569: "interval cause inconclusive",
+            570: "long canonical block interval consistent with alert",
+            599: "long canonical block interval consistent with alert",
+            600: "long canonical block interval confirmed",
+        }
+        for interval, expected_title in expected_titles.items():
+            with self.subTest(interval=interval):
+                state = self.empty_state()
+                self.drive(state, self.agreed_snapshot(), now=1_000.0)
+                self.posted.clear()
+                advanced = self.agreed_snapshot(
+                    height=101,
+                    block_hash="bb",
+                    stalled_for=5.0,
+                    health="healthy",
+                    block_time=10_000 + interval,
+                    previous_block_time=10_000,
+                    ancestor_hashes={"1": "aa"},
+                )
+                self.drive(state, advanced, now=1_131.0)
+                self.assertEqual(len(self.posted), 1)
+                self.assertIn(expected_title, self.posted[0])
+
+    def test_observed_age_must_reach_the_threshold(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(stalled_for=599.0), now=1_000.0)
+        self.assertEqual(self.posted, [])
+        self.assertNotIn("mainnet", state["chains"])
+
+        self.drive(state, self.agreed_snapshot(stalled_for=600.0), now=1_001.0)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("extended block interval", self.posted[0])
+        self.assertEqual(state["chains"]["mainnet"]["anchor_hash"], "aa")
+
+    def test_failed_resolution_delivery_preserves_the_exact_result(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+
+        attempts: list[str] = []
+        results = iter((False, True))
+        watchdog.post_slack = lambda text, args: (
+            attempts.append(text),
+            next(results),
+        )[1]
+        replacement = self.agreed_snapshot(block_hash="bb")
+        self.drive(state, replacement, now=1_020.0)
+
+        incident = state["chains"]["mainnet"]
+        self.assertEqual(incident["anchor_hash"], "aa")
+        self.assertIn("canonical branch changed", incident["pending_resolution_text"])
+
+        successor = self.agreed_snapshot(
+            height=103,
+            block_hash="dd",
+            stalled_for=5.0,
+            health="healthy",
+            ancestor_hashes={"3": "bb"},
+        )
+        self.drive(state, successor, now=1_080.0)
+
+        self.assertEqual(attempts[0], attempts[1])
+        self.assertNotIn("mainnet", state["chains"])
+
+    def test_pending_evidence_survives_state_reload(self):
+        state = self.empty_state()
+        self.drive(state, self.agreed_snapshot(), now=1_000.0)
+        self.posted.clear()
+        missing = self.agreed_snapshot(
+            height=101,
+            block_hash="bb",
+            stalled_for=5.0,
+            health="healthy",
+            block_time=None,
+            previous_block_time=None,
+            ancestor_hashes={"1": "aa"},
+        )
+        self.drive(state, missing, now=1_131.0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "state.json"
+            watchdog.save_state(state_path, state)
+            restored = watchdog.load_state(state_path)
+
+        incident = restored["chains"]["mainnet"]
+        self.assertEqual(incident["anchor_hash"], "aa")
+        self.assertEqual(incident["evidence_deadline"], 1_251.0)
+
+    def test_mixed_stall_ages_do_not_hide_an_individual_stall(self):
+        state = self.empty_state()
+        snapshot = self.snapshot(
+            [
+                self.row("node-a", "zakurad"),
+                self.row(
+                    "node-b",
+                    "zcashd",
+                    stalled_for=5.0,
+                    health="healthy",
+                ),
+            ]
+        )
+
+        self.drive(state, snapshot, now=1_000.0)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`node-a` stalled", self.posted[0])
+        self.assertNotIn("extended block interval", self.posted[0])
+
+    def test_behind_node_still_alerts_beside_the_majority_interval(self):
+        state = self.empty_state()
+        snapshot = self.snapshot(
+            [
+                self.row("node-a", "zakurad"),
+                self.row("node-b", "zcashd"),
+                self.row("node-c", "zakurad", height=99, block_hash="99"),
+            ]
+        )
+
+        self.drive(state, snapshot, now=1_000.0)
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(
+            sum("extended block interval" in text for text in self.posted), 1
+        )
+        self.assertEqual(sum("`node-c` stalled" in text for text in self.posted), 1)
+        self.assertEqual(sum("`node-a` stalled" in text for text in self.posted), 0)
+        self.assertEqual(sum("`node-b` stalled" in text for text in self.posted), 0)
+
+    def test_ahead_reference_keeps_old_majority_node_stall_alerts(self):
+        state = self.empty_state()
+        snapshot = self.snapshot(
+            [
+                self.row("node-a", "zakurad"),
+                self.row("node-b", "zakurad"),
+                self.row(
+                    "node-c",
+                    "zcashd",
+                    height=101,
+                    block_hash="bb",
+                    stalled_for=5.0,
+                    health="healthy",
+                ),
+            ]
+        )
+
+        self.drive(state, snapshot, now=1_000.0)
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertFalse(any("extended block interval" in text for text in self.posted))
+        self.assertTrue(any("`node-a` stalled" in text for text in self.posted))
+        self.assertTrue(any("`node-b` stalled" in text for text in self.posted))
 
 
 if __name__ == "__main__":

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -4,7 +4,7 @@
 Reads a deploy/deployer nodes TOML, polls each node over SSH, and serves a small
 HTML dashboard showing the running commit, Zakura node ID, restart time, current
 height, latest block hash, tip agreement across the fleet, per-node reorg
-candidates, and whether the node has advanced recently. It also serves a
+candidates, and whether the node's tip has changed recently. It also serves a
 deliberately small public Ironwood status response for zakura.com.
 
 Only the Python stdlib is used.
@@ -808,10 +808,35 @@ if rpc_url:
 
         best_hash = out.get("block_hash")
         if best_hash:
+            # Depths 1 and 2 are used for alert classification, so only accept
+            # hashes walked directly from the saved tip. Height lookups can race
+            # with a reorg between RPC calls and describe a different branch.
+            ancestor_hashes.pop("1", None)
+            ancestor_hashes.pop("2", None)
             try:
                 header = rpc_call("getblockheader", [best_hash, True])
                 if isinstance(header, dict):
-                    out["previous_hash"] = header.get("previousblockhash") or ""
+                    previous_hash = header.get("previousblockhash") or ""
+                    block_time = header.get("time")
+                    out["previous_hash"] = previous_hash
+                    out["block_time"] = block_time
+                    if previous_hash:
+                        ancestor_hashes["1"] = previous_hash
+                        try:
+                            previous_header = rpc_call(
+                                "getblockheader", [previous_hash, True]
+                            )
+                            if isinstance(previous_header, dict):
+                                grandparent_hash = (
+                                    previous_header.get("previousblockhash") or ""
+                                )
+                                if grandparent_hash:
+                                    ancestor_hashes["2"] = grandparent_hash
+                                    out["grandparent_hash"] = grandparent_hash
+                                previous_block_time = previous_header.get("time")
+                                out["previous_block_time"] = previous_block_time
+                        except Exception as error:
+                            out["previous_block_time_error"] = str(error)
             except Exception as error:
                 out["previous_hash_error"] = str(error)
 
@@ -903,7 +928,12 @@ print(json.dumps(out, separators=(",", ":")))
 
 
 def ssh_capture_script(node: Node, script: str) -> subprocess.CompletedProcess:
-    return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True, capture_output=True)
+    return subprocess.run(
+        node.ssh_cmd("bash", "-s"),
+        input=script,
+        text=True,
+        capture_output=True,
+    )
 
 
 def probe_node(node: Node, want_metrics: bool = True) -> dict:
@@ -1007,9 +1037,15 @@ class ClusterCollector:
         self.last_height: dict[str, int | None] = {
             node.name: restored_progress.get(node.name, {}).get("height") for node in nodes
         }
-        self.last_block_hash: dict[str, str | None] = {node.name: None for node in nodes}
+        self.last_block_hash: dict[str, str | None] = {
+            node.name: restored_progress.get(node.name, {}).get("block_hash")
+            for node in nodes
+        }
         self.last_ancestors: dict[str, dict[str, str]] = {
-            node.name: {} for node in nodes
+            node.name: dict(
+                restored_progress.get(node.name, {}).get("ancestor_hashes") or {}
+            )
+            for node in nodes
         }
         self.last_advanced_at: dict[str, float | None] = {
             node.name: restored_progress.get(node.name, {}).get("last_advanced_at")
@@ -1064,7 +1100,7 @@ class ClusterCollector:
             self.last_poll = now
             self.record_node_history(now, rows)
             snapshot = self.progress_snapshot()
-        # Snapshot under the lock, write outside it: the stall timers must
+        # Snapshot under the lock, write outside it: the tip-change timers must
         # survive a restart or every node reports as freshly advanced on the
         # next process start.
         self.persist_state(snapshot)
@@ -1073,6 +1109,8 @@ class ClusterCollector:
         return {
             name: {
                 "height": self.last_height.get(name),
+                "block_hash": self.last_block_hash.get(name),
+                "ancestor_hashes": dict(self.last_ancestors.get(name) or {}),
                 "last_advanced_at": self.last_advanced_at.get(name),
             }
             for name in self.last_advanced_at
@@ -1183,9 +1221,9 @@ class ClusterCollector:
             )
             if previous_height is None and self.last_advanced_at.get(node.name) is None:
                 self.last_advanced_at[node.name] = now
-            elif previous_height is not None and height > previous_height:
+            elif tip_event in ("advanced", "reorg_height_drop", "tip_switch"):
                 self.last_advanced_at[node.name] = now
-                advanced = True
+                advanced = tip_event == "advanced"
             self.last_height[node.name] = height
             if block_hash:
                 self.last_block_hash[node.name] = block_hash
@@ -1245,10 +1283,10 @@ class ClusterCollector:
             detail = str(probe.get("rpc_error") or "RPC height unavailable")
         elif not recent:
             health = "stale"
-            detail = "height has not advanced within stale window"
+            detail = "tip has not changed within stale window"
         else:
             health = "healthy"
-            detail = "advanced this poll" if advanced else "height recently advanced"
+            detail = "advanced this poll" if advanced else "tip recently changed"
 
         if tip_event == "reorg_height_drop":
             detail = (
@@ -1300,6 +1338,7 @@ class ClusterCollector:
             "commit": probe.get("commit") or "",
             "block_hash": block_hash,
             "previous_hash": previous_block_hash,
+            "grandparent_hash": str(probe.get("grandparent_hash") or ""),
             "ancestor_hashes": ancestor_hashes,
             "node_id": node.node_id or probe.get("node_id") or "",
             "version": probe.get("version") or "",
@@ -1307,6 +1346,8 @@ class ClusterCollector:
             "height": height,
             "headers": headers,
             "header_lag": header_lag,
+            "block_time": coerce_int(probe.get("block_time")),
+            "previous_block_time": coerce_int(probe.get("previous_block_time")),
             "tip_event": tip_event,
             "chain_role": "unknown",
             "active_state": active_state,
@@ -1584,10 +1625,10 @@ def save_orphan_pairs(
 
 
 def load_progress(path: Path | None) -> dict[str, dict]:
-    """Restore per-node height/last-advanced timers written by a previous process.
+    """Restore per-node tip and progress timers written by a previous process.
 
     Without this the stall clock restarts from zero on every dashboard restart,
-    which reports every node as freshly advanced regardless of its real height.
+    and a hash replacement across the restart cannot be identified as a reorg.
     """
     if path is None or not path.exists():
         return {}
@@ -1605,9 +1646,14 @@ def load_progress(path: Path | None) -> dict[str, dict]:
         if not isinstance(record, dict):
             continue
         height = record.get("height")
+        block_hash = record.get("block_hash")
         advanced_at = record.get("last_advanced_at")
         restored[str(name)] = {
             "height": int(height) if isinstance(height, (int, float)) else None,
+            "block_hash": str(block_hash) if block_hash else None,
+            "ancestor_hashes": normalize_ancestor_hashes(
+                record.get("ancestor_hashes")
+            ),
             "last_advanced_at": (
                 float(advanced_at) if isinstance(advanced_at, (int, float)) else None
             ),
@@ -2555,7 +2601,7 @@ footer {
             <th class="col-chain sortable" data-sort="chain_role">Chain<span class="arrow"></span></th>
             <th class="col-height col-num sortable" data-sort="height">Height<span class="arrow"></span></th>
             <th class="col-hdr col-num sortable" data-sort="header_lag" title="headers minus blocks">Hdr<span class="arrow"></span></th>
-            <th class="col-adv col-num sortable" data-sort="seconds_since_advanced" title="time since the tip last advanced">Adv<span class="arrow"></span></th>
+            <th class="col-adv col-num sortable" data-sort="seconds_since_advanced" title="time since the tip last changed">Age<span class="arrow"></span></th>
             <th class="col-commit sortable" data-sort="commit">Commit<span class="arrow"></span></th>
             <th class="col-tip">Tip</th>
             <th class="col-restarted sortable" data-sort="last_restarted">Restarted<span class="arrow"></span></th>
@@ -3043,7 +3089,7 @@ function drawerHtml(row) {
     + fieldHtml('Headers / blocks', num(row.headers) + ' / ' + num(row.height))
     + fieldHtml('Commit', row.commit, { mono: true, copy: true })
     + fieldHtml('Tip event', tipEventLabel(row.tip_event) || row.tip_event)
-    + fieldHtml('Tip last advanced', row.last_advanced_at
+    + fieldHtml('Tip last changed', row.last_advanced_at
       ? new Date(row.last_advanced_at * 1000).toLocaleString() : '')
     + fieldHtml('Last probed', row.last_seen_at
       ? new Date(row.last_seen_at * 1000).toLocaleString() : '')
@@ -3333,7 +3379,7 @@ function renderNodeChain(data) {
     kvRow('vs fleet majority', delta == null ? '—' : (delta > 0 ? '+' : '') + num(delta),
       delta ? 'warn' : null),
     kvRow('Advance rate', rate == null ? '—' : decimal(rate, 1) + ' blocks/min'),
-    kvRow('Tip last advanced', age(row.seconds_since_advanced) + ' ago'),
+    kvRow('Tip last changed', age(row.seconds_since_advanced) + ' ago'),
     kvRowHtml('Tip hash', copyCell(row.block_hash, shortHash(row.block_hash), 'Copy tip hash')),
     kvRowHtml('Parent hash', copyCell(row.previous_hash, shortHash(row.previous_hash), 'Copy parent hash')),
     kvRow('RPC chain', String(row.rpc_chain || 'unknown')),
@@ -3800,7 +3846,7 @@ def main() -> None:
         "--stale-after",
         type=float,
         default=300.0,
-        help="mark a node stale if height has not advanced in this many seconds",
+        help="mark a node stale if its tip has not changed in this many seconds",
     )
     parser.add_argument(
         "--state-file",

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -2,7 +2,8 @@
 """Slack watchdog for Zakura fleet status dashboards.
 
 Polls one or more `zakura-cluster-status.py` `/data` endpoints, tracks sustained
-node failures in a small JSON state file, and posts transition alerts to Slack.
+node failures and extended block intervals in a small JSON state file, and posts
+transition alerts to Slack.
 
 Only the Python stdlib is used.
 """
@@ -11,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import time
@@ -18,12 +20,14 @@ import tomllib
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
 
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
+BLOCK_INTERVAL_TOLERANCE_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -31,6 +35,23 @@ class Fleet:
     name: str
     url: str
     dashboard_url: str
+    target_block_seconds: float = 75.0
+    block_explorer_url: str = ""
+
+
+class SuccessorEvidenceKind(Enum):
+    WAITING = "waiting"
+    SAME_BRANCH = "same_branch"
+    BRANCH_CHANGED = "branch_changed"
+    RETRYABLE_MISSING = "retryable_missing"
+    TERMINAL_MISSING = "terminal_missing"
+
+
+@dataclass(frozen=True)
+class SuccessorEvidence:
+    kind: SuccessorEvidenceKind
+    interval_seconds: int | None = None
+    detail: str = ""
 
 
 def load_fleets(config_path: Path) -> list[Fleet]:
@@ -51,7 +72,28 @@ def load_fleets(config_path: Path) -> list[Fleet]:
 
         url = str(raw["url"])
         dashboard_url = str(raw.get("dashboard_url") or url.removesuffix("/data"))
-        fleets.append(Fleet(name=name, url=url, dashboard_url=dashboard_url))
+        block_explorer_url = str(raw.get("block_explorer_url") or "").rstrip("/")
+        try:
+            target_block_seconds = float(raw.get("target_block_seconds", 75.0))
+        except (TypeError, ValueError) as error:
+            raise SystemExit(
+                f"fleet {name} has invalid target_block_seconds: "
+                f"{raw.get('target_block_seconds')}"
+            ) from error
+        if not math.isfinite(target_block_seconds) or target_block_seconds <= 0:
+            raise SystemExit(
+                f"fleet {name} target_block_seconds must be a finite number "
+                "greater than zero"
+            )
+        fleets.append(
+            Fleet(
+                name=name,
+                url=url,
+                dashboard_url=dashboard_url,
+                target_block_seconds=target_block_seconds,
+                block_explorer_url=block_explorer_url,
+            )
+        )
 
     if not fleets:
         raise SystemExit(f"no [[fleets]] defined in {config_path}")
@@ -61,16 +103,17 @@ def load_fleets(config_path: Path) -> list[Fleet]:
 
 def load_state(state_path: Path) -> dict[str, Any]:
     if not state_path.exists():
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}, "chains": {}}
 
     with state_path.open(encoding="utf-8") as state_file:
         state = json.load(state_file)
 
     if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}, "chains": {}}
 
     state.setdefault("nodes", {})
     state.setdefault("fleets", {})
+    state.setdefault("chains", {})
     return state
 
 
@@ -103,6 +146,15 @@ def coerce_float(value: object) -> float | None:
         return None
 
 
+def coerce_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def format_duration(seconds: float) -> str:
     seconds = max(0, int(seconds))
     if seconds < 60:
@@ -114,6 +166,12 @@ def format_duration(seconds: float) -> str:
 
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h" if minutes == 0 else f"{hours}h {minutes}m"
+
+
+def format_header_interval(seconds: int) -> str:
+    if seconds < 0:
+        return f"-{format_duration(-seconds)}"
+    return format_duration(seconds)
 
 
 def suppression_until(path: Path) -> float | None:
@@ -194,6 +252,7 @@ def node_condition(
     now: float,
     grace_since: float,
     args: argparse.Namespace,
+    suppress_stall: bool = False,
 ) -> tuple[str, float, float]:
     health = str(row.get("health") or "unknown")
     seconds_since_advanced = coerce_float(row.get("seconds_since_advanced"))
@@ -205,7 +264,8 @@ def node_condition(
         return ("down", now, args.down_after)
 
     if (
-        seconds_since_advanced is not None
+        not suppress_stall
+        and seconds_since_advanced is not None
         and seconds_since_advanced >= args.stalled_after
     ):
         return ("stalled", now - seconds_since_advanced, args.stalled_after)
@@ -213,20 +273,500 @@ def node_condition(
     return ("ok", now, 0)
 
 
-def stall_cleared(entry: dict[str, Any], height: float | None) -> bool:
+def agreed_int(rows: list[dict[str, Any]], key: str) -> int | None:
+    values = [
+        value
+        for row in rows
+        if (value := coerce_int(row.get(key))) is not None
+    ]
+    if len(values) < 2:
+        return None
+    return values[0] if len(set(values)) == 1 else None
+
+
+def agreed_hash(rows: list[dict[str, Any]], key: str) -> str | None:
+    values = [str(row.get(key) or "") for row in rows if row.get(key)]
+    if len(values) < 2:
+        return None
+    return values[0] if len(set(values)) == 1 else None
+
+
+def dashboard_poll_age(snapshot: dict[str, Any]) -> float | None:
+    generated_at = coerce_float(snapshot.get("generated_at"))
+    last_poll = coerce_float(snapshot.get("last_poll"))
+    if generated_at is None or last_poll is None:
+        return None
+    return generated_at - last_poll
+
+
+def majority_tip(
+    snapshot: dict[str, Any], rows: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Return the usable fleet-majority tip and whether it can replace node stalls."""
+    chain = snapshot.get("chain")
+    if not isinstance(chain, dict):
+        return None
+
+    height = coerce_int(chain.get("majority_height"))
+    block_hash = str(chain.get("majority_hash") or "")
+    if height is None or not block_hash:
+        return None
+
+    tipped_rows = [
+        row
+        for row in rows
+        if coerce_int(row.get("height")) is not None and row.get("block_hash")
+    ]
+    members = [
+        row
+        for row in tipped_rows
+        if coerce_int(row.get("height")) == height
+        and str(row.get("block_hash") or "") == block_hash
+        and str(row.get("health") or "unknown") not in DOWN_HEALTH
+    ]
+    if not members:
+        return None
+
+    has_ahead_tip = any(coerce_int(row.get("height")) > height for row in tipped_rows)
+    has_competing_tip = any(
+        coerce_int(row.get("height")) == height
+        and str(row.get("block_hash") or "") != block_hash
+        for row in tipped_rows
+    )
+    stalled_for = [coerce_float(row.get("seconds_since_advanced")) for row in members]
+    min_stalled_for = (
+        min(value for value in stalled_for if value is not None)
+        if all(value is not None for value in stalled_for)
+        else None
+    )
+    return {
+        "height": height,
+        "block_hash": block_hash,
+        "node_names": sorted(str(row.get("name") or "unknown") for row in members),
+        "client_names": sorted(
+            {str(row.get("client_name") or "unknown") for row in members}
+        ),
+        "node_count": len(members),
+        "min_stalled_for": min_stalled_for,
+        "block_time": agreed_int(members, "block_time"),
+        "previous_block_time": agreed_int(members, "previous_block_time"),
+        "previous_hash": agreed_hash(members, "previous_hash"),
+        "grandparent_hash": agreed_hash(members, "grandparent_hash"),
+        "can_consolidate": (
+            len(members) >= 2 and not has_ahead_tip and not has_competing_tip
+        ),
+    }
+
+
+def reorg_observations_since(chain: object, since: float) -> int:
+    """Count real orphan/reorg observations recorded during an interval."""
+    if not isinstance(chain, dict):
+        return 0
+    events = chain.get("recent_reorgs")
+    if not isinstance(events, list):
+        return 0
+
+    count = 0
+    for event in events:
+        if not isinstance(event, dict) or event.get("demo"):
+            continue
+        observed_at = coerce_float(event.get("at"))
+        if observed_at is not None and observed_at >= since:
+            count += 1
+    return count
+
+
+def format_clients(client_names: object) -> str:
+    if not isinstance(client_names, (list, tuple)):
+        return "unknown client"
+    names = [str(name) for name in client_names if name]
+    return " + ".join(names) if names else "unknown client"
+
+
+def target_multiple(age: float, fleet: Fleet) -> str:
+    return f"{age / fleet.target_block_seconds:.1f}×"
+
+
+def block_explorer_links(fleet: Fleet, height: int | None) -> str:
+    if not fleet.block_explorer_url or height is None:
+        return ""
+
+    successor_height = height + 1
+    return (
+        f"CipherScan: <{fleet.block_explorer_url}/{height}|block {height}> → "
+        f"<{fleet.block_explorer_url}/{successor_height}|block {successor_height}>\n"
+    )
+
+
+def chain_interval_candidate(tip: dict[str, Any] | None, stalled_after: float) -> bool:
+    return bool(
+        tip is not None
+        and tip["can_consolidate"]
+        and tip["min_stalled_for"] is not None
+        and tip["min_stalled_for"] >= stalled_after
+    )
+
+
+def successor_evidence(
+    incident: dict[str, Any], tip: dict[str, Any]
+) -> SuccessorEvidence:
+    """Classify progress relative to the immutable block that opened an incident."""
+    anchor_height = coerce_int(incident.get("anchor_height"))
+    anchor_hash = str(incident.get("anchor_hash") or "")
+    current_height = coerce_int(tip.get("height"))
+    current_hash = str(tip.get("block_hash") or "")
+    if anchor_height is None or not anchor_hash or current_height is None:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.TERMINAL_MISSING,
+            detail="the persisted incident anchor or current agreed height is unavailable",
+        )
+
+    if current_height == anchor_height and current_hash == anchor_hash:
+        return SuccessorEvidence(SuccessorEvidenceKind.WAITING)
+
+    distance = current_height - anchor_height
+    if current_height < anchor_height:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.BRANCH_CHANGED,
+            detail=(
+                f"the agreed tip rolled back from alerted height {anchor_height} "
+                f"to {current_height}"
+            ),
+        )
+
+    if current_height == anchor_height:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.BRANCH_CHANGED,
+            detail=(
+                f"alerted block `{anchor_hash}` at height {anchor_height} was "
+                f"replaced by `{current_hash}`"
+            ),
+        )
+
+    if distance > 2:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.TERMINAL_MISSING,
+            detail=(
+                f"the fleet advanced to H+{distance}, beyond the dashboard's exact "
+                "H+1 timestamp window"
+            ),
+        )
+
+    ancestor_key = "previous_hash" if distance == 1 else "grandparent_hash"
+    ancestor_hash = str(tip.get(ancestor_key) or "")
+    if not ancestor_hash:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.RETRYABLE_MISSING,
+            detail=(
+                f"the agreed tip did not provide a consistent hash-linked "
+                f"depth-{distance} ancestor"
+            ),
+        )
+
+    if ancestor_hash != anchor_hash:
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.BRANCH_CHANGED,
+            detail=(
+                f"alerted block `{anchor_hash}` at height {anchor_height} is not "
+                f"the agreed tip's canonical ancestor; height {anchor_height} is "
+                f"now `{ancestor_hash}`"
+            ),
+        )
+
+    if distance == 1:
+        block_time = coerce_int(tip.get("block_time"))
+        previous_block_time = coerce_int(tip.get("previous_block_time"))
+        if block_time is not None and previous_block_time is not None:
+            return SuccessorEvidence(
+                SuccessorEvidenceKind.SAME_BRANCH,
+                interval_seconds=block_time - previous_block_time,
+            )
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.RETRYABLE_MISSING,
+            detail="the agreed H+1 header timestamps were unavailable or inconsistent",
+        )
+
+    if distance == 2:
+        anchor_block_time = coerce_int(incident.get("anchor_block_time"))
+        successor_block_time = coerce_int(tip.get("previous_block_time"))
+        if anchor_block_time is not None and successor_block_time is not None:
+            return SuccessorEvidence(
+                SuccessorEvidenceKind.SAME_BRANCH,
+                interval_seconds=successor_block_time - anchor_block_time,
+            )
+        return SuccessorEvidence(
+            SuccessorEvidenceKind.RETRYABLE_MISSING,
+            detail="the agreed H or H+1 header timestamp was unavailable",
+        )
+
+    raise AssertionError("successor distance must be one or two")
+
+
+def chain_interval_alert_text(
+    fleet: Fleet,
+    tip: dict[str, Any],
+    age: float,
+    orphan_observations: int,
+) -> str:
+    clients = tip["client_names"]
+    if {"zakurad", "zcashd"}.issubset(clients):
+        classification = (
+            "Zakura and its pinned zcashd compatibility sidecar agree, but "
+            "the sidecar is not an independent network reference. The cause "
+            "stays unclassified until the next agreed tip."
+        )
+    else:
+        classification = (
+            f"The agreeing tip is reported by {format_clients(clients)}; "
+            "a shared fleet stall is not ruled out yet."
+        )
+
+    return (
+        f":hourglass_flowing_sand: *Zcash {fleet.name}* extended block interval\n"
+        f"no new agreed tip for {format_duration(age)} "
+        f"({target_multiple(age, fleet)} the {fleet.target_block_seconds:g}s target)\n"
+        f"{tip['node_count']} nodes ({format_clients(clients)}) agree at "
+        f"height {tip['height']} - hash {tip['block_hash']}\n"
+        f"{classification}\n"
+        "individual stall notices for these agreeing nodes are consolidated here\n"
+        f"orphan/reorg observations during interval: {orphan_observations}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
+def chain_interval_resolution_text(
+    fleet: Fleet,
+    incident: dict[str, Any],
+    tip: dict[str, Any],
+    evidence: SuccessorEvidence,
+    age: float,
+    orphan_observations: int,
+    stalled_after: float,
+) -> str:
+    previous_height = coerce_int(incident.get("anchor_height"))
+    current_height = tip["height"]
+    clients = tip["client_names"]
+    header_interval = evidence.interval_seconds
+    interval_heights = (
+        f" {previous_height}→{previous_height + 1}"
+        if previous_height is not None
+        else ""
+    )
+    threshold = coerce_float(incident.get("threshold_seconds")) or stalled_after
+    tolerance = max(
+        0.0,
+        coerce_float(incident.get("tolerance_seconds")) or 0.0,
+    )
+    long_interval_floor = max(0.0, threshold - tolerance)
+    fleet_delay_ceiling = 2 * fleet.target_block_seconds
+
+    if evidence.kind is SuccessorEvidenceKind.BRANCH_CHANGED:
+        title = f":twisted_rightwards_arrows: *Zcash {fleet.name}* canonical branch changed"
+        classification = (
+            f"{evidence.detail}; this is consistent with an orphan/reorg and the "
+            "original interval is not classified as a Zakura fleet delay"
+        )
+    elif header_interval is not None and header_interval >= threshold:
+        title = (
+            f":stopwatch: *Zcash {fleet.name}* "
+            "long canonical block interval confirmed"
+        )
+        classification = (
+            f"canonical header interval{interval_heights}: "
+            f"{format_header_interval(header_interval)}; "
+            "this confirms a long canonical block interval, so a Zakura fleet "
+            "delay is not needed to explain the alert"
+        )
+    elif header_interval is not None and header_interval >= long_interval_floor:
+        title = (
+            f":stopwatch: *Zcash {fleet.name}* "
+            "long canonical block interval consistent with alert"
+        )
+        classification = (
+            f"canonical header interval{interval_heights}: "
+            f"{format_header_interval(header_interval)}; this is within the "
+            f"{format_duration(tolerance)} observation allowance around the "
+            "alert threshold, so a Zakura fleet delay is not needed to explain it"
+        )
+    elif (
+        header_interval is not None
+        and header_interval >= 0
+        and header_interval <= fleet_delay_ceiling
+    ):
+        title = f":warning: *Zcash {fleet.name}* fleet delay suspected"
+        classification = (
+            f"canonical header interval{interval_heights}: "
+            f"{format_header_interval(header_interval)}; "
+            f"this was at most twice the {fleet.target_block_seconds:g}s target "
+            "and materially shorter than the fleet's observed delay, so the fleet "
+            "did not observe the canonical successor promptly"
+        )
+    elif header_interval is not None:
+        title = f":information_source: *Zcash {fleet.name}* interval cause inconclusive"
+        if header_interval < 0:
+            classification = (
+                f"canonical header interval{interval_heights}: "
+                f"{format_header_interval(header_interval)}; header timestamps were "
+                "nonmonotonic, so they cannot classify this event"
+            )
+        else:
+            classification = (
+                f"canonical header interval{interval_heights}: "
+                f"{format_header_interval(header_interval)}; this was longer than "
+                f"the {fleet.target_block_seconds:g}s target but not long enough to "
+                "explain the observed delay within the polling allowance"
+            )
+    else:
+        title = f":white_check_mark: *Zcash {fleet.name}* fleet progress resumed"
+        classification = (
+            f"{evidence.detail}; the exact successor header interval remained "
+            "unavailable, so the event remains unclassified"
+        )
+
+    if (
+        evidence.kind is not SuccessorEvidenceKind.BRANCH_CHANGED
+        or (previous_height is not None and current_height > previous_height)
+    ):
+        explorer_links = block_explorer_links(fleet, previous_height)
+    else:
+        explorer_links = (
+            f"CipherScan: <{fleet.block_explorer_url}/{current_height}|"
+            f"canonical block {current_height}>\n"
+            if fleet.block_explorer_url
+            else ""
+        )
+
+    return (
+        f"{title}\n"
+        f"observed interval: {format_duration(age)} "
+        f"({target_multiple(age, fleet)} the {fleet.target_block_seconds:g}s target)\n"
+        f"agreed height {previous_height if previous_height is not None else '-'} "
+        f"→ {current_height}\n"
+        f"{tip['node_count']} nodes ({format_clients(clients)}) agree on the new tip\n"
+        f"{classification}\n"
+        f"{explorer_links}"
+        f"orphan/reorg observations during interval: {orphan_observations}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
+def update_chain_interval_state(
+    state_bucket: dict[str, Any],
+    fleet: Fleet,
+    tip: dict[str, Any] | None,
+    chain: object,
+    now: float,
+    suppressed: bool,
+    args: argparse.Namespace,
+) -> bool:
+    """Track one fleet-wide no-progress interval and confirm it on advancement."""
+    key = fleet.name
+    incident = dict(state_bucket.get(key, {}))
+    is_open = coerce_int(incident.get("anchor_height")) is not None and bool(
+        incident.get("anchor_hash")
+    )
+    candidate = chain_interval_candidate(tip, args.stalled_after)
+
+    if not is_open:
+        state_bucket.pop(key, None)
+        if not candidate or tip is None:
+            return False
+
+        bad_since = now - float(tip["min_stalled_for"])
+        age = now - bad_since
+        orphan_observations = reorg_observations_since(chain, bad_since)
+        if suppressed:
+            print(
+                f"suppressed alert for {key}: extended block interval for "
+                f"{format_duration(age)}"
+            )
+            return True
+        if post_slack(
+            chain_interval_alert_text(fleet, tip, age, orphan_observations), args
+        ):
+            state_bucket[key] = {
+                "bad_since": bad_since,
+                "anchor_height": tip["height"],
+                "anchor_hash": tip["block_hash"],
+                "anchor_block_time": coerce_int(tip.get("block_time")),
+                "threshold_seconds": float(args.stalled_after),
+                "tolerance_seconds": BLOCK_INTERVAL_TOLERANCE_SECONDS,
+            }
+        return True
+
+    pending_resolution_text = str(incident.get("pending_resolution_text") or "")
+    if pending_resolution_text:
+        if post_slack(pending_resolution_text, args):
+            state_bucket.pop(key, None)
+        return True
+
+    if tip is None or not tip["can_consolidate"]:
+        state_bucket[key] = incident
+        return False
+
+    evidence = successor_evidence(incident, tip)
+    if evidence.kind is SuccessorEvidenceKind.WAITING:
+        incident.pop("evidence_deadline", None)
+        state_bucket[key] = incident
+        return True
+
+    if evidence.kind is SuccessorEvidenceKind.RETRYABLE_MISSING:
+        evidence_deadline = coerce_float(incident.get("evidence_deadline"))
+        if evidence_deadline is None:
+            evidence_deadline = now + 2 * float(args.interval)
+        if now < evidence_deadline:
+            incident["evidence_deadline"] = evidence_deadline
+            state_bucket[key] = incident
+            return True
+        evidence = SuccessorEvidence(
+            SuccessorEvidenceKind.TERMINAL_MISSING,
+            detail=(
+                f"{evidence.detail} through the "
+                f"{format_duration(2 * float(args.interval))} retry window"
+            ),
+        )
+
+    bad_since = float(incident.get("bad_since", now))
+    age = now - bad_since
+    orphan_observations = reorg_observations_since(chain, bad_since)
+    resolution_text = chain_interval_resolution_text(
+        fleet,
+        incident,
+        tip,
+        evidence,
+        age,
+        orphan_observations,
+        args.stalled_after,
+    )
+    if post_slack(resolution_text, args):
+        state_bucket.pop(key, None)
+    else:
+        incident["pending_resolution_text"] = resolution_text
+        state_bucket[key] = incident
+    return True
+
+
+def stall_cleared(
+    entry: dict[str, Any],
+    height: float | None,
+    block_hash: str | None = None,
+) -> bool:
     """True when a stalled alert may be retired.
 
-    A stall is only over once the node is strictly higher than it was when the
-    alert fired. The dashboard's stall timer lives in memory, so any restart
-    reports every node as freshly advanced and would otherwise clear the alert
-    at an unchanged height.
+    A higher height or a different known tip hash proves that the node moved.
+    The dashboard's stall timer lives in memory, so a timer reset at the same
+    height and hash must not clear the alert.
     """
     if entry.get("condition") != "stalled":
         return True
     alert_height = coerce_float(entry.get("alert_height"))
     if alert_height is None:
         return True
-    return height is not None and height > alert_height
+    if height is not None and height > alert_height:
+        return True
+    alert_hash = str(entry.get("alert_hash") or "")
+    current_hash = str(block_hash or "")
+    return bool(alert_hash and current_hash and current_hash != alert_hash)
 
 
 def update_alert_state(
@@ -241,13 +781,14 @@ def update_alert_state(
     suppressed: bool,
     args: argparse.Namespace,
     height: float | None = None,
+    block_hash: str | None = None,
 ) -> None:
     entry = state_bucket.get(key, {"condition": "ok", "alerting": False})
     was_alerting = bool(entry.get("alerting"))
 
     if condition == "ok":
         if was_alerting:
-            if not stall_cleared(entry, height):
+            if not stall_cleared(entry, height, block_hash):
                 # Keep the alert latched; the timer reset but the node did not move.
                 anchor = coerce_float(entry.get("alert_height"))
                 if height is not None and anchor is not None and height < anchor:
@@ -256,6 +797,8 @@ def update_alert_state(
                     # only clear once it re-synced past it, so a node that was fixed
                     # by a resync would never post a recovery.
                     entry = {**entry, "alert_height": height}
+                if not entry.get("alert_hash") and block_hash:
+                    entry = {**entry, "alert_hash": block_hash}
                 state_bucket[key] = entry
                 return
             if post_slack(recovery_text, args):
@@ -288,6 +831,11 @@ def update_alert_state(
             anchor = height
         if anchor is not None:
             next_entry["alert_height"] = anchor
+        anchor_hash = entry.get("alert_hash")
+        if not anchor_hash and condition == "stalled":
+            anchor_hash = block_hash
+        if anchor_hash:
+            next_entry["alert_hash"] = anchor_hash
 
     if not alerting and age >= threshold:
         if suppressed:
@@ -298,6 +846,8 @@ def update_alert_state(
             if condition == "stalled" and height is not None:
                 # Anchor recovery to this height, not to the dashboard's timer.
                 next_entry["alert_height"] = height
+            if condition == "stalled" and block_hash:
+                next_entry["alert_hash"] = block_hash
 
     state_bucket[key] = next_entry
 
@@ -333,7 +883,7 @@ def node_recovery_text(fleet: Fleet, row: dict[str, Any], previous: dict[str, An
 
 def fleet_alert_text(fleet: Fleet, error: Exception, age: float) -> str:
     return (
-        f":rotating_light: *Zakura {fleet.name}* dashboard unreachable "
+        f":rotating_light: *Zakura {fleet.name}* dashboard telemetry unavailable "
         f"for {format_duration(age)}\n"
         f"endpoint: {fleet.url}\n"
         f"error: {error}"
@@ -341,10 +891,8 @@ def fleet_alert_text(fleet: Fleet, error: Exception, age: float) -> str:
 
 
 def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
-    condition = previous.get("condition") or "unreachable"
     return (
-        f":white_check_mark: *Zakura {fleet.name}* dashboard recovered "
-        f"from {condition}\n"
+        f":white_check_mark: *Zakura {fleet.name}* dashboard telemetry recovered\n"
         f"endpoint: {fleet.url}"
     )
 
@@ -368,14 +916,89 @@ class Watchdog:
                 self.handle_fleet_error(state, fleet, error, now, suppressed)
                 continue
 
+            poll_age = dashboard_poll_age(snapshot)
+            if poll_age is None:
+                self.handle_fleet_error(
+                    state,
+                    fleet,
+                    RuntimeError("snapshot is missing generated_at or last_poll"),
+                    now,
+                    suppressed,
+                )
+                continue
+            if poll_age < 0:
+                freshness_error = RuntimeError(
+                    "snapshot generated_at precedes last_poll"
+                )
+            elif poll_age > max(float(self.args.interval), 1.0):
+                freshness_error = RuntimeError(
+                    f"last completed poll is {poll_age:.1f}s behind the snapshot"
+                )
+            else:
+                freshness_error = None
+            if freshness_error is not None:
+                self.handle_fleet_error(
+                    state,
+                    fleet,
+                    freshness_error,
+                    now,
+                    suppressed,
+                )
+                continue
+
             self.handle_fleet_recovered(state, fleet, now)
             rows = snapshot.get("rows", [])
             if not isinstance(rows, list):
                 rows = []
+            rows = [row for row in rows if isinstance(row, dict)]
+            consolidated_nodes = self.handle_chain(
+                state, fleet, snapshot, rows, now, suppressed
+            )
 
             for row in rows:
-                if isinstance(row, dict):
-                    self.handle_node(state, fleet, row, now, suppressed)
+                self.handle_node(
+                    state,
+                    fleet,
+                    row,
+                    now,
+                    suppressed,
+                    suppress_stall=str(row.get("name") or "unknown")
+                    in consolidated_nodes,
+                )
+
+    def handle_chain(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        snapshot: dict[str, Any],
+        rows: list[dict[str, Any]],
+        now: float,
+        suppressed: bool,
+    ) -> set[str]:
+        tip = majority_tip(snapshot, rows)
+        bucket = state.setdefault("chains", {})
+        was_open = fleet.name in bucket
+        suppress_stalls = update_chain_interval_state(
+            bucket,
+            fleet,
+            tip,
+            snapshot.get("chain"),
+            now,
+            suppressed,
+            self.args,
+        )
+        if tip is None or not tip["can_consolidate"] or not suppress_stalls:
+            return set()
+
+        consolidated_nodes = set(tip["node_names"])
+        if was_open or fleet.name in bucket:
+            node_bucket = state.setdefault("nodes", {})
+            for node_name in consolidated_nodes:
+                node_key = f"{fleet.name}/{node_name}"
+                if node_bucket.get(node_key, {}).get("condition") == "stalled":
+                    node_bucket[node_key] = {"condition": "ok", "alerting": False}
+
+        return consolidated_nodes
 
     def handle_fleet_error(
         self,
@@ -439,13 +1062,16 @@ class Watchdog:
         row: dict[str, Any],
         now: float,
         suppressed: bool,
+        suppress_stall: bool = False,
     ) -> None:
         node_name = str(row.get("name") or "unknown")
         key = f"{fleet.name}/{node_name}"
         bucket = state.setdefault("nodes", {})
         previous = dict(bucket.get(key, {}))
         grace_since = max(self.started_at, self.fetch_recovered_at.get(fleet.name, 0))
-        condition, bad_since, threshold = node_condition(row, now, grace_since, self.args)
+        condition, bad_since, threshold = node_condition(
+            row, now, grace_since, self.args, suppress_stall
+        )
         if condition != "ok" and previous.get("condition") == condition:
             bad_since = min(float(previous.get("bad_since", bad_since)), bad_since)
         age = now - bad_since
@@ -462,12 +1088,15 @@ class Watchdog:
             suppressed,
             self.args,
             coerce_float(row.get("height")),
+            str(row.get("block_hash") or "") or None,
         )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Alert Slack when Zakura fleet dashboard nodes stay unhealthy."
+        description=(
+            "Alert Slack about unhealthy Zakura nodes and extended block intervals."
+        )
     )
     parser.add_argument("--config", required=True, type=Path, help="fleet TOML config")
     parser.add_argument(
@@ -487,7 +1116,7 @@ def parse_args() -> argparse.Namespace:
         "--stalled-after",
         type=float,
         default=600.0,
-        help="alert after no block progress for this many seconds",
+        help="alert after no node or agreed-fleet block progress for this many seconds",
     )
     parser.add_argument(
         "--dashboard-down-after",


### PR DESCRIPTION
## Motivation

When the freshest reachable cohort agrees on one stalled tip and no node reports an ahead or competing tip, separate node alerts are noisy and cannot distinguish a genuinely long network interval from a shared Zakura observation delay. This follows the recent alert triage; there is no GitHub issue.

## Solution

Consolidate that agreeing cohort into one interval incident and keep the alerted height, hash, time, and start time immutable. Once progress resumes, verify the exact H to H+1 relationship from hash-linked headers before classifying the timestamp delta. Same-height replacements, rollbacks, and mismatched ancestry resolve as branch changes; short canonical intervals can indicate fleet delay; near-threshold and intermediate intervals use conservative wording; missing evidence is retried and then left unclassified. A stale completed dashboard poll produces one telemetry incident, while row timestamps may span a normal multi-wave collection cycle.

Design note: H+2 preserves classification when one extra block arrives between watchdog polls. H+3 or later deliberately resolves unclassified because the dashboard no longer carries the exact H+1 evidence. CipherScan links remain a human cross-check rather than a new external dependency in the alert path. Of the 1,766 added lines, 982 are scenario tests; production monitoring code accounts for 712, and docs/config account for 72.

## Testing

- Watchdog suite: 40 passed
- Platform-independent dashboard suite: 53 passed
- Full dashboard suite: 53 passed; the unchanged Linux host-vitals fixture fails locally on macOS because procfs and journalctl are unavailable
- Python bytecode compilation, git diff check, and README markdownlint passed

## Changelog

No fragment is required because this PR changes internal deployment monitoring only.

### AI Disclosure

Codex was used for implementation, tests, documentation, and PR description updates.
