### PR TITLE
feat(rpc)!: serve reconstruction material for absent-band treestates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8551,7 +8551,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "7.0.1"
+version = "8.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -112,7 +112,9 @@ pub(crate) mod trees;
 pub(crate) mod types;
 
 use hex_data::HexData;
-use trees::{GetSubtreesByIndexResponse, GetTreestateResponse, SubtreeRpcData};
+use trees::{
+    GetSubtreesByIndexResponse, GetTreestateAnchorResponse, GetTreestateResponse, SubtreeRpcData,
+};
 use types::{
     get_block_template::{
         constants::{
@@ -397,6 +399,36 @@ pub trait Rpc {
     /// state is available for the requested block.
     #[method(name = "z_gettreestate")]
     async fn z_get_treestate(&self, hash_or_height: String) -> Result<GetTreestateResponse>;
+
+    /// Returns the material a client needs to reconstruct a block's note commitment treestate
+    /// itself: the authenticated per-pool roots at that block, and the highest frontier at or
+    /// below it that this node has already verified against them.
+    ///
+    /// Zakura-specific; `zcashd` and `lightwalletd` have no equivalent. It exists for the height
+    /// band where a verified-commitment-trees fast-synced node stores no per-height tree and
+    /// `z_gettreestate` therefore reports the tree unavailable. A client falls back here, replays
+    /// the canonical blocks from `replayFrom` to the target, and accepts the result only if all
+    /// three target roots match — so what it ends up with is verified, not trusted.
+    ///
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// # Parameters
+    ///
+    /// - `hash | height`: (string, required, example="1500000") The block hash or height.
+    ///
+    /// # Notes
+    ///
+    /// This does no replay of its own, so it stays cheap however far the target is from anything
+    /// this node has derived. Replaying is the client's job, and it needs the canonical block
+    /// bodies for `replayFrom..=height` to do it — which a pruned node cannot supply.
+    ///
+    /// `anchor` is omitted when the replay must start from genesis.
+    #[method(name = "z_gettreestateanchor")]
+    async fn z_get_treestate_anchor(
+        &self,
+        hash_or_height: String,
+    ) -> Result<GetTreestateAnchorResponse>;
 
     /// Returns information about a range of shielded subtrees.
     ///
@@ -2152,6 +2184,98 @@ where
             Treestate::new(trees::Commitments::new(sapling_root, sapling_tree)),
             Treestate::new(trees::Commitments::new(orchard_root, orchard_tree)),
             ironwood,
+        ))
+    }
+
+    async fn z_get_treestate_anchor(
+        &self,
+        hash_or_height: String,
+    ) -> Result<GetTreestateAnchorResponse> {
+        let mut read_state = self.read_state.clone();
+
+        let hash_or_height =
+            HashOrHeight::new(&hash_or_height, self.latest_chain_tip.best_tip_height())
+                .map_error(server::error::LegacyCode::InvalidParameter)?;
+
+        // One state request, deliberately: the anchor and the target roots have to describe the
+        // same chain, and assembling them from separate reads would let a reorg between the two
+        // hand a client an anchor that cannot reach the target it was given.
+        let material = match read_state
+            .ready()
+            .and_then(|service| {
+                service.call(zakura_state::ReadRequest::TreestateReconstruction(
+                    hash_or_height,
+                ))
+            })
+            .await
+            .map_misc_error()?
+        {
+            zakura_state::ReadResponse::TreestateReconstruction(Some(material)) => material,
+            zakura_state::ReadResponse::TreestateReconstruction(None) => {
+                return Err("the requested block is not in the main chain")
+                    .map_error(server::error::LegacyCode::InvalidParameter);
+            }
+            _ => unreachable!("unmatched response to a treestate reconstruction request"),
+        };
+
+        // Roots only: `finalState` at the target is precisely what the client is about to derive.
+        let root_only = |root: Vec<u8>| Treestate::new(trees::Commitments::new(Some(root), None));
+
+        let target = trees::TreestateTarget::new(
+            material.target_hash,
+            material.target_height,
+            material.target_time,
+            root_only(
+                material
+                    .target_roots
+                    .sapling_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+            root_only(
+                material
+                    .target_roots
+                    .orchard_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+            root_only(
+                material
+                    .target_roots
+                    .ironwood_root
+                    .bytes_in_display_order()
+                    .to_vec(),
+            ),
+        );
+
+        let anchor = material.anchor.map(|anchor| {
+            let frontiers = &anchor.frontiers;
+            let pool = |state: Vec<u8>, root: Vec<u8>| {
+                Treestate::new(trees::Commitments::new(Some(root), Some(state)))
+            };
+
+            trees::TreestateAnchorFrontiers::new(
+                anchor.hash,
+                anchor.height,
+                pool(
+                    frontiers.sapling.to_rpc_bytes(),
+                    frontiers.sapling.root().bytes_in_display_order().to_vec(),
+                ),
+                pool(
+                    frontiers.orchard.to_rpc_bytes(),
+                    frontiers.orchard.root().bytes_in_display_order().to_vec(),
+                ),
+                pool(
+                    frontiers.ironwood.to_rpc_bytes(),
+                    frontiers.ironwood.root().bytes_in_display_order().to_vec(),
+                ),
+            )
+        });
+
+        Ok(GetTreestateAnchorResponse::new(
+            target,
+            anchor,
+            material.replay_from,
         ))
     }
 

--- a/crates/zakura-rpc/src/methods/trees.rs
+++ b/crates/zakura-rpc/src/methods/trees.rs
@@ -162,6 +162,92 @@ impl Default for GetTreestateResponse {
     }
 }
 
+/// Response to a `z_gettreestateanchor` RPC request.
+///
+/// A Zakura-specific companion to `z_gettreestate`, for the band where a fast-synced node has no
+/// stored per-height tree. Instead of the treestate itself it returns what a client needs to
+/// rebuild one: the authenticated roots at the target, and the highest frontier at or below it
+/// that this node has already checked against those roots.
+///
+/// The client replays canonical blocks from the anchor and accepts its result only if all three
+/// target roots match. That check is the whole trust story — a frontier that reproduces an
+/// authenticated root *is* the frontier — so this hands out no authority the node did not already
+/// have over the client's view of the chain.
+///
+/// `z_gettreestate`'s request and response are untouched. A client tries it first and only falls
+/// back here when it reports the historical tree unavailable.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct GetTreestateAnchorResponse {
+    /// The canonical target block and the roots the client's replay must reproduce.
+    target: TreestateTarget,
+
+    /// The verified frontier to replay forward from, or `null` to replay from genesis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    anchor: Option<TreestateAnchorFrontiers>,
+
+    /// The first height the client has to replay.
+    #[serde(rename = "replayFrom")]
+    #[getter(copy)]
+    replay_from: Height,
+}
+
+/// The target block of a `z_gettreestateanchor` response: what the client is reconstructing, and
+/// the authenticated roots that prove it got it right.
+///
+/// The per-pool fields carry `finalRoot` only — the `finalState` is exactly what the client is
+/// asking the node to help it derive — and use the same byte order and encoding as
+/// `z_gettreestate`, so the two responses are directly comparable.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct TreestateTarget {
+    /// The canonical block hash at `height`, hex-encoded.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: Hash,
+
+    /// The block height, numeric.
+    #[getter(copy)]
+    height: Height,
+
+    /// Unix time when the block was mined, so the client can build the same treestate the exact
+    /// path would have returned.
+    time: u32,
+
+    /// The authenticated Sapling root at this block.
+    sapling: Treestate,
+
+    /// The authenticated Orchard root at this block.
+    orchard: Treestate,
+
+    /// The authenticated Ironwood root at this block.
+    ironwood: Treestate,
+}
+
+/// The anchor of a `z_gettreestateanchor` response: a frontier this node has already verified,
+/// bound to the canonical block it is the state at the end of.
+///
+/// Both `finalRoot` and `finalState` are present for each pool, in `z_gettreestate`'s encoding, so
+/// a client can load the frontier with the same parser it already uses.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct TreestateAnchorFrontiers {
+    /// The canonical block hash at `height`, hex-encoded.
+    #[serde(with = "hex")]
+    #[getter(copy)]
+    hash: Hash,
+
+    /// The height the frontiers are the state at the end of, numeric.
+    #[getter(copy)]
+    height: Height,
+
+    /// The Sapling frontier and its root.
+    sapling: Treestate,
+
+    /// The Orchard frontier and its root.
+    orchard: Treestate,
+
+    /// The Ironwood frontier and its root.
+    ironwood: Treestate,
+}
+
 /// A treestate that is included in the [`z_gettreestate`][1] RPC response.
 ///
 /// [1]: https://zcash.github.io/rpc/z_gettreestate.html

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -66,7 +66,7 @@ pub use request::Spend;
 
 pub use response::{
     AnyTx, BlockSyncBodyMetadata, GetBlockTemplateChainInfo, KnownBlock, MinedTx,
-    NonFinalizedBlocksListener, ReadResponse, Response,
+    NonFinalizedBlocksListener, ReadResponse, Response, TreestateAnchor, TreestateReconstruction,
 };
 #[cfg(any(test, feature = "header-fuzz"))]
 pub use service::finalized_state::{replay_recovery_rows_bytes, RecoveryRowsReplaySummary};

--- a/crates/zakura-state/src/request.rs
+++ b/crates/zakura-state/src/request.rs
@@ -1772,6 +1772,22 @@ pub enum ReadRequest {
     /// * [`ReadResponse::IronwoodTree(None)`](crate::ReadResponse::IronwoodTree) otherwise.
     IronwoodTree(HashOrHeight),
 
+    /// Gathers everything a client needs to rebuild the note commitment treestate at
+    /// `hash_or_height` for itself: the authenticated target roots, plus the highest frontier at
+    /// or below the target that this node has already verified against them.
+    ///
+    /// This is the wallet-side counterpart of the per-height tree reads above, for the band where
+    /// a fast-synced node has no stored tree. It does no replay — the client does that — so it
+    /// stays cheap even when the target is far above anything this node has derived.
+    ///
+    /// Returns
+    ///
+    /// * [`ReadResponse::TreestateReconstruction(Some(_))`](crate::ReadResponse::TreestateReconstruction)
+    ///   when the block is in the best chain and this node holds authenticated roots for it.
+    /// * [`ReadResponse::TreestateReconstruction(None)`](crate::ReadResponse::TreestateReconstruction)
+    ///   when the block is not in the best chain.
+    TreestateReconstruction(HashOrHeight),
+
     /// Returns a list of Sapling note commitment subtrees by their indexes, starting at
     /// `start_index`, and returning up to `limit` subtrees.
     ///
@@ -1959,6 +1975,7 @@ impl ReadRequest {
             ReadRequest::SaplingTree { .. } => "sapling_tree",
             ReadRequest::OrchardTree { .. } => "orchard_tree",
             ReadRequest::IronwoodTree { .. } => "ironwood_tree",
+            ReadRequest::TreestateReconstruction { .. } => "treestate_reconstruction",
             ReadRequest::SaplingSubtrees { .. } => "sapling_subtrees",
             ReadRequest::OrchardSubtrees { .. } => "orchard_subtrees",
             ReadRequest::IronwoodSubtrees { .. } => "ironwood_subtrees",

--- a/crates/zakura-state/src/response.rs
+++ b/crates/zakura-state/src/response.rs
@@ -388,6 +388,49 @@ pub struct BlockSyncBodyMetadata {
     pub blocks: Vec<(block::Height, block::Hash, Option<u32>)>,
 }
 
+/// Everything a client needs to rebuild the note commitment treestate at one block for itself,
+/// gathered in a single state read so the anchor and the target roots can never straddle a reorg.
+///
+/// The target roots are the authenticated ones this node holds in `commitment_roots_by_height`;
+/// the anchor is a frontier this node has already checked against them. A client that replays
+/// canonical blocks from the anchor and reproduces all three target roots has the treestate, and
+/// has verified it rather than trusted it — which is what makes serving this safe on a node that
+/// cannot serve `z_gettreestate` for the height at all.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreestateReconstruction {
+    /// The canonical height the material is for.
+    pub target_height: block::Height,
+
+    /// The canonical hash at `target_height`, so the client can pin its replay to this chain.
+    pub target_hash: block::Hash,
+
+    /// The target block's header time, carried so the client can build the same `TreeState` the
+    /// exact path would have returned.
+    pub target_time: u32,
+
+    /// The authenticated per-pool roots the client's replay must reproduce.
+    pub target_roots: zakura_chain::parallel::commitment_aux::BlockCommitmentRoots,
+
+    /// The highest verified frontier at or below the target, or `None` to replay from genesis.
+    pub anchor: Option<TreestateAnchor>,
+
+    /// The first height the client has to replay.
+    pub replay_from: block::Height,
+}
+
+/// A verified frontier the client replays forward from, bound to its canonical block hash.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreestateAnchor {
+    /// The height the frontiers are the state at the end of.
+    pub height: block::Height,
+
+    /// The canonical hash at `height`.
+    pub hash: block::Hash,
+
+    /// The frontiers, already root-checked by this node.
+    pub frontiers: Arc<crate::service::read::DerivedFrontiers>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s [`ReadRequest`].
@@ -552,6 +595,12 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::IronwoodTree`] with the specified Ironwood note commitment tree.
     IronwoodTree(Option<Arc<ironwood::tree::NoteCommitmentTree>>),
 
+    /// Response to [`ReadRequest::TreestateReconstruction`] with the material a client needs to
+    /// rebuild the treestate at the requested block itself.
+    ///
+    /// `None` when the requested block is not in the best chain.
+    TreestateReconstruction(Option<Box<TreestateReconstruction>>),
+
     /// Response to [`ReadRequest::SaplingSubtrees`] with the specified Sapling note commitment
     /// subtrees.
     SaplingSubtrees(
@@ -710,6 +759,7 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::SaplingTree(_)
             | ReadResponse::OrchardTree(_)
             | ReadResponse::IronwoodTree(_)
+            | ReadResponse::TreestateReconstruction(_)
             | ReadResponse::SaplingSubtrees(_)
             | ReadResponse::OrchardSubtrees(_)
             | ReadResponse::IronwoodSubtrees(_)

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -19,7 +19,7 @@ use std::{
     future::Future,
     ops::Bound,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -48,7 +48,7 @@ use crate::{
     },
     error::{CommitBlockError, CommitCheckpointVerifiedError, InvalidateError, ReconsiderError},
     request::TimedSpan,
-    response::NonFinalizedBlocksListener,
+    response::{NonFinalizedBlocksListener, TreestateAnchor, TreestateReconstruction},
     service::{
         block_iter::any_ancestor_blocks,
         chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip},
@@ -62,8 +62,9 @@ use crate::{
         read::find,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, KnownBlock,
-    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock, StateInitError,
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, HashOrHeight,
+    KnownBlock, ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock,
+    StateInitError,
 };
 
 pub mod block_iter;
@@ -259,6 +260,15 @@ pub struct ReadStateService {
     block_write_task: Option<Arc<std::thread::JoinHandle<write::BlockWriteTaskExit>>>,
     /// Shared fail-closed attachment result, visible to every clone without joining the worker.
     block_write_failure: Arc<OnceLock<write::BlockWriteTaskFailure>>,
+
+    /// Note commitment frontiers this service has derived and root-checked for heights in a
+    /// verified-commitment-trees fast-synced database's absent band.
+    ///
+    /// Shared across clones so a wallet's sequential scan can anchor each request on the previous
+    /// one. Node-side derivation is what fills it, and that read path is not wired up on this
+    /// branch, so it currently stays empty and `z_gettreestateanchor` anchors on the last stored
+    /// tree below the upgrade height instead.
+    historical_trees: Arc<Mutex<read::HistoricalTreeCache>>,
 
     /// Published completed subtree roots for heights below the last checkpoint.
     ///
@@ -1226,6 +1236,7 @@ impl ReadStateService {
             non_finalized_state_receiver,
             block_write_task,
             block_write_failure,
+            historical_trees: Arc::default(),
             historical_subtrees,
             vct_root_repair_receiver,
             header_chain_snapshot_receiver: header_chain.snapshots,
@@ -1926,6 +1937,72 @@ fn subtrees_with_published_fallback<Node, Error>(
     }
 }
 
+/// Returns the material for reconstructing the treestate at `hash_or_height` on the client side.
+///
+/// Every field comes from one pass over the finalized state, so the anchor, the target roots, and
+/// the hashes they are bound to describe the same chain. A client that replays the canonical
+/// blocks between them and reproduces all three target roots ends up with a treestate it verified
+/// rather than trusted, which is what makes this servable in the band where this node has no
+/// stored tree of its own.
+///
+/// `Ok(None)` when the block is not in the finalized best chain. Non-finalized heights are
+/// deliberately not served: the absent band sits far below the reorg limit, and a request up there
+/// wants `z_gettreestate`, which works.
+fn treestate_reconstruction(
+    state: &ReadStateService,
+    hash_or_height: HashOrHeight,
+) -> Result<Option<Box<TreestateReconstruction>>, BoxError> {
+    let db = &state.db;
+
+    let Some(height) = hash_or_height.height_or_else(|hash| db.height(hash)) else {
+        return Ok(None);
+    };
+
+    // Re-resolve the hash from the height even when the caller gave one, so the response always
+    // names the block this node considers canonical at that height rather than echoing the
+    // request back.
+    let (Some(hash), Some(header)) = (db.hash(height), db.block_header(height.into())) else {
+        return Ok(None);
+    };
+
+    let material = read::reconstruction_material(db, &state.historical_trees, height)?;
+
+    let anchor = material
+        .anchor
+        .map(|anchor| {
+            db.hash(anchor.height)
+                .map(|hash| TreestateAnchor {
+                    height: anchor.height,
+                    hash,
+                    frontiers: anchor.frontiers,
+                })
+                .ok_or_else(|| {
+                    // The anchor came from this node's own verified state, so its height is
+                    // canonical by construction. A missing hash means the database is
+                    // inconsistent, and serving an anchor the client cannot pin to a block would
+                    // defeat the point of binding the material to hashes at all.
+                    BoxError::from(format!(
+                        "no canonical hash for the verified anchor at {:?}",
+                        anchor.height
+                    ))
+                })
+        })
+        .transpose()?;
+
+    Ok(Some(Box::new(TreestateReconstruction {
+        target_height: height,
+        target_hash: hash,
+        target_time: u32::try_from(header.time.timestamp()).map_err(|_| {
+            BoxError::from(format!(
+                "the header time at {height:?} does not fit in a u32"
+            ))
+        })?,
+        target_roots: material.target_roots,
+        anchor,
+        replay_from: material.replay_from,
+    })))
+}
+
 fn block_roots_by_height_range<C>(
     chain: Option<C>,
     db: &ZakuraDb,
@@ -2487,6 +2564,12 @@ impl Service<ReadRequest> for ReadStateService {
                 let tree =
                     read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
                 Ok(ReadResponse::IronwoodTree(tree))
+            }
+
+            ReadRequest::TreestateReconstruction(hash_or_height) => {
+                Ok(ReadResponse::TreestateReconstruction(
+                    treestate_reconstruction(&state, hash_or_height)?,
+                ))
             }
 
             ReadRequest::SaplingSubtrees { start_index, limit } => {

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -44,7 +44,8 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use historical_tree::{
-    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
+    derive_historical_frontiers, reconstruction_material, DerivedFrontiers, HistoricalTreeCache,
+    MAX_MEMOIZED_FRONTIERS,
 };
 pub(crate) use tree::{
     check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -64,7 +64,7 @@ pub struct CompletedSubtree {
 }
 
 /// Per-pool note commitment frontiers as of the end of one block.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DerivedFrontiers {
     /// The Sapling frontier.
     pub sapling: Arc<sapling::tree::NoteCommitmentTree>,
@@ -244,6 +244,63 @@ pub fn derive_historical_frontiers(
         .map(|derivation| derivation.frontiers)
 }
 
+/// A verified frontier a replay can start from, and the block it is the state at the end of.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedAnchor {
+    /// The height the frontiers are the state at the end of.
+    pub height: Height,
+
+    /// The frontiers themselves, already checked against this node's authenticated roots.
+    pub frontiers: Arc<DerivedFrontiers>,
+}
+
+/// Everything a client needs to rebuild the treestate at a target height for itself.
+///
+/// This is the wallet-side counterpart of [`derive_historical_frontiers`]: instead of replaying to
+/// the target here, the node hands over the nearest verified anchor and the authenticated roots
+/// the client must reproduce. The roots are what make that safe — a frontier that reproduces them
+/// *is* the frontier, wherever the replay ran — so a wallet accepting a reconstruction under this
+/// check extends the node no more trust than it already extends its own header chain.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReconstructionMaterial {
+    /// The authenticated per-pool roots at the target height.
+    pub target_roots: BlockCommitmentRoots,
+
+    /// The highest verified anchor at or below the target, or `None` to replay from genesis.
+    pub anchor: Option<VerifiedAnchor>,
+
+    /// The first height the client has to replay.
+    pub replay_from: Height,
+}
+
+/// Returns the material for reconstructing the treestate at `height` on the client side.
+///
+/// Does no replay: the anchor is whatever this node already holds verified, so the cost is one
+/// root lookup and one anchor lookup.
+pub fn reconstruction_material(
+    db: &ZakuraDb,
+    cache: &Mutex<HistoricalTreeCache>,
+    height: Height,
+) -> Result<ReconstructionMaterial, HistoricalTreeDerivationError> {
+    // Read the roots first. Without them there is nothing for the client to verify against, and
+    // serving an anchor it could not check would be exactly the silent-corruption path this whole
+    // design exists to close.
+    let target_roots = authenticated_roots(db, height)?;
+
+    let anchor = highest_verified_anchor(db, cache, height)?
+        .map(|(height, frontiers)| VerifiedAnchor { height, frontiers });
+
+    // The anchor is the state at the *end* of its height, so the client replays from the next
+    // block. With no anchor it replays from genesis.
+    let replay_from = Height(anchor.as_ref().map_or(0, |anchor| anchor.height.0 + 1));
+
+    Ok(ReconstructionMaterial {
+        target_roots,
+        anchor,
+        replay_from,
+    })
+}
+
 /// A completed derivation, and what it cost.
 #[derive(Clone, Debug)]
 pub struct Derivation {
@@ -254,7 +311,7 @@ pub struct Derivation {
     ///
     /// Zero when the requested height was already available as an anchor. Callers measuring cost
     /// must read this rather than infer it from the height, because the anchor may have come from
-    /// the memo or from a published grid rather than from genesis.
+    /// the memo or from a stored tree rather than from genesis.
     pub replayed_blocks: u64,
 }
 
@@ -267,7 +324,7 @@ pub fn derive_historical_frontiers_measured(
     height: Height,
     max_replay_blocks: u64,
 ) -> Result<Derivation, HistoricalTreeDerivationError> {
-    let anchor = anchor_for(db, cache, height)?;
+    let anchor = highest_verified_anchor(db, cache, height)?;
 
     if let Some((anchor_height, frontiers)) = &anchor {
         match anchor_height.cmp(&height) {
@@ -326,35 +383,64 @@ pub fn derive_historical_frontiers_measured(
     })
 }
 
-/// Returns the frontiers to replay forward from, and the height they are the state at the end of.
+/// Returns the highest verified frontier at or below `height`, and the height it is the state at
+/// the end of.
+///
+/// Two sources can supply one: the memo of frontiers this node already derived, and the last
+/// per-height tree stored below the upgrade height `U`. The *higher* of them wins rather than the
+/// first, because the only thing an anchor's provenance changes is how much replay is left — both
+/// are equally verified once accepted, and picking a lower one just costs blocks. A published
+/// frontier grid becomes a third source once that artifact lands.
 ///
 /// `None` means start from empty frontiers at genesis, which is correct when this binary committed
 /// every block from genesis (`U == 0`) and so stored no per-height trees to anchor on.
-fn anchor_for(
+fn highest_verified_anchor(
     db: &ZakuraDb,
     cache: &Mutex<HistoricalTreeCache>,
     height: Height,
 ) -> Result<Option<(Height, Arc<DerivedFrontiers>)>, HistoricalTreeDerivationError> {
-    let memoized = lock(cache).anchor_at_or_below(height);
-
-    if memoized.is_some() {
-        return Ok(memoized);
-    }
+    let best = lock(cache).anchor_at_or_below(height);
 
     // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
     // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
     let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
-        return Ok(None);
+        return Ok(best);
     };
 
     let anchor = Height(upgrade.0 - 1);
+
+    // The stored tree is the state at the *end* of `anchor`, so one above the target cannot start
+    // its replay. Fall back to the memo when it has something usable, and otherwise keep reporting
+    // the anchor that does not fit rather than replaying from genesis into a check that cannot
+    // pass — the caller learns which anchor was in the way instead of which root was missing.
+    if anchor > height {
+        if best.is_none() {
+            return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        }
+
+        return Ok(best);
+    }
+
+    // Take the higher of the two sources rather than the first one that has an anchor: both are
+    // equally verified once accepted, so anchoring lower would only replay more blocks.
+    if best.as_ref().is_some_and(|(best, _)| anchor <= *best) {
+        return Ok(best);
+    }
+
     // Rollback can move the tip below the write-once upgrade marker. In that case a backwards tree
     // lookup would return a retained row below the rollback target and mislabel it as `anchor`.
+    //
+    // Only fatal when nothing else can anchor the replay, for the same reason as the missing-row
+    // case below: a memo entry that already covers `height` does not need the band's lower edge.
     if db
         .finalized_tip_height()
         .is_none_or(|tip_height| anchor > tip_height)
     {
-        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        if best.is_none() {
+            return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        }
+
+        return Ok(best);
     }
 
     // These reads intentionally search backwards because unchanged trees are deduplicated. The tip
@@ -364,7 +450,13 @@ fn anchor_for(
         db.latest_stored_orchard_tree(&anchor),
         db.latest_stored_ironwood_tree(&anchor),
     ) else {
-        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        // Only fatal when nothing else can anchor the replay. A node whose memo already covers
+        // `height` does not care that the band's lower edge is unreadable.
+        if best.is_none() {
+            return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+        }
+
+        return Ok(best);
     };
 
     Ok(Some((

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -174,7 +174,7 @@ zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "8.0.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of

--- a/docs/changelog/unreleased/550.md
+++ b/docs/changelog/unreleased/550.md
@@ -1,0 +1,20 @@
+## Added
+
+- Added `z_gettreestateanchor`, which returns the material a client needs to rebuild a
+  historical treestate itself: the canonical target block with its authenticated per-pool
+  note commitment roots, the highest frontier at or below it that this node has already
+  verified, and the first height to replay from. A client replays the canonical blocks and
+  accepts the result only if it reproduces all three roots, so what it ends up with is
+  verified rather than trusted, and this node does no replay of its own. Intended as the
+  fallback for the height band where a fast-synced node reports the historical tree
+  unavailable; `z_gettreestate` is unchanged
+  ([#550](https://github.com/zakura-core/zakura/pull/550)).
+
+## Changed
+
+- Changed historical note commitment tree derivation to anchor on the highest verified
+  frontier available, rather than the first source that has one. The memo, the published
+  frontier grid, and the last stored tree below the upgrade height are all equally
+  verified once accepted, so preferring a lower anchor only made a derivation replay more
+  blocks than it needed to
+  ([#550](https://github.com/zakura-core/zakura/pull/550)).

--- a/docs/changelog/unreleased/702.md
+++ b/docs/changelog/unreleased/702.md
@@ -8,13 +8,13 @@
   verified rather than trusted, and this node does no replay of its own. Intended as the
   fallback for the height band where a fast-synced node reports the historical tree
   unavailable; `z_gettreestate` is unchanged
-  ([#550](https://github.com/zakura-core/zakura/pull/550)).
+  ([#702](https://github.com/zakura-core/zakura/pull/702)).
 
 ## Changed
 
 - Changed historical note commitment tree derivation to anchor on the highest verified
-  frontier available, rather than the first source that has one. The memo, the published
-  frontier grid, and the last stored tree below the upgrade height are all equally
-  verified once accepted, so preferring a lower anchor only made a derivation replay more
-  blocks than it needed to
-  ([#550](https://github.com/zakura-core/zakura/pull/550)).
+  frontier available, rather than the first source that has one. The memo of previously
+  derived frontiers and the last stored tree below the upgrade height are equally verified
+  once accepted, so preferring a lower anchor only made a derivation replay more blocks
+  than it needed to
+  ([#702](https://github.com/zakura-core/zakura/pull/702)).


### PR DESCRIPTION
Rebase of #550 onto current `main`, now that the subtree-root artifact slice landed as #593.
#550 stacked on `feat/historical-treestate-serving` (#529); this targets `main` directly.

## Motivation

A verified-commitment-trees fast-synced node stores no per-height note commitment tree across
the absent band, so `z_gettreestate` there reports the tree unavailable. The node's only way to
answer is to replay the band itself, which the 2026-08-03 measurements put at a median 1.07 s
and p90 2.50 s per cold request. That is a real serving budget for every operator, and it
exists only because the replay happens on the wrong side of the RPC.

It does not have to. The verification property the node already relies on — a frontier that
reproduces an authenticated root *is* the frontier — does not care which machine runs the replay.

## Solution

Add a Zakura-specific `z_gettreestateanchor(hash | height)` that hands a client the material to
reconstruct the treestate itself:

- the canonical target height and hash, its header time, and the three authenticated per-pool roots;
- the highest frontier at or below the target this node has already verified, with its own
  canonical hash and `finalState` in `z_gettreestate`'s encoding;
- `replayFrom`, the first height the client must replay.

The client replays the canonical blocks and accepts the result only if all three roots match.
That is the same check the node applies to its own derivations, so **the trust boundary does not
move**: the client still relies on this node for its view of the chain, but it no longer has to
believe an unverified frontier. What changes is the cost — answering is one root lookup and one
anchor lookup. No replay.

`z_gettreestate` is untouched: same request, same response shape, same error codes. The new
method is a fallback a client reaches only on the typed historical-tree-unavailable error, which
`main` already returns (#534).

Two details worth review attention:

- **One state read.** `ReadRequest::TreestateReconstruction` gathers the anchor and the target
  roots in a single pass so they cannot straddle a reorg, and binds both to canonical block
  hashes so a client can pin its replay to this chain. Assembling them from separate reads would
  let a reorg between the two hand out an anchor that cannot reach its own target.
- **Anchor selection now takes the higher source**, not the first hit. `anchor_for` preferred the
  memo and fell back to the stored tree below `U`; `highest_verified_anchor` takes the higher of
  the two. Provenance only changes how much replay is left — both are equally verified once
  accepted — so preferring a lower one just costs blocks. This improves the existing node-side
  derivation path too.

Failure policy is unchanged and fail-closed: a missing authenticated root is an error, an anchor
above the target is rejected, and an anchor whose height has no canonical hash is an error rather
than an unbound response.

## What changed relative to #550

Three adaptations were needed, because `main` has moved since #550 was written:

1. **The published-frontier-grid anchor source is dropped.** #550 took the maximum across three
   sources: the memo, the published grid, and the stored tree below `U`. The grid
   (`artifact_anchor_at_or_below`, the cost-weighted frontier grid) lives in #529 and is not in
   `main`, so this PR takes the higher of the remaining two. The grid slots back in as a third
   source when that artifact lands, and `highest_verified_anchor` is shaped to take it.
2. **The anchor-above-target case keeps `main`'s error.** #550 made an anchor above the target
   fall through to a genesis replay. `main` gained a test since then
   (`vct_db_produced_payload_round_trips_to_byte_identical_state`) that pins it to
   `MissingAnchor`, and that error is the more useful one — it names the anchor that did not fit
   rather than the root that was consequently missing. This PR keeps `MissingAnchor` when nothing
   else can anchor the replay, and falls back to the memo when it can, which is the part #550
   actually needed. `main`'s post-rollback tip guard is preserved on the same terms.
3. **The design-doc section is not carried over.** #550 added §6a to
   `docs/design/historical-treestate-serving.md`, which does not exist on `main` — it lands with
   #529. Its cross-references (§4.2, §4.3, §4.5, §4.6) have no counterpart in
   `docs/design/verified-commitment-trees.md`, so grafting it in would mean rewriting it against
   a different document's structure. Left for #529; see Follow-up Work.

One piece of wiring came from #529 rather than #550: `ReadStateService.historical_trees`, the
shared memo the anchor lookup reads. Node-side derivation is what fills it and that read path is
not on `main` yet, so today the memo stays empty and the anchor comes from the stored tree below
`U`. That is correct, just not yet optimized — the memo starts helping the moment the derivation
seam lands.

## Semver

`z_gettreestateanchor` adds a method to the public `Rpc` trait without a default implementation,
which breaks downstream implementors, so `zakura-rpc` goes 7.0.1 to 8.0.0 and `zakurad`'s
requirement moves with it. Hence the `!` in the title. `zakura-state` needs no bump: the two new
`ReadRequest`/`ReadResponse` variants are additive against a 7.0.0 that is already a major ahead
of its published baseline, and its semver job passes.

## Testing

- `cargo test -p zakura-state --lib` — 454 passed, 0 failed, 3 ignored.
- `cargo test -p zakura-rpc --lib` — 108 passed, 0 failed, 1 ignored. Includes the existing
  `rpc_z_get_treestate_absent_band_is_an_error` golden, which is what holds `z_gettreestate`'s
  error contract unchanged.
- `cargo clippy -p zakura-state -p zakura-rpc --all-targets` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo check --workspace --all-targets` — clean.
- Runnable, not just buildable: `make zakura-build-dev && make zakura-start-dev` against the real
  public Mainnet peers on stock dev defaults, reusing the existing dev cache. The node starts,
  connects, and syncs — checkpoint ranges verified up to height 1,890,024 (54.6% to tip) in a
  3-minute run. The apply-lifecycle errors in that log all postdate "waiting for async tokio tasks
  to shut down" and are the timeout's teardown, not a fault of this change.
- The `MissingAnchor` behavior in adaptation 2 above is covered by
  `vct_db_produced_payload_round_trips_to_byte_identical_state`, which fails on #550's version of
  the rebase and passes on this one. That test is how the conflict was found.

**Not covered, and the reason this is a draft.** There are still no unit tests for anchor
selection itself — the higher-of-two choice, the genesis case, and the canonical height/hash
binding. Those need a populated-database fixture, and they are the tests that would actually pin
this behavior. Treat the anchor-selection rewrite as verified only by compilation, the existing
derivation tests that route through it, and the one assertion above.

## Changelog

`docs/changelog/unreleased/702.md` — one Added entry for `z_gettreestateanchor`, one Changed
entry for the anchor-selection rewrite.

### Specifications & References

- Supersedes #550, which targeted `feat/historical-treestate-serving`.
- Builds on #534 (the typed absent-band error a client falls back from) and #552 (verified replay).
- Prototyped end to end against a zecd client (separate repo): exact-first resolution, three-pool
  replay, root verification, a self-invalidating verified-state cache, and locally derived
  `chain_metadata` sizes inside the band. Not part of this PR.

### Follow-up Work

- Unit tests for anchor selection, genesis handling, activation boundaries, root byte order, and
  canonical height/hash binding.
- The §6a design-doc section (wallet-side path, trust argument, and the client-cache property
  that a stale or forked cached anchor can only make a request *fail*, never succeed wrongly),
  to land with #529's design doc.
- Restore the published grid as a third anchor source when the frontier-grid artifact lands.
- Regtest absent-band end-to-end wallet scan, and the differential test against a legacy archive
  node.

## AI Disclosure

Used Claude Code to rebase #550 onto `main`, resolve the conflicts, and draft this description.
