### PR TITLE
fix(header-chain): finalize past headers the same transition inserted

### DIFF
--- a/crates/zakura-header-chain/src/graph/overlay.rs
+++ b/crates/zakura-header-chain/src/graph/overlay.rs
@@ -50,6 +50,15 @@ pub(crate) struct GraphDelta {
     pub(super) finalized_frontier: Option<Frontier>,
     pub(super) updated_header_nodes: Vec<HeaderNode>,
     pub(super) deleted_header_hashes: Vec<block::Hash>,
+    /// Finalized-path nodes this transition inserted and then retired.
+    ///
+    /// A finality advance deletes every header below the new finalized frontier, including
+    /// headers the same transition inserted. Such a header cancels out: it reaches neither
+    /// [`Self::updated_header_nodes`] nor [`Self::deleted_header_hashes`], because the live
+    /// graph never stores it. The delta must still prove the new finalized frontier descends
+    /// from the base frontier, so it carries exactly the retired nodes that proof reads.
+    /// Delta application ignores this evidence.
+    pub(super) retired_finalized_path_nodes: Vec<HeaderNode>,
     pub(super) new_consensus_invalid_body_tombstones: Vec<ConsensusInvalidBodyTombstone>,
 }
 
@@ -79,6 +88,7 @@ impl GraphDelta {
             finalized_frontier: None,
             updated_header_nodes: Vec::new(),
             deleted_header_hashes: Vec::new(),
+            retired_finalized_path_nodes: Vec::new(),
             new_consensus_invalid_body_tombstones: Vec::new(),
         }
     }
@@ -104,6 +114,15 @@ impl GraphDelta {
     /// Return removed header hashes in deterministic order.
     pub(crate) fn deleted_header_hashes(&self) -> &[block::Hash] {
         &self.deleted_header_hashes
+    }
+
+    /// Return the retired finalized-path evidence in deterministic order.
+    ///
+    /// Delta validation reads the field directly. This accessor exists so tests outside this
+    /// module can assert that the evidence stays out of the durable write set.
+    #[cfg(test)]
+    pub(crate) fn retired_finalized_path_nodes(&self) -> &[HeaderNode] {
+        &self.retired_finalized_path_nodes
     }
 
     /// Return newly created append-only consensus-invalid body tombstones.
@@ -135,6 +154,12 @@ pub(crate) struct GraphOverlay<'a> {
     finalized_frontier: Frontier,
     updated_header_nodes_by_hash: HashMap<block::Hash, HeaderNode>,
     deleted_header_hashes: HashSet<block::Hash>,
+    /// Nodes this overlay inserted and then deleted, kept only as delta evidence.
+    ///
+    /// Every overlay read hides these, because the projected graph does not contain them.
+    /// They survive here so [`GraphOverlay::delta`] can prove finalized descendancy across
+    /// headers one transition both inserted and retired.
+    retired_inserted_nodes: HashMap<block::Hash, HeaderNode>,
     added_header_children: HashMap<block::Hash, HashSet<block::Hash>>,
     removed_header_children: HashMap<block::Hash, HashSet<block::Hash>>,
     eligible_header_tips: HashSet<block::Hash>,
@@ -154,6 +179,7 @@ impl<'a> GraphOverlay<'a> {
             finalized_frontier: base_graph.finalized_frontier,
             updated_header_nodes_by_hash: HashMap::new(),
             deleted_header_hashes: HashSet::new(),
+            retired_inserted_nodes: HashMap::new(),
             added_header_children: HashMap::new(),
             removed_header_children: HashMap::new(),
             eligible_header_tips: base_graph.eligible_header_tips.clone(),
@@ -215,6 +241,31 @@ impl<'a> GraphOverlay<'a> {
                 return Err(GraphError::UnknownHeaderNode(*hash));
             }
         }
+        let retired_inserted_nodes = delta
+            .retired_finalized_path_nodes
+            .iter()
+            .cloned()
+            .map(|node| (node.hash, node))
+            .collect::<HashMap<_, _>>();
+        if retired_inserted_nodes.len() != delta.retired_finalized_path_nodes.len() {
+            let mut seen = HashSet::new();
+            let duplicate = delta
+                .retired_finalized_path_nodes
+                .iter()
+                .find_map(|node| (!seen.insert(node.hash)).then_some(node.hash))
+                .expect("different map and sequence lengths imply a duplicate hash");
+            return Err(GraphError::DuplicateHeaderNode(duplicate));
+        }
+        for hash in retired_inserted_nodes.keys() {
+            // A retired node never reaches the live graph. A base-graph node is a real
+            // deletion instead, and an updated node is a real insertion, so either overlap
+            // means the delta describes one header two ways.
+            if base_graph.nodes.contains_key(hash)
+                || updated_header_nodes_by_hash.contains_key(hash)
+            {
+                return Err(GraphError::DuplicateHeaderNode(*hash));
+            }
+        }
         let new_consensus_invalid_body_tombstones_by_hash = delta
             .new_consensus_invalid_body_tombstones
             .iter()
@@ -238,7 +289,14 @@ impl<'a> GraphOverlay<'a> {
         let mut added_header_children: HashMap<_, HashSet<_>> = HashMap::new();
         let mut removed_header_children: HashMap<_, HashSet<_>> = HashMap::new();
         for node in updated_header_nodes_by_hash.values() {
-            if !base_graph.nodes.contains_key(&node.hash) {
+            // A finality advance deletes the new frontier's parent, and a transition may
+            // retire a parent it also inserted. Recording a child edge under a parent the
+            // projected graph does not retain would strand that entry in the child index,
+            // because nothing deletes the parent again.
+            let parent_retained = updated_header_nodes_by_hash.contains_key(&node.parent_hash)
+                || (base_graph.nodes.contains_key(&node.parent_hash)
+                    && !deleted_header_hashes.contains(&node.parent_hash));
+            if !base_graph.nodes.contains_key(&node.hash) && parent_retained {
                 added_header_children
                     .entry(node.parent_hash)
                     .or_default()
@@ -279,6 +337,7 @@ impl<'a> GraphOverlay<'a> {
             finalized_frontier,
             updated_header_nodes_by_hash,
             deleted_header_hashes,
+            retired_inserted_nodes,
             added_header_children,
             removed_header_children,
             eligible_header_tips: base_graph.eligible_header_tips.clone(),
@@ -339,7 +398,9 @@ impl<'a> GraphOverlay<'a> {
 
     /// Require the projected finalized frontier to be an exact descendant of the base frontier.
     ///
-    /// The ancestry walk may cross nodes deleted by the same finality transition.
+    /// The ancestry walk may cross nodes deleted by the same finality transition. A node the
+    /// same transition also inserted survives in neither the base graph nor the updated set,
+    /// so the walk reads it from the retired finalized-path evidence the delta carries.
     fn validate_finalized_descendant(&self) -> Result<(), GraphError> {
         if self.finalized_frontier == self.base_graph.finalized_frontier {
             return Ok(());
@@ -350,6 +411,7 @@ impl<'a> GraphOverlay<'a> {
                 .updated_header_nodes_by_hash
                 .get(&cursor.hash)
                 .or_else(|| self.base_graph.nodes.get(&cursor.hash))
+                .or_else(|| self.retired_inserted_nodes.get(&cursor.hash))
                 .ok_or(GraphError::UnknownHeaderNode(cursor.hash))?;
             if node.height != cursor.height {
                 return Err(GraphError::UnknownHeaderNode(cursor.hash));
@@ -806,6 +868,8 @@ impl<'a> GraphOverlay<'a> {
 
         self.deleted_header_hashes.remove(&hash);
 
+        self.retired_inserted_nodes.remove(&hash);
+
         self.record_header_child_addition(parent_hash, hash);
 
         self.header_node_count = self.header_node_count.saturating_add(1);
@@ -1154,6 +1218,7 @@ impl<'a> GraphOverlay<'a> {
             self.deleted_header_hashes.iter().copied().collect();
         deleted_header_hashes.sort_unstable_by_key(|hash| hash.0);
         GraphDelta {
+            retired_finalized_path_nodes: self.retired_finalized_path_nodes(),
             base_revision: self.base_revision,
             work_coordinate_transition: if self.work_coordinates_rebased {
                 WorkCoordinateTransition::RebaseToFinalizedFrontier
@@ -1177,6 +1242,44 @@ impl<'a> GraphOverlay<'a> {
         }
     }
 
+    /// Collect the finalized-path nodes this transition inserted and then retired.
+    ///
+    /// The walk mirrors [`Self::validate_finalized_descendant`] and emits only the hashes that
+    /// walk cannot otherwise resolve, so the evidence stays as small as the proof requires. It
+    /// spans the heights the finality advance already traversed, so it adds no new bound.
+    ///
+    /// An unresolvable or inconsistent hash stops the walk and leaves the evidence short.
+    /// The staged frontier is then incoherent, and delta validation reports it.
+    fn retired_finalized_path_nodes(&self) -> Vec<HeaderNode> {
+        let mut retired = Vec::new();
+        if self.finalized_frontier == self.base_graph.finalized_frontier {
+            return retired;
+        }
+        let mut cursor = self.finalized_frontier;
+        while cursor.height > self.base_graph.finalized_frontier.height {
+            let node = match self
+                .updated_header_nodes_by_hash
+                .get(&cursor.hash)
+                .or_else(|| self.base_graph.nodes.get(&cursor.hash))
+            {
+                Some(node) => node,
+                None => {
+                    let Some(node) = self.retired_inserted_nodes.get(&cursor.hash) else {
+                        break;
+                    };
+                    retired.push(node.clone());
+                    node
+                }
+            };
+            if node.height != cursor.height {
+                break;
+            }
+            cursor = Frontier::new(block::Height(cursor.height.0 - 1), node.parent_hash);
+        }
+        retired.sort_unstable_by_key(|node| (node.height, node.hash.0));
+        retired
+    }
+
     /// Removes a node from the overlay.
     fn delete_header_node(&mut self, hash: block::Hash) -> Result<(), GraphError> {
         let node = self
@@ -1186,6 +1289,10 @@ impl<'a> GraphOverlay<'a> {
         self.updated_header_nodes_by_hash.remove(&hash);
         if self.base_graph.nodes.contains_key(&hash) {
             self.deleted_header_hashes.insert(hash);
+        } else {
+            // This deletion cancels an insertion from the same transition, so the delta
+            // records neither. Keep the node as evidence for the finalized-descendant proof.
+            self.retired_inserted_nodes.insert(hash, node.clone());
         }
         self.record_header_child_removal(node.parent_hash, hash);
         self.eligible_header_tips.remove(&hash);
@@ -1966,5 +2073,159 @@ mod tests {
         assert!(eligibility
             .header_node(right_child.hash)
             .is_some_and(HeaderNode::is_eligible));
+    }
+
+    /// Insert a chain of `length` children onto `parent` in one overlay.
+    fn insert_overlay_chain(
+        overlay: &mut GraphOverlay<'_>,
+        parent: Frontier,
+        length: u8,
+    ) -> Vec<Frontier> {
+        let mut chain = vec![parent];
+        let mut cursor = parent;
+        for marker in 1..=length {
+            cursor = match overlay
+                .insert(
+                    header(cursor.hash, marker),
+                    HeaderValidationState::Valid,
+                    [],
+                    BodyValidationState::Unknown,
+                )
+                .expect("the fixture child inserts")
+            {
+                InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => {
+                    frontier
+                }
+            };
+            chain.push(cursor);
+        }
+        chain
+    }
+
+    #[test]
+    fn finality_across_same_transition_headers_applies_and_carries_its_evidence() {
+        // Finalizing two above the base anchor retires a header this same transition inserted.
+        // That header cancels out of both delta sets, so only the carried evidence proves the
+        // new frontier descends from the base frontier.
+        for advance in 1..=3usize {
+            let base_graph = store();
+            let anchor = base_graph.finalized_frontier();
+            let mut overlay = GraphOverlay::new(&base_graph);
+            let chain = insert_overlay_chain(&mut overlay, anchor, 4);
+            let new_anchor = chain[advance];
+            overlay
+                .advance_finalized_frontier(new_anchor)
+                .expect("the eligible descendant becomes the new anchor");
+
+            let delta = overlay.delta();
+            let retired: Vec<_> = delta
+                .retired_finalized_path_nodes
+                .iter()
+                .map(|node| Frontier::new(node.height, node.hash))
+                .collect();
+            assert_eq!(
+                retired,
+                chain[1..advance].to_vec(),
+                "the evidence is exactly the inserted headers below the new anchor"
+            );
+            for node in &delta.retired_finalized_path_nodes {
+                assert!(
+                    !delta
+                        .updated_header_nodes
+                        .iter()
+                        .any(|updated| updated.hash == node.hash),
+                    "retired evidence never doubles as a durable write"
+                );
+                assert!(
+                    !delta.deleted_header_hashes.contains(&node.hash),
+                    "retired evidence never doubles as a durable deletion"
+                );
+            }
+
+            let projected = MemHeaderStore::reconstruct(crate::HeaderGraphReconstruction::new(
+                new_anchor,
+                overlay.header_nodes().cloned(),
+                base_graph.consensus_invalid_body_tombstones().cloned(),
+            ))
+            .expect("the overlay materializes as a coherent graph");
+            let mut applied = base_graph.clone();
+            applied
+                .apply_delta(&delta)
+                .expect("the delta proves descendancy across the retired headers");
+
+            assert_eq!(applied.finalized_frontier, projected.finalized_frontier);
+            assert_eq!(applied.nodes, projected.nodes);
+            assert_eq!(applied.heights, projected.heights);
+            assert_eq!(applied.eligible_header_tips, projected.eligible_header_tips);
+            // The retired anchor keeps no child entry: nothing would ever delete it again.
+            assert_eq!(applied.children, projected.children);
+        }
+    }
+
+    #[test]
+    fn retired_evidence_conflicting_with_a_live_node_is_rejected() {
+        let base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let mut overlay = GraphOverlay::new(&base_graph);
+        let chain = insert_overlay_chain(&mut overlay, anchor, 3);
+        overlay
+            .advance_finalized_frontier(chain[2])
+            .expect("the eligible descendant becomes the new anchor");
+        let delta = overlay.delta();
+        let retired = delta
+            .retired_finalized_path_nodes
+            .first()
+            .expect("finalizing two above the anchor retires one inserted header")
+            .clone();
+
+        let mut duplicated = delta.clone();
+        duplicated
+            .retired_finalized_path_nodes
+            .push(retired.clone());
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &duplicated),
+            Err(GraphError::DuplicateHeaderNode(hash)) if hash == retired.hash
+        ));
+
+        let mut also_updated = delta.clone();
+        also_updated.updated_header_nodes.push(retired.clone());
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &also_updated),
+            Err(GraphError::DuplicateHeaderNode(hash)) if hash == retired.hash
+        ));
+
+        let mut claims_a_base_node = delta.clone();
+        claims_a_base_node.retired_finalized_path_nodes = vec![base_graph
+            .nodes
+            .get(&anchor.hash)
+            .expect("the live graph retains its finalized frontier")
+            .clone()];
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &claims_a_base_node),
+            Err(GraphError::DuplicateHeaderNode(hash)) if hash == anchor.hash
+        ));
+    }
+
+    #[test]
+    fn missing_retired_evidence_fails_the_finalized_descendant_proof() {
+        let base_graph = store();
+        let anchor = base_graph.finalized_frontier();
+        let mut overlay = GraphOverlay::new(&base_graph);
+        let chain = insert_overlay_chain(&mut overlay, anchor, 3);
+        overlay
+            .advance_finalized_frontier(chain[2])
+            .expect("the eligible descendant becomes the new anchor");
+        let mut delta = overlay.delta();
+        let retired = delta
+            .retired_finalized_path_nodes
+            .first()
+            .expect("finalizing two above the anchor retires one inserted header")
+            .hash;
+        delta.retired_finalized_path_nodes.clear();
+
+        assert!(matches!(
+            GraphOverlay::from_delta(&base_graph, &delta),
+            Err(GraphError::UnknownHeaderNode(hash)) if hash == retired
+        ));
     }
 }

--- a/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/finality.rs
@@ -1283,3 +1283,56 @@ fn validate_finality_rebase_path_table() {
         "first-record predecessor height is intentionally ignored when it does not retreat"
     );
 }
+
+#[test]
+fn one_insertion_finalizes_past_the_headers_it_inserted() {
+    // Depth finality lands at `tip - depth`, so a batch longer than the depth finalizes above
+    // headers the same transition inserted. Those headers cancel out of the delta: the
+    // insertion never reaches the graph and the deletion has nothing durable to remove. The
+    // transition commits only because the delta carries them as descendancy evidence.
+    let depth = 2u32;
+    let (mut store, mut config) = TestStore::new(EngineMode::HeadersOnly);
+    config.limits.local_finality_depth = std::num::NonZeroU32::new(depth).expect("two is nonzero");
+    let clock = ManualClock(Utc::now());
+    let anchor = store.metadata.frontiers.finalized;
+    store.lease = validation_lease_for(&store, anchor);
+
+    let count = depth + 3;
+    let plan = apply_transition(
+        &store,
+        insertion(&store, count, EvidenceId::from_digest([0xb1; 32])),
+        &context(&config, &clock, None),
+    )
+    .expect("a batch longer than the finality depth commits");
+
+    let record = plan
+        .change_set
+        .finality_append
+        .expect("the batch advances depth finality");
+    assert_eq!(record.previous, anchor);
+    assert_eq!(
+        record.current.height,
+        block::Height(anchor.height.0 + count - depth),
+        "depth finality lands the configured depth below the new tip"
+    );
+
+    let retired = plan.graph_delta().retired_finalized_path_nodes();
+    let expected: Vec<_> = ((anchor.height.0 + 1)..record.current.height.0)
+        .map(block::Height)
+        .collect();
+    assert_eq!(
+        retired.iter().map(|node| node.height).collect::<Vec<_>>(),
+        expected,
+        "every inserted header between the old and new anchors is carried as evidence"
+    );
+    for node in retired {
+        assert!(
+            !plan
+                .graph_delta()
+                .updated_header_nodes()
+                .iter()
+                .any(|updated| updated.hash == node.hash),
+            "evidence for a retired header is never a durable write"
+        );
+    }
+}

--- a/docs/changelog/unreleased/706.md
+++ b/docs/changelog/unreleased/706.md
@@ -1,0 +1,11 @@
+## Fixed
+
+- Accepted header batches that finalize past headers the same transition
+  inserted. A batch longer than the local finality depth advanced the finalized
+  frontier above a header it had just inserted, and the graph transition rejected
+  it, so header sync stalled on every retry of that batch
+  ([#706](https://github.com/zakura-core/zakura/pull/706)).
+- Stopped leaking one header child-index entry on every finality advance. The
+  advance deletes the new finalized frontier's parent, and the transition then
+  restored a child edge under that deleted parent
+  ([#706](https://github.com/zakura-core/zakura/pull/706)).


### PR DESCRIPTION
## Motivation

A finality advance deletes every header below the new finalized frontier. When the
same transition also inserted one of those headers, its insertion cancels against
its deletion: the delta records it in neither `updated_header_nodes` nor
`deleted_header_hashes`, because the live graph never stores it.

`validate_finalized_descendant` still walks the new frontier's ancestry to prove it
descends from the base frontier, and that walk resolves hashes only from the base
graph or the updated set. The cancelled header is in neither, so the walk returned
`UnknownHeaderNode` and the planner rejected the transition.

Depth finality lands `local_finality_depth` below the new selected tip, so any
insertion of more than `local_finality_depth + 1` headers finalizes above a header
it just inserted. A sweep of batch size against depth gives an exact boundary —
a transition is refused whenever it inserts `local_finality_depth + 2` headers or
more:

| depth | last accepted batch | first rejected |
|---|---|---|
| 1 | 2 | 3 |
| 2 | 3 | 4 |
| 3 | 4 | 5 |
| 4 | 5 | 6 |

Equivalently, a transition could never advance the finalized frontier by more than
one height when it inserted the intervening headers itself.

Under the v1 limits (`local_finality_depth` = 1000) that refuses every batch of
1002 headers or more, while `MAX_HEADERS_PER_TRANSITION_V1` and `MAX_HS_RANGE`
both admit 4000 and a peer advertises its own `max_headers_per_response` up to
that bound. `DEFAULT_HS_RANGE` is 1000, two headers below the cliff, so the
default is safe only by coincidence: a peer advertising 1002 stalls header sync
on that batch permanently, since every retry fails identically.

The refusal happens in `verify_candidate`, before any durable write, so durable
state stays coherent.

This PR also fixes a second, independent defect found in the same validation. It
recorded a child edge for every inserted node, including the new finalized
frontier, whose parent that same advance deletes. Application deletes the parent
before re-adding the edge, so the child index kept an entry keyed by a header the
graph no longer held, and nothing deleted it again. Every finality advance leaked
one entry for the process lifetime. This one predates the first: it fires on an
advance of a single height, the path that always worked.

## Solution

`GraphOverlay` now retains the nodes it inserts and then deletes, and `GraphDelta`
carries the ones on the new finalized path as `retired_finalized_path_nodes`. The
descendancy walk reads them as a third source after the updated set and the base
graph.

The evidence is minimal — exactly the hashes the proof cannot otherwise resolve,
spanning heights the finality advance already traversed — and delta application
ignores it, so the durable write set is unchanged. `from_delta` rejects evidence
that duplicates itself or overlaps a live node, since a base-graph node is a real
deletion and an updated node is a real insertion.

For the child index, `from_delta` now records an added edge only when the
projected graph retains the parent.

## Testing

Four regression tests, each verified to fail against the unfixed code by reverting
one fix at a time:

- `finality_across_same_transition_headers_applies_and_carries_its_evidence` walks
  advances of one, two, and three heights. It asserts the evidence is exactly the
  inserted headers below the new anchor, that none of it appears in the durable
  write set, and that the applied graph equals a freshly reconstructed one —
  including the child index, which is the assertion that catches the leak.
- `retired_evidence_conflicting_with_a_live_node_is_rejected` covers the three
  rejection paths: a duplicate, an overlap with an updated node, and evidence
  claiming a base-graph node.
- `missing_retired_evidence_fails_the_finalized_descendant_proof` confirms the
  proof still fails closed when the evidence is stripped.
- `one_insertion_finalizes_past_the_headers_it_inserted` covers the engine
  boundary: a headers-only batch longer than the depth commits and advances
  finality by more than one height.

Reverting the descendancy fix alone fails two of these; reverting the child-index
fix alone fails one. The two pre-existing delta tests,
`applying_delta_matches_the_complete_overlay_projection` and
`finality_delta_keeps_the_new_root_after_deleting_its_parent`, pass with the leak
present — neither constructs a newly inserted node whose parent is deleted, which
is why it went unnoticed.

Gates: `cargo test -p zakura-header-chain` (229 passed), `cargo test -p
zakura-state --lib` (460 passed), `cargo fmt --all -- --check`, `cargo clippy -p
zakura-header-chain --all-targets -- -D warnings`, `cargo check --workspace
--all-targets`, and `cargo xtask header-conformance` (114 rules).

## Changelog

Added after this draft opens.

### Follow-up Work

`MAX_HEADERS_PER_TRANSITION_V1` (4000) and `local_finality_depth` (1000) are
independent constants, and this fix removes the interaction between them. Worth
confirming separately that header sync handles a peer advertising the full 4000
range end to end.
