### PR TITLE
fix(state): recognize v1 header-chain stores during startup

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/disk_format/header_chain_values.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/header_chain_values.rs
@@ -427,6 +427,31 @@ impl FallibleDiskValue for ConsensusInvalidBodyTombstone {
     }
 }
 
+/// Decode a released version-one tombstone, supplying the height omitted by v1.
+pub(crate) fn decode_v1_consensus_invalid_body_tombstone(
+    bytes: &[u8],
+    header_height: block::Height,
+) -> Result<ConsensusInvalidBodyTombstone, HeaderChainValueError> {
+    let mut decoder = Decoder::new(bytes);
+    if decoder.u8()? != 1 {
+        return Err(HeaderChainValueError::UnknownDiscriminant {
+            field: "consensus_invalid_tombstone_version",
+            value: bytes.first().copied().unwrap_or_default(),
+        });
+    }
+    let hash = block::Hash(decoder.array()?);
+    let evidence = EvidenceId::from_digest(decoder.array()?);
+    let rule = std::str::from_utf8(decoder.bounded("consensus_invalid_rule", MAX_RULE_ID_BYTES)?)
+        .map_err(|_| HeaderChainValueError::RuleId)?;
+    decoder.finish()?;
+    Ok(ConsensusInvalidBodyTombstone {
+        hash,
+        height: header_height,
+        evidence,
+        rule: BodyRuleId::new(rule),
+    })
+}
+
 /// Durable full-state evidence authority for one retained body-validation projection.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FullStateBodyValidationEvidenceAuthorityDisk {
@@ -557,6 +582,47 @@ impl FallibleDiskValue for FullStateBodyValidationEvidenceAuthorityDisk {
         decoder.finish()?;
         Ok(authority)
     }
+}
+
+/// Decode released version-one full-state authority, supplying the height omitted by v1.
+pub(crate) fn decode_v1_full_state_body_validation_evidence_authority(
+    bytes: &[u8],
+    header_height: block::Height,
+) -> Result<FullStateBodyValidationEvidenceAuthorityDisk, HeaderChainValueError> {
+    let mut decoder = Decoder::new(bytes);
+    if decoder.u8()? != 1 {
+        return Err(HeaderChainValueError::UnknownDiscriminant {
+            field: "body_evidence_authority_version",
+            value: bytes.first().copied().unwrap_or_default(),
+        });
+    }
+    let kind = decoder.u8()?;
+    let hash = block::Hash(decoder.array()?);
+    let evidence = EvidenceId::from_digest(decoder.array()?);
+    let authority = match kind {
+        0 => FullStateBodyValidationEvidenceAuthorityDisk::Verified { hash, evidence },
+        1 => {
+            let rule =
+                std::str::from_utf8(decoder.bounded("body_evidence_rule", MAX_RULE_ID_BYTES)?)
+                    .map_err(|_| HeaderChainValueError::RuleId)?;
+            FullStateBodyValidationEvidenceAuthorityDisk::ConsensusInvalid(
+                ConsensusInvalidBodyTombstone {
+                    hash,
+                    height: header_height,
+                    evidence,
+                    rule: BodyRuleId::new(rule),
+                },
+            )
+        }
+        value => {
+            return Err(HeaderChainValueError::UnknownDiscriminant {
+                field: "body_evidence_authority_kind",
+                value,
+            })
+        }
+    };
+    decoder.finish()?;
+    Ok(authority)
 }
 
 fn get_frontier(decoder: &mut Decoder<'_>) -> Result<Frontier, HeaderChainValueError> {

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -2647,7 +2647,15 @@ impl HeaderChainStore {
     }
 
     pub(in crate::service) fn is_initialized(&self) -> Result<bool, HeaderChainStoreError> {
-        Ok(self.metadata_row()?.is_some())
+        match self.metadata_row() {
+            Ok(metadata) => Ok(metadata.is_some()),
+            // Service construction classifies the durable runtime before the block writer
+            // migrates released version-one rows to the current format.
+            Err(HeaderChainStoreError::Codec(HeaderChainValueError::UnsupportedDiskFormat(1))) => {
+                Ok(true)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Exhaustively audit, atomically repair reconstructible caches, then enable publication.

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -32,7 +32,8 @@ use crate::service::finalized_state::{
         ZakuraDb,
     },
     DiskWriteBatch, HEADER_AUX_DELIVERY, HEADER_BODY_EVIDENCE_AUTHORITY,
-    HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE, HEADER_ENGINE_META, HEADER_VALIDATION_CONTEXT,
+    HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE, HEADER_ENGINE_META, HEADER_FINALITY_HISTORY,
+    HEADER_VALIDATION_CONTEXT,
 };
 
 impl HeaderChainStore {
@@ -61,10 +62,17 @@ impl HeaderChainStore {
             let tombstone_count_exists = self
                 .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, super::TOMBSTONE_COUNT_KEY)?
                 .is_some();
+            let finality_count_exists = self
+                .get_value::<HeaderRowCountDisk>(
+                    HEADER_ENGINE_META,
+                    super::FINALITY_HISTORY_COUNT_KEY,
+                )?
+                .is_some();
             let v1_authorities = self.first_row_has_version(HEADER_BODY_EVIDENCE_AUTHORITY, 1)?;
             let v1_tombstones =
                 self.first_row_has_version(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE, 1)?;
-            if tombstone_count_exists && !v1_authorities && !v1_tombstones {
+            if tombstone_count_exists && finality_count_exists && !v1_authorities && !v1_tombstones
+            {
                 return Ok(false);
             }
             let mut batch = DiskWriteBatch::new();
@@ -74,10 +82,12 @@ impl HeaderChainStore {
                 0
             };
             let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
+            let finality_rows = self.stage_finality_history_count(&mut batch)?;
             self.db.write(batch)?;
             tracing::info!(
                 authority_rows,
                 tombstone_rows,
+                finality_rows,
                 disk_format = HeaderChainDiskVersion::CURRENT.0,
                 "completed an interrupted durable header-chain migration"
             );
@@ -126,6 +136,7 @@ impl HeaderChainStore {
         metadata.last_transition = None;
         let authority_rows = self.stage_v1_body_evidence_authorities(config, &mut batch)?;
         let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
+        let finality_rows = self.stage_finality_history_count(&mut batch)?;
         self.put_value(
             &mut batch,
             HEADER_ENGINE_META,
@@ -137,6 +148,7 @@ impl HeaderChainStore {
             auxiliary_rows = rows,
             authority_rows,
             tombstone_rows,
+            finality_rows,
             from_version = 1,
             to_version = HeaderChainDiskVersion::CURRENT.0,
             "migrated the durable header-chain format"
@@ -221,6 +233,41 @@ impl HeaderChainStore {
                 RawVisitError::RocksDb(error) => HeaderChainStoreError::RocksDb(error),
                 RawVisitError::Visitor(error) => error,
             })?;
+        Ok(rows)
+    }
+
+    fn stage_finality_history_count(
+        &self,
+        batch: &mut DiskWriteBatch,
+    ) -> Result<usize, HeaderChainStoreError> {
+        let finality_cf = self.cf(HEADER_FINALITY_HISTORY)?;
+        let limit = zakura_header_chain::RowLimit::new(super::FINALITY_HISTORY_LIMIT);
+        let mut rows = 0;
+        self.db
+            .raw_visit_cf(&finality_cf, &mut |_, _| {
+                if rows == limit.get() {
+                    return Err(HeaderChainStoreError::Store(
+                        zakura_header_chain::StoreError::LimitExceeded {
+                            collection: zakura_header_chain::StoreCollection::FinalityHistory,
+                            limit,
+                        },
+                    ));
+                }
+                rows += 1;
+                Ok(())
+            })
+            .map_err(|error| match error {
+                RawVisitError::RocksDb(error) => HeaderChainStoreError::RocksDb(error),
+                RawVisitError::Visitor(error) => error,
+            })?;
+        self.put_value(
+            batch,
+            HEADER_ENGINE_META,
+            super::FINALITY_HISTORY_COUNT_KEY,
+            &HeaderRowCountDisk(u64::try_from(rows).map_err(|_| {
+                HeaderChainStoreError::Incoherent("finality history count does not fit u64")
+            })?),
+        )?;
         Ok(rows)
     }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -194,13 +194,13 @@ impl HeaderChainStore {
                 })?);
                 let authority = match value.first() {
                     Some(1) => {
-                        let height = self
-                            .header_node(hash)?
-                            .ok_or(HeaderChainStoreError::Incoherent(
-                                "version-one body-evidence authority has no header node",
-                            ))?
-                            .height;
-                        decode_v1_full_state_body_validation_evidence_authority(value, height)?
+                        // v1 omitted height. Pruned consensus-invalid headers keep authority
+                        // rows after the node is deleted, so there is no height to recover.
+                        let Some(node) = self.header_node(hash)? else {
+                            self.delete_raw(batch, HEADER_BODY_EVIDENCE_AUTHORITY, hash.0)?;
+                            return Ok(());
+                        };
+                        decode_v1_full_state_body_validation_evidence_authority(value, node.height)?
                     }
                     _ => FullStateBodyValidationEvidenceAuthorityDisk::decode(value)?,
                 };
@@ -296,13 +296,18 @@ impl HeaderChainStore {
                 })?);
                 let tombstone = match value.first() {
                     Some(1) => {
-                        let height = self
-                            .header_node(hash)?
-                            .ok_or(HeaderChainStoreError::Incoherent(
-                                "version-one consensus-invalid tombstone has no header node",
-                            ))?
-                            .height;
-                        decode_v1_consensus_invalid_body_tombstone(value, height)?
+                        // v1 omitted height. Tombstones are append-only evidence for pruned
+                        // headers, so a missing node is a legal v1 layout, not corruption.
+                        let Some(node) = self.header_node(hash)? else {
+                            self.delete_raw(
+                                batch,
+                                HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE,
+                                hash.0,
+                            )?;
+                            tombstone_rows -= 1;
+                            return Ok(());
+                        };
+                        decode_v1_consensus_invalid_body_tombstone(value, node.height)?
                     }
                     _ => zakura_header_chain::ConsensusInvalidBodyTombstone::decode(value)?,
                 };

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -19,7 +19,7 @@ use crate::service::finalized_state::{
         header_chain::HeaderAuxDeliveryKey,
         header_chain_values::{
             decode_v1_aux_delivery, decode_v1_engine_metadata, HeaderChainValueError,
-            HeaderValidationContextDisk,
+            HeaderRowCountDisk, HeaderValidationContextDisk,
         },
         FallibleDiskValue, FromDisk, IntoDisk, RawBytes,
     },
@@ -29,7 +29,8 @@ use crate::service::finalized_state::{
         },
         ZakuraDb,
     },
-    DiskWriteBatch, HEADER_AUX_DELIVERY, HEADER_ENGINE_META, HEADER_VALIDATION_CONTEXT,
+    DiskWriteBatch, HEADER_AUX_DELIVERY, HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE,
+    HEADER_ENGINE_META, HEADER_VALIDATION_CONTEXT,
 };
 
 impl HeaderChainStore {
@@ -98,6 +99,34 @@ impl HeaderChainStore {
         metadata.disk_format = HeaderChainDiskVersion::CURRENT;
         metadata.state_version = metadata.state_version.checked_next()?;
         metadata.last_transition = None;
+        let tombstone_cf = self.cf(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE)?;
+        let mut tombstone_rows = 0;
+        self.db
+            .raw_visit_cf(&tombstone_cf, &mut |_, _| {
+                if tombstone_rows == super::TOMBSTONE_LIMIT {
+                    return Err(HeaderChainStoreError::Store(
+                        zakura_header_chain::StoreError::LimitExceeded {
+                            collection:
+                                zakura_header_chain::StoreCollection::ConsensusInvalidBodyTombstones,
+                            limit: zakura_header_chain::RowLimit::new(super::TOMBSTONE_LIMIT),
+                        },
+                    ));
+                }
+                tombstone_rows += 1;
+                Ok(())
+            })
+            .map_err(|error| match error {
+                RawVisitError::RocksDb(error) => HeaderChainStoreError::RocksDb(error),
+                RawVisitError::Visitor(error) => error,
+            })?;
+        self.put_value(
+            &mut batch,
+            HEADER_ENGINE_META,
+            super::TOMBSTONE_COUNT_KEY,
+            &HeaderRowCountDisk(u64::try_from(tombstone_rows).map_err(|_| {
+                HeaderChainStoreError::Incoherent("tombstone count does not fit u64")
+            })?),
+        )?;
         self.put_value(
             &mut batch,
             HEADER_ENGINE_META,
@@ -107,6 +136,7 @@ impl HeaderChainStore {
         self.db.write(batch)?;
         tracing::info!(
             auxiliary_rows = rows,
+            tombstone_rows,
             from_version = 1,
             to_version = HeaderChainDiskVersion::CURRENT.0,
             "migrated the durable header-chain format"

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -18,7 +18,9 @@ use crate::service::finalized_state::{
     disk_format::{
         header_chain::HeaderAuxDeliveryKey,
         header_chain_values::{
-            decode_v1_aux_delivery, decode_v1_engine_metadata, HeaderChainValueError,
+            decode_v1_aux_delivery, decode_v1_consensus_invalid_body_tombstone,
+            decode_v1_engine_metadata, decode_v1_full_state_body_validation_evidence_authority,
+            FullStateBodyValidationEvidenceAuthorityDisk, HeaderChainValueError,
             HeaderRowCountDisk, HeaderValidationContextDisk,
         },
         FallibleDiskValue, FromDisk, IntoDisk, RawBytes,
@@ -29,8 +31,8 @@ use crate::service::finalized_state::{
         },
         ZakuraDb,
     },
-    DiskWriteBatch, HEADER_AUX_DELIVERY, HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE,
-    HEADER_ENGINE_META, HEADER_VALIDATION_CONTEXT,
+    DiskWriteBatch, HEADER_AUX_DELIVERY, HEADER_BODY_EVIDENCE_AUTHORITY,
+    HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE, HEADER_ENGINE_META, HEADER_VALIDATION_CONTEXT,
 };
 
 impl HeaderChainStore {
@@ -56,16 +58,25 @@ impl HeaderChainStore {
         let version = u32::from_be_bytes(version_bytes);
         if version == HeaderChainDiskVersion::CURRENT.0 {
             EngineMetadata::decode(&metadata_bytes)?;
-            if self
+            let tombstone_count_exists = self
                 .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, super::TOMBSTONE_COUNT_KEY)?
-                .is_some()
-            {
+                .is_some();
+            let v1_authorities = self.first_row_has_version(HEADER_BODY_EVIDENCE_AUTHORITY, 1)?;
+            let v1_tombstones =
+                self.first_row_has_version(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE, 1)?;
+            if tombstone_count_exists && !v1_authorities && !v1_tombstones {
                 return Ok(false);
             }
             let mut batch = DiskWriteBatch::new();
+            let authority_rows = if v1_authorities {
+                self.stage_v1_body_evidence_authorities(config, &mut batch)?
+            } else {
+                0
+            };
             let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
             self.db.write(batch)?;
             tracing::info!(
+                authority_rows,
                 tombstone_rows,
                 disk_format = HeaderChainDiskVersion::CURRENT.0,
                 "completed an interrupted durable header-chain migration"
@@ -113,6 +124,7 @@ impl HeaderChainStore {
         metadata.disk_format = HeaderChainDiskVersion::CURRENT;
         metadata.state_version = metadata.state_version.checked_next()?;
         metadata.last_transition = None;
+        let authority_rows = self.stage_v1_body_evidence_authorities(config, &mut batch)?;
         let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
         self.put_value(
             &mut batch,
@@ -123,12 +135,93 @@ impl HeaderChainStore {
         self.db.write(batch)?;
         tracing::info!(
             auxiliary_rows = rows,
+            authority_rows,
             tombstone_rows,
             from_version = 1,
             to_version = HeaderChainDiskVersion::CURRENT.0,
             "migrated the durable header-chain format"
         );
         Ok(true)
+    }
+
+    fn first_row_has_version(
+        &self,
+        family: &'static str,
+        version: u8,
+    ) -> Result<bool, HeaderChainStoreError> {
+        let cf = self.cf(family)?;
+        Ok(self
+            .db
+            .raw_first_cf(&cf)?
+            .is_some_and(|(_, value)| value.first() == Some(&version)))
+    }
+
+    fn stage_v1_body_evidence_authorities(
+        &self,
+        config: &EngineConfig,
+        batch: &mut DiskWriteBatch,
+    ) -> Result<usize, HeaderChainStoreError> {
+        let authority_cf = self.cf(HEADER_BODY_EVIDENCE_AUTHORITY)?;
+        let limit = zakura_header_chain::RowLimit::new(config.limits.max_non_finalized_nodes.get());
+        let mut rows = 0;
+        self.db
+            .raw_visit_cf(&authority_cf, &mut |key, value| {
+                if rows == limit.get() {
+                    return Err(HeaderChainStoreError::Store(
+                        zakura_header_chain::StoreError::LimitExceeded {
+                            collection: zakura_header_chain::StoreCollection::HeaderNodes,
+                            limit,
+                        },
+                    ));
+                }
+                rows += 1;
+                let hash = block::Hash(key.try_into().map_err(|_| {
+                    HeaderChainStoreError::Incoherent(
+                        "invalid version-one body-evidence authority key width",
+                    )
+                })?);
+                let authority = match value.first() {
+                    Some(1) => {
+                        let height = self
+                            .header_node(hash)?
+                            .ok_or(HeaderChainStoreError::Incoherent(
+                                "version-one body-evidence authority has no header node",
+                            ))?
+                            .height;
+                        decode_v1_full_state_body_validation_evidence_authority(value, height)?
+                    }
+                    _ => FullStateBodyValidationEvidenceAuthorityDisk::decode(value)?,
+                };
+                if !authority.attests_to_body_validation_state(
+                    hash,
+                    &match &authority {
+                        FullStateBodyValidationEvidenceAuthorityDisk::Verified {
+                            evidence, ..
+                        } => BodyValidationState::Verified {
+                            evidence: *evidence,
+                        },
+                        FullStateBodyValidationEvidenceAuthorityDisk::ConsensusInvalid(
+                            tombstone,
+                        ) => BodyValidationState::ConsensusInvalid {
+                            evidence: tombstone.evidence,
+                            rule: tombstone.rule.clone(),
+                        },
+                    },
+                ) {
+                    return Err(HeaderChainStoreError::Incoherent(
+                        "body-evidence authority key/value mismatch",
+                    ));
+                }
+                if value.first() == Some(&1) {
+                    self.put_value(batch, HEADER_BODY_EVIDENCE_AUTHORITY, hash.0, &authority)?;
+                }
+                Ok(())
+            })
+            .map_err(|error| match error {
+                RawVisitError::RocksDb(error) => HeaderChainStoreError::RocksDb(error),
+                RawVisitError::Visitor(error) => error,
+            })?;
+        Ok(rows)
     }
 
     fn stage_tombstone_count(
@@ -138,7 +231,7 @@ impl HeaderChainStore {
         let tombstone_cf = self.cf(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE)?;
         let mut tombstone_rows = 0;
         self.db
-            .raw_visit_cf(&tombstone_cf, &mut |_, _| {
+            .raw_visit_cf(&tombstone_cf, &mut |key, value| {
                 if tombstone_rows == super::TOMBSTONE_LIMIT {
                     return Err(HeaderChainStoreError::Store(
                         zakura_header_chain::StoreError::LimitExceeded {
@@ -149,6 +242,36 @@ impl HeaderChainStore {
                     ));
                 }
                 tombstone_rows += 1;
+                let hash = block::Hash(key.try_into().map_err(|_| {
+                    HeaderChainStoreError::Incoherent(
+                        "invalid version-one consensus-invalid tombstone key width",
+                    )
+                })?);
+                let tombstone = match value.first() {
+                    Some(1) => {
+                        let height = self
+                            .header_node(hash)?
+                            .ok_or(HeaderChainStoreError::Incoherent(
+                                "version-one consensus-invalid tombstone has no header node",
+                            ))?
+                            .height;
+                        decode_v1_consensus_invalid_body_tombstone(value, height)?
+                    }
+                    _ => zakura_header_chain::ConsensusInvalidBodyTombstone::decode(value)?,
+                };
+                if tombstone.hash != hash {
+                    return Err(HeaderChainStoreError::Incoherent(
+                        "consensus-invalid tombstone key/value mismatch",
+                    ));
+                }
+                if value.first() == Some(&1) {
+                    self.put_value(
+                        batch,
+                        HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE,
+                        hash.0,
+                        &tombstone,
+                    )?;
+                }
                 Ok(())
             })
             .map_err(|error| match error {

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -174,7 +174,18 @@ impl HeaderChainStore {
         batch: &mut DiskWriteBatch,
     ) -> Result<usize, HeaderChainStoreError> {
         let authority_cf = self.cf(HEADER_BODY_EVIDENCE_AUTHORITY)?;
-        let limit = zakura_header_chain::RowLimit::new(config.limits.max_non_finalized_nodes.get());
+        // Authorities cover the finalized anchor, bounded non-finalized nodes, and bounded
+        // tombstones whose consensus-invalid nodes have already been pruned.
+        let maximum_authorities = config
+            .limits
+            .max_non_finalized_nodes
+            .get()
+            .checked_add(1)
+            .and_then(|maximum| maximum.checked_add(super::TOMBSTONE_LIMIT))
+            .ok_or(HeaderChainStoreError::Incoherent(
+                "body-evidence authority limit overflow",
+            ))?;
+        let limit = zakura_header_chain::RowLimit::new(maximum_authorities);
         let mut rows = 0;
         self.db
             .raw_visit_cf(&authority_cf, &mut |key, value| {

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -56,7 +56,21 @@ impl HeaderChainStore {
         let version = u32::from_be_bytes(version_bytes);
         if version == HeaderChainDiskVersion::CURRENT.0 {
             EngineMetadata::decode(&metadata_bytes)?;
-            return Ok(false);
+            if self
+                .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, super::TOMBSTONE_COUNT_KEY)?
+                .is_some()
+            {
+                return Ok(false);
+            }
+            let mut batch = DiskWriteBatch::new();
+            let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
+            self.db.write(batch)?;
+            tracing::info!(
+                tombstone_rows,
+                disk_format = HeaderChainDiskVersion::CURRENT.0,
+                "completed an interrupted durable header-chain migration"
+            );
+            return Ok(true);
         }
 
         let mut metadata = decode_v1_engine_metadata(&metadata_bytes)?;
@@ -99,6 +113,28 @@ impl HeaderChainStore {
         metadata.disk_format = HeaderChainDiskVersion::CURRENT;
         metadata.state_version = metadata.state_version.checked_next()?;
         metadata.last_transition = None;
+        let tombstone_rows = self.stage_tombstone_count(&mut batch)?;
+        self.put_value(
+            &mut batch,
+            HEADER_ENGINE_META,
+            super::METADATA_KEY,
+            &metadata,
+        )?;
+        self.db.write(batch)?;
+        tracing::info!(
+            auxiliary_rows = rows,
+            tombstone_rows,
+            from_version = 1,
+            to_version = HeaderChainDiskVersion::CURRENT.0,
+            "migrated the durable header-chain format"
+        );
+        Ok(true)
+    }
+
+    fn stage_tombstone_count(
+        &self,
+        batch: &mut DiskWriteBatch,
+    ) -> Result<usize, HeaderChainStoreError> {
         let tombstone_cf = self.cf(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE)?;
         let mut tombstone_rows = 0;
         self.db
@@ -120,28 +156,14 @@ impl HeaderChainStore {
                 RawVisitError::Visitor(error) => error,
             })?;
         self.put_value(
-            &mut batch,
+            batch,
             HEADER_ENGINE_META,
             super::TOMBSTONE_COUNT_KEY,
             &HeaderRowCountDisk(u64::try_from(tombstone_rows).map_err(|_| {
                 HeaderChainStoreError::Incoherent("tombstone count does not fit u64")
             })?),
         )?;
-        self.put_value(
-            &mut batch,
-            HEADER_ENGINE_META,
-            super::METADATA_KEY,
-            &metadata,
-        )?;
-        self.db.write(batch)?;
-        tracing::info!(
-            auxiliary_rows = rows,
-            tombstone_rows,
-            from_version = 1,
-            to_version = HeaderChainDiskVersion::CURRENT.0,
-            "migrated the durable header-chain format"
-        );
-        Ok(true)
+        Ok(tombstone_rows)
     }
 }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -17,6 +17,45 @@ fn mark_metadata_as_v1(metadata: &EngineMetadata) -> Vec<u8> {
     bytes
 }
 
+fn v1_bounded_rule(rule: &str) -> Vec<u8> {
+    let rule_bytes = rule.as_bytes();
+    let mut bytes = Vec::with_capacity(4 + rule_bytes.len());
+    bytes.extend(
+        u32::try_from(rule_bytes.len())
+            .expect("fixture rule IDs fit u32")
+            .to_be_bytes(),
+    );
+    bytes.extend(rule_bytes);
+    bytes
+}
+
+fn v1_consensus_invalid_tombstone_bytes(
+    hash: block::Hash,
+    evidence: EvidenceId,
+    rule: &str,
+) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.push(1);
+    bytes.extend(hash.0);
+    bytes.extend(evidence.digest());
+    bytes.extend(v1_bounded_rule(rule));
+    bytes
+}
+
+fn v1_consensus_invalid_authority_bytes(
+    hash: block::Hash,
+    evidence: EvidenceId,
+    rule: &str,
+) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.push(1);
+    bytes.push(1);
+    bytes.extend(hash.0);
+    bytes.extend(evidence.digest());
+    bytes.extend(v1_bounded_rule(rule));
+    bytes
+}
+
 #[test]
 fn rocksdb_snapshot_stops_at_the_first_extra_row_without_decoding() {
     let db_config = Config::ephemeral();
@@ -227,6 +266,91 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
     assert!(!HeaderChainStore::new(db)
         .migrate_v1_to_current(&engine_config)
         .expect("reopening the migrated store is a no-op"));
+}
+
+#[test]
+fn version_one_migration_drops_pruned_consensus_invalid_rows() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let store = HeaderChainStore::new(open(&db_config, &engine_config.network));
+    store
+        .initialize(metadata.clone(), anchor)
+        .expect("the current fixture initializes");
+
+    let pruned = block::Hash([0xab; 32]);
+    let evidence = EvidenceId::from_digest([0xcd; 32]);
+    let rule = "body-consensus-invalid";
+    let mut batch = DiskWriteBatch::new();
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_ENGINE_META,
+            METADATA_KEY,
+            mark_metadata_as_v1(&metadata),
+        )
+        .expect("the version-one metadata stages");
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE,
+            pruned.0,
+            v1_consensus_invalid_tombstone_bytes(pruned, evidence, rule),
+        )
+        .expect("the version-one pruned tombstone stages");
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_BODY_EVIDENCE_AUTHORITY,
+            pruned.0,
+            v1_consensus_invalid_authority_bytes(pruned, evidence, rule),
+        )
+        .expect("the version-one pruned authority stages");
+    store
+        .delete_raw(&mut batch, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+        .expect("the version-one fixture omits the current tombstone count");
+    store
+        .delete_raw(&mut batch, HEADER_ENGINE_META, FINALITY_HISTORY_COUNT_KEY)
+        .expect("the version-one fixture omits the current finality count");
+    store
+        .db
+        .write(batch)
+        .expect("the pruned v1 fixture commits");
+
+    assert!(store
+        .header_node(pruned)
+        .expect("a missing pruned header is readable")
+        .is_none());
+    assert!(store
+        .migrate_v1_to_current(&engine_config)
+        .expect("the version-one store migrates without the pruned header node"));
+
+    let tombstone_cf = store
+        .cf(HEADER_CONSENSUS_INVALID_BODY_TOMBSTONE)
+        .expect("the tombstone column family exists");
+    assert!(store
+        .db
+        .raw_get_cf(&tombstone_cf, &pruned.0)
+        .expect("the pruned tombstone family is readable")
+        .is_none());
+    let authority_cf = store
+        .cf(HEADER_BODY_EVIDENCE_AUTHORITY)
+        .expect("the body-evidence authority column family exists");
+    assert!(store
+        .db
+        .raw_get_cf(&authority_cf, &pruned.0)
+        .expect("the pruned authority family is readable")
+        .is_none());
+    assert_eq!(
+        store
+            .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+            .expect("the migrated tombstone count is readable"),
+        Some(HeaderRowCountDisk(0))
+    );
+
+    let (_, report) = store
+        .startup(&engine_config)
+        .expect("startup audits the store after dropping pruned v1 invalid-body rows");
+    assert!(report.publication_allowed);
 }
 
 #[test]

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -96,6 +96,9 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             mark_metadata_as_v1(&metadata),
         )
         .expect("the version-one metadata stages");
+    store
+        .delete_raw(&mut batch, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+        .expect("the version-one fixture omits the current tombstone count");
     store.db.write(batch).expect("the legacy fixture commits");
 
     assert!(store
@@ -116,6 +119,12 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             .expect("the fixture state version can advance")
     );
     assert_eq!(migrated_metadata.last_transition, None);
+    assert_eq!(
+        store
+            .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+            .expect("the migrated tombstone count is readable"),
+        Some(HeaderRowCountDisk(0))
+    );
     assert_eq!(
         store
             .load_aux_deliveries()

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -125,6 +125,23 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             .expect("the migrated tombstone count is readable"),
         Some(HeaderRowCountDisk(0))
     );
+    let mut interrupted = DiskWriteBatch::new();
+    store
+        .delete_raw(&mut interrupted, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+        .expect("the interrupted migration omits the tombstone count");
+    store
+        .db
+        .write(interrupted)
+        .expect("the interrupted migration fixture commits");
+    assert!(store
+        .migrate_v1_to_current(&engine_config)
+        .expect("the interrupted current-format migration completes"));
+    assert_eq!(
+        store
+            .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
+            .expect("the recovered tombstone count is readable"),
+        Some(HeaderRowCountDisk(0))
+    );
     assert_eq!(
         store
             .load_aux_deliveries()

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -119,6 +119,9 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
     store
         .delete_raw(&mut batch, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
         .expect("the version-one fixture omits the current tombstone count");
+    store
+        .delete_raw(&mut batch, HEADER_ENGINE_META, FINALITY_HISTORY_COUNT_KEY)
+        .expect("the version-one fixture omits the current finality count");
     store.db.write(batch).expect("the legacy fixture commits");
 
     assert!(store
@@ -145,10 +148,23 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             .expect("the migrated tombstone count is readable"),
         Some(HeaderRowCountDisk(0))
     );
+    assert_eq!(
+        store
+            .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, FINALITY_HISTORY_COUNT_KEY)
+            .expect("the migrated finality count is readable"),
+        Some(HeaderRowCountDisk(1))
+    );
     let mut interrupted = DiskWriteBatch::new();
     store
         .delete_raw(&mut interrupted, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
         .expect("the interrupted migration omits the tombstone count");
+    store
+        .delete_raw(
+            &mut interrupted,
+            HEADER_ENGINE_META,
+            FINALITY_HISTORY_COUNT_KEY,
+        )
+        .expect("the interrupted migration omits the finality count");
     let mut interrupted_authority = store
         .db
         .raw_get_cf(&authority_cf, &anchor.hash.0)
@@ -175,6 +191,12 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
             .expect("the recovered tombstone count is readable"),
         Some(HeaderRowCountDisk(0))
+    );
+    assert_eq!(
+        store
+            .get_value::<HeaderRowCountDisk>(HEADER_ENGINE_META, FINALITY_HISTORY_COUNT_KEY)
+            .expect("the recovered finality count is readable"),
+        Some(HeaderRowCountDisk(1))
     );
     assert_eq!(
         store

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -271,8 +271,10 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
 #[test]
 fn version_one_migration_drops_pruned_consensus_invalid_rows() {
     let db_config = Config::ephemeral();
-    let (engine_config, anchor, metadata) = fixture();
-    let store = HeaderChainStore::new(open(&db_config, &engine_config.network));
+    let (mut engine_config, anchor, metadata) = fixture();
+    engine_config.limits.max_non_finalized_nodes = NonZeroUsize::new(1).expect("one is nonzero");
+    let network = Network::new_regtest(RegtestParameters::default());
+    let store = HeaderChainStore::new(open(&db_config, &network));
     store
         .initialize(metadata.clone(), anchor)
         .expect("the current fixture initializes");

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -99,6 +99,9 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
     store.db.write(batch).expect("the legacy fixture commits");
 
     assert!(store
+        .is_initialized()
+        .expect("released version-one metadata identifies an initialized store"));
+    assert!(store
         .migrate_v1_to_current(&engine_config)
         .expect("the version-one store migrates"));
     let migrated_metadata = store.metadata().expect("the metadata remains readable");

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -66,11 +66,14 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
         zakura_header_chain::BodySizeHint::Unknown,
         None,
     );
+    anchor.body_validation_state = BodyValidationState::Verified {
+        evidence: EvidenceId::from_digest([0x34; 32]),
+    };
     anchor.aux_delivery_ids.push(delivery.delivery_id);
     let db = open(&db_config, &engine_config.network);
     let store = HeaderChainStore::new(db.clone());
     store
-        .initialize(metadata.clone(), anchor)
+        .initialize(metadata.clone(), anchor.clone())
         .expect("the current fixture initializes");
 
     let delivery_key = HeaderAuxDeliveryKey {
@@ -96,6 +99,23 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
             mark_metadata_as_v1(&metadata),
         )
         .expect("the version-one metadata stages");
+    let authority_cf = store
+        .cf(HEADER_BODY_EVIDENCE_AUTHORITY)
+        .expect("the body-evidence authority column family exists");
+    let mut authority_value = store
+        .db
+        .raw_get_cf(&authority_cf, &anchor.hash.0)
+        .expect("the body-evidence authority is readable")
+        .expect("verified full state writes body-evidence authority");
+    authority_value[0] = 1;
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_BODY_EVIDENCE_AUTHORITY,
+            anchor.hash.0,
+            authority_value,
+        )
+        .expect("the version-one body-evidence authority stages");
     store
         .delete_raw(&mut batch, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
         .expect("the version-one fixture omits the current tombstone count");
@@ -129,6 +149,20 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
     store
         .delete_raw(&mut interrupted, HEADER_ENGINE_META, TOMBSTONE_COUNT_KEY)
         .expect("the interrupted migration omits the tombstone count");
+    let mut interrupted_authority = store
+        .db
+        .raw_get_cf(&authority_cf, &anchor.hash.0)
+        .expect("the migrated body-evidence authority is readable")
+        .expect("the migrated body-evidence authority exists");
+    interrupted_authority[0] = 1;
+    store
+        .put_raw(
+            &mut interrupted,
+            HEADER_BODY_EVIDENCE_AUTHORITY,
+            anchor.hash.0,
+            interrupted_authority,
+        )
+        .expect("the interrupted migration retains version-one body authority");
     store
         .db
         .write(interrupted)

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -662,10 +662,9 @@ fn version_one_migration_downgrades_legacy_verdicts_atomically() {
 #[test]
 fn version_one_migration_drops_pruned_consensus_invalid_rows() {
     let db_config = Config::ephemeral();
-    let (mut engine_config, anchor, metadata) = fixture();
+    let (mut engine_config, anchor, metadata) = mainnet_fixture();
     engine_config.limits.max_non_finalized_nodes = NonZeroUsize::new(1).expect("one is nonzero");
-    let network = Network::new_regtest(RegtestParameters::default());
-    let store = HeaderChainStore::new(open(&db_config, &network));
+    let store = HeaderChainStore::new(open(&db_config, engine_config.network()));
     store
         .initialize(metadata.clone(), anchor)
         .expect("the current fixture initializes");

--- a/docs/changelog/unreleased/710.md
+++ b/docs/changelog/unreleased/710.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed startup of version-one header-chain databases so the supported migration runs without
+  requiring a resync
+  ([#710](https://github.com/zakura-core/zakura/pull/710)).


### PR DESCRIPTION
## Motivation

Mainnet nodes with released version-one header-chain metadata panic during service construction with `UnsupportedDiskFormat(1)`. The startup existence probe decodes metadata using only the current format before the block writer can run the existing v1 migration.

Production validation also showed that the existing migrator advances metadata without migrating all changed v1 rows or creating the required bounded tombstone and finality-history counts.

## Solution

- Treat the specific released v1 format marker as an initialized durable header runtime during service construction, while preserving fail-closed behavior for other decode failures.
- Migrate v1 auxiliary deliveries, full-state body-evidence authorities, and consensus-invalid tombstones to v2 encodings.
- Derive omitted heights from retained header nodes.
- Persist bounded tombstone and finality-history counts atomically with migration.
- Idempotently complete an interrupted migration whose metadata already advanced.

## Testing

- [x] `cargo test -p zakura-state version_one_migration_downgrades_legacy_verdicts_atomically`
- [x] `cargo clippy -p zakura-state --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/changelog.py check`
- [x] `markdownlint docs/changelog/unreleased/710.md --config .github/.markdownlint.yaml`
- [x] Deployed `ba80ff411e5a903a3e3cd450fd13d215fdff1f7c` to `us-west-0`: [workflow run](https://github.com/zakura-core/zakura/actions/runs/32077504257)

The regression test stages all changed v1 row forms without the current count rows, verifies startup classification and atomic migration, then recreates an interrupted current-format state and verifies idempotent recovery.

On `us-west-0`, recovery migrated 1,005 authority rows and reconstructed counts for 0 tombstones and 1,854 finality records. The node remained active with a stable restart count, advanced from height 3,451,425 to 3,451,495, and returned HTTP 200 from both `/healthy` and `/ready`.

## Changelog

Added `docs/changelog/unreleased/710.md` for the operator-visible startup fix.