### PR TITLE
fix(release): rewrite prerelease dependency requirements

### DIFF
--- a/scripts/lib/release-packages.sh
+++ b/scripts/lib/release-packages.sh
@@ -36,3 +36,14 @@ list_release_packages_at() {
     printf '%s\t%s\n' "$package" "$manifest_rel"
   done < <(git ls-tree -r --name-only "$revision")
 }
+
+# Rewrite every requirement for a workspace dependency to an explicit
+# prerelease target. Stable requirements never select prerelease versions, even
+# when they select the corresponding stable package version.
+rewrite_prerelease_dependency_requirements() {
+  local manifest="$1" crate="$2" target="$3"
+
+  CRATE="$crate" TARGET="$target" perl -0777 -pi -e \
+    's/(\Q$ENV{CRATE}\E\s*=\s*\{[^}]*?version\s*=\s*")[^"]+(")/$1$ENV{TARGET}$2/gs' \
+    "$manifest"
+}

--- a/scripts/lib/release-packages.sh
+++ b/scripts/lib/release-packages.sh
@@ -39,11 +39,33 @@ list_release_packages_at() {
 
 # Rewrite every requirement for a workspace dependency to an explicit
 # prerelease target. Stable requirements never select prerelease versions, even
-# when they select the corresponding stable package version.
+# when they select the corresponding stable package version, so any requirement
+# left behind fails the release run at the next `cargo metadata`.
+#
+# Covers the spellings the workspace uses: an inline table keyed by the crate
+# name, an inline table that renames the crate through `package = "<crate>"`,
+# and a bare version string. Renaming is impossible in the bare-string form, so
+# that case matches on the key alone.
 rewrite_prerelease_dependency_requirements() {
   local manifest="$1" crate="$2" target="$3"
 
-  CRATE="$crate" TARGET="$target" perl -0777 -pi -e \
-    's/(\Q$ENV{CRATE}\E\s*=\s*\{[^}]*?version\s*=\s*")[^"]+(")/$1$ENV{TARGET}$2/gs' \
-    "$manifest"
+  CRATE="$crate" TARGET="$target" perl -0777 -pi -e '
+    my ($crate, $target) = ($ENV{CRATE}, $ENV{TARGET});
+
+    # Inline tables. The body stops at the first closing brace, so it cannot
+    # run past its own entry, and it may span lines (a wrapped feature list).
+    s{^([ \t]*(?:"\Q$crate\E"|[A-Za-z0-9_.-]+))(\s*=\s*\{)([^\}]*)(\})}{
+      my ($key, $sep, $body, $close) = ($1, $2, $3, $4);
+      my $name = $key;
+      $name =~ s/^[ \t]*//;
+      $name =~ s/^"|"$//g;
+      if ($name eq $crate || $body =~ /package\s*=\s*"\Q$crate\E"/) {
+        $body =~ s/(version\s*=\s*")[^"]*(")/$1 . $target . $2/e;
+      }
+      $key . $sep . $body . $close;
+    }gme;
+
+    # Bare version string.
+    s/^([ \t]*\Q$crate\E\s*=\s*")[^"]*(")/$1 . $target . $2/gme;
+  ' "$manifest"
 }

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -198,9 +198,7 @@ set_crate_version() {
       "$manifest_rel"
     local dep_manifest
     while IFS= read -r dep_manifest; do
-      CRATE="$crate" OLD="$current" NEW="$target" perl -0777 -pi -e \
-        's/(\Q$ENV{CRATE}\E\s*=\s*\{[^}]*?version\s*=\s*")\Q$ENV{OLD}\E(")/$1$ENV{NEW}$2/gs' \
-        "$dep_manifest"
+      rewrite_prerelease_dependency_requirements "$dep_manifest" "$crate" "$target"
     done < <(jq -r '.packages[].manifest_path' <<<"$metadata")
   else
     cargo release version "$target" \

--- a/scripts/tests/test_release_packages.sh
+++ b/scripts/tests/test_release_packages.sh
@@ -34,4 +34,36 @@ if [ "$actual" != "$expected" ]; then
   exit 1
 fi
 
+cat > dependent.toml <<'EOF'
+[dependencies]
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+
+[dev-dependencies]
+zakura-node-services = {
+    path = "../zakura-node-services",
+    version = "3.2.1",
+    features = ["rpc-client"],
+}
+EOF
+cat > expected-dependent.toml <<'EOF'
+[dependencies]
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
+zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+
+[dev-dependencies]
+zakura-node-services = {
+    path = "../zakura-node-services",
+    version = "3.2.1-rc0",
+    features = ["rpc-client"],
+}
+EOF
+
+rewrite_prerelease_dependency_requirements \
+  dependent.toml zakura-node-services 3.2.1-rc0
+if ! diff -u expected-dependent.toml dependent.toml; then
+  exit 1
+fi
+
 printf 'release package identity survives manifest moves\n'
+printf 'prerelease dependency rewrites include older compatible requirements\n'

--- a/scripts/tests/test_release_packages.sh
+++ b/scripts/tests/test_release_packages.sh
@@ -38,25 +38,29 @@ cat > dependent.toml <<'EOF'
 [dependencies]
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0" }
 zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+zakura-node-services-legacy = { package = "zakura-node-services", path = "../zakura-node-services", version = "3.1.0" }
 
 [dev-dependencies]
-zakura-node-services = {
-    path = "../zakura-node-services",
-    version = "3.2.1",
-    features = ["rpc-client"],
-}
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = [
+    "rpc-client",
+] }
+
+[target.'cfg(unix)'.dependencies]
+zakura-node-services = "3.2.0"
 EOF
 cat > expected-dependent.toml <<'EOF'
 [dependencies]
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
 zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+zakura-node-services-legacy = { package = "zakura-node-services", path = "../zakura-node-services", version = "3.2.1-rc0" }
 
 [dev-dependencies]
-zakura-node-services = {
-    path = "../zakura-node-services",
-    version = "3.2.1-rc0",
-    features = ["rpc-client"],
-}
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0", features = [
+    "rpc-client",
+] }
+
+[target.'cfg(unix)'.dependencies]
+zakura-node-services = "3.2.1-rc0"
 EOF
 
 rewrite_prerelease_dependency_requirements \
@@ -67,3 +71,4 @@ fi
 
 printf 'release package identity survives manifest moves\n'
 printf 'prerelease dependency rewrites include older compatible requirements\n'
+printf 'prerelease dependency rewrites cover renamed and bare-string requirements\n'


### PR DESCRIPTION
## Motivation

The Prepare release PR workflow failed while preparing v1.3.0-rc0 because converting `zakura-node-services` from `3.2.1` to `3.2.1-rc0` left dependents requiring `3.2.0`. Stable Cargo requirements do not select prerelease versions, so the next `cargo metadata` invocation failed.

## Solution

Rewrite every workspace requirement for a crate when converting its stable version to an explicit prerelease target, rather than only replacing requirements equal to the crate's current stable version. Add regression coverage for older compatible requirements and multiline dependency declarations.

## Testing

- `bash scripts/tests/test_release_packages.sh`
- `bash -n scripts/prepare-release.sh scripts/lib/release-packages.sh scripts/tests/test_release_packages.sh`
- `shellcheck scripts/prepare-release.sh scripts/lib/release-packages.sh scripts/tests/test_release_packages.sh`
- `git diff --check`

The regression test models the failing `3.2.0`/`3.2.1` to `3.2.1-rc0` transition and verifies unrelated requirements remain unchanged.

## Changelog

No changelog fragment is required because this changes internal release shell tooling only, without Rust or Cargo manifest changes.

### Specifications & References

- Failing workflow: https://github.com/zakura-core/zakura/actions/runs/32095398911/job/95585677981