### PR TITLE
fix(state): migrate version-two header-chain stores on startup

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/disk_format/header_chain_values.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_format/header_chain_values.rs
@@ -1519,7 +1519,7 @@ impl FallibleDiskValue for EngineMetadata {
     }
 
     fn decode(bytes: &[u8]) -> Result<Self, HeaderChainValueError> {
-        decode_engine_metadata(bytes, None)
+        decode_engine_metadata(bytes, HeaderChainDiskVersion::CURRENT, None)
     }
 }
 
@@ -1531,18 +1531,34 @@ pub(crate) fn decode_v1_engine_metadata(
     bytes: &[u8],
     network_policy_digest: [u8; 32],
 ) -> Result<EngineMetadata, HeaderChainValueError> {
-    decode_engine_metadata(bytes, Some(network_policy_digest))
+    decode_engine_metadata(
+        bytes,
+        HeaderChainDiskVersion(1),
+        Some(network_policy_digest),
+    )
 }
 
-/// Decode metadata, reading the network policy digest unless the caller supplies a version-one one.
+/// Decode metadata that carries the released version-two marker.
+///
+/// Version two also omitted the durable network policy digest. The layout matches version one
+/// except for the format marker; the migration injects the running node's policy the same way.
+pub(crate) fn decode_v2_engine_metadata(
+    bytes: &[u8],
+    network_policy_digest: [u8; 32],
+) -> Result<EngineMetadata, HeaderChainValueError> {
+    decode_engine_metadata(
+        bytes,
+        HeaderChainDiskVersion(2),
+        Some(network_policy_digest),
+    )
+}
+
+/// Decode metadata, reading the network policy digest unless the caller supplies a legacy one.
 fn decode_engine_metadata(
     bytes: &[u8],
-    v1_network_policy_digest: Option<[u8; 32]>,
+    expected_disk_format: HeaderChainDiskVersion,
+    injected_network_policy_digest: Option<[u8; 32]>,
 ) -> Result<EngineMetadata, HeaderChainValueError> {
-    let expected_disk_format = match v1_network_policy_digest {
-        Some(_) => HeaderChainDiskVersion(1),
-        None => HeaderChainDiskVersion::CURRENT,
-    };
     let mut decoder = Decoder::new(bytes);
     let disk_format = decoder.u32()?;
     if disk_format != expected_disk_format.0 {
@@ -1570,7 +1586,7 @@ fn decode_engine_metadata(
             })
         }
     };
-    let network_policy_digest = match v1_network_policy_digest {
+    let network_policy_digest = match injected_network_policy_digest {
         Some(digest) => digest,
         None => decoder.array()?,
     };
@@ -1958,6 +1974,21 @@ mod tests {
             decode_v1_engine_metadata(&version_one_bytes, metadata.network_policy_digest),
             Ok(EngineMetadata {
                 disk_format: HeaderChainDiskVersion(1),
+                ..metadata.clone()
+            })
+        );
+        // Version two used the same layout as version one with a different format marker.
+        let mut version_two_bytes = bytes.clone();
+        version_two_bytes[..4].copy_from_slice(&2_u32.to_be_bytes());
+        version_two_bytes.drain(6..38);
+        assert_eq!(
+            EngineMetadata::decode(&version_two_bytes),
+            Err(HeaderChainValueError::UnsupportedDiskFormat(2))
+        );
+        assert_eq!(
+            decode_v2_engine_metadata(&version_two_bytes, metadata.network_policy_digest),
+            Ok(EngineMetadata {
+                disk_format: HeaderChainDiskVersion(2),
                 ..metadata.clone()
             })
         );

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -2699,10 +2699,10 @@ impl HeaderChainStore {
         match self.metadata_row() {
             Ok(metadata) => Ok(metadata.is_some()),
             // Service construction classifies the durable runtime before the block writer
-            // migrates released version-one rows to the current format.
-            Err(HeaderChainStoreError::Codec(HeaderChainValueError::UnsupportedDiskFormat(1))) => {
-                Ok(true)
-            }
+            // migrates released version-one and version-two rows to the current format.
+            Err(HeaderChainStoreError::Codec(HeaderChainValueError::UnsupportedDiskFormat(
+                1 | 2,
+            ))) => Ok(true),
             Err(error) => Err(error),
         }
     }

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -20,8 +20,8 @@ use crate::service::finalized_state::{
         header_chain_values::{
             decode_v1_aux_delivery, decode_v1_consensus_invalid_body_tombstone,
             decode_v1_engine_metadata, decode_v1_full_state_body_validation_evidence_authority,
-            FullStateBodyValidationEvidenceAuthorityDisk, HeaderChainValueError,
-            HeaderRowCountDisk, HeaderValidationContextDisk,
+            decode_v2_engine_metadata, FullStateBodyValidationEvidenceAuthorityDisk,
+            HeaderChainValueError, HeaderRowCountDisk, HeaderValidationContextDisk,
         },
         FallibleDiskValue, FromDisk, IntoDisk, RawBytes,
     },
@@ -37,7 +37,7 @@ use crate::service::finalized_state::{
 };
 
 impl HeaderChainStore {
-    /// Atomically migrate released version-one rows to the current format.
+    /// Atomically migrate released version-one and version-two rows to the current format.
     pub(in crate::service) fn migrate_v1_to_current(
         &self,
         config: &EngineConfig,
@@ -92,6 +92,10 @@ impl HeaderChainStore {
                 "completed an interrupted durable header-chain migration"
             );
             return Ok(true);
+        }
+
+        if version == 2 {
+            return self.migrate_v2_metadata_to_current(config, &metadata_bytes);
         }
 
         let mut metadata =
@@ -161,6 +165,46 @@ impl HeaderChainStore {
             tombstone_rows,
             finality_rows,
             from_version = 1,
+            to_version = HeaderChainDiskVersion::CURRENT.0,
+            "migrated the durable header-chain format"
+        );
+        Ok(true)
+    }
+
+    /// Rewrite version-two metadata to the current format.
+    ///
+    /// Version two used the version-one metadata layout (network kind, no policy digest) with
+    /// format marker 2. Auxiliary and authority rows are already in the current encoding.
+    fn migrate_v2_metadata_to_current(
+        &self,
+        config: &EngineConfig,
+        metadata_bytes: &[u8],
+    ) -> Result<bool, HeaderChainStoreError> {
+        let mut metadata =
+            decode_v2_engine_metadata(metadata_bytes, config.network_policy_digest())?;
+        if metadata.network_id != config.network().kind() {
+            return Err(HeaderChainStoreError::Incoherent(
+                "version-two network kind does not match the configured network",
+            ));
+        }
+        if metadata.network_id != NetworkKind::Mainnet {
+            return Err(HeaderChainStoreError::Incoherent(
+                "version-two network policy is ambiguous; rebuild the header-chain database",
+            ));
+        }
+        metadata.disk_format = HeaderChainDiskVersion::CURRENT;
+        metadata.state_version = metadata.state_version.checked_next()?;
+        metadata.last_transition = None;
+        let mut batch = DiskWriteBatch::new();
+        self.put_value(
+            &mut batch,
+            HEADER_ENGINE_META,
+            super::METADATA_KEY,
+            &metadata,
+        )?;
+        self.db.write(batch)?;
+        tracing::info!(
+            from_version = 2,
             to_version = HeaderChainDiskVersion::CURRENT.0,
             "migrated the durable header-chain format"
         );

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -401,9 +401,17 @@ fn legacy_rejected_aux_bytes(delivery: AuxDelivery, evidence: [u8; 32]) -> Vec<u
 }
 
 fn mark_metadata_as_v1(metadata: &EngineMetadata) -> Vec<u8> {
+    mark_metadata_as_legacy_without_policy(metadata, 1)
+}
+
+fn mark_metadata_as_v2(metadata: &EngineMetadata) -> Vec<u8> {
+    mark_metadata_as_legacy_without_policy(metadata, 2)
+}
+
+fn mark_metadata_as_legacy_without_policy(metadata: &EngineMetadata, version: u32) -> Vec<u8> {
     let mut bytes = metadata.encode().expect("the metadata fixture encodes");
-    bytes[..4].copy_from_slice(&1_u32.to_be_bytes());
-    // Version one wrote the network kind but no network policy digest.
+    bytes[..4].copy_from_slice(&version.to_be_bytes());
+    // Version one and two wrote the network kind but no network policy digest.
     bytes.drain(6..38);
     bytes
 }
@@ -888,6 +896,146 @@ fn version_one_migration_rejects_an_ambiguous_network_policy_without_writing() {
         store.migrate_v1_to_current(&changed_config),
         Err(HeaderChainStoreError::Incoherent(
             "version-one network policy is ambiguous; rebuild the header-chain database"
+        ))
+    ));
+    let metadata_cf = store
+        .cf(HEADER_ENGINE_META)
+        .expect("the metadata column family exists");
+    assert_eq!(
+        store
+            .db
+            .raw_get_cf(&metadata_cf, METADATA_KEY)
+            .expect("the metadata row is readable"),
+        Some(metadata_value)
+    );
+}
+
+#[test]
+fn version_two_migration_injects_network_policy_and_leaves_current_aux_unchanged() {
+    let db_config = Config::ephemeral();
+    let (engine_config, mut anchor, metadata) = mainnet_fixture();
+    let previous_state_version = metadata.state_version;
+    let delivery = AuxDelivery::new(
+        EvidenceId::from_digest([0x21; 32]),
+        anchor.hash,
+        SourceId::from_digest([0x22; 32]),
+        header_owner(&metadata.snapshot(), anchor.hash, 3, 1),
+        zakura_header_chain::BodySizeHint::Unknown,
+        None,
+    );
+    anchor.aux_delivery_ids.push(delivery.delivery_id);
+    let db = open(&db_config, engine_config.network());
+    let store = HeaderChainStore::new(db.clone());
+    store
+        .initialize(metadata.clone(), anchor.clone())
+        .expect("the current fixture initializes");
+
+    let delivery_key = HeaderAuxDeliveryKey {
+        header: delivery.header_hash,
+        delivery: delivery.delivery_id,
+    }
+    .as_bytes();
+    let current_aux = delivery
+        .encode()
+        .expect("the current auxiliary fixture encodes");
+    let mut batch = DiskWriteBatch::new();
+    store
+        .put_raw(&mut batch, HEADER_AUX_DELIVERY, delivery_key, &current_aux)
+        .expect("the current auxiliary row stages");
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_ENGINE_META,
+            METADATA_KEY,
+            mark_metadata_as_v2(&metadata),
+        )
+        .expect("the version-two metadata stages");
+    store
+        .db
+        .write(batch)
+        .expect("the version-two fixture commits");
+    let aux_cf = store
+        .cf(HEADER_AUX_DELIVERY)
+        .expect("the auxiliary column family exists");
+
+    assert!(store
+        .is_initialized()
+        .expect("released version-two metadata identifies an initialized store"));
+    assert!(store
+        .migrate_v1_to_current(&engine_config)
+        .expect("the version-two store migrates"));
+    let migrated_metadata = store.metadata().expect("the metadata remains readable");
+    assert_eq!(
+        migrated_metadata.disk_format,
+        HeaderChainDiskVersion::CURRENT
+    );
+    assert_eq!(
+        migrated_metadata.network_policy_digest,
+        engine_config.network_policy_digest()
+    );
+    assert_eq!(
+        migrated_metadata.state_version,
+        previous_state_version
+            .checked_next()
+            .expect("the fixture state version can advance")
+    );
+    assert_eq!(migrated_metadata.last_transition, None);
+    assert_eq!(
+        store
+            .db
+            .raw_get_cf(&aux_cf, &delivery_key)
+            .expect("the auxiliary row stays readable"),
+        Some(current_aux)
+    );
+    let (_, report) = store
+        .clone()
+        .startup(&engine_config)
+        .expect("startup audits the migrated version-two store");
+    assert!(report.publication_allowed);
+    assert!(!HeaderChainStore::new(db)
+        .migrate_v1_to_current(&engine_config)
+        .expect("reopening the migrated store is a no-op"));
+}
+
+#[test]
+fn version_two_migration_rejects_an_ambiguous_network_policy_without_writing() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let changed_network = Network::new_regtest(RegtestParameters {
+        activation_heights: ConfiguredActivationHeights {
+            canopy: Some(10),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    let changed_config = EngineConfig::new(
+        engine_config.mode,
+        changed_network,
+        engine_config.bootstrap_anchor().clone(),
+        CheckpointSet::default(),
+    )
+    .expect("the changed policy accepts the same bootstrap anchor");
+    let metadata_value = mark_metadata_as_v2(&metadata);
+    let db = open(&db_config, engine_config.network());
+    let store = HeaderChainStore::new(db);
+    store
+        .initialize(metadata, anchor)
+        .expect("the current fixture initializes");
+    let mut batch = DiskWriteBatch::new();
+    store
+        .put_raw(
+            &mut batch,
+            HEADER_ENGINE_META,
+            METADATA_KEY,
+            &metadata_value,
+        )
+        .expect("the version-two metadata stages");
+    store.db.write(batch).expect("the legacy fixture commits");
+
+    assert!(matches!(
+        store.migrate_v1_to_current(&changed_config),
+        Err(HeaderChainStoreError::Incoherent(
+            "version-two network policy is ambiguous; rebuild the header-chain database"
         ))
     ));
     let metadata_cf = store

--- a/docs/changelog/unreleased/715.md
+++ b/docs/changelog/unreleased/715.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed startup of version-two header-chain databases so they migrate to the current
+  format without a resync
+  ([#715](https://github.com/zakura-core/zakura/pull/715)).


### PR DESCRIPTION
## Motivation

Mainnet nodes already running `ba80ff411` (`CURRENT = 2`) migrated header-chain metadata **1 → 2**. Deploying `ec81c294` (`CURRENT = 3`) panics during service construction:

`Codec(UnsupportedDiskFormat(2))`

`is_initialized()` only special-cased format 1, so the writer never reached a v2 → v3 migration. `europe-west-0` crash-looped on that SHA and was rolled back.

Root cause: [#692](https://github.com/zakura-core/zakura/pull/692) inserted `network_policy_digest` and bumped the format to 3. [#710](https://github.com/zakura-core/zakura/pull/710) taught startup to open format 1 only. Version 2 uses the same layout as version 1 (network kind, no policy digest) with marker 2.

## Solution

- Treat formats **1 and 2** as an initialized store during service construction.
- Decode v2 metadata with the version-one layout and inject the running node's network policy digest.
- Rewrite only the metadata row to format 3. Auxiliary and authority rows are already current.
- Keep the Mainnet-only policy rule used for v1, because v2 still cannot authenticate Testnet/Regtest configuration.

## Testing

- `version_two_migration_injects_network_policy_and_leaves_current_aux_unchanged` — a Mainnet v2 store classifies as initialized, migrates, preserves current aux rows, and passes startup audit.
- `version_two_migration_rejects_an_ambiguous_network_policy_without_writing` — a non-Mainnet v2 store is left unchanged.
- Existing v1 migration tests still pass.

Local: `cargo test -p zakura-state --lib version_two_migration` and `cargo test -p zakura-state --lib version_one_migration`.

## Changelog

- `docs/changelog/unreleased/715.md`

### Specifications & References

- Follow-up to [#710](https://github.com/zakura-core/zakura/pull/710) and the format bump in [#692](https://github.com/zakura-core/zakura/pull/692).
- `europe-west-0` rollback after `ec81c294`: https://github.com/zakura-core/zakura/actions/runs/32101534608