### PR TITLE
ci: exempt zakura binary from semver checks

### DIFF
--- a/.github/workflows/scripts/affected_semver_packages.py
+++ b/.github/workflows/scripts/affected_semver_packages.py
@@ -12,6 +12,10 @@ import sys
 # comparison baseline. Maintainers must remove this exclusion after that publication.
 UNPUBLISHED_BASELINE_EXCLUSIONS = {"zakura-header-chain"}
 
+# `zakura` is the node binary package, rather than a supported Rust library API.
+# Its command and configuration types can change without library SemVer bumps.
+SEMVER_ENFORCEMENT_EXCLUSIONS = {"zakura"}
+
 
 def is_publishable(package):
     publish = package.get("publish")
@@ -132,6 +136,7 @@ def affected_publishable_packages(metadata, changed_files=None, check_all=False)
         for package_id in ordered
         if is_publishable(packages[package_id])
         and packages[package_id]["name"] not in UNPUBLISHED_BASELINE_EXCLUSIONS
+        and packages[package_id]["name"] not in SEMVER_ENFORCEMENT_EXCLUSIONS
     ]
 
 

--- a/.github/workflows/scripts/test_affected_semver_packages.py
+++ b/.github/workflows/scripts/test_affected_semver_packages.py
@@ -135,6 +135,22 @@ class AffectedSemverPackagesTest(unittest.TestCase):
 
         self.assertEqual(affected, ["dependent"])
 
+    def test_excludes_zakura_node_package_from_semver_enforcement(self):
+        packages = [
+            self.package("library"),
+            self.package(
+                "zakura",
+                dependencies=[self.dependency("library")],
+            ),
+        ]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=["library/src/lib.rs", "zakura/src/main.rs"],
+        )
+
+        self.assertEqual(affected, ["library"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -20,6 +20,8 @@
 #   keeps optional heavy features (e.g. lightwalletd-grpc-tests and its
 #   protoc dependency) out of the rustdoc builds. Feature-gated public APIs
 #   are not semver-checked, mirroring existing release practice.
+# - The `zakura` node binary package is excluded because its Rust types are not
+#   a supported library API. Its release version is managed separately.
 # - publish = false members (xtask, zakura-watchdog) are skipped automatically.
 # - A NEW publishable crate that has never been published to crates.io fails
 #   with "no baseline": add `--exclude <crate>` to the check command in the


### PR DESCRIPTION
## Motivation

The `zakura` package is the node binary, not a supported Rust library API.
Enforcing library SemVer on its public command and configuration types blocks
intentional CLI cleanup such as #716.

## Solution

Exclude only the `zakura` package from the affected-package list used by
SemVer CI. Continue checking every affected publishable library crate and add
a regression test covering a changed library with `zakura` as its dependent.

## Testing

- `python3 .github/workflows/scripts/test_affected_semver_packages.py`
- `git diff --check`

## Changelog

Not required: this PR changes CI only.

### Follow-up Work

- Re-run #716 after this policy change reaches its base branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only policy change with a regression test; no runtime or library API behavior changes.
> 
> **Overview**
> SemVer CI no longer treats the **`zakura`** node binary as a library whose public Rust API must stay compatible with crates.io baselines.
> 
> The affected-package script adds **`SEMVER_ENFORCEMENT_EXCLUSIONS`** and drops **`zakura`** from the publishable crate list used by **`cargo-semver-checks`**, while still checking other affected library crates (including when **`zakura`** depends on them). **`semver-checks.yml`** documents that policy, and a unit test locks in that a change to both a library and **`zakura`** only schedules the library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76cb39760d96703a01d3bc8b527a2b406982593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->