### PR TITLE
refactor(state): remove Zebra 2.4 corruption check

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -22,7 +22,6 @@ use crate::{
         disk_db::DiskDb,
         disk_format::{
             block::MAX_ON_DISK_HEIGHT,
-            transparent::AddressLocation,
             upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
@@ -222,17 +221,6 @@ impl ZakuraDb {
         // longer be made safe: refuse to expose it at all, in every open mode.
         if is_unrepairable_vct_database(&db, disk_version_before_open.as_ref()) {
             return Err(StateInitError::VctSproutHistoryUnrepairable);
-        }
-
-        let zero_location_utxos =
-            db.address_utxo_locations(AddressLocation::from_usize(Height(0), 0, 0));
-        if !zero_location_utxos.is_empty() {
-            warn!(
-                "You have been impacted by the Zebra 2.4.0 address indexer corruption bug. \
-                If you rely on the data from the RPC interface, you will need to recover your database. \
-                Follow the instructions in the 2.4.1 release notes: https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1 \
-                If you just run the node for consensus and don't use data from the RPC interface, you can ignore this warning."
-            )
         }
 
         db.run_startup_format_change(format_change)?;

--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -14,7 +14,7 @@ use std::{path::Path, sync::Arc};
 use crossbeam_channel::bounded;
 use semver::Version;
 
-use zakura_chain::{block::Height, diagnostic::task::WaitForPanics, parameters::Network};
+use zakura_chain::{diagnostic::task::WaitForPanics, parameters::Network};
 
 use crate::{
     config::database_format_version_on_disk,
@@ -502,6 +502,7 @@ impl Drop for ZakuraDb {
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
+    use zakura_chain::block::Height;
 
     use crate::{
         constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},

--- a/docs/changelog/unreleased/720.md
+++ b/docs/changelog/unreleased/720.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR removes an unsupported legacy Zebra database diagnostic and has no
+operator-visible effect for supported Zakura databases.


### PR DESCRIPTION
## Motivation

Every database open performs an indexed lookup for the sentinel address
location corrupted by Zebra 2.4.0 and emits recovery instructions for affected
Zebra databases. Zakura does not support importing those legacy databases, so
the detector cannot provide a supported recovery path.

## Solution

Remove the Zebra 2.4.0 address-index corruption lookup and warning from
`ZakuraDb` startup. Current database format validation and Zakura migrations
remain unchanged.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-state --locked`
- `cargo check -p zakura-state --locked --no-default-features`
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/720.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `git diff --check`

## Changelog

Added an internal-only fragment because supported Zakura databases have no
operator-visible behavior change.

### Follow-up Work

- Audit pre-Zakura database migrations separately from migrations required by
  existing Zakura databases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup-only removal of a legacy diagnostic; no changes to migrations, format checks, or consensus-critical database logic.
> 
> **Overview**
> Removes the **Zebra 2.4.0 address-index corruption** check that ran on every `ZakuraDb` open: an indexed lookup at the sentinel `AddressLocation` at height 0 and a `warn!` with Zebra 2.4.1 recovery links.
> 
> Zakura does not support importing those legacy Zebra databases, so the detector could not offer a supported recovery path and only added startup work. **VCT Sprout history** refusal, format validation, and migrations are unchanged.
> 
> A changelog fragment notes there is no operator-visible effect for supported Zakura databases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb1dc8a9abb8c582e4c830f117f3de75ad88007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->