### PR TITLE
refactor(rpc)!: remove deprecated type aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8552,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "7.0.1"
+version = "8.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-rpc/src/client.rs
+++ b/crates/zakura-rpc/src/client.rs
@@ -9,7 +9,6 @@
 
 pub use zakura_chain;
 
-#[allow(deprecated)]
 pub use crate::methods::{
     hex_data::HexData,
     trees::{
@@ -28,7 +27,7 @@ pub use crate::methods::{
         network_info::GetNetworkInfoResponse,
         peer_info::{GetPeerInfoResponse, PeerInfo},
         submit_block::{SubmitBlockErrorResponse, SubmitBlockResponse},
-        subsidy::{BlockSubsidy, FundingStream, GetBlockSubsidyResponse},
+        subsidy::{FundingStream, GetBlockSubsidyResponse},
         transaction::{
             Input, JoinSplit, Orchard, OrchardAction, OrchardFlags, Output, ScriptPubKey,
             ScriptSig, ShieldedOutput, ShieldedSpend, TransactionObject, TransactionTemplate,
@@ -37,7 +36,7 @@ pub use crate::methods::{
         validate_address::ValidateAddressResponse,
         z_validate_address::{ZValidateAddressResponse, ZValidateAddressType},
     },
-    AddressStrings, BlockHeaderObject, BlockObject, EndOfService, GetAddressBalanceRequest,
+    BlockHeaderObject, BlockObject, EndOfService, GetAddressBalanceRequest,
     GetAddressBalanceResponse, GetAddressTxIdsRequest, GetAddressUtxosResponse,
     GetAddressUtxosResponseObject, GetBlockHashResponse, GetBlockHeaderResponse,
     GetBlockHeightAndHashResponse, GetBlockResponse, GetBlockTransaction, GetBlockTrees,

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -178,7 +178,8 @@ mod tests;
 #[rpc(server)]
 /// RPC method signatures.
 pub trait Rpc {
-    /// Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+    /// Returns software information from the RPC server, as a
+    /// [`GetInfoResponse`] JSON struct.
     ///
     /// zcashd reference: [`getinfo`](https://zcash.github.io/rpc/getinfo.html)
     /// method: post
@@ -187,10 +188,12 @@ pub trait Rpc {
     /// # Notes
     ///
     /// [The zcashd reference](https://zcash.github.io/rpc/getinfo.html) might not show some fields
-    /// in Zebra's [`GetInfo`]. Zebra uses the field names and formats from the
-    /// [zcashd code](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).
+    /// in Zebra's [`GetInfoResponse`]. Zebra uses the field names and formats
+    /// from the [zcashd
+    /// code](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).
     ///
-    /// Some fields from the zcashd reference are missing from Zebra's [`GetInfo`]. It only contains the fields
+    /// Some fields from the zcashd reference are missing from Zebra's
+    /// [`GetInfoResponse`]. It only contains the fields
     /// [required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)
     #[method(name = "getinfo")]
     async fn get_info(&self) -> Result<GetInfoResponse>;
@@ -236,7 +239,8 @@ pub trait Rpc {
     #[method(name = "getblockchaininfo")]
     async fn get_blockchain_info(&self) -> Result<GetBlockchainInfoResponse>;
 
-    /// Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+    /// Returns the total balance of provided `addresses` in a
+    /// [`GetAddressBalanceResponse`] instance.
     ///
     /// zcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)
     /// method: post
@@ -265,7 +269,8 @@ pub trait Rpc {
     ) -> Result<GetAddressBalanceResponse>;
 
     /// Sends the raw bytes of a signed transaction to the local node's mempool, if the transaction is valid.
-    /// Returns the [`SentTransactionHash`] for the transaction, as a JSON string.
+    /// Returns the [`SendRawTransactionResponse`] for the transaction, as a
+    /// JSON string.
     ///
     /// zcashd reference: [`sendrawtransaction`](https://zcash.github.io/rpc/sendrawtransaction.html)
     /// method: post
@@ -287,7 +292,8 @@ pub trait Rpc {
         _allow_high_fees: Option<bool>,
     ) -> Result<SendRawTransactionResponse>;
 
-    /// Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+    /// Returns the requested block by hash or height, as a
+    /// [`GetBlockResponse`] JSON string.
     /// If the block is not in Zebra's state, returns
     /// [error code `-8`.](https://github.com/zcash/zcash/issues/5758) if a height was
     /// passed or -5 if a hash was passed.
@@ -317,7 +323,8 @@ pub trait Rpc {
         verbosity: Option<u8>,
     ) -> Result<GetBlockResponse>;
 
-    /// Returns the requested block header by hash or height, as a [`GetBlockHeader`] JSON string.
+    /// Returns the requested block header by hash or height, as a
+    /// [`GetBlockHeaderResponse`] JSON string.
     /// If the block is not in Zebra's state,
     /// returns [error code `-8`.](https://github.com/zcash/zcash/issues/5758)
     /// if a height was passed or -5 if a hash was passed.
@@ -341,7 +348,8 @@ pub trait Rpc {
         verbose: Option<bool>,
     ) -> Result<GetBlockHeaderResponse>;
 
-    /// Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+    /// Returns the hash of the current best blockchain tip block, as a
+    /// [`GetBlockHashResponse`] JSON string.
     ///
     /// zcashd reference: [`getbestblockhash`](https://zcash.github.io/rpc/getbestblockhash.html)
     /// method: post
@@ -425,7 +433,8 @@ pub trait Rpc {
         limit: Option<NoteCommitmentSubtreeIndex>,
     ) -> Result<GetSubtreesByIndexResponse>;
 
-    /// Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+    /// Returns the raw transaction data, as a [`GetRawTransactionResponse`]
+    /// JSON string or structure.
     ///
     /// zcashd reference: [`getrawtransaction`](https://zcash.github.io/rpc/getrawtransaction.html)
     /// method: post
@@ -1282,7 +1291,7 @@ where
         }
     }
 
-    // TODO: use HexData or GetRawTransaction::Bytes to handle the transaction data argument
+    // TODO: use HexData to handle the transaction data argument.
     async fn send_raw_transaction(
         &self,
         raw_transaction_hex: String,
@@ -3449,9 +3458,6 @@ pub struct GetInfoResponse {
     errors_timestamp: i64,
 }
 
-#[deprecated(note = "Use `GetInfoResponse` instead")]
-pub use self::GetInfoResponse as GetInfo;
-
 impl Default for GetInfoResponse {
     fn default() -> Self {
         GetInfoResponse {
@@ -3473,7 +3479,7 @@ impl Default for GetInfoResponse {
 }
 
 impl GetInfoResponse {
-    /// Constructs [`GetInfo`] from its constituent parts.
+    /// Constructs [`GetInfoResponse`] from its constituent parts.
     #[allow(clippy::too_many_arguments)]
     #[deprecated(note = "Use `GetInfoResponse::new` instead")]
     pub fn from_parts(
@@ -3508,7 +3514,7 @@ impl GetInfoResponse {
         }
     }
 
-    /// Returns the contents of ['GetInfo'].
+    /// Returns the contents of [`GetInfoResponse`].
     pub fn into_parts(
         self,
     ) -> (
@@ -3953,7 +3959,7 @@ impl From<DGetAddressBalanceRequest> for GetAddressBalanceRequest {
     }
 }
 
-/// An intermediate type used to deserialize [`AddressStrings`].
+/// An intermediate type used to deserialize [`GetAddressBalanceRequest`].
 #[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize, JsonSchema)]
 #[serde(untagged)]
 enum DGetAddressBalanceRequest {
@@ -3962,10 +3968,6 @@ enum DGetAddressBalanceRequest {
     /// A single address string.
     Address(String),
 }
-
-/// A request to get the transparent balance of a set of addresses.
-#[deprecated(note = "Use `GetAddressBalanceRequest` instead.")]
-pub type AddressStrings = GetAddressBalanceRequest;
 
 /// A collection of validatable addresses
 pub trait ValidateAddresses {
@@ -3999,14 +4001,16 @@ impl ValidateAddresses for GetAddressBalanceRequest {
 }
 
 impl GetAddressBalanceRequest {
-    /// Creates a new `AddressStrings` given a vector.
+    /// Creates a new [`GetAddressBalanceRequest`] from a vector.
     pub fn new(addresses: Vec<String>) -> GetAddressBalanceRequest {
         GetAddressBalanceRequest { addresses }
     }
 
-    /// Creates a new [`AddressStrings`] from a given vector, returns an error if any addresses are incorrect.
+    /// Creates a new [`GetAddressBalanceRequest`] from a vector, returning an
+    /// error if any addresses are incorrect.
     #[deprecated(
-        note = "Use `AddressStrings::new` instead. Validity will be checked by the server."
+        note = "Use `GetAddressBalanceRequest::new` instead. Validity will be \
+                checked by the server."
     )]
     pub fn new_valid(addresses: Vec<String>) -> Result<GetAddressBalanceRequest> {
         let req = Self { addresses };
@@ -4035,9 +4039,6 @@ pub struct GetAddressBalanceResponse {
     /// The total received balance, including change.
     pub received: u64,
 }
-
-#[deprecated(note = "Use `GetAddressBalanceResponse` instead.")]
-pub use self::GetAddressBalanceResponse as AddressBalance;
 
 /// Parameters of [`RpcServer::get_address_utxos`] RPC method.
 #[derive(
@@ -4202,9 +4203,6 @@ impl TipConsensusBranch {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SendRawTransactionResponse(#[serde(with = "hex")] transaction::Hash);
 
-#[deprecated(note = "Use `SendRawTransactionResponse` instead")]
-pub use self::SendRawTransactionResponse as SentTransactionHash;
-
 impl Default for SendRawTransactionResponse {
     fn default() -> Self {
         Self(transaction::Hash::from([0; 32]))
@@ -4212,18 +4210,18 @@ impl Default for SendRawTransactionResponse {
 }
 
 impl SendRawTransactionResponse {
-    /// Constructs a new [`SentTransactionHash`].
+    /// Constructs a new [`SendRawTransactionResponse`].
     pub fn new(hash: transaction::Hash) -> Self {
         SendRawTransactionResponse(hash)
     }
 
-    /// Returns the contents of ['SentTransactionHash'].
-    #[deprecated(note = "Use `SentTransactionHash::hash` instead")]
+    /// Returns the contents of [`SendRawTransactionResponse`].
+    #[deprecated(note = "Use `SendRawTransactionResponse::hash` instead")]
     pub fn inner(&self) -> transaction::Hash {
         self.hash()
     }
 
-    /// Returns the contents of ['SentTransactionHash'].
+    /// Returns the contents of [`SendRawTransactionResponse`].
     pub fn hash(&self) -> transaction::Hash {
         self.0
     }
@@ -4240,9 +4238,6 @@ pub enum GetBlockResponse {
     /// The block object.
     Object(Box<BlockObject>),
 }
-
-#[deprecated(note = "Use `GetBlockResponse` instead")]
-pub use self::GetBlockResponse as GetBlock;
 
 impl Default for GetBlockResponse {
     fn default() -> Self {
@@ -4425,9 +4420,6 @@ pub enum GetBlockHeaderResponse {
     Object(Box<BlockHeaderObject>),
 }
 
-#[deprecated(note = "Use `GetBlockHeaderResponse` instead")]
-pub use self::GetBlockHeaderResponse as GetBlockHeader;
-
 #[allow(clippy::too_many_arguments)]
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
 /// Verbose response to a `getblockheader` RPC request.
@@ -4506,9 +4498,6 @@ pub struct BlockHeaderObject {
     next_block_hash: Option<block::Hash>,
 }
 
-#[deprecated(note = "Use `BlockHeaderObject` instead")]
-pub use BlockHeaderObject as GetBlockHeaderObject;
-
 impl Default for GetBlockHeaderResponse {
     fn default() -> Self {
         GetBlockHeaderResponse::Object(Box::default())
@@ -4560,9 +4549,6 @@ impl GetBlockHashResponse {
     }
 }
 
-#[deprecated(note = "Use `GetBlockHashResponse` instead")]
-pub use self::GetBlockHashResponse as GetBlockHash;
-
 /// A block hash used by this crate that encodes as hex by default.
 pub type Hash = GetBlockHashResponse;
 
@@ -4576,9 +4562,6 @@ pub struct GetBlockHeightAndHashResponse {
     #[getter(copy)]
     hash: block::Hash,
 }
-
-#[deprecated(note = "Use `GetBlockHeightAndHashResponse` instead.")]
-pub use GetBlockHeightAndHashResponse as GetBestBlockHeightAndHash;
 
 impl Default for GetBlockHeightAndHashResponse {
     fn default() -> Self {
@@ -4606,9 +4589,6 @@ pub enum GetRawTransactionResponse {
     /// The transaction object.
     Object(Box<TransactionObject>),
 }
-
-#[deprecated(note = "Use `GetRawTransactionResponse` instead")]
-pub use self::GetRawTransactionResponse as GetRawTransaction;
 
 impl Default for GetRawTransactionResponse {
     fn default() -> Self {
@@ -4669,9 +4649,6 @@ pub struct Utxo {
     height: Height,
 }
 
-#[deprecated(note = "Use `Utxo` instead")]
-pub use self::Utxo as GetAddressUtxos;
-
 impl Default for Utxo {
     fn default() -> Self {
         Self {
@@ -4689,7 +4666,7 @@ impl Default for Utxo {
 }
 
 impl Utxo {
-    /// Constructs a new instance of [`GetAddressUtxos`].
+    /// Constructs a new [`Utxo`].
     #[deprecated(note = "Use `Utxo::new` instead")]
     pub fn from_parts(
         address: transparent::Address,
@@ -4709,7 +4686,7 @@ impl Utxo {
         }
     }
 
-    /// Returns the contents of [`GetAddressUtxos`].
+    /// Returns the contents of [`Utxo`].
     pub fn into_parts(
         &self,
     ) -> (

--- a/crates/zakura-rpc/src/methods/types/subsidy.rs
+++ b/crates/zakura-rpc/src/methods/types/subsidy.rs
@@ -56,9 +56,6 @@ pub struct GetBlockSubsidyResponse {
     pub(crate) total_block_subsidy: Zec<NonNegative>,
 }
 
-#[deprecated(note = "Use `GetBlockSubsidyResponse` instead")]
-pub use self::GetBlockSubsidyResponse as BlockSubsidy;
-
 /// A single funding stream's information in a  `getblocksubsidy` RPC request
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Getters, new)]
 pub struct FundingStream {

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -885,7 +885,8 @@ impl Default for TransactionObject {
 }
 
 impl TransactionObject {
-    /// Converts `tx` and `height` into a new `GetRawTransaction` in the `verbose` format.
+    /// Converts `tx` and `height` into a verbose
+    /// [`GetRawTransactionResponse`](crate::methods::GetRawTransactionResponse).
     #[allow(clippy::unwrap_in_result)]
     #[allow(clippy::too_many_arguments)]
     pub fn from_transaction(

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -174,7 +174,7 @@ zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.1.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "7.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "8.0.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of

--- a/crates/zakurad/tests/common/regtest.rs
+++ b/crates/zakurad/tests/common/regtest.rs
@@ -20,7 +20,7 @@ use zakura_rpc::{
         BlockTemplateResponse, BlockTemplateTimeSource, GetBlockchainInfoResponse, HexData,
         SubmitBlockResponse,
     },
-    methods::GetBlockHash,
+    methods::GetBlockHashResponse,
     proposal_block_from_template,
     server::{self, OPENED_RPC_ENDPOINT_MSG},
 };
@@ -147,7 +147,9 @@ impl MiningRpcMethods for RpcRequestClient {
     async fn generate(&self, num_blocks: u32) -> Result<Vec<block::Hash>> {
         self.json_result_from_call("generate", format!("[{num_blocks}]"))
             .await
-            .map(|response: Vec<GetBlockHash>| response.into_iter().map(|rsp| rsp.hash()).collect())
+            .map(|response: Vec<GetBlockHashResponse>| {
+                response.into_iter().map(|rsp| rsp.hash()).collect()
+            })
             .map_err(|err| eyre!(err))
     }
 

--- a/docs/changelog/unreleased/723.md
+++ b/docs/changelog/unreleased/723.md
@@ -1,0 +1,20 @@
+## Removed
+
+- Removed the deprecated Zebra-era Rust type aliases from `zakura-rpc`
+  ([#723](https://github.com/zakura-core/zakura/pull/723)). Crate consumers
+  should replace them as follows:
+
+  - `GetInfo` with `GetInfoResponse`;
+  - `AddressStrings` with `GetAddressBalanceRequest`;
+  - `AddressBalance` with `GetAddressBalanceResponse`;
+  - `SentTransactionHash` with `SendRawTransactionResponse`;
+  - `GetBlock` with `GetBlockResponse`;
+  - `GetBlockHeader` with `GetBlockHeaderResponse`;
+  - `GetBlockHeaderObject` with `BlockHeaderObject`;
+  - `GetBlockHash` with `GetBlockHashResponse`;
+  - `GetBestBlockHeightAndHash` with `GetBlockHeightAndHashResponse`;
+  - `GetRawTransaction` with `GetRawTransactionResponse`;
+  - `GetAddressUtxos` with `Utxo`; and
+  - `BlockSubsidy` with `GetBlockSubsidyResponse`.
+
+  RPC endpoints and wire formats are unchanged.

--- a/docs/changelog/unreleased/723.md
+++ b/docs/changelog/unreleased/723.md
@@ -1,6 +1,6 @@
 ## Removed
 
-- Removed the deprecated Zebra-era Rust type aliases from `zakura-rpc`
+- Removed the deprecated Zebra-era Rust type aliases in `zakura-rpc` 8.0.0
   ([#723](https://github.com/zakura-core/zakura/pull/723)). Crate consumers
   should replace them as follows:
 


### PR DESCRIPTION
## Motivation

`zakura-rpc` still publishes 12 deprecated Zebra-era names for canonical RPC
request and response types. The aliases predate Zakura and duplicate the Rust
API without changing RPC wire formats.

## Solution

Remove the 12 deprecated type aliases, migrate the flattened client exports and
the one internal test using an alias, and update rustdoc to name the canonical
types. Bump `zakura-rpc` to 8.0.0 and update `zakurad`'s dependency requirement
because 7.0.0 published the aliases.

The nine deprecated compatibility methods remain. No JSON-RPC or gRPC method,
parameter, response schema, or serialization implementation changes.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-rpc --locked`
- `cargo check -p zakura --tests --locked`
- `cargo metadata --no-deps --format-version 1 --locked`
- `cargo semver-checks --package zakura-rpc --default-features`
- `./scripts/check-crate-publish-graph.sh`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/723.md`

## Changelog

`docs/changelog/unreleased/723.md` documents all 12 old-to-new type mappings
and confirms that RPC endpoints and wire formats are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major version bump breaks downstream crates that still import the removed aliases; RPC behavior and serialization are unchanged, so runtime risk is low.
> 
> **Overview**
> **Breaking Rust API cleanup** in `zakura-rpc` 8.0.0: removes 12 deprecated Zebra-era type aliases that duplicated canonical request/response names (`GetInfo`, `AddressStrings`, `GetBlock`, `GetRawTransaction`, `BlockSubsidy`, etc.) without changing JSON-RPC methods or wire formats.
> 
> The flattened **`client`** exports and **`zakurad`** regtest tests now use the canonical types (e.g. `GetBlockHashResponse`). RPC trait rustdoc references the `*Response` / `GetAddressBalanceRequest` names consistently. **`zakurad`**’s dependency on `zakura-rpc` is bumped to 8.0.0; deprecated compatibility **methods** on the canonical types are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3d3f425f2cbea31176627576e50085d6f6bbe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->