### PR TITLE
refactor(rpc)!: remove deprecated compatibility methods

### DIFF
--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -3402,41 +3402,6 @@ impl Default for GetInfoResponse {
 }
 
 impl GetInfoResponse {
-    /// Constructs [`GetInfoResponse`] from its constituent parts.
-    #[allow(clippy::too_many_arguments)]
-    #[deprecated(note = "Use `GetInfoResponse::new` instead")]
-    pub fn from_parts(
-        version: u64,
-        build: String,
-        subversion: String,
-        protocol_version: u32,
-        blocks: u32,
-        connections: usize,
-        proxy: Option<String>,
-        difficulty: f64,
-        testnet: bool,
-        pay_tx_fee: f64,
-        relay_fee: f64,
-        errors: String,
-        errors_timestamp: i64,
-    ) -> Self {
-        Self {
-            version,
-            build,
-            subversion,
-            protocol_version,
-            blocks,
-            connections,
-            proxy,
-            difficulty,
-            testnet,
-            pay_tx_fee,
-            relay_fee,
-            errors,
-            errors_timestamp,
-        }
-    }
-
     /// Returns the contents of [`GetInfoResponse`].
     pub fn into_parts(
         self,
@@ -3928,18 +3893,6 @@ impl GetAddressBalanceRequest {
     pub fn new(addresses: Vec<String>) -> GetAddressBalanceRequest {
         GetAddressBalanceRequest { addresses }
     }
-
-    /// Creates a new [`GetAddressBalanceRequest`] from a vector, returning an
-    /// error if any addresses are incorrect.
-    #[deprecated(
-        note = "Use `GetAddressBalanceRequest::new` instead. Validity will be \
-                checked by the server."
-    )]
-    pub fn new_valid(addresses: Vec<String>) -> Result<GetAddressBalanceRequest> {
-        let req = Self { addresses };
-        req.valid_addresses()?;
-        Ok(req)
-    }
 }
 
 /// The transparent balance of a set of addresses.
@@ -4136,12 +4089,6 @@ impl SendRawTransactionResponse {
     /// Constructs a new [`SendRawTransactionResponse`].
     pub fn new(hash: transaction::Hash) -> Self {
         SendRawTransactionResponse(hash)
-    }
-
-    /// Returns the contents of [`SendRawTransactionResponse`].
-    #[deprecated(note = "Use `SendRawTransactionResponse::hash` instead")]
-    pub fn inner(&self) -> transaction::Hash {
-        self.hash()
     }
 
     /// Returns the contents of [`SendRawTransactionResponse`].
@@ -4589,26 +4536,6 @@ impl Default for Utxo {
 }
 
 impl Utxo {
-    /// Constructs a new [`Utxo`].
-    #[deprecated(note = "Use `Utxo::new` instead")]
-    pub fn from_parts(
-        address: transparent::Address,
-        txid: transaction::Hash,
-        output_index: OutputIndex,
-        script: transparent::Script,
-        satoshis: u64,
-        height: Height,
-    ) -> Self {
-        Utxo {
-            address,
-            txid,
-            output_index,
-            script,
-            satoshis,
-            height,
-        }
-    }
-
     /// Returns the contents of [`Utxo`].
     pub fn into_parts(
         &self,
@@ -4649,16 +4576,6 @@ pub struct GetAddressTxIdsRequest {
 }
 
 impl GetAddressTxIdsRequest {
-    /// Constructs [`GetAddressTxIdsRequest`] from its constituent parts.
-    #[deprecated(note = "Use `GetAddressTxIdsRequest::new` instead.")]
-    pub fn from_parts(addresses: Vec<String>, start: u32, end: u32) -> Self {
-        GetAddressTxIdsRequest {
-            addresses,
-            start: Some(start),
-            end: Some(end),
-        }
-    }
-
     /// Returns the contents of [`GetAddressTxIdsRequest`].
     pub fn into_parts(&self) -> (Vec<String>, u32, u32) {
         (

--- a/docs/changelog/unreleased/726.md
+++ b/docs/changelog/unreleased/726.md
@@ -1,0 +1,17 @@
+## Removed
+
+- Removed five deprecated Rust compatibility methods from `zakura-rpc`
+  ([#726](https://github.com/zakura-core/zakura/pull/726)). Crate consumers
+  should replace them as follows:
+
+  - `GetInfoResponse::from_parts` with `GetInfoResponse::new`;
+  - `GetAddressBalanceRequest::new_valid` with
+    `GetAddressBalanceRequest::new` and rely on server-side validation;
+  - `SendRawTransactionResponse::inner` with
+    `SendRawTransactionResponse::hash`;
+  - `Utxo::from_parts` with `Utxo::new`; and
+  - `GetAddressTxIdsRequest::from_parts(addresses, start, end)` with
+    `GetAddressTxIdsRequest::new(addresses, Some(start), Some(end))`.
+
+  The deprecated treestate compatibility methods remain available. RPC
+  endpoints and wire formats are unchanged.


### PR DESCRIPTION
## Motivation

`zakura-rpc` still exposes five deprecated Rust compatibility methods that
have canonical replacements and no workspace callers. They were inherited
from Zebra and are already covered by the unpublished 8.0.0 major bump.

## Solution

Remove the five non-treestate compatibility methods:

- `GetInfoResponse::from_parts`;
- `GetAddressBalanceRequest::new_valid`;
- `SendRawTransactionResponse::inner`;
- `Utxo::from_parts`; and
- `GetAddressTxIdsRequest::from_parts`.

Retain the four deprecated treestate methods in `methods/trees.rs`. No RPC
endpoint, parameter, response schema, or serialization implementation changes.

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p zakura-rpc --locked`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/726.md`

## Changelog

`docs/changelog/unreleased/726.md` documents each replacement and confirms that
the treestate methods and RPC wire contracts remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for downstream Rust consumers of `zakura-rpc`, but no changes to live RPC behavior, auth, or consensus paths—mis-migrated dependents fail at compile time rather than at runtime.
> 
> **Overview**
> This PR **removes five deprecated Rust-only helpers** from `zakura-rpc` that duplicated `new` / `hash` constructors and getters. **RPC endpoints, parameters, responses, and serialization are unchanged.**
> 
> External `zakura-rpc` users on the unpublished **8.0.0** bump should migrate:
> 
> - `GetInfoResponse::from_parts` → `GetInfoResponse::new`
> - `GetAddressBalanceRequest::new_valid` → `GetAddressBalanceRequest::new` (validation stays on the server)
> - `SendRawTransactionResponse::inner` → `SendRawTransactionResponse::hash`
> - `Utxo::from_parts` → `Utxo::new`
> - `GetAddressTxIdsRequest::from_parts(...)` → `GetAddressTxIdsRequest::new(addresses, Some(start), Some(end))`
> 
> The four deprecated **treestate** compatibility methods in `methods/trees.rs` are **still present**. `docs/changelog/unreleased/726.md` records the removals and replacements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec379d1f24de1b3cd2f057891e2a370f6c9247f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->