### PR TITLE
build(zakurad): replace vergen metadata collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,43 +653,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "cast"
@@ -1330,36 +1297,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1377,22 +1320,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -1465,37 +1397,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -4077,15 +3978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6167,7 +6059,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6727,9 +6619,7 @@ checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -7484,46 +7374,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
- "rustc_version",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
 
 [[package]]
 name = "version_check"
@@ -8318,7 +8168,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
- "vergen-gitcl",
  "zakura-chain",
  "zakura-consensus",
  "zakura-header-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,6 @@ opentelemetry = "0.32"
 opentelemetry_sdk = "0.32.1"
 opentelemetry-otlp = "0.32"
 uint = "0.10"
-vergen-gitcl = { version = "9", default-features = false }
 x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -281,7 +281,6 @@ derive-new.workspace = true
 hex.workspace = true
 
 [build-dependencies]
-vergen-gitcl = { workspace = true, features = ["cargo", "rustc"] }
 
 # test feature lightwalletd-grpc-tests
 tonic-prost-build = { workspace = true, optional = true }

--- a/crates/zakurad/build.rs
+++ b/crates/zakurad/build.rs
@@ -6,66 +6,61 @@
 //! When compiling the `lightwalletd` gRPC tests, also builds a gRPC client
 //! Rust API for `lightwalletd`.
 
-use vergen_gitcl::{CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
+#[path = "build/metadata.rs"]
+mod metadata;
 
-/// Process entry point for `zakurad`'s build script
+use std::{env, path::PathBuf};
+
+/// Process entry point for `zakurad`'s build script.
 #[allow(clippy::print_stderr)]
 fn main() {
-    let mut emitter = Emitter::default();
-
-    // Configures an [`Emitter`] for everything except for `git` env vars.
-    // This builder fails the build on error.
-    //
-    // The cargo instructions are listed explicitly instead of using
-    // `all_cargo()`: its `dependencies` instruction (whose output nothing
-    // consumes) runs `cargo metadata` at compile time, which resolves the
-    // dependency graph against the registry index — that fails in the
-    // `cargo package`/`cargo publish` verify build of the packaged crate
-    // (before the zakura-* dependencies are published) and in offline builds.
-    let cargo_instructions = CargoBuilder::default()
-        .debug(true)
-        .features(true)
-        .opt_level(true)
-        .target_triple(true)
-        .build()
-        .expect("cargo instruction builder should build successfully");
-
-    emitter
-        .fail_on_error()
-        .add_instructions(&cargo_instructions)
-        .expect("adding cargo instructions should succeed")
-        .add_instructions(
-            &RustcBuilder::all_rustc().expect("all_rustc() should build successfully"),
+    for (name, value) in metadata::cargo_metadata()
+        .expect("Cargo should provide the required build metadata")
+        .into_iter()
+        .chain(
+            metadata::rustc_metadata()
+                .expect("rustc -vV should provide the required compiler metadata"),
         )
-        .expect("adding all_rustc() instructions should succeed");
-
-    // Get git information. This is used by e.g. ZakuradApp::register_components()
-    // to log the commit hash
-    let all_git = GitclBuilder::default()
-        .branch(true)
-        .commit_author_email(true)
-        .commit_author_name(true)
-        .commit_count(true)
-        .commit_date(true)
-        .commit_message(true)
-        .commit_timestamp(true)
-        .describe(false, false, None)
-        .sha(true)
-        .dirty(false)
-        .describe(true, true, Some("v*.*.*"))
-        .build()
-        .expect("all_git + describe + sha should build successfully");
-
-    if let Err(e) = emitter.add_instructions(&all_git) {
-        // The most common failure here is due to a missing `.git` directory,
-        // e.g., when building from `cargo install zakurad`. We simply
-        // proceed with the build.
-        // Note that this won't be printed unless in cargo very verbose mode (-vv).
-        // We could emit a build warning, but that might scare users.
-        eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);
+    {
+        metadata::emit_rustc_env(name, &value)
+            .expect("Cargo and rustc metadata should be safe Cargo directive values");
     }
 
-    emitter.emit().expect("base emit should succeed");
+    let manifest_dir = PathBuf::from(
+        env::var_os("CARGO_MANIFEST_DIR")
+            .expect("Cargo should provide the package manifest directory"),
+    );
+    let out_dir = PathBuf::from(
+        env::var_os("OUT_DIR").expect("Cargo should provide the build output directory"),
+    );
+
+    match metadata::git_metadata(&manifest_dir, &out_dir) {
+        Ok(git) => {
+            for (name, value) in [
+                ("VERGEN_GIT_BRANCH", git.branch.as_str()),
+                ("VERGEN_GIT_COMMIT_TIMESTAMP", git.commit_timestamp.as_str()),
+                ("VERGEN_GIT_DESCRIBE", git.describe.as_str()),
+                ("VERGEN_GIT_SHA", git.sha.as_str()),
+            ] {
+                metadata::emit_rustc_env(name, value)
+                    .expect("Git metadata should be safe Cargo directive values");
+            }
+
+            for path in metadata::git_rerun_paths(&git) {
+                metadata::emit_rerun_path(&path)
+                    .expect("Git metadata paths should be safe Cargo directive values");
+            }
+        }
+        Err(error) => {
+            // Packaged sources and some Docker contexts intentionally have no
+            // `.git` directory. Git metadata is optional in those builds.
+            eprintln!("git metadata unavailable: {error}");
+        }
+    }
+
+    // Watch the whole package so dirty-source changes refresh `git describe`.
+    metadata::emit_rerun_path(&manifest_dir)
+        .expect("the package path should be a safe Cargo directive value");
 
     #[cfg(feature = "lightwalletd-grpc-tests")]
     tonic_prost_build::configure()

--- a/crates/zakurad/build/metadata.rs
+++ b/crates/zakurad/build/metadata.rs
@@ -1,0 +1,267 @@
+//! Build metadata collection shared by `build.rs` and its integration tests.
+
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+/// Git metadata compiled into `zakurad` when the source is in a Git checkout.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct GitMetadata {
+    /// The checked-out branch, or `HEAD` for a detached checkout.
+    pub(super) branch: String,
+    /// The commit timestamp in UTC.
+    pub(super) commit_timestamp: String,
+    /// Output from the version-tag-constrained `git describe` invocation.
+    pub(super) describe: String,
+    /// The seven-character abbreviated commit hash used by existing builds.
+    pub(super) sha: String,
+    /// The checkout-specific Git directory.
+    pub(super) git_dir: PathBuf,
+    /// The shared Git directory, which owns refs in linked worktrees.
+    pub(super) common_git_dir: PathBuf,
+}
+
+/// Returns the Cargo metadata consumed by `zakurad` diagnostics.
+pub(super) fn cargo_metadata() -> Result<Vec<(&'static str, String)>, String> {
+    cargo_metadata_from(env::vars_os())
+}
+
+/// Returns Cargo metadata derived from a supplied environment.
+pub(super) fn cargo_metadata_from(
+    variables: impl IntoIterator<Item = (OsString, OsString)>,
+) -> Result<Vec<(&'static str, String)>, String> {
+    let variables: Vec<_> = variables.into_iter().collect();
+    let required = |name: &str| {
+        variables
+            .iter()
+            .find_map(|(key, value)| (key == OsStr::new(name)).then(|| value.clone()))
+            .ok_or_else(|| format!("Cargo did not set required build variable {name}"))
+            .and_then(|value| {
+                value
+                    .into_string()
+                    .map_err(|_| format!("Cargo build variable {name} is not valid UTF-8"))
+            })
+    };
+
+    let mut features: Vec<_> = variables
+        .iter()
+        .filter_map(|(key, _)| key.to_str()?.strip_prefix("CARGO_FEATURE_"))
+        .map(str::to_ascii_lowercase)
+        .collect();
+    features.sort_unstable();
+    features.dedup();
+
+    Ok(vec![
+        ("VERGEN_CARGO_DEBUG", required("DEBUG")?),
+        ("VERGEN_CARGO_FEATURES", features.join(",")),
+        ("VERGEN_CARGO_OPT_LEVEL", required("OPT_LEVEL")?),
+        ("VERGEN_CARGO_TARGET_TRIPLE", required("TARGET")?),
+    ])
+}
+
+/// Returns the rustc metadata consumed by `zakurad` diagnostics.
+pub(super) fn rustc_metadata() -> Result<Vec<(&'static str, String)>, String> {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let output = Command::new(&rustc)
+        .arg("-vV")
+        .output()
+        .map_err(|error| format!("failed to run {rustc:?} -vV: {error}"))?;
+
+    if !output.status.success() {
+        return Err(command_failure("rustc -vV", &output));
+    }
+
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|error| format!("rustc -vV output is not valid UTF-8: {error}"))?;
+    rustc_metadata_from(&stdout)
+}
+
+/// Parses the stable fields used from `rustc -vV` output.
+pub(super) fn rustc_metadata_from(output: &str) -> Result<Vec<(&'static str, String)>, String> {
+    let field = |name: &str| {
+        output
+            .lines()
+            .find_map(|line| line.strip_prefix(name))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| format!("rustc -vV output is missing {name}"))
+    };
+
+    Ok(vec![
+        ("VERGEN_RUSTC_COMMIT_DATE", field("commit-date:")?),
+        ("VERGEN_RUSTC_SEMVER", field("release:")?),
+    ])
+}
+
+/// Collects Git metadata without invoking a shell or configurable Git helpers.
+pub(super) fn git_metadata(manifest_dir: &Path, out_dir: &Path) -> Result<GitMetadata, String> {
+    fs::create_dir_all(out_dir)
+        .map_err(|error| format!("failed to create build output directory: {error}"))?;
+
+    let empty_config = out_dir.join("empty-gitconfig");
+    fs::write(&empty_config, b"")
+        .map_err(|error| format!("failed to create empty Git configuration: {error}"))?;
+    let no_hooks = out_dir.join("no-git-hooks");
+    fs::create_dir_all(&no_hooks)
+        .map_err(|error| format!("failed to create empty Git hooks directory: {error}"))?;
+
+    let run = |arguments: &[&str]| git_output(manifest_dir, &empty_config, &no_hooks, arguments);
+
+    let git_dir = absolute_path(manifest_dir, &run(&["rev-parse", "--absolute-git-dir"])?);
+    let common_git_dir = absolute_path(
+        manifest_dir,
+        &run(&["rev-parse", "--path-format=absolute", "--git-common-dir"])?,
+    );
+
+    Ok(GitMetadata {
+        branch: run(&["rev-parse", "--abbrev-ref", "HEAD"])?,
+        commit_timestamp: run(&[
+            "show",
+            "-s",
+            "--date=format-local:%Y-%m-%dT%H:%M:%S.000000000Z",
+            "--format=%cd",
+            "HEAD",
+        ])?,
+        describe: run(&[
+            "describe",
+            "--tags",
+            "--dirty",
+            "--match=v*.*.*",
+            "--abbrev=7",
+        ])?,
+        sha: run(&["rev-parse", "--short=7", "HEAD"])?,
+        git_dir,
+        common_git_dir,
+    })
+}
+
+/// Returns files and directories that can change the emitted Git metadata.
+pub(super) fn git_rerun_paths(metadata: &GitMetadata) -> Vec<PathBuf> {
+    let head = metadata.git_dir.join("HEAD");
+    let mut paths = vec![head.clone()];
+
+    if let Ok(contents) = fs::read_to_string(&head) {
+        if let Some(reference) = contents.trim().strip_prefix("ref: ") {
+            paths.push(metadata.common_git_dir.join(reference));
+        }
+    }
+
+    for path in [
+        metadata.git_dir.join("index"),
+        metadata.common_git_dir.join("packed-refs"),
+        metadata.common_git_dir.join("refs/tags"),
+    ] {
+        if path.exists() {
+            paths.push(path);
+        }
+    }
+
+    paths
+}
+
+/// Emits one compile-time environment variable for rustc.
+#[allow(clippy::print_stdout)]
+pub(super) fn emit_rustc_env(name: &str, value: &str) -> Result<(), String> {
+    validate_directive_value(name)?;
+    validate_directive_value(value)?;
+    println!("cargo:rustc-env={name}={value}");
+    Ok(())
+}
+
+/// Emits one Cargo rebuild path.
+#[allow(clippy::print_stdout)]
+pub(super) fn emit_rerun_path(path: &Path) -> Result<(), String> {
+    let path = path.to_string_lossy();
+    validate_directive_value(&path)?;
+    println!("cargo:rerun-if-changed={path}");
+    Ok(())
+}
+
+/// Rejects values that could inject additional Cargo build-script directives.
+pub(super) fn validate_directive_value(value: &str) -> Result<(), String> {
+    if value
+        .chars()
+        .any(|character| matches!(character, '\n' | '\r' | '\0'))
+    {
+        Err("build metadata contains a forbidden control character".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn git_output(
+    manifest_dir: &Path,
+    empty_config: &Path,
+    no_hooks: &Path,
+    arguments: &[&str],
+) -> Result<String, String> {
+    let mut command = Command::new("git");
+    command.current_dir(manifest_dir);
+
+    // Strip all caller-provided Git behavior before setting the small set of
+    // deterministic variables needed by these local, read-only commands.
+    for (name, _) in env::vars_os() {
+        if name
+            .to_string_lossy()
+            .to_ascii_uppercase()
+            .starts_with("GIT_")
+        {
+            command.env_remove(name);
+        }
+    }
+
+    let hooks_path = format!("core.hooksPath={}", no_hooks.display());
+    command
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", empty_config)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC0")
+        .arg("--no-optional-locks")
+        .args(["-c", "core.fsmonitor=false"])
+        .args(["-c", hooks_path.as_str()])
+        .args(["-c", "diff.external="])
+        .args(["-c", "core.abbrev=7"])
+        .args(arguments);
+
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to run git {arguments:?}: {error}"))?;
+    if !output.status.success() {
+        return Err(command_failure(&format!("git {arguments:?}"), &output));
+    }
+
+    let value = String::from_utf8(output.stdout)
+        .map_err(|error| format!("git {arguments:?} output is not valid UTF-8: {error}"))?;
+    let value = value.trim_end_matches(['\r', '\n'].as_slice());
+    if value.is_empty() {
+        return Err(format!("git {arguments:?} returned empty output"));
+    }
+    if value.len() > 4096 {
+        return Err(format!(
+            "git {arguments:?} returned unexpectedly long output"
+        ));
+    }
+    validate_directive_value(value)?;
+    Ok(value.to_string())
+}
+
+fn command_failure(command: &str, output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr: String = stderr.trim().chars().take(512).collect();
+    format!("{command} failed with status {}: {stderr}", output.status)
+}
+
+fn absolute_path(base: &Path, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}

--- a/crates/zakurad/src/application.rs
+++ b/crates/zakurad/src/application.rs
@@ -67,7 +67,7 @@ pub fn build_version() -> Version {
         )
     });
 
-    let mut version = vergen_build_version().unwrap_or(fallback_version);
+    let mut version = git_describe_build_version().unwrap_or(fallback_version);
 
     // Docker builds do not include `.git`, so use the explicitly supplied
     // commit when `git describe` could not add build metadata.
@@ -92,9 +92,9 @@ pub fn clap_build_version() -> &'static str {
         .as_str()
 }
 
-/// Returns the `zakurad` version from this build, if available from `vergen`.
-fn vergen_build_version() -> Option<Version> {
-    // VERGEN_GIT_DESCRIBE should be in the format:
+/// Returns the `zakurad` version derived from `git describe`, when available.
+fn git_describe_build_version() -> Option<Version> {
+    // The build-time Git description should be in the format:
     // - v1.0.0-rc.9-6-g319b01bb84
     // - v1.0.0-6-g319b01bb84
     // but sometimes it is just a short commit hash. See #6879 for details.
@@ -111,18 +111,18 @@ fn vergen_build_version() -> Option<Version> {
     // - version: major`.`minor`.`patch
     // - optional pre-release: `-`tag[`.`tag ...]
     // - optional build: `+`tag[`.`tag ...]
-    // change the git describe format to the semver 2.0 format
-    let vergen_git_describe = VERGEN_GIT_DESCRIBE?;
+    // Change the `git describe` format to the SemVer 2.0 format.
+    let git_describe = VERGEN_GIT_DESCRIBE?;
 
     // `git describe` uses "dirty" for uncommitted changes,
     // but users won't understand what that means.
-    let vergen_git_describe = vergen_git_describe.replace("dirty", "modified");
+    let git_describe = git_describe.replace("dirty", "modified");
 
     // Split using "git describe" separators.
-    let mut vergen_git_describe = vergen_git_describe.split('-').peekable();
+    let mut git_describe = git_describe.split('-').peekable();
 
     // Check the "version core" part.
-    let mut version = vergen_git_describe.next()?;
+    let mut version = git_describe.next()?;
 
     // strip the leading "v", if present.
     version = version.strip_prefix('v').unwrap_or(version);
@@ -136,7 +136,7 @@ fn vergen_build_version() -> Option<Version> {
 
     // Check if the next part is a pre-release or build part,
     // but only consume it if it is a pre-release tag.
-    let Some(part) = vergen_git_describe.peek() else {
+    let Some(part) = git_describe.peek() else {
         // No pre-release or build.
         return semver.parse().ok();
     };
@@ -147,11 +147,11 @@ fn vergen_build_version() -> Option<Version> {
         semver.push_str(part);
 
         // Consume the pre-release tag to move on to the build tags, if any.
-        let _ = vergen_git_describe.next();
+        let _ = git_describe.next();
     }
 
     // Check if the next part is a build part.
-    let Some(build) = vergen_git_describe.peek() else {
+    let Some(build) = git_describe.peek() else {
         // No build tags.
         return semver.parse().ok();
     };
@@ -162,7 +162,7 @@ fn vergen_build_version() -> Option<Version> {
     }
 
     // Append the rest of the build parts with the correct `+` and `.` separators.
-    let build_parts: Vec<_> = vergen_git_describe.collect();
+    let build_parts: Vec<_> = git_describe.collect();
     let build_parts = build_parts.join(".");
 
     semver.push('+');

--- a/crates/zakurad/tests/build_metadata.rs
+++ b/crates/zakurad/tests/build_metadata.rs
@@ -1,0 +1,174 @@
+//! Compatibility and authority tests for Zakura's build metadata collector.
+
+#[allow(dead_code)]
+#[path = "../build/metadata.rs"]
+mod metadata;
+
+use std::{
+    ffi::OsString,
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+#[test]
+fn cargo_metadata_is_complete_and_deterministic() {
+    let variables = [
+        ("TARGET", "aarch64-unknown-linux-gnu"),
+        ("CARGO_FEATURE_ZETA", "1"),
+        ("DEBUG", "false"),
+        ("CARGO_FEATURE_ALPHA_BETA", "1"),
+        ("OPT_LEVEL", "3"),
+    ]
+    .map(|(name, value)| (OsString::from(name), OsString::from(value)));
+
+    assert_eq!(
+        metadata::cargo_metadata_from(variables).expect("the fixture is complete"),
+        [
+            ("VERGEN_CARGO_DEBUG", "false"),
+            ("VERGEN_CARGO_FEATURES", "alpha_beta,zeta"),
+            ("VERGEN_CARGO_OPT_LEVEL", "3"),
+            ("VERGEN_CARGO_TARGET_TRIPLE", "aarch64-unknown-linux-gnu"),
+        ]
+        .map(|(name, value)| (name, value.to_string()))
+    );
+}
+
+#[test]
+fn rustc_metadata_uses_stable_verbose_version_fields() {
+    let output = "rustc 1.91.0 (example 2025-10-30)\n\
+                  binary: rustc\n\
+                  commit-hash: example\n\
+                  commit-date: 2025-10-30\n\
+                  host: x86_64-unknown-linux-gnu\n\
+                  release: 1.91.0\n\
+                  LLVM version: 20.1.8\n";
+
+    assert_eq!(
+        metadata::rustc_metadata_from(output).expect("the fixture is complete"),
+        [
+            ("VERGEN_RUSTC_COMMIT_DATE", "2025-10-30"),
+            ("VERGEN_RUSTC_SEMVER", "1.91.0"),
+        ]
+        .map(|(name, value)| (name, value.to_string()))
+    );
+}
+
+#[test]
+fn cargo_directive_values_reject_line_injection() {
+    assert!(metadata::validate_directive_value("ordinary-value").is_ok());
+    assert!(metadata::validate_directive_value("value\ncargo:warning=injected").is_err());
+    assert!(metadata::validate_directive_value("value\rcargo:warning=injected").is_err());
+    assert!(metadata::validate_directive_value("value\0suffix").is_err());
+}
+
+#[test]
+fn git_metadata_preserves_version_semantics() {
+    let repository = tempfile::tempdir().expect("temporary repository should be created");
+    initialize_repository(repository.path());
+
+    fs::write(repository.path().join("tracked"), "first").expect("fixture should be written");
+    git(repository.path(), &["add", "tracked"]);
+    git(repository.path(), &["commit", "-m", "first"]);
+    git(repository.path(), &["tag", "v1.2.3"]);
+
+    fs::write(repository.path().join("tracked"), "second").expect("fixture should be updated");
+    git(repository.path(), &["commit", "-am", "second"]);
+    git(repository.path(), &["tag", "zakura-rpc-v9.0.0"]);
+
+    let build_output = repository.path().join("build-output");
+    let clean = metadata::git_metadata(repository.path(), &build_output)
+        .expect("Git metadata should be available");
+    assert_eq!(clean.branch, "main");
+    assert_eq!(clean.sha.len(), 7);
+    assert_eq!(clean.describe, format!("v1.2.3-1-g{}", clean.sha));
+    assert!(clean.commit_timestamp.ends_with(".000000000Z"));
+
+    let rerun_paths = metadata::git_rerun_paths(&clean);
+    assert!(rerun_paths.iter().any(|path| path.ends_with("HEAD")));
+    assert!(rerun_paths
+        .iter()
+        .any(|path| path.ends_with("refs/heads/main")));
+    assert!(rerun_paths.iter().any(|path| path.ends_with("refs/tags")));
+
+    fs::write(repository.path().join("tracked"), "dirty").expect("fixture should be made dirty");
+    let dirty = metadata::git_metadata(repository.path(), &build_output)
+        .expect("dirty Git metadata should be available");
+    assert_eq!(dirty.describe, format!("v1.2.3-1-g{}-dirty", dirty.sha));
+
+    git(repository.path(), &["checkout", "--detach"]);
+    let detached = metadata::git_metadata(repository.path(), &build_output)
+        .expect("detached Git metadata should be available");
+    assert_eq!(detached.branch, "HEAD");
+}
+
+#[test]
+fn missing_git_directory_is_nonfatal_to_callers() {
+    let source = tempfile::tempdir().expect("temporary source directory should be created");
+    let build_output = source.path().join("build-output");
+
+    assert!(metadata::git_metadata(source.path(), &build_output).is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn configured_fsmonitor_is_not_executed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repository = tempfile::tempdir().expect("temporary repository should be created");
+    initialize_repository(repository.path());
+    fs::write(repository.path().join("tracked"), "content").expect("fixture should be written");
+    git(repository.path(), &["add", "tracked"]);
+    git(repository.path(), &["commit", "-m", "fixture"]);
+    git(repository.path(), &["tag", "v1.0.0"]);
+
+    let sentinel = repository.path().join("fsmonitor-ran");
+    let helper = repository.path().join("fsmonitor-helper");
+    fs::write(
+        &helper,
+        format!("#!/bin/sh\ntouch '{}'\nexit 1\n", sentinel.display()),
+    )
+    .expect("helper should be written");
+    let mut permissions = fs::metadata(&helper)
+        .expect("helper metadata should exist")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&helper, permissions).expect("helper should be executable");
+    git(
+        repository.path(),
+        &[
+            "config",
+            "core.fsmonitor",
+            helper.to_str().expect("UTF-8 path"),
+        ],
+    );
+
+    metadata::git_metadata(repository.path(), &repository.path().join("build-output"))
+        .expect("local fsmonitor configuration should be overridden");
+    assert!(!sentinel.exists(), "the configured fsmonitor helper ran");
+}
+
+fn initialize_repository(repository: &Path) {
+    git(repository, &["init", "-b", "main"]);
+    git(repository, &["config", "user.name", "Zakura Test"]);
+    git(
+        repository,
+        &["config", "user.email", "zakura-test@example.com"],
+    );
+    git(repository, &["config", "commit.gpgSign", "false"]);
+    git(repository, &["config", "tag.gpgSign", "false"]);
+}
+
+fn git(repository: &Path, arguments: &[&str]) -> Output {
+    let output = Command::new("git")
+        .current_dir(repository)
+        .args(arguments)
+        .output()
+        .expect("test Git command should run");
+    assert!(
+        output.status.success(),
+        "git {arguments:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}

--- a/deny.toml
+++ b/deny.toml
@@ -162,9 +162,6 @@ skip-tree = [
     { name = "rand_core", version = "0.6" },
     { name = "rand_chacha", version = "0.3" },
 
-    # wait for derive_builder to update
-    { name = "darling", version = "0.20.11" },
-
     # wait until `config` updates `convert_case`
     { name = "convert_case", version = "0.6.0" },
 

--- a/docs/changelog/unreleased/727.md
+++ b/docs/changelog/unreleased/727.md
@@ -1,0 +1,4 @@
+## Security
+
+- Constrained build-time Git metadata collection to avoid invoking configured
+  Git helpers ([#727](https://github.com/zakura-core/zakura/pull/727)).

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -288,17 +288,6 @@ version = "0.2.31"
 criteria = "safe-to-deploy"
 notes = "Audit held: timestamp parsing rounds arbitrary fractional precision to nanoseconds before calling Timestamp::__new_unchecked. timestamp!(0.9999999999) reproducibly produces 1_000_000_000 nanoseconds and fails the ranged-integer invariant during compilation instead of yielding a valid value or a normal macro diagnostic. Retain the exemption pending explicit carry or truncation handling."
 
-[[exemptions.vergen-gitcl]]
-version = "9.1.0"
-criteria = "safe-to-deploy"
-suggest = false
-notes = "Audit deferred in #691: the crate executes the shell and Git selected from the ambient build environment, and Git operations can invoke configured helpers such as core.fsmonitor. PR #619 keeps a fixed describe pattern and writes Git errors to stderr rather than Cargo directives, but that does not remove the broader SHELL, PATH, and Git-configuration authority. Retain this exemption until #691 chooses and verifies a constrained CLI backend, a patched git2 backend, or a reasonably auditable gix backend."
-
-[[exemptions.vergen-lib]]
-version = "9.1.0"
-criteria = "safe-to-deploy"
-notes = "Audit held: the optional emit_and_set feature exposes a safe method that calls unsafe process-environment mutation without requiring callers to guarantee that no other thread reads or writes the environment. Zakura does not enable that feature, but a version-wide safe-to-deploy certification is deferred pending an unsafe API boundary or internal synchronization."
-
 [[exemptions.wait-timeout]]
 version = "0.2.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Motivation

`vergen-gitcl` gives the build script more ambient authority than this use case
needs: it can use the caller's shell and Git configuration, including configured
helpers such as `core.fsmonitor`. It also adds a sizeable build-only dependency
graph and unresolved supply-chain exemptions.

Closes #691.

## Solution

- replace `vergen-gitcl` with a small standard-library metadata collector
- derive Cargo fields from Cargo-provided environment variables and compiler
  fields from `rustc -vV`
- run only the read-only Git commands needed for branch, SHA, timestamp, and
  `git describe --tags --dirty --match=v*.*.*`
- avoid a shell, remove inherited `GIT_*` variables, disable system/global Git
  config, and override helper-capable local settings used by these commands
- preserve builds without a `.git` directory
- remove the now-unused dependency graph, duplicate allowance, and Vet
  exemptions

The `git` executable is still selected through `PATH`, as is conventional for a
portable build, but its invocation and configuration inputs are constrained.

## Testing

- `cargo test -p zakura --test build_metadata --locked`
- `cargo clippy -p zakura --test build_metadata --locked -- -D warnings`
- `cargo vet check --store-path ./qa/supply-chain/`
- `cargo run -p zakura --bin zakurad --locked -- --version`
- tests cover metadata compatibility, version-tag matching, dirty and detached
  checkouts, missing `.git`, Cargo-directive injection, and suppression of a
  configured `core.fsmonitor` helper

The real binary reported the expected package version plus commit-count, short
SHA, and modified-worktree metadata. `cargo-deny` is not installed locally, so
that dependency-policy check and broader workspace coverage are left to CI.

## Changelog

Added `docs/changelog/unreleased/727.md`.

### Specifications & References

- #691
