### PR TITLE
fix(batch): stop re-polling a finished batch worker handle

### DIFF
--- a/crates/tower-batch-control/src/service.rs
+++ b/crates/tower-batch-control/src/service.rs
@@ -71,6 +71,9 @@ where
     /// A worker task handle shared between all service clones for the same worker.
     ///
     /// Only used when the worker is spawned on the tokio runtime.
+    ///
+    /// [`poll_ready`](Service::poll_ready) clears this handle when the worker finishes,
+    /// because a [`JoinHandle`] panics when it is polled after it completes.
     worker_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
@@ -270,41 +273,63 @@ where
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Check to see if the worker has returned or panicked.
         //
-        // Correctness: Registers this task for wakeup when the worker finishes.
-        if let Some(worker_handle) = self
-            .worker_handle
-            .lock()
-            .expect("previous task panicked while holding the worker handle mutex")
-            .as_mut()
-        {
-            // # Correctness
-            //
-            // The inner service used with `Batch` MUST NOT return recoverable errors from its:
-            // - `poll_ready` method, or
-            // - `call` method when called with a `BatchControl::Flush` request.
-            //
-            // If the inner service returns an error in those cases, this `poll_ready` method will
-            // return an error the first time its called, and will panic the second time its called
-            // as it attempts to call `poll` on a `JoinHandle` that has already completed.
-            match Pin::new(worker_handle).poll(cx) {
-                Poll::Ready(Ok(())) => {
-                    let worker_error = self.get_worker_error();
-                    tracing::warn!(?worker_error, "batch worker finished unexpectedly");
-                    return Poll::Ready(Err(worker_error));
-                }
-                Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
-                    tracing::warn!(
-                        "batch task cancelled: {task_cancelled}\n\
-                         Is Zakura shutting down?"
-                    );
+        // # Correctness
+        //
+        // Polling the handle registers this task for wakeup when the worker finishes.
+        //
+        // A `JoinHandle` panics when it is polled after it completes, and every `Batch`
+        // clone polls this same shared handle. So take the finished handle out of the
+        // shared slot here. Later calls skip this check, and report the worker failure
+        // from the closed channel or the closed semaphore below.
+        let worker_result = {
+            let mut worker_handle = self
+                .worker_handle
+                .lock()
+                .expect("previous task panicked while holding the worker handle mutex");
 
-                    return Poll::Ready(Err(task_cancelled.into()));
+            let poll_result = worker_handle
+                .as_mut()
+                .map(|handle| Pin::new(handle).poll(cx));
+
+            match poll_result {
+                Some(Poll::Ready(worker_result)) => {
+                    *worker_handle = None;
+                    Some(worker_result)
                 }
-                Poll::Ready(Err(task_panic)) => {
-                    std::panic::resume_unwind(task_panic.into_panic());
-                }
-                Poll::Pending => {}
+                Some(Poll::Pending) | None => None,
             }
+        };
+
+        // # Correctness
+        //
+        // The worker handle mutex is unlocked here, so the `resume_unwind()` below does not
+        // poison it. A poisoned mutex would make every later `poll_ready()` call panic when
+        // it locks the mutex, instead of returning the worker error.
+        //
+        // The inner service used with `Batch` SHOULD NOT return recoverable errors from its:
+        // - `poll_ready` method, or
+        // - `call` method when called with a `BatchControl::Flush` request.
+        //
+        // If the inner service returns an error in those cases, the worker fails permanently
+        // and exits, and every later request on every `Batch` clone fails with that error.
+        match worker_result {
+            Some(Ok(())) => {
+                let worker_error = self.get_worker_error();
+                tracing::warn!(?worker_error, "batch worker finished unexpectedly");
+                return Poll::Ready(Err(worker_error));
+            }
+            Some(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
+                tracing::warn!(
+                    "batch task cancelled: {task_cancelled}\n\
+                     Is Zakura shutting down?"
+                );
+
+                return Poll::Ready(Err(task_cancelled.into()));
+            }
+            Some(Err(task_panic)) => {
+                std::panic::resume_unwind(task_panic.into_panic());
+            }
+            None => {}
         }
 
         // Check if the worker has set an error and closed its channels.

--- a/crates/tower-batch-control/tests/worker.rs
+++ b/crates/tower-batch-control/tests/worker.rs
@@ -1,11 +1,49 @@
 //! Fixed test cases for batch worker tasks.
 
-use std::time::Duration;
+use std::{
+    future::Ready,
+    panic::AssertUnwindSafe,
+    task::{Context, Poll},
+    time::Duration,
+};
 
+use tokio::sync::oneshot;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};
 use tower::{Service, ServiceExt};
 use tower_batch_control::{error, Batch, BatchControl, RequestWeight};
 use tower_test::mock;
+
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Sends on `tx` when it is dropped, including while a panic unwinds the worker task.
+struct SendOnDrop(Option<oneshot::Sender<()>>);
+
+impl Drop for SendOnDrop {
+    fn drop(&mut self) {
+        let _ = self
+            .0
+            .take()
+            .expect("the sender is only taken by this drop impl")
+            .send(());
+    }
+}
+
+/// An inner service that panics when the batch worker checks its readiness.
+struct PanicService;
+
+impl Service<BatchControl<()>> for PanicService {
+    type Response = ();
+    type Error = BoxError;
+    type Future = Ready<Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        panic!("inner service panicked");
+    }
+
+    fn call(&mut self, _req: BatchControl<()>) -> Self::Future {
+        unreachable!("the worker panics before it calls the inner service");
+    }
+}
 
 #[tokio::test]
 async fn wakes_pending_waiters_on_close() {
@@ -190,4 +228,112 @@ async fn try_flush_completes_zero_weight_items() {
         .await
         .expect("item response should complete")
         .expect("zero-weight item should verify");
+}
+
+/// The batch worker exits when its inner service returns a recoverable error. Every later
+/// readiness check must report that failure, rather than polling the completed
+/// [`JoinHandle`](tokio::task::JoinHandle) again and panicking.
+#[tokio::test]
+async fn poll_ready_reports_worker_exit_every_time() {
+    let _init_guard = zakura_test::init();
+
+    let (inner_service, mut inner_handle) = mock::pair::<BatchControl<()>, ()>();
+    let (mut service, worker) = Batch::pair(inner_service, 1, 1, Duration::from_secs(1));
+
+    let (worker_exited_tx, worker_exited_rx) = oneshot::channel();
+    let worker_handle = tokio::spawn(async move {
+        let _signal_exit = SendOnDrop(Some(worker_exited_tx));
+        worker.run().await;
+    });
+    service.register_worker(worker_handle);
+
+    // Hold the item in the worker, so the worker is waiting on the inner service.
+    inner_handle.allow(0);
+    service.ready().await.expect("batch starts ready");
+    let _response = service.call(());
+
+    // A recoverable inner error permanently fails the worker, which then drains its queue
+    // and returns. This is the `Poll::Ready(Ok(()))` case in `Batch::poll_ready()`.
+    inner_handle.send_error("inner service error");
+    worker_exited_rx.await.expect("worker task should exit");
+
+    let Err(first_error) = service.ready().await else {
+        panic!("readiness should fail once the worker has exited");
+    };
+    assert!(
+        first_error.is::<error::ServiceError>(),
+        "the first check should return the worker error, got: {first_error:?}",
+    );
+
+    // Before the fix, this check polled the completed `JoinHandle` again, and panicked.
+    let Err(second_error) = service.ready().await else {
+        panic!("readiness should keep failing once the worker has exited");
+    };
+    assert_eq!(
+        first_error.to_string(),
+        second_error.to_string(),
+        "every check should return the same worker error",
+    );
+
+    // Clones share the worker handle, so they must not poll it again either.
+    let mut cloned_service = service.clone();
+    let Err(cloned_error) = cloned_service.ready().await else {
+        panic!("clones should fail once the worker has exited");
+    };
+    assert_eq!(
+        first_error.to_string(),
+        cloned_error.to_string(),
+        "clones should return the same worker error",
+    );
+}
+
+/// A panicking worker propagates its panic to one readiness check. Every later check must
+/// report the worker failure, rather than panicking on a poisoned worker handle mutex.
+#[tokio::test]
+async fn poll_ready_after_worker_panic_does_not_poison_the_handle_mutex() {
+    let _init_guard = zakura_test::init();
+
+    let (mut service, worker) = Batch::pair(PanicService, 1, 1, Duration::from_secs(1));
+
+    let (worker_exited_tx, worker_exited_rx) = oneshot::channel();
+    let worker_handle = tokio::spawn(async move {
+        let _signal_exit = SendOnDrop(Some(worker_exited_tx));
+        worker.run().await;
+    });
+    service.register_worker(worker_handle);
+
+    service.ready().await.expect("batch starts ready");
+    let _response = service.call(());
+    worker_exited_rx.await.expect("worker task should panic");
+
+    // The first check resumes the worker panic.
+    let mut context_task = task::spawn(());
+    let panic_payload = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        context_task.enter(|cx, _| service.poll_ready(cx))
+    }))
+    .expect_err("the first check should resume the worker panic");
+    assert_eq!(
+        panic_payload.downcast_ref::<&str>().copied(),
+        Some("inner service panicked"),
+        "the first check should resume the inner service panic",
+    );
+
+    // Before the fix, the panic unwound through the locked worker handle mutex, so this
+    // check panicked on the poisoned mutex instead of returning the worker error.
+    let Err(error) = service.ready().await else {
+        panic!("readiness should fail once the worker has panicked");
+    };
+    assert!(
+        error.is::<error::ServiceError>(),
+        "later checks should return the worker error, got: {error:?}",
+    );
+
+    let mut cloned_service = service.clone();
+    let Err(cloned_error) = cloned_service.ready().await else {
+        panic!("clones should fail once the worker has panicked");
+    };
+    assert!(
+        cloned_error.is::<error::ServiceError>(),
+        "clones should return the worker error, got: {cloned_error:?}",
+    );
 }

--- a/docs/changelog/unreleased/728.md
+++ b/docs/changelog/unreleased/728.md
@@ -1,0 +1,9 @@
+## Fixed
+
+- Fixed a panic in the batch verification services. `Batch::poll_ready` polled the shared
+  worker task handle after that task had finished, which Tokio panics on, and propagated a
+  worker panic while holding the handle's mutex, which poisoned it. Once a batch worker
+  exited, the next readiness check on any clone of that verifier panicked instead of
+  returning the worker's error. The finished handle is now taken out of the shared slot, and
+  the lock is released before the panic is propagated, so every later caller receives the
+  worker error ([#728](https://github.com/zakura-core/zakura/pull/728)).


### PR DESCRIPTION
## Motivation

`Batch::poll_ready` polls the shared worker `JoinHandle` on every call, but never clears it
once the handle returns `Ready`. Tokio panics with `JoinHandle polled after completion`
([`tokio/src/runtime/task/core.rs:422`](https://github.com/tokio-rs/tokio/blob/master/tokio/src/runtime/task/core.rs))
when a completed handle is polled again, so the first readiness check after a worker exit
returns the worker error, and the next one panics. The existing code comment acknowledged
this.

Two things make that reachable and severe:

- A recoverable error from the inner service's `poll_ready`, or from its `call` with a
  `BatchControl::Flush` request, fails the worker permanently. `Worker::failed` closes the
  channel and the semaphore, the run loop drains its queue, and `Worker::run` returns
  normally. So a plain `Poll::Ready(Ok(()))` completion is reachable, not just cancellation
  or a panic.
- Every `Batch` clone shares one `Arc<Mutex<Option<JoinHandle<()>>>>`. One worker exit
  therefore breaks every clone of a process-wide verifier, and no surviving handle can
  recover without reconstructing the batch service.

Separately, `poll_ready` called `std::panic::resume_unwind` on a worker panic while it still
held the worker handle `MutexGuard`. Unwinding through the guard poisoned the mutex, so every
later call panicked at `.lock().expect("previous task panicked while holding the worker
handle mutex")` instead of returning the worker error.

Root cause: worker completion is observed through a shared future that is never consumed, and
the panic is propagated while shared synchronization state is still locked.

## Solution

- Take the handle out of the shared slot as soon as it returns `Ready`, so no clone polls it
  again. Later calls skip the handle check and report the worker failure from the closed
  channel or the closed semaphore, so every caller sees the same error.
- Release the worker handle lock before propagating the worker panic, so `resume_unwind` no
  longer poisons the mutex.

Panic propagation itself is unchanged: one readiness check still resumes the worker's panic.
The change is that the mutex survives it, so later calls return the worker error rather than
panicking on a poisoned lock.

No public API changes.

## Testing

Two regression tests in `crates/tower-batch-control/tests/worker.rs`, both driving a real
spawned worker task through `Batch::pair` + `register_worker`, so they exercise the
`JoinHandle` path rather than only the channel path. A `SendOnDrop` guard inside the spawned
task signals when the worker future is dropped, which makes both tests deterministic on the
current-thread runtime that `#[tokio::test]` uses, including when the worker unwinds.

- `poll_ready_reports_worker_exit_every_time` — a recoverable inner-service error exits the
  worker, then asserts the first, second, and a clone's readiness checks all return the same
  `ServiceError`. This covers the `Poll::Ready(Ok(()))` case.
- `poll_ready_after_worker_panic_does_not_poison_the_handle_mutex` — a `PanicService` panics
  the worker; the test asserts the first check resumes that exact panic payload, then that
  later checks on the same service and on a clone return the worker error.

Both tests fail on `main` with the two distinct panics named above, and pass with the fix:

| test | failure without the fix |
| --- | --- |
| `poll_ready_reports_worker_exit_every_time` | `JoinHandle polled after completion` |
| `poll_ready_after_worker_panic_does_not_poison_the_handle_mutex` | `previous task panicked while holding the worker handle mutex: PoisonError { .. }` |

Checks run:

- `cargo test -p zakura-tower-batch-control` — 16 passed (10 `ed25519`, 6 `worker`)
- `cargo clippy -p zakura-tower-batch-control --all-targets` — clean
- `cargo fmt -p zakura-tower-batch-control -- --check` — clean
- `cargo check -p zakura-consensus` — the downstream consumer of `Batch`

## Changelog

Fragment added in `docs/changelog/unreleased/`.
