### PR TITLE
fix: bound peer-controlled allocation and validate configured network parameters

### DIFF
--- a/crates/tower-batch-control/src/service.rs
+++ b/crates/tower-batch-control/src/service.rs
@@ -173,10 +173,16 @@ where
 
         // Clamp config to sensible values.
         let max_items_weight_in_batch = max(max_items_weight_in_batch, 1);
-        let max_batches = max_batches
-            .into()
-            .unwrap_or_else(rayon::current_num_threads);
-        let max_batches_in_queue = max_batches.clamp(1, QUEUE_BATCH_LIMIT);
+        // The worker can only run a batch if it is allowed at least one concurrent batch:
+        // with a limit of zero it never reads from `rx`, so every request queued against the
+        // semaphore below waits forever.
+        let max_batches = max(
+            max_batches
+                .into()
+                .unwrap_or_else(rayon::current_num_threads),
+            1,
+        );
+        let max_batches_in_queue = max_batches.min(QUEUE_BATCH_LIMIT);
 
         // The semaphore bound limits the maximum number of concurrent requests
         // (specifically, requests which got a `Ready` from `poll_ready`, but haven't

--- a/crates/tower-batch-control/src/service.rs
+++ b/crates/tower-batch-control/src/service.rs
@@ -174,8 +174,8 @@ where
         // Clamp config to sensible values.
         let max_items_weight_in_batch = max(max_items_weight_in_batch, 1);
         // The worker can only run a batch if it is allowed at least one concurrent batch:
-        // with a limit of zero it never reads from `rx`, so every request queued against the
-        // semaphore below waits forever.
+        // with a limit of zero, every branch of the worker's `select!` is disabled, so the
+        // worker panics on its first poll and fails every request with `Closed`.
         let max_batches = max(
             max_batches
                 .into()

--- a/crates/tower-batch-control/src/worker.rs
+++ b/crates/tower-batch-control/src/worker.rs
@@ -149,7 +149,16 @@ where
                 // Floor each item at weight 1 so `pending_items_weight == 0` always
                 // means "no queued items": a zero-weight item must still start the
                 // batch timer and be flushed. See `RequestWeight::request_weight`.
-                self.pending_items_weight += req.request_weight().max(1);
+                //
+                // Saturate rather than wrap on overflow: `RequestWeight` is a public
+                // trait, so a weight large enough to wrap the counter back to zero
+                // would make `flush_service()` skip the flush for items the inner
+                // service has already been given, stranding their response futures.
+                // Saturating keeps the counter above `max_items_weight_in_batch`, so
+                // the run loop flushes the batch instead.
+                self.pending_items_weight = self
+                    .pending_items_weight
+                    .saturating_add(req.request_weight().max(1));
                 let rsp = svc.call(req.into());
                 let _ = tx.send(Ok(rsp));
             }

--- a/crates/tower-batch-control/tests/worker.rs
+++ b/crates/tower-batch-control/tests/worker.rs
@@ -337,3 +337,94 @@ async fn poll_ready_after_worker_panic_does_not_poison_the_handle_mutex() {
         "clones should return the worker error, got: {cloned_error:?}",
     );
 }
+
+#[tokio::test]
+async fn zero_max_batches_still_runs_batches() {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    let (service, mut handle) = mock::pair::<BatchControl<()>, ()>();
+    // A limit of zero concurrent batches must be clamped to one: otherwise every branch of
+    // the worker's `select!` is disabled, so the worker panics on its first poll and fails
+    // every request with `Closed`.
+    let (mut service, worker) = Batch::pair(service, 1, 0, Duration::from_secs(1000));
+    tokio::spawn(worker.run());
+
+    handle.allow(2);
+    service.ready().await.unwrap();
+    let response = service.call(());
+
+    let (request, send_item) = timeout(Duration::from_secs(5), handle.next_request())
+        .await
+        .expect("item should reach the inner service")
+        .expect("inner service should stay open");
+    assert!(matches!(request, BatchControl::Item(())));
+    send_item.send_response(());
+
+    let (request, send_flush) = timeout(Duration::from_secs(5), handle.next_request())
+        .await
+        .expect("flush should reach the inner service")
+        .expect("inner service should stay open");
+    assert!(matches!(request, BatchControl::Flush));
+    send_flush.send_response(());
+
+    timeout(Duration::from_secs(5), response)
+        .await
+        .expect("item response should complete")
+        .expect("item should verify");
+}
+
+#[tokio::test]
+async fn overflowing_request_weight_still_flushes() {
+    use tokio::time::timeout;
+    let _init_guard = zakura_test::init();
+
+    #[derive(Debug)]
+    struct WeightedItem(usize);
+
+    impl RequestWeight for WeightedItem {
+        fn request_weight(&self) -> usize {
+            self.0
+        }
+    }
+
+    let (service, mut handle) = mock::pair::<BatchControl<WeightedItem>, ()>();
+    // A long latency, so only the item weights can flush this batch.
+    let (mut service, worker) = Batch::pair(service, 100, 1, Duration::from_secs(1000));
+    tokio::spawn(worker.run());
+
+    handle.allow(3);
+    service.ready().await.unwrap();
+    let light_response = service.call(WeightedItem(1));
+
+    // The weight of these two items sums to zero if the counter wraps. A wrapped counter
+    // means "no queued items", so the worker would skip the flush for items the inner
+    // service has already been given, and neither response would ever complete.
+    service.ready().await.unwrap();
+    let heavy_response = service.call(WeightedItem(usize::MAX));
+
+    for _ in 0..2 {
+        let (request, send_item) = timeout(Duration::from_secs(5), handle.next_request())
+            .await
+            .expect("item should reach the inner service")
+            .expect("inner service should stay open");
+        assert!(matches!(request, BatchControl::Item(_)));
+        send_item.send_response(());
+    }
+
+    let (request, send_flush) = timeout(Duration::from_secs(5), handle.next_request())
+        .await
+        .expect("flush should reach the inner service")
+        .expect("inner service should stay open");
+    assert!(matches!(request, BatchControl::Flush));
+    send_flush.send_response(());
+
+    timeout(Duration::from_secs(5), light_response)
+        .await
+        .expect("light item response should complete")
+        .expect("light item should verify");
+    timeout(Duration::from_secs(5), heavy_response)
+        .await
+        .expect("heavy item response should complete")
+        .expect("heavy item should verify");
+}

--- a/crates/zakura-chain/src/parameters/network/error.rs
+++ b/crates/zakura-chain/src/parameters/network/error.rs
@@ -108,4 +108,15 @@ pub enum ParametersBuilderError {
     )]
     #[non_exhaustive]
     IndivisibleFoundersReward { slow_start_interval: Height },
+
+    #[error("lockbox disbursement address {address} must parse as a transparent address: {err}")]
+    #[non_exhaustive]
+    InvalidLockboxDisbursementAddress { address: String, err: String },
+
+    #[error(
+        "lockbox disbursement address {address} must be a P2SH address, because the lockbox \
+         disbursement consensus rule only accepts P2SH outputs"
+    )]
+    #[non_exhaustive]
+    LockboxDisbursementAddressNotP2SH { address: String },
 }

--- a/crates/zakura-chain/src/parameters/network/error.rs
+++ b/crates/zakura-chain/src/parameters/network/error.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+use crate::{block::Height, parameters::subsidy::FundingStreamReceiver};
+
 /// An error that can occur when building `Parameters` using `ParametersBuilder`.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum ParametersBuilderError {
@@ -88,4 +90,22 @@ pub enum ParametersBuilderError {
     )]
     #[non_exhaustive]
     InsufficientCheckpointCoverage,
+
+    #[error(
+        "funding stream address {address} for receiver {receiver:?} must be a P2SH address, \
+         because the funding stream consensus rule only accepts P2SH outputs"
+    )]
+    #[non_exhaustive]
+    FundingStreamAddressNotP2SH {
+        receiver: FundingStreamReceiver,
+        address: String,
+    },
+
+    #[error(
+        "slow start interval {slow_start_interval:?} must divide the block subsidy limit into \
+         a rate that is a multiple of five, because the founders reward is an exact fifth of \
+         the block subsidy"
+    )]
+    #[non_exhaustive]
+    IndivisibleFoundersReward { slow_start_interval: Height },
 }

--- a/crates/zakura-chain/src/parameters/network/error.rs
+++ b/crates/zakura-chain/src/parameters/network/error.rs
@@ -119,4 +119,11 @@ pub enum ParametersBuilderError {
     )]
     #[non_exhaustive]
     LockboxDisbursementAddressNotP2SH { address: String },
+
+    #[error(
+        "the configured lockbox disbursement amounts must sum to a valid amount, because the \
+         deferred pool balance is calculated from their total"
+    )]
+    #[non_exhaustive]
+    InvalidLockboxDisbursementTotal,
 }

--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -1,6 +1,10 @@
 //! Types and implementation for Testnet consensus parameters
 
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 
 use crate::{
     amount::{Amount, NonNegative},
@@ -15,10 +19,10 @@ use crate::{
             constants::testnet,
             constants::{
                 BLOSSOM_POW_TARGET_SPACING_RATIO, FUNDING_STREAM_RECEIVER_DENOMINATOR,
-                POST_BLOSSOM_HALVING_INTERVAL, PRE_BLOSSOM_HALVING_INTERVAL,
+                MAX_BLOCK_SUBSIDY, POST_BLOSSOM_HALVING_INTERVAL, PRE_BLOSSOM_HALVING_INTERVAL,
             },
             funding_stream_address_period, FundingStreamReceiver, FundingStreamRecipient,
-            FundingStreams,
+            FundingStreams, ParameterSubsidy,
         },
         Network, NetworkKind, NetworkUpgrade,
     },
@@ -229,6 +233,19 @@ impl ConfiguredFundingStreams {
         let recipients = self
             .recipients
             .map(|recipients| {
+                // Recipients are keyed by receiver, so a repeated receiver would silently
+                // replace the earlier entry, and the numerator check below would only see
+                // the last one. Reject the ambiguous configuration instead.
+                let mut seen_receivers = HashSet::new();
+                for recipient in &recipients {
+                    assert!(
+                        seen_receivers.insert(recipient.receiver),
+                        "funding stream receiver {:?} must not be configured more than once \
+                         in the same funding stream",
+                        recipient.receiver
+                    );
+                }
+
                 recipients
                     .into_iter()
                     .map(ConfiguredFundingStreamRecipient::into_recipient)
@@ -250,12 +267,17 @@ impl ConfiguredFundingStreams {
         let funding_streams = FundingStreams::new(height_range.clone(), recipients);
 
         // check that sum of receiver numerators is valid.
-
+        //
+        // The numerators are operator-supplied, so sum them with checked arithmetic: a
+        // wrapping sum can land back inside the valid range, and the check below would
+        // then accept numerators that make every block subsidy calculation fail.
         let sum_numerators: u64 = funding_streams
             .recipients()
             .values()
-            .map(|r| r.numerator())
-            .sum();
+            .try_fold(0u64, |sum, recipient| {
+                sum.checked_add(recipient.numerator())
+            })
+            .expect("sum of funding stream numerators must not overflow");
 
         assert!(
             sum_numerators <= FUNDING_STREAM_RECEIVER_DENOMINATOR,
@@ -334,6 +356,79 @@ fn check_funding_stream_address_period(funding_streams: &FundingStreams, network
             );
         }
     }
+}
+
+/// Checks that every funding stream recipient address in the provided [`FundingStreams`]
+/// is a P2SH address.
+///
+/// The funding stream consensus rule only accepts P2SH outputs, so block validation
+/// panics when an expected funding stream address is any other type. Rejecting those
+/// addresses here surfaces the problem when the network is configured, rather than at
+/// the activation height of the stream.
+fn check_funding_stream_address_types(
+    funding_streams: &FundingStreams,
+) -> Result<(), ParametersBuilderError> {
+    for (&receiver, recipient) in funding_streams.recipients() {
+        if receiver == FundingStreamReceiver::Deferred {
+            // The `Deferred` receiver has no addresses, and pays no outputs.
+            continue;
+        }
+
+        for address in recipient.addresses() {
+            if !address.is_script_hash() {
+                return Err(ParametersBuilderError::FundingStreamAddressNotP2SH {
+                    receiver,
+                    address: address.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// The divisor used to calculate the founders reward from the block subsidy.
+///
+/// The founders reward is 20% of the block subsidy, calculated with exact division.
+const FOUNDERS_REWARD_DIVISOR: u64 = 5;
+
+/// Checks that the founders reward is an exact fifth of the block subsidy at every height
+/// that pays it.
+///
+/// `founders_reward()` divides the block subsidy by five and panics on a remainder, and the
+/// slow start rate is the block subsidy limit divided by the configured slow start interval,
+/// truncated. An interval that leaves a remainder modulo five therefore crashes block
+/// validation at the first block that pays a founders reward.
+fn check_founders_reward_is_exact(network: &Network) -> Result<(), ParametersBuilderError> {
+    let slow_start_interval = network.slow_start_interval();
+
+    // The founders reward is paid below both the first halving and Canopy, and the genesis
+    // block does not pay one. If either boundary is at or below the first block, or the slow
+    // start ends there, no block uses a slow start subsidy to pay a founders reward.
+    let canopy_height = NetworkUpgrade::Canopy
+        .activation_height(network)
+        .unwrap_or(Height::MAX);
+    if slow_start_interval <= Height(1)
+        || canopy_height <= Height(1)
+        || network.height_for_first_halving() <= Height(1)
+    {
+        return Ok(());
+    }
+
+    // Every slow start subsidy is a multiple of this rate, and the first block pays exactly
+    // one or two of them, so the rate itself must divide evenly by five.
+    //
+    // Subsidies above the slow start interval are the block subsidy limit, optionally divided
+    // by the Blossom spacing ratio, and both of those constants divide evenly by five.
+    let slow_start_rate = MAX_BLOCK_SUBSIDY / u64::from(slow_start_interval);
+
+    if !slow_start_rate.is_multiple_of(FOUNDERS_REWARD_DIVISOR) {
+        return Err(ParametersBuilderError::IndivisibleFoundersReward {
+            slow_start_interval,
+        });
+    }
+
+    Ok(())
 }
 
 /// Configurable activation heights for Regtest and configured Testnets.
@@ -909,7 +1004,10 @@ impl ParametersBuilder {
         for fs in &self.funding_streams {
             // Check that the funding streams are valid for the configured Testnet parameters.
             check_funding_stream_address_period(fs, &network);
+            check_funding_stream_address_types(fs)?;
         }
+
+        check_founders_reward_is_exact(&network)?;
 
         // Final check that the configured checkpoints are valid for this network.
         if network.checkpoint_list().hash(Height(0)) != Some(network.genesis_hash()) {
@@ -1081,6 +1179,12 @@ impl Parameters {
 
         if Some(true) == extend_funding_stream_addresses_as_required {
             parameters = parameters.extend_funding_streams();
+        }
+
+        // Regtest does not run the `to_network()` checks, so check the address types here:
+        // block validation panics on a funding stream address that is not P2SH.
+        for funding_stream in &parameters.funding_streams {
+            check_funding_stream_address_types(funding_stream)?;
         }
 
         Ok(Self {

--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -388,18 +388,24 @@ fn check_funding_stream_address_types(
     Ok(())
 }
 
-/// Checks that every configured NU6.1 one-time lockbox disbursement address parses and is a
-/// P2SH address.
+/// Checks that every configured NU6.1 one-time lockbox disbursement can be paid: each address
+/// parses and is a P2SH address, and the amounts sum to a valid amount.
 ///
 /// [`Parameters::lockbox_disbursements()`] parses these addresses with an `expect`, and the
 /// disbursement consensus rule only accepts P2SH outputs, so an address that does not parse
-/// or is not P2SH crashes block validation at the NU6.1 activation height. Rejecting those
-/// addresses here surfaces the problem when the network is configured, rather than at that
-/// activation height.
-fn check_lockbox_disbursement_addresses(
+/// or is not P2SH crashes block validation at the NU6.1 activation height.
+/// [`Parameters::lockbox_disbursement_total_amount()`] sums the amounts with an `expect`, so
+/// a total above the money supply crashes the deferred pool balance calculation. Checking
+/// both here surfaces the problem when the network is configured.
+///
+/// The address network kind is deliberately not checked: a P2SH script is the address hash
+/// alone, so a Mainnet P2SH address and a Testnet one with the same hash pay the same script.
+fn check_lockbox_disbursements(
     lockbox_disbursements: &[(String, Amount<NonNegative>)],
 ) -> Result<(), ParametersBuilderError> {
-    for (address, _amount) in lockbox_disbursements {
+    let mut total = Amount::<NonNegative>::zero();
+
+    for (address, amount) in lockbox_disbursements {
         let parsed: transparent::Address = address.parse().map_err(|err: SerializationError| {
             ParametersBuilderError::InvalidLockboxDisbursementAddress {
                 address: address.clone(),
@@ -412,6 +418,9 @@ fn check_lockbox_disbursement_addresses(
                 address: address.clone(),
             });
         }
+
+        total = (total + *amount)
+            .map_err(|_| ParametersBuilderError::InvalidLockboxDisbursementTotal)?;
     }
 
     Ok(())
@@ -1048,7 +1057,7 @@ impl ParametersBuilder {
         }
 
         check_founders_reward_is_exact(&network)?;
-        check_lockbox_disbursement_addresses(&self.lockbox_disbursements)?;
+        check_lockbox_disbursements(&self.lockbox_disbursements)?;
 
         // Final check that the configured checkpoints are valid for this network.
         if network.checkpoint_list().hash(Height(0)) != Some(network.genesis_hash()) {
@@ -1222,13 +1231,12 @@ impl Parameters {
             parameters = parameters.extend_funding_streams();
         }
 
-        // Regtest does not run the `to_network()` checks, so check the address types here:
-        // block validation panics on a funding stream or lockbox disbursement address that is
-        // not P2SH.
+        // Regtest does not run the `to_network()` checks, so run them here: block validation
+        // panics on a funding stream or lockbox disbursement address that is not P2SH.
         for funding_stream in &parameters.funding_streams {
             check_funding_stream_address_types(funding_stream)?;
         }
-        check_lockbox_disbursement_addresses(&parameters.lockbox_disbursements)?;
+        check_lockbox_disbursements(&parameters.lockbox_disbursements)?;
 
         Ok(Self {
             network_name: "Regtest".to_string(),

--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -26,6 +26,7 @@ use crate::{
         },
         Network, NetworkKind, NetworkUpgrade,
     },
+    serialization::SerializationError,
     transparent,
     work::difficulty::{ExpandedDifficulty, U256},
 };
@@ -387,6 +388,35 @@ fn check_funding_stream_address_types(
     Ok(())
 }
 
+/// Checks that every configured NU6.1 one-time lockbox disbursement address parses and is a
+/// P2SH address.
+///
+/// [`Parameters::lockbox_disbursements()`] parses these addresses with an `expect`, and the
+/// disbursement consensus rule only accepts P2SH outputs, so an address that does not parse
+/// or is not P2SH crashes block validation at the NU6.1 activation height. Rejecting those
+/// addresses here surfaces the problem when the network is configured, rather than at that
+/// activation height.
+fn check_lockbox_disbursement_addresses(
+    lockbox_disbursements: &[(String, Amount<NonNegative>)],
+) -> Result<(), ParametersBuilderError> {
+    for (address, _amount) in lockbox_disbursements {
+        let parsed: transparent::Address = address.parse().map_err(|err: SerializationError| {
+            ParametersBuilderError::InvalidLockboxDisbursementAddress {
+                address: address.clone(),
+                err: err.to_string(),
+            }
+        })?;
+
+        if !parsed.is_script_hash() {
+            return Err(ParametersBuilderError::LockboxDisbursementAddressNotP2SH {
+                address: address.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// The divisor used to calculate the founders reward from the block subsidy.
 ///
 /// The founders reward is 20% of the block subsidy, calculated with exact division.
@@ -408,8 +438,18 @@ fn check_founders_reward_is_exact(network: &Network) -> Result<(), ParametersBui
     let canopy_height = NetworkUpgrade::Canopy
         .activation_height(network)
         .unwrap_or(Height::MAX);
-    if slow_start_interval <= Height(1)
-        || canopy_height <= Height(1)
+    if slow_start_interval <= Height(1) || canopy_height <= Height(1) {
+        return Ok(());
+    }
+
+    // For a configured Testnet, `height_for_first_halving()` derives the height from the
+    // Blossom activation height and panics when the network has none, so check for Blossom
+    // first. `activation_height()` falls back to the next configured upgrade, so Blossom is
+    // only absent when every configured upgrade precedes it, which also leaves Canopy absent.
+    // `mandatory_checkpoint_height()` already panics on such a network later in
+    // `to_network()`, so this guard is unreachable today; it keeps this check from being the
+    // one that panics if that height ever becomes fallible.
+    if NetworkUpgrade::Blossom.activation_height(network).is_none()
         || network.height_for_first_halving() <= Height(1)
     {
         return Ok(());
@@ -1008,6 +1048,7 @@ impl ParametersBuilder {
         }
 
         check_founders_reward_is_exact(&network)?;
+        check_lockbox_disbursement_addresses(&self.lockbox_disbursements)?;
 
         // Final check that the configured checkpoints are valid for this network.
         if network.checkpoint_list().hash(Height(0)) != Some(network.genesis_hash()) {
@@ -1182,10 +1223,12 @@ impl Parameters {
         }
 
         // Regtest does not run the `to_network()` checks, so check the address types here:
-        // block validation panics on a funding stream address that is not P2SH.
+        // block validation panics on a funding stream or lockbox disbursement address that is
+        // not P2SH.
         for funding_stream in &parameters.funding_streams {
             check_funding_stream_address_types(funding_stream)?;
         }
+        check_lockbox_disbursement_addresses(&parameters.lockbox_disbursements)?;
 
         Ok(Self {
             network_name: "Regtest".to_string(),

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -974,6 +974,34 @@ fn check_configured_lockbox_disbursement_addresses_parse() {
     );
 }
 
+/// Checks that configured lockbox disbursement amounts which sum above the money supply are
+/// rejected when the network is configured, rather than panicking when the deferred pool
+/// balance is calculated during sync.
+#[test]
+fn check_configured_lockbox_disbursement_total_is_valid() {
+    // A valid Testnet P2SH address, so the amounts are what fails the check.
+    const TESTNET_P2SH_ADDRESS: &str = "t2RnBRiqrN1nW4ecZs1Fj3WWjNdnSs4kiX8";
+
+    // Two disbursements of the whole money supply cannot be summed into an `Amount`.
+    let max_money = Amount::<NonNegative>::try_from(crate::amount::MAX_MONEY)
+        .expect("the money supply is a valid amount");
+    let disbursement = ConfiguredLockboxDisbursement {
+        address: TESTNET_P2SH_ADDRESS.to_string(),
+        amount: max_money,
+    };
+
+    let error = testnet::Parameters::build()
+        .with_lockbox_disbursements(vec![disbursement.clone(), disbursement])
+        .to_network()
+        .expect_err("an overflowing lockbox disbursement total must be rejected");
+
+    assert_eq!(
+        error,
+        ParametersBuilderError::InvalidLockboxDisbursementTotal,
+        "configuring an overflowing lockbox disbursement total must report it"
+    );
+}
+
 /// Check that `new_regtest()` constructs a network with the provided funding streams.
 #[test]
 fn check_configured_funding_stream_regtest() {

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -962,7 +962,7 @@ fn check_configured_lockbox_disbursement_addresses_parse() {
             amount: Amount::new_from_zec(78_750),
         }])
         .to_network()
-        .expect_err("an unparseable lockbox disbursement address must be rejected");
+        .expect_err("an unparsable lockbox disbursement address must be rejected");
 
     assert!(
         matches!(
@@ -970,7 +970,7 @@ fn check_configured_lockbox_disbursement_addresses_parse() {
             ParametersBuilderError::InvalidLockboxDisbursementAddress { ref address, .. }
                 if address == INVALID_ADDRESS
         ),
-        "configuring an unparseable lockbox disbursement address must report it, got: {error:?}"
+        "configuring an unparsable lockbox disbursement address must report it, got: {error:?}"
     );
 }
 

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -915,6 +915,65 @@ fn check_configured_slow_start_interval_keeps_founders_reward_exact() {
         .expect("the default slow start interval must keep the founders reward exact");
 }
 
+/// Checks that a configured lockbox disbursement address which is not P2SH is rejected when the
+/// network is configured, rather than panicking in block validation at the NU6.1 activation
+/// height.
+#[test]
+fn check_configured_lockbox_disbursement_addresses_are_p2sh() {
+    // A valid Testnet address that is P2PKH instead of P2SH.
+    const TESTNET_P2PKH_ADDRESS: &str = "tmWbBGi7TjExNmLZyMcFpxVh3ZPbGrpbX3H";
+
+    let error = testnet::Parameters::build()
+        .with_lockbox_disbursements(vec![ConfiguredLockboxDisbursement {
+            address: TESTNET_P2PKH_ADDRESS.to_string(),
+            amount: Amount::new_from_zec(78_750),
+        }])
+        .to_network()
+        .expect_err("a P2PKH lockbox disbursement address must be rejected");
+
+    assert_eq!(
+        error,
+        ParametersBuilderError::LockboxDisbursementAddressNotP2SH {
+            address: TESTNET_P2PKH_ADDRESS.to_string(),
+        },
+        "configuring a non-P2SH lockbox disbursement address must report which address is invalid"
+    );
+
+    // Regtest skips the `to_network()` checks, so it must reject the address on its own path.
+    testnet::Parameters::new_regtest(RegtestParameters {
+        lockbox_disbursements: Some(vec![ConfiguredLockboxDisbursement {
+            address: TESTNET_P2PKH_ADDRESS.to_string(),
+            amount: Amount::new_from_zec(78_750),
+        }]),
+        ..Default::default()
+    })
+    .expect_err("a P2PKH lockbox disbursement address must be rejected on Regtest");
+}
+
+/// Checks that a configured lockbox disbursement address which does not parse is rejected when
+/// the network is configured, rather than panicking in the `lockbox_disbursements()` accessor.
+#[test]
+fn check_configured_lockbox_disbursement_addresses_parse() {
+    const INVALID_ADDRESS: &str = "not a transparent address";
+
+    let error = testnet::Parameters::build()
+        .with_lockbox_disbursements(vec![ConfiguredLockboxDisbursement {
+            address: INVALID_ADDRESS.to_string(),
+            amount: Amount::new_from_zec(78_750),
+        }])
+        .to_network()
+        .expect_err("an unparseable lockbox disbursement address must be rejected");
+
+    assert!(
+        matches!(
+            error,
+            ParametersBuilderError::InvalidLockboxDisbursementAddress { ref address, .. }
+                if address == INVALID_ADDRESS
+        ),
+        "configuring an unparseable lockbox disbursement address must report it, got: {error:?}"
+    );
+}
+
 /// Check that `new_regtest()` constructs a network with the provided funding streams.
 #[test]
 fn check_configured_funding_stream_regtest() {

--- a/crates/zakura-chain/src/parameters/network/tests/vectors.rs
+++ b/crates/zakura-chain/src/parameters/network/tests/vectors.rs
@@ -771,6 +771,150 @@ fn check_configured_funding_stream_constraints() {
         .expect_err("should panic when recipient addresses are for Mainnet");
 }
 
+/// Checks that funding stream numerators which sum to a multiple of `2^64` are rejected,
+/// instead of wrapping to a value inside the valid range.
+#[test]
+fn check_configured_funding_stream_numerator_sum_does_not_wrap() {
+    std::panic::set_hook(Box::new(|_| {}));
+
+    // These numerators sum to exactly `2^64`, which wraps to zero.
+    let wrapping_sum = std::panic::catch_unwind(|| {
+        testnet::Parameters::build()
+            .with_funding_streams(vec![ConfiguredFundingStreams {
+                recipients: Some(vec![
+                    ConfiguredFundingStreamRecipient {
+                        receiver: FundingStreamReceiver::Ecc,
+                        numerator: u64::MAX,
+                        addresses: Some(
+                            subsidy::constants::testnet::FUNDING_STREAM_ECC_ADDRESSES
+                                .map(Into::into)
+                                .to_vec(),
+                        ),
+                    },
+                    ConfiguredFundingStreamRecipient {
+                        receiver: FundingStreamReceiver::ZcashFoundation,
+                        numerator: 1,
+                        addresses: Some(
+                            subsidy::constants::testnet::FUNDING_STREAM_ZF_ADDRESSES
+                                .map(Into::into)
+                                .to_vec(),
+                        ),
+                    },
+                ]),
+                ..Default::default()
+            }])
+            .to_network()
+    });
+
+    let _ = std::panic::take_hook();
+
+    let panic = wrapping_sum.expect_err("wrapping numerator sum must be rejected");
+    let message = panic
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| panic.downcast_ref::<&str>().copied())
+        .unwrap_or_default();
+
+    // Without the checked sum, release builds accept the wrapped total, and debug builds
+    // abort with the generic overflow panic instead of this invariant.
+    assert!(
+        message.contains("sum of funding stream numerators must not overflow"),
+        "numerator sum must be checked explicitly, got panic: {message}"
+    );
+}
+
+/// Checks that funding stream recipient addresses which are not P2SH are rejected when the
+/// network is configured, rather than panicking in block validation at the activation height.
+#[test]
+fn check_configured_funding_stream_addresses_are_p2sh() {
+    // A valid Testnet address that is P2PKH instead of P2SH.
+    const TESTNET_P2PKH_ADDRESS: &str = "tmWbBGi7TjExNmLZyMcFpxVh3ZPbGrpbX3H";
+
+    let num_addresses = subsidy::constants::testnet::FUNDING_STREAM_ECC_ADDRESSES.len();
+
+    let error = testnet::Parameters::build()
+        .with_funding_streams(vec![ConfiguredFundingStreams {
+            recipients: Some(vec![ConfiguredFundingStreamRecipient {
+                receiver: FundingStreamReceiver::Ecc,
+                numerator: 10,
+                addresses: Some(vec![TESTNET_P2PKH_ADDRESS.to_string(); num_addresses]),
+            }]),
+            ..Default::default()
+        }])
+        .to_network()
+        .expect_err("P2PKH funding stream addresses must be rejected");
+
+    assert_eq!(
+        error,
+        ParametersBuilderError::FundingStreamAddressNotP2SH {
+            receiver: FundingStreamReceiver::Ecc,
+            address: TESTNET_P2PKH_ADDRESS.to_string(),
+        },
+        "configuring a non-P2SH funding stream address must report which address is invalid"
+    );
+}
+
+/// Checks that a receiver configured twice in the same funding stream is rejected, instead of
+/// the last entry silently replacing the earlier one.
+#[test]
+fn check_configured_funding_stream_receivers_are_unique() {
+    std::panic::set_hook(Box::new(|_| {}));
+
+    let duplicate_receiver = std::panic::catch_unwind(|| {
+        let addresses = subsidy::constants::testnet::FUNDING_STREAM_ECC_ADDRESSES
+            .map(Into::into)
+            .to_vec();
+
+        testnet::Parameters::build().with_funding_streams(vec![ConfiguredFundingStreams {
+            recipients: Some(vec![
+                ConfiguredFundingStreamRecipient {
+                    receiver: FundingStreamReceiver::Ecc,
+                    numerator: 10,
+                    addresses: Some(addresses.clone()),
+                },
+                ConfiguredFundingStreamRecipient {
+                    receiver: FundingStreamReceiver::Ecc,
+                    numerator: 90,
+                    addresses: Some(addresses),
+                },
+            ]),
+            ..Default::default()
+        }])
+    });
+
+    let _ = std::panic::take_hook();
+
+    duplicate_receiver.expect_err("a receiver configured twice must be rejected");
+}
+
+/// Checks that a slow start interval which makes the founders reward inexact is rejected when
+/// the network is configured, rather than panicking in block validation at the first block.
+#[test]
+fn check_configured_slow_start_interval_keeps_founders_reward_exact() {
+    // The block subsidy limit divided by three leaves a remainder modulo five, so the founders
+    // reward for the first block cannot be calculated with exact division.
+    // The funding streams are cleared because the slow start interval also moves the first
+    // halving, which changes how many funding stream addresses the height range needs.
+    let error = testnet::Parameters::build()
+        .with_slow_start_interval(Height(3))
+        .clear_funding_streams()
+        .to_network()
+        .expect_err("an indivisible slow start interval must be rejected");
+
+    assert_eq!(
+        error,
+        ParametersBuilderError::IndivisibleFoundersReward {
+            slow_start_interval: Height(3)
+        },
+        "configuring an indivisible slow start interval must report the interval"
+    );
+
+    // The default interval divides the block subsidy limit into a multiple of five.
+    testnet::Parameters::build()
+        .to_network()
+        .expect("the default slow start interval must keep the founders reward exact");
+}
+
 /// Check that `new_regtest()` constructs a network with the provided funding streams.
 #[test]
 fn check_configured_funding_stream_regtest() {

--- a/crates/zakura-chain/src/serialization/tests/preallocate.rs
+++ b/crates/zakura-chain/src/serialization/tests/preallocate.rs
@@ -5,7 +5,8 @@ use proptest::{collection::size_range, prelude::*};
 use std::matches;
 
 use crate::serialization::{
-    arbitrary::max_allocation_is_big_enough, zcash_deserialize::MAX_U8_ALLOCATION,
+    arbitrary::max_allocation_is_big_enough,
+    zcash_deserialize::{MAX_INITIAL_ALLOCATION, MAX_U8_ALLOCATION},
     CompactSizeMessage, SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize,
     MAX_PROTOCOL_MESSAGE_LEN,
 };
@@ -121,19 +122,26 @@ impl std::io::Read for TruncatedReader {
 /// Confirm that a short message declaring a near-maximal byte vector length does not
 /// make the deserializer allocate that length before the bytes arrive.
 ///
-/// `read_exact()` is handed the uninitialised tail of the output buffer, so the largest
-/// buffer the reader sees is the largest amount the deserializer has allocated. A peer
-/// that declares `MAX_U8_ALLOCATION` bytes and then ends the message used to force a
-/// two megabyte allocation from a few hundred bytes of input, which is the byte vector
-/// case of GHSA-xr93-pcq3-pxf8.
+/// `read_exact()` is handed the tail of the output buffer that the deserializer has
+/// grown so far, so the largest buffer the reader sees tracks how much the deserializer
+/// allocates as it goes. A peer that declares `MAX_U8_ALLOCATION` bytes and then ends
+/// the message used to force a two megabyte allocation from a few hundred bytes of
+/// input, which is the byte vector case of GHSA-xr93-pcq3-pxf8.
+///
+/// This proxy has one blind spot: it can not see a `Vec::with_capacity(external_count)`
+/// that is followed by chunked reads, because that reserves the full length while still
+/// handing the reader small buffers. Safe Rust can not observe the capacity from the
+/// reader side, and a counting global allocator needs `unsafe`, which this workspace
+/// denies. So the deserializer carries a matching comment telling the reader never to
+/// pre-reserve the declared length.
 fn u8_deser_does_not_preallocate_declared_length() {
     /// The number of body bytes the peer actually sends.
     const SUPPLIED_LEN: usize = 512;
 
     /// The largest buffer the deserializer may hand to the reader. The chunked read grows
-    /// the buffer in `MAX_INITIAL_ALLOCATION` steps, so this bound is far below
-    /// `MAX_U8_ALLOCATION` but leaves room to retune the chunk size.
-    const MAX_ALLOWED_READ_LEN: usize = 64 * 1024;
+    /// the buffer in `MAX_INITIAL_ALLOCATION` steps, so one chunk is the exact maximum;
+    /// the factor of two leaves room to retune the chunk size without editing this test.
+    const MAX_ALLOWED_READ_LEN: usize = 2 * MAX_INITIAL_ALLOCATION;
 
     // A CompactSize length prefix for `MAX_U8_ALLOCATION`, followed by a truncated body.
     let mut serialized = Vec::new();

--- a/crates/zakura-chain/src/serialization/tests/preallocate.rs
+++ b/crates/zakura-chain/src/serialization/tests/preallocate.rs
@@ -6,7 +6,7 @@ use std::matches;
 
 use crate::serialization::{
     arbitrary::max_allocation_is_big_enough, zcash_deserialize::MAX_U8_ALLOCATION,
-    SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize,
+    CompactSizeMessage, SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize,
     MAX_PROTOCOL_MESSAGE_LEN,
 };
 
@@ -93,4 +93,75 @@ fn u8_max_allocation_is_correct() {
     assert_eq!(largest_allowed_vec_len, MAX_U8_ALLOCATION);
     // Check that our largest_allowed_vec is the size of a maximal protocol message
     assert_eq!(largest_allowed_serialized_len, MAX_PROTOCOL_MESSAGE_LEN);
+}
+
+/// A reader that supplies `remaining` zero bytes, then reports end of file,
+/// and records the largest buffer it was asked to fill.
+struct TruncatedReader {
+    /// The number of bytes left to supply.
+    remaining: usize,
+
+    /// The largest `read()` buffer seen so far.
+    max_read_len: usize,
+}
+
+impl std::io::Read for TruncatedReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.max_read_len = self.max_read_len.max(buf.len());
+
+        let len = buf.len().min(self.remaining);
+        buf[..len].fill(0);
+        self.remaining -= len;
+
+        Ok(len)
+    }
+}
+
+#[test]
+/// Confirm that a short message declaring a near-maximal byte vector length does not
+/// make the deserializer allocate that length before the bytes arrive.
+///
+/// `read_exact()` is handed the uninitialised tail of the output buffer, so the largest
+/// buffer the reader sees is the largest amount the deserializer has allocated. A peer
+/// that declares `MAX_U8_ALLOCATION` bytes and then ends the message used to force a
+/// two megabyte allocation from a few hundred bytes of input, which is the byte vector
+/// case of GHSA-xr93-pcq3-pxf8.
+fn u8_deser_does_not_preallocate_declared_length() {
+    /// The number of body bytes the peer actually sends.
+    const SUPPLIED_LEN: usize = 512;
+
+    /// The largest buffer the deserializer may hand to the reader. The chunked read grows
+    /// the buffer in `MAX_INITIAL_ALLOCATION` steps, so this bound is far below
+    /// `MAX_U8_ALLOCATION` but leaves room to retune the chunk size.
+    const MAX_ALLOWED_READ_LEN: usize = 64 * 1024;
+
+    // A CompactSize length prefix for `MAX_U8_ALLOCATION`, followed by a truncated body.
+    let mut serialized = Vec::new();
+    CompactSizeMessage::try_from(MAX_U8_ALLOCATION)
+        .expect("MAX_U8_ALLOCATION is a valid CompactSize")
+        .zcash_serialize(&mut serialized)
+        .expect("serialization to vec must succeed");
+
+    let mut reader = std::io::Read::chain(
+        std::io::Cursor::new(serialized),
+        TruncatedReader {
+            remaining: SUPPLIED_LEN,
+            max_read_len: 0,
+        },
+    );
+
+    let deserialized = <Vec<u8>>::zcash_deserialize(&mut reader);
+
+    // The message ends before the declared length, so it must be rejected.
+    assert!(
+        matches!(&deserialized, Err(SerializationError::Io(error)) if error.kind() == std::io::ErrorKind::UnexpectedEof),
+        "truncated byte vector must be rejected with UnexpectedEof, got: {deserialized:?}"
+    );
+
+    let max_read_len = reader.into_inner().1.max_read_len;
+    assert!(
+        max_read_len <= MAX_ALLOWED_READ_LEN,
+        "a {SUPPLIED_LEN} byte message declaring {MAX_U8_ALLOCATION} bytes allocated a \
+         {max_read_len} byte buffer, which is above the {MAX_ALLOWED_READ_LEN} byte limit"
+    );
 }

--- a/crates/zakura-chain/src/serialization/zcash_deserialize.rs
+++ b/crates/zakura-chain/src/serialization/zcash_deserialize.rs
@@ -8,7 +8,7 @@ use super::{AtLeastOne, CompactSizeMessage, SerializationError, MAX_PROTOCOL_MES
 ///
 /// 1024 is large enough that honest messages amortize their growth to a few
 /// reallocations.
-const MAX_INITIAL_ALLOCATION: usize = 1024;
+pub(crate) const MAX_INITIAL_ALLOCATION: usize = 1024;
 
 /// Consensus-critical deserialization for Zcash.
 ///
@@ -50,7 +50,8 @@ impl<T: ZcashDeserialize + TrustedPreallocate> ZcashDeserialize for AtLeastOne<T
 
 /// Implement ZcashDeserialize for `Vec<u8>` directly instead of using the blanket Vec implementation
 ///
-/// This allows us to optimize the inner loop into a single call to `read_exact()`
+/// This allows us to optimize the inner loop into a small number of `read_exact()`
+/// calls, rather than one call per byte.
 /// Note that we don't implement TrustedPreallocate for u8.
 /// This allows the optimization without relying on specialization.
 impl ZcashDeserialize for Vec<u8> {
@@ -131,9 +132,15 @@ pub fn zcash_deserialize_bytes_external_count<R: io::Read>(
     // Grow the buffer as the bytes arrive, rather than reserving `external_count`
     // up front. A peer can declare a length near `MAX_U8_ALLOCATION` in a message
     // that ends after a few hundred bytes, so an upfront reservation lets a small
-    // message force a multi-megabyte allocation. This bounds the allocation to the
-    // bytes the peer actually sends, plus one chunk. Fixes the byte-vector case of
+    // message force a multi-megabyte allocation. `resize()` below grows the capacity
+    // by doubling, so this bounds the allocation to about twice the bytes the peer
+    // actually sends, matching the `Vec<T>` path. Fixes the byte-vector case of
     // GHSA-xr93-pcq3-pxf8.
+    //
+    // Never reserve `external_count` here, even as an optimisation to avoid the
+    // reallocations: that reintroduces the vulnerability, and
+    // `u8_deser_does_not_preallocate_declared_length` can not catch it, because it
+    // observes the read buffer size rather than the capacity.
     let mut vec = Vec::with_capacity(external_count.min(MAX_INITIAL_ALLOCATION));
 
     while vec.len() < external_count {
@@ -152,7 +159,8 @@ pub fn zcash_deserialize_bytes_external_count<R: io::Read>(
 /// `zcash_deserialize_external_count`, specialised for [`String`].
 /// The external count is in bytes. (Not UTF-8 characters.)
 ///
-/// This allows us to optimize the inner loop into a single call to `read_exact()`.
+/// This allows us to optimize the inner loop into a small number of `read_exact()`
+/// calls, rather than one call per byte.
 ///
 /// This function has a `zcash_` prefix to alert the reader that the
 /// serialization in use is consensus-critical serialization, rather than

--- a/crates/zakura-chain/src/serialization/zcash_deserialize.rs
+++ b/crates/zakura-chain/src/serialization/zcash_deserialize.rs
@@ -112,7 +112,8 @@ pub fn zcash_deserialize_external_count<R: io::Read, T: ZcashDeserialize + Trust
 
 /// `zcash_deserialize_external_count`, specialised for raw bytes.
 ///
-/// This allows us to optimize the inner loop into a single call to `read_exact()`.
+/// This reads in chunks, so the inner loop is a small number of `read_exact()`
+/// calls rather than one call per byte.
 ///
 /// This function has a `zcash_` prefix to alert the reader that the
 /// serialization in use is consensus-critical serialization, rather than
@@ -126,8 +127,25 @@ pub fn zcash_deserialize_bytes_external_count<R: io::Read>(
             "Byte vector longer than MAX_U8_ALLOCATION",
         ));
     }
-    let mut vec = vec![0u8; external_count];
-    reader.read_exact(&mut vec)?;
+
+    // Grow the buffer as the bytes arrive, rather than reserving `external_count`
+    // up front. A peer can declare a length near `MAX_U8_ALLOCATION` in a message
+    // that ends after a few hundred bytes, so an upfront reservation lets a small
+    // message force a multi-megabyte allocation. This bounds the allocation to the
+    // bytes the peer actually sends, plus one chunk. Fixes the byte-vector case of
+    // GHSA-xr93-pcq3-pxf8.
+    let mut vec = Vec::with_capacity(external_count.min(MAX_INITIAL_ALLOCATION));
+
+    while vec.len() < external_count {
+        let chunk_end = (vec.len() + MAX_INITIAL_ALLOCATION).min(external_count);
+        let chunk_start = vec.len();
+
+        vec.resize(chunk_end, 0);
+        // Returns `UnexpectedEof` if the reader runs out before `external_count`,
+        // which is the same error the single `read_exact()` call used to return.
+        reader.read_exact(&mut vec[chunk_start..])?;
+    }
+
     Ok(vec)
 }
 

--- a/docs/changelog/unreleased/729.md
+++ b/docs/changelog/unreleased/729.md
@@ -10,7 +10,8 @@
 - Rejected configured network parameters that made block validation panic at a later height:
   funding stream numerators that overflow, a receiver configured twice in one funding stream,
   funding stream addresses that are not P2SH, lockbox disbursement addresses that do not parse
-  or are not P2SH, and slow start intervals that make the founders reward inexact
+  or are not P2SH, lockbox disbursement amounts that do not sum to a valid amount, and slow
+  start intervals that make the founders reward inexact
   ([#729](https://github.com/zakura-core/zakura/pull/729)).
 - Clamped the batch verifier's concurrent batch limit to at least one, so the batch worker can
   no longer be built in a state where it panics on its first poll and fails every request, and

--- a/docs/changelog/unreleased/729.md
+++ b/docs/changelog/unreleased/729.md
@@ -1,0 +1,18 @@
+## Security
+
+- Bounded the allocation for a peer-declared byte vector length, so a short message that
+  declares a near-maximal length no longer forces a multi-megabyte allocation before the
+  message is rejected
+  ([#729](https://github.com/zakura-core/zakura/pull/729)).
+
+## Fixed
+
+- Rejected configured network parameters that made block validation panic at a later height:
+  funding stream numerators that overflow, a receiver configured twice in one funding stream,
+  funding stream addresses that are not P2SH, and slow start intervals that make the founders
+  reward inexact
+  ([#729](https://github.com/zakura-core/zakura/pull/729)).
+- Clamped the batch verifier's concurrent batch limit to at least one, and saturated request
+  weight accumulation, so a batch service can no longer be built with a worker that never runs
+  or strand its callers' responses
+  ([#729](https://github.com/zakura-core/zakura/pull/729)).

--- a/docs/changelog/unreleased/729.md
+++ b/docs/changelog/unreleased/729.md
@@ -9,10 +9,11 @@
 
 - Rejected configured network parameters that made block validation panic at a later height:
   funding stream numerators that overflow, a receiver configured twice in one funding stream,
-  funding stream addresses that are not P2SH, and slow start intervals that make the founders
-  reward inexact
+  funding stream addresses that are not P2SH, lockbox disbursement addresses that do not parse
+  or are not P2SH, and slow start intervals that make the founders reward inexact
   ([#729](https://github.com/zakura-core/zakura/pull/729)).
-- Clamped the batch verifier's concurrent batch limit to at least one, and saturated request
-  weight accumulation, so a batch service can no longer be built with a worker that never runs
-  or strand its callers' responses
+- Clamped the batch verifier's concurrent batch limit to at least one, so the batch worker can
+  no longer be built in a state where it panics on its first poll and fails every request, and
+  saturated request weight accumulation so an overflowing weight can no longer strand its
+  callers' responses
   ([#729](https://github.com/zakura-core/zakura/pull/729)).


### PR DESCRIPTION
## Motivation

Fixes the medium severity V12 audit findings that either reach Mainnet or are cheap to close
where they are configured. Each one lets an accepted input reach code that assumes the input
was already validated.

The only Mainnet-reachable finding is the byte vector allocation:
`zcash_deserialize_bytes_external_count` allocated and zeroed the peer-declared length before
`read_exact` could discover that the message ended early. A transaction prefix of a few hundred
bytes can declare about two megabytes of Orchard or Ironwood proof, so mass connections amplify
sub-kilobyte messages into repeated multi-megabyte allocations. This is the byte vector case of
GHSA-xr93-pcq3-pxf8, which was already fixed for the generic `Vec<T>` path.

The remaining findings are reachable through operator configuration rather than the network,
but each one turns a configuration mistake into a panic in consensus code at a specific block
height, rather than an error at startup.

## Solution

**Untrusted allocation** (`zakura-chain`): read byte vectors in chunks, so the buffer only
grows as the peer actually delivers data. The error on a truncated message is unchanged.

**Batch control** (`tower-batch-control`):

- `Batch::pair` clamped `max_batches` to at least one for the semaphore but passed the raw
  value to the worker. With zero, the worker's `select!` has no enabled branch, so it panics
  and never reads its request channel, while the semaphore still reports capacity. Apply the
  same floor to both.
- `Worker::process_req` accumulated caller-supplied request weights with an unchecked `+=`,
  while using zero as the "no queued items" sentinel. A wrapped sum made `flush_service` skip
  the flush for items already handed to the inner service, stranding their response futures;
  overflow-checked builds panicked the shared worker instead. `RequestWeight` is public, so
  this crate does not bound the weight. Accumulate with `saturating_add`, which keeps the
  counter above the flush threshold.

**Configured network parameters** (`zakura-chain`):

- Sum recipient numerators with checked arithmetic. A set of numerators summing to a multiple
  of 2^64 wrapped back under the denominator, passed the guard, and then failed subsidy
  validation for every affected block. Release and debug builds now agree.
- Reject a receiver configured twice in one funding stream. Recipients are collected into a
  map keyed by receiver, so the later entry silently replaced the earlier one before the
  numerator check ran.
- Reject funding stream addresses that are not P2SH, for configured Testnets and Regtest. The
  funding stream consensus rule only accepts P2SH outputs and block validation asserts it, so
  a valid Testnet P2PKH address panicked every node at the stream's activation height.
- Reject slow start intervals that make the founders reward inexact. `founders_reward` divides
  the block subsidy by five with `div_exact`, which panics on a remainder, and the slow start
  rate truncates the block subsidy limit. An interval of three crashes validation at the first
  block that pays a founders reward. The check only applies when a block can actually pay a
  slow start founders reward, so the `Height::MIN` intervals used by Regtest, `local_genesis`,
  and the acceptance tests still build.

## Testing

`cargo test -p zakura-chain -p zakura-tower-batch-control -p zakura-consensus -p zakura-network`,
`cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`.

Every fix has a regression test that fails on `main`, verified by reverting each fix in place:

- `u8_deser_does_not_preallocate_declared_length` declares the maximum length, supplies 512
  bytes, and asserts the largest buffer handed to the reader. `read_exact` receives the
  uninitialised tail of the output buffer, so that buffer is the deserializer's allocation:
  2,097,147 bytes before the fix, at most one chunk after it.
- `zero_max_batches_still_runs_batches` and `overflowing_request_weight_still_flushes` assert
  that the item and its flush both reach the inner service and the response completes. Both
  panic the worker without the fixes.
- `check_configured_funding_stream_numerator_sum_does_not_wrap` asserts the explicit invariant
  panic, which distinguishes the checked sum from the generic debug-build overflow panic and
  from release builds accepting the wrapped total.
- `check_configured_funding_stream_receivers_are_unique`,
  `check_configured_funding_stream_addresses_are_p2sh`, and
  `check_configured_slow_start_interval_keeps_founders_reward_exact` cover the parameter
  checks, the last one also asserting that the default parameters still build.

## Follow-up Work

Three findings from the same set are deferred, because they have no Mainnet effect and each
needs a decision rather than a guard:

- **Regtest skips `to_network()`**, and `Network::new_regtest` unwraps the remaining fallible
  construction. Running the full check on Regtest adds mandatory-checkpoint coverage, which
  every existing Regtest config would have to satisfy, and making the wrapper fallible touches
  105 call sites. This PR closes the reachable part by checking funding stream address types in
  `Parameters::new_regtest`.
- **Overlapping funding stream height ranges** silently shadow later streams. Rejecting them
  breaks configurations this repository already treats as valid: the existing
  `check_configured_funding_stream_constraints` test builds a second stream inside the default
  first stream's range. Implemented and reverted here; it needs a decision about which stream
  wins.
- **`verify_supplied_roots_from_parts` preconditions** are documented but not enforced. Current
  VCT callers build height and hash bound direct-successor windows and check tree placement, so
  no peer-supplied shape reaches the panic-based history tree assertion. Enforcing the
  preconditions inside the function is a design change to a verification boundary that has
  active parallel work.
