### PR TITLE
fix(state): seek past evicted epochs when trimming finality history

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -1251,17 +1251,33 @@ impl DiskDb {
             .map(|entry| entry.map(|(key, value)| (key.to_vec(), value.to_vec())))
     }
 
-    /// Read at most `limit` raw rows from the start of one column family.
-    pub(crate) fn raw_prefix_cf<C>(
+    /// Read at most `limit` raw rows at or after `lower` from one column family.
+    ///
+    /// # Performance
+    ///
+    /// This seeks straight to `lower` instead of walking from the start of the key space, so
+    /// deleted keys below `lower` never reach the iterator. A caller that evicts from the low
+    /// end of a column family must bound the read this way: every eviction leaves a tombstone
+    /// at the start of the key space, and a small column family never grows enough to trigger
+    /// the compaction that would collect them, so reading from the start there costs one
+    /// iterator step per eviction ever performed.
+    pub(crate) fn raw_prefix_cf_from<C>(
         &self,
         cf: &C,
+        lower: &[u8],
         limit: usize,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, rocksdb::Error>
     where
         C: rocksdb::AsColumnFamilyRef,
     {
+        let mut options = ReadOptions::default();
+        options.set_iterate_lower_bound(lower.to_vec());
         self.db
-            .iterator_cf(cf, rocksdb::IteratorMode::Start)
+            .iterator_cf_opt(
+                cf,
+                options,
+                rocksdb::IteratorMode::From(lower, rocksdb::Direction::Forward),
+            )
             .take(limit)
             .map(|entry| entry.map(|(key, value)| (key.to_vec(), value.to_vec())))
             .collect()

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -4291,9 +4291,25 @@ impl HeaderChainStore {
                     ));
                 }
                 let history_cf = self.cf(HEADER_FINALITY_HISTORY)?;
-                let prefix = self
-                    .db
-                    .raw_prefix_cf(&history_cf, eviction_count.saturating_add(1))?;
+                // The published checkpoint names the last epoch a previous eviction removed, so
+                // every epoch at or below it is already deleted and the oldest surviving record
+                // sits above it. Seeking from there keeps eviction independent of how many
+                // evictions preceded it. Starting at the beginning of the column family instead
+                // would step over the tombstone left by every previous eviction: the retained
+                // window is a few MB, far too small to trigger the compaction that collects
+                // them, so that cost grows without bound and eventually dominates every block
+                // commit.
+                let retained_low = self
+                    .get_value::<FinalityHistoryCheckpoint>(
+                        HEADER_ENGINE_META,
+                        FINALITY_HISTORY_CHECKPOINT_KEY,
+                    )?
+                    .map_or(0, |checkpoint| checkpoint.epoch.get().saturating_add(1));
+                let prefix = self.db.raw_prefix_cf_from(
+                    &history_cf,
+                    &retained_low.to_be_bytes(),
+                    eviction_count.saturating_add(1),
+                )?;
                 let mut decoded_prefix = Vec::with_capacity(prefix.len());
                 for (key, value) in prefix {
                     let row = FinalityRecord::decode(&value).map_err(|_| {

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -574,6 +574,134 @@ fn finality_history_creates_an_authenticated_checkpoint_at_the_retained_bound() 
 }
 
 #[test]
+fn finality_history_eviction_does_not_walk_earlier_tombstones() {
+    // Every eviction deletes the lowest key in the retained window, so it leaves a tombstone
+    // exactly where a from-the-start seek begins. The window is a few MB, far too small to
+    // trigger the compaction that would collect those tombstones, so locating the oldest
+    // record by walking from the start costs one skipped delete per eviction ever performed
+    // and eventually dominates every block commit. Eviction must seek past the published
+    // checkpoint instead, which keeps its cost flat.
+    const ROUNDS: u64 = 64;
+    const ALLOWED_GROWTH: u64 = 8;
+
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor_node, metadata) = fixture();
+    let anchor = metadata.frontiers.finalized;
+    let store = HeaderChainStore::new(open(&db_config, engine_config.network()));
+    store
+        .initialize(metadata.clone(), anchor_node)
+        .expect("the bounded history fixture initializes");
+
+    let limit = u64::try_from(FINALITY_HISTORY_LIMIT).expect("the limit fits u64");
+    let mut seed = DiskWriteBatch::new();
+    stage_full_state_canonical_hash(&store, &mut seed, anchor);
+    for epoch in 1..limit {
+        let record = FinalityRecord {
+            previous: anchor,
+            current: anchor,
+            source: full_state_source(EvidenceId::from_digest([0x90; 32])),
+            epoch: FinalityEpoch::new(epoch),
+        };
+        store
+            .put_value(
+                &mut seed,
+                HEADER_FINALITY_HISTORY,
+                HeaderFinalityKey(record.epoch).as_bytes(),
+                &record,
+            )
+            .expect("the retained history row encodes");
+    }
+    store
+        .put_value(
+            &mut seed,
+            HEADER_ENGINE_META,
+            FINALITY_HISTORY_COUNT_KEY,
+            &HeaderRowCountDisk(limit),
+        )
+        .expect("the retained history count encodes");
+    store.db.write(seed).expect("the bounded history seeds");
+
+    let mut next_metadata = metadata;
+    rocksdb::perf::set_perf_stats(rocksdb::PerfStatsLevel::EnableCount);
+    let mut context = rocksdb::PerfContext::default();
+    let mut skipped_deletes =
+        Vec::with_capacity(usize::try_from(ROUNDS).expect("the round count fits usize"));
+
+    for round in 0..ROUNDS {
+        let appended = FinalityRecord {
+            previous: anchor,
+            current: anchor,
+            source: full_state_source(EvidenceId::from_digest([0x91; 32])),
+            epoch: FinalityEpoch::new(limit + round),
+        };
+        next_metadata.finality_epoch = appended.epoch;
+        let changes = ChangeSet {
+            put_nodes: Vec::new(),
+            delete_nodes: Vec::new(),
+            put_consensus_invalid_body_tombstones: Vec::new(),
+            index_changes: zakura_header_chain::IndexChanges::default(),
+            selected_projection: zakura_header_chain::ProjectionDelta::default(),
+            verified_projection: zakura_header_chain::ProjectionDelta::default(),
+            eligibility_changes: Vec::new(),
+            aux_changes: Vec::new(),
+            finality_append: Some(appended),
+            finality_ancestry: zakura_header_chain::FinalityWitnessProof::default(),
+            metadata: next_metadata.clone(),
+        };
+
+        context.reset();
+        let batch = store
+            .batch_for(&changes)
+            .expect("the bounded append evicts the oldest record");
+        skipped_deletes.push(context.metric(rocksdb::PerfMetric::InternalDeleteSkippedCount));
+
+        store
+            .db
+            .write(batch)
+            .expect("the eviction commits atomically");
+    }
+    rocksdb::perf::set_perf_stats(rocksdb::PerfStatsLevel::Disable);
+
+    let first = skipped_deletes.first().copied().expect("a round ran");
+    let last = skipped_deletes.last().copied().expect("a round ran");
+    assert!(
+        last <= first + ALLOWED_GROWTH,
+        "eviction cost grows with the number of prior evictions: the first eviction skipped \
+         {first} deleted keys and eviction {ROUNDS} skipped {last}. Eviction is seeking from \
+         the start of the retained window instead of from the published checkpoint. \
+         Per-round counts: {skipped_deletes:?}"
+    );
+
+    // The window still holds exactly `limit` records, ending at the last epoch appended.
+    let audit = store
+        .audit_snapshot()
+        .expect("the checkpoint snapshot opens");
+    assert_eq!(
+        audit
+            .finality_history_count()
+            .expect("the retained count decodes"),
+        FINALITY_HISTORY_LIMIT
+    );
+    assert_eq!(
+        audit
+            .finality_history_checkpoint()
+            .expect("the checkpoint decodes")
+            .map(|checkpoint| checkpoint.epoch),
+        Some(FinalityEpoch::new(ROUNDS - 1)),
+        "each round must evict exactly one record, advancing the checkpoint by one"
+    );
+    let mut epochs = Vec::with_capacity(FINALITY_HISTORY_LIMIT);
+    audit
+        .visit_finality_history(RowLimit::new(FINALITY_HISTORY_LIMIT), &mut |record| {
+            epochs.push(record.epoch);
+            Ok(())
+        })
+        .expect("the retained history remains bounded");
+    assert_eq!(epochs.first(), Some(&FinalityEpoch::new(ROUNDS)));
+    assert_eq!(epochs.last(), Some(&FinalityEpoch::new(limit + ROUNDS - 1)));
+}
+
+#[test]
 fn prepared_full_state_swaps_only_after_combined_commit() {
     let db_config = Config::ephemeral();
     let (engine_config, anchor, metadata) = fixture();

--- a/docs/changelog/unreleased/731.md
+++ b/docs/changelog/unreleased/731.md
@@ -1,0 +1,14 @@
+## Fixed
+
+- Fixed a sync throughput collapse on nodes running the Zakura header chain.
+  Trimming the bounded finality history located the record to evict by walking
+  from the start of its column family, and because each eviction deletes the
+  lowest key there, that walk stepped over one more tombstone per eviction ever
+  performed. The window is too small to trigger the compaction that would collect
+  them, so per-block commit time grew without bound once the ring filled: a
+  dual-stack Mainnet sync went from 254 to 8.6 blocks per second between height
+  9.6k and 928k and could no longer reach the tip. Eviction now seeks past the
+  published checkpoint epoch, which is O(1) and independent of how many evictions
+  preceded it. An existing state directory gets the fix on its next eviction
+  without a migration
+  ([#731](https://github.com/zakura-core/zakura/pull/731)).


### PR DESCRIPTION
## Motivation

The bounded finality-history ring locates the record to evict with `raw_first_cf`, which
walks from the start of the `header_finality_history` column family. Every eviction deletes
the lowest key in that column family, so it leaves a tombstone exactly where the next
eviction starts looking. The retained window holds a few MB, far too small to trip any
size- or L0-based compaction trigger, so those tombstones are never collected and the walk
grows by one skipped key per eviction ever performed.

A finality epoch is appended once per committed block, so once the ring reaches
`FINALITY_HISTORY_LIMIT` (65,536, about height 65k on a fresh sync) the cost of every
subsequent block commit grows without bound.

Measured on `temp-zakura-sync-test-1` (dual stack, mainnet, genesis sync):

| height | per-block commit | rate |
| --- | --- | --- |
| 9,593 | 3.9 ms | 254.6 blk/s |
| 94,884 | 8.9 ms | 112.1 blk/s |
| 564,040 | 17.3 ms | 57.7 blk/s |
| 926,804 | 72.4 ms | 13.8 blk/s |
| 20 min later | ~116 ms | 8.6 blk/s |

The node cannot reach the tip: 2.53M blocks remaining at 8.6 blk/s is 82+ hours against a
48h run cap, and the rate is still falling.

Supporting evidence:

- One thread, the dedicated state block-write thread, pinned at ~99% of one core while the
  box is 86% idle across 8 cores and the disk is at 0.2% util with 0.71 ms write latency.
- `zakura.state.rocksdb.batch_commit.duration_seconds` p50 = 77.6 ms against an observed
  74.2 ms interval between consecutive block commits.
- `perf record --call-graph dwarf` on that thread: 89% of cycles under
  `DiskDb::raw_first_cf` -> `iterator_cf` -> `DBIter::SeekToFirst` ->
  `FindNextUserEntryInternal`, which is tombstone skipping. Fully symbolized, the chain is
  `WriteBlockWorkerTask::run` -> `commit_finalized_direct_with_aux` -> `write_block_with` ->
  `HeaderChainWriter::commit_checkpoint_finalized` -> `apply_aux_then_checkpoint_combined`
  -> `HeaderChainStore::batch_for_combined` -> `raw_first_cf`. 731 of ~740 samples are that
  one seek; `DiskDb::write`, the actual disk write, takes 3.
- `header_finality_history_v1` holds 19.21 MB across 2 SST files for a window whose live
  data is a few MB, and RocksDB logged zero compactions on it in the last 80-minute
  interval.

Nodes without the header chain are unaffected, which is what isolates this to the ring
rather than to the block commit generally: on the same commit `temp-zakura-sync-test-5`
(`p2p_stack = "legacy"`) synced genesis to tip, 3,452,314 blocks in 32,868 s, 105 blk/s
sustained, while the dual-stack node was still at 928k.

## Solution

The published checkpoint already names the last epoch the eviction loop removed, so every
epoch at or below it is deleted and the oldest surviving record sits above it. Seek from
there instead of from the start of the column family. Deleted keys below the bound never
reach the iterator, which makes eviction O(1) and independent of how many evictions
preceded it.

`FINALITY_HISTORY_CHECKPOINT_KEY` is written in exactly one place, this eviction, and its
documented meaning is "last finality epoch removed from the retained window", so the
invariant the seek bound relies on is the one the checkpoint already guarantees.

The durable format does not change, so an existing store gets the fix on its next eviction
without a migration. Every coherence check the eviction already performed - the key/value
agreement check and the canonical-authentication check - is unchanged.

## Testing

`finality_history_eviction_does_not_walk_earlier_tombstones` fills the ring, then evicts 64
times while reading RocksDB's `InternalDeleteSkippedCount` around each eviction, and fails
if the last eviction skips meaningfully more deleted keys than the first.

Against the unfixed code the per-round counts are exactly `[0, 1, 2, ... 63]` - one skipped
tombstone per prior eviction, the reported mechanism reproduced in isolation. With the seek
they stay flat. I verified the test fails on the unfixed code and passes with the fix.

The test also asserts the window still holds `FINALITY_HISTORY_LIMIT` records, that the
checkpoint advances by exactly one per round, and that the retained epochs are the expected
contiguous range, so a fix that skipped the wrong record would fail too.

- `cargo test -p zakura-state --lib` - 472 passed, 0 failed
- `cargo clippy -p zakura-state --all-targets -- -D warnings` - clean
- `cargo fmt --all -- --check` - clean

## Follow-up Work

- `raw_first_cf` has one other caller, the deferred-index earliest-deadline lookup. It has
  the same latent shape - `SeekToFirst` on a column family that takes deletes - but it did
  not appear in the profile and has no equally cheap lower bound, so I left it alone.
- The stall this produced was survivable: the node's own body-sync watchdog hands over to
  the legacy syncer after 600s. The continuous-sync controller used the same 600s deadline
  and killed the node 7 seconds after the handover began. That is fixed separately in
  `fix/continuous-sync-stall-deadline`.
- Separately, a block stuck in `floor_gap_state = "in_flight_without_outstanding"` with
  `outstanding = 0` is never re-requested, which deadlocked two earlier runs on commits
  predating this one. Not addressed here.
