### PR TITLE
fix(continuous-sync): give the node's body-sync fallback room to recover

### DIFF
--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -29,7 +29,13 @@ ready_url = "http://127.0.0.1:8080/ready"
 healthy_url = "http://127.0.0.1:8080/healthy"
 poll_interval_seconds = 30
 startup_timeout_seconds = 600
-stall_seconds = 600
+# Must stay comfortably above the node's own body-sync watchdog
+# (ZAKURA_BODY_SYNC_STALL_TIMEOUT, 600s, in crates/zakurad/src/components/sync.rs). On a
+# dual-stack node that watchdog hands body sync to the legacy syncer after 600s of frozen
+# height, and the handover needs to download and verify before the height moves again. A
+# 600s controller deadline killed the node 7 seconds after the handover started, so the
+# recovery could never complete and every stall became a halted run.
+stall_seconds = 1800
 max_run_seconds = 172800
 ready_samples = 6
 ready_sample_interval_seconds = 30
@@ -77,4 +83,3 @@ alias = "temp-zakura-sync-test-5"
 public_ip = "142.93.27.189"
 mode_label = "Zebra/legacy-only"
 p2p_stack = "legacy"
-stall_seconds = 1800


### PR DESCRIPTION
## Motivation

The controller's stall deadline was 600s, exactly the node's own
`ZAKURA_BODY_SYNC_STALL_TIMEOUT` in `crates/zakurad/src/components/sync.rs`. On a dual-stack
node that watchdog hands body sync to the legacy syncer after 600s of frozen height, and the
handover still has to download and verify before the height moves again, so the two
deadlines raced and the controller always won.

Run `20260816T063927Z-3f0430579062` on `temp-zakura-sync-test-1` shows the outcome:

```
10:58:17.612825 WARN  Zakura body sync is not closing the gap to the network tip;
                      resuming legacy ChainSync as the body-sync driver ... stall=600s
10:58:17.612896 INFO  sync apply lifecycle changed apply_phase="fallback_draining"
10:58:24.556334 INFO  received SIGTERM, starting shutdown
```

The controller killed the run 7 seconds after the recovery began, and the controller does
not retry after a halt. So every Zakura body-sync stall became a halted node waiting for an
operator rather than a node that healed itself. That run stayed halted for 43h48m, which is
what pushed `last_success_at` past the audit's four-day threshold and paged the fleet -
the node was never down, and its own recovery path was never allowed to run.

The same run failed the same way on 2026-08-15 at height 1,736,266 and on 2026-08-16 at
height 1,861,914.

## Solution

Raise the default `stall_seconds` to 1800s, which is what the legacy node already used, and
drop that node's now-redundant override so the fleet has one deadline. The comment at the
setting names the Rust constant it has to clear and why, so the next person to tune it sees
the constraint.

A genuinely wedged run is still bounded by `max_run_seconds` (48h), so the only cost is
slower detection of a stall the node cannot recover from.

The alert monitor's `cluster_stall_seconds` stays at 600s. It only posts to Slack and is
retired while the controller owns the lifecycle, so it keeps reporting the stall promptly
without ending the run.

## Testing

- `python3 -m unittest discover -s tests` in `deploy/continuous-sync` - 49 passed
- Confirmed the effective per-node values parse as intended: all three nodes now resolve to
  1800s.

Takes effect on a host only after `deploy.py deploy`, which rewrites
`/etc/zakura-continuous-sync/controller.toml`.

## Changelog

<!-- changelog: none -->

No Rust source or `Cargo.toml` change; this is fleet deployment configuration.

## Follow-up Work

- The controller still does not retry after a halt. A stall that the node can recover from
  costs a human round trip, and in this incident that was 43h48m of lost canary coverage.
  Retrying once and paging on the retry would keep the fleet collecting data.
- The 600s constant now lives in both the Rust node and this TOML. A check that reads the
  constant, or a documented shared source, would stop them drifting back together.
