### PR TITLE
fix(ci): bound Ubuntu package installation

### DIFF
--- a/.github/actions/setup-zakura-build/action.yml
+++ b/.github/actions/setup-zakura-build/action.yml
@@ -6,14 +6,69 @@ runs:
     - name: Install libclang, protoc, and librocksdb-dev on Ubuntu
       if: runner.os == 'Linux'
       shell: bash
+      env:
+        # Wall-clock budget for the whole package phase. A healthy runner needs
+        # about 20 seconds, and a degraded package mirror has needed 13 minutes.
+        # GitHub ignores `timeout-minutes` on composite action steps, so this
+        # step enforces its own bound. Without it, one stalled fetch consumes
+        # the entire job timeout and reports nothing.
+        APT_BUDGET_SECONDS: '1200'
       run: |
+        set -euo pipefail
+
+        packages=(clang libclang-dev protobuf-compiler librocksdb-dev)
+        apt_options=(
+          # Retry an individual transfer before the whole command fails.
+          -o Acquire::Retries=3
+          # Abandon a connection that stops sending data.
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
+          # Fail instead of waiting forever for another package manager.
+          -o DPkg::Lock::Timeout=120
+        )
+        deadline=$(( SECONDS + APT_BUDGET_SECONDS ))
+
+        # Run one apt-get command under the shared budget and retry a failure
+        # that leaves useful time. `timeout` signals the whole process group,
+        # so a killed attempt cannot keep downloading in the background.
+        run_apt() {
+          local label="$1"
+          shift
+          local attempt=1
+          local status remaining
+          while true; do
+            remaining=$(( deadline - SECONDS ))
+            if (( remaining < 60 )); then
+              echo "::error::apt ${label}: the ${APT_BUDGET_SECONDS}s package budget ran out after ${attempt} attempt(s)"
+              return 1
+            fi
+            echo "apt ${label}: attempt ${attempt}, ${remaining}s of budget left"
+            status=0
+            sudo timeout --kill-after=30 "${remaining}" "$@" || status=$?
+            if (( status == 0 )); then
+              echo "apt ${label}: attempt ${attempt} succeeded"
+              return 0
+            fi
+            if (( status == 124 || status == 137 )); then
+              echo "apt ${label}: attempt ${attempt} exhausted the remaining ${remaining}s and was killed"
+            else
+              echo "apt ${label}: attempt ${attempt} exited ${status}"
+            fi
+            attempt=$(( attempt + 1 ))
+            sleep 15
+          done
+        }
+
         sudo rm -f /etc/apt/sources.list.d/{microsoft-prod,azure-cli}.{list,sources}
-        sudo apt-get -qq update
+        run_apt update apt-get "${apt_options[@]}" update
+        # Download separately from install: interrupting a download is safe,
+        # and interrupting dpkg leaves a half-configured package set.
+        run_apt download apt-get "${apt_options[@]}" install -y --no-install-recommends --download-only "${packages[@]}"
         # libclang is needed at build time: librocksdb-sys always runs bindgen
         # (via clang-sys) to generate FFI bindings, even when linking the system
         # RocksDB via ROCKSDB_LIB_DIR.
-        sudo apt-get -qq install -y --no-install-recommends clang libclang-dev protobuf-compiler librocksdb-dev
-        echo "ROCKSDB_LIB_DIR=/usr/lib/" >> $GITHUB_ENV
+        run_apt install apt-get "${apt_options[@]}" install -y --no-install-recommends "${packages[@]}"
+        echo "ROCKSDB_LIB_DIR=/usr/lib/" >> "$GITHUB_ENV"
 
     - name: Install protoc and RocksDB on macOS
       if: runner.os == 'macOS'


### PR DESCRIPTION
## Problem

`.github/actions/setup-zakura-build` runs `apt-get update` and `apt-get install`
with no timeout and no retry. GitHub ignores `timeout-minutes` on composite
action steps, so one stalled package fetch consumes the whole job timeout and
reports nothing useful.

In [run 32162388799](https://github.com/zakura-core/zakura/actions/runs/32162388799?pr=707):

| Job | Time in `setup-zakura-build` |
| --- | --- |
| [Unit tests shard 1 (Central US)](https://github.com/zakura-core/zakura/actions/runs/32162388799/job/95799057118?pr=707) | 60 min, canceled by the job timeout |
| [Unit tests shard 2 (West US 3)](https://github.com/zakura-core/zakura/actions/runs/32162388799/job/95799057064?pr=707) | 60 min, canceled by the job timeout |
| Unit tests shard 3 (West US 2) | 8 min 17 s, succeeded |
| Config compatibility, RPC semver | 11–13 min, succeeded |
| [Same action on `main`](https://github.com/zakura-core/zakura/actions/runs/32151533918) | 12–20 s |

The stalled shards burned their full 60-minute budget on a job that normally
finishes in three minutes. The `-qq` option hid which source stalled, so the
logs do not name one endpoint.

## Change

This pull request touches one file and changes only the Linux step. It keeps the
package set, the Microsoft and Azure source removal, the `ROCKSDB_LIB_DIR`
export, and the macOS and Windows steps.

- Give the whole package phase a 1200-second budget and run every `apt-get`
  command under `timeout` against that budget.
- Retry a command that fails while budget remains, and fail the step with an
  `::error::` line that names the operation once the budget runs out.
- Download the packages before installing them. Interrupting a download is safe,
  and interrupting dpkg leaves a half-configured package set.
- Set `Acquire::Retries=3`, 30-second HTTP and HTTPS timeouts, and
  `DPkg::Lock::Timeout=120` so apt stops waiting forever for another package
  manager.
- Drop `-qq` so the log names the source that fails.

## Why 1200 seconds

A healthy runner needs 20 seconds and a degraded mirror has needed 13 minutes,
so 20 minutes preserves every observed success. Every job that uses this action
allows 30 minutes or more, so the guard reports the failure before the job
timeout hides it.

## Validation

`actionlint` passes. I exercised the helper against stub commands and confirmed
that a fast success returns immediately, a transient failure retries, a hang is
killed at the budget without leaving a background process, and the failure
propagates through `set -e` to fail the step.

I did not run the package installation locally, because a local install would
not reproduce a GitHub-hosted runner network path.

This action is shared by the unit test, lint, crate build, coverage, semver,
compatibility, release, and end-to-end workflows, so this pull request's own
checks exercise it broadly. A bounded failure with a named source is the
expected result while the package service is degraded, and it is still an
improvement over a silent hour.
