### PR TITLE
fix(state): classify released header-chain formats before migration

### DIFF
--- a/crates/zakura-header-chain/src/transition/recovery/audit/authoritative_rows.rs
+++ b/crates/zakura-header-chain/src/transition/recovery/audit/authoritative_rows.rs
@@ -196,7 +196,11 @@ pub(super) fn check_authoritative_rows<S: StoreAuditSnapshot>(
         }
         previous = Some(record);
         last = Some(record);
-        work_origin_seen |= record.current == metadata.work_origin;
+        // v3→v4 migration replaces history with one DiskMigration row at finalized.
+        // Production nodes rebase work_origin to the init tip, which can sit below that frontier.
+        work_origin_seen |= record.current == metadata.work_origin
+            || matches!(record.source, FinalitySource::DiskMigration { .. })
+                && metadata.work_origin.height <= record.current.height;
         Ok(())
     })?;
     let history_has_expected_count = history_count == expected_history_count;

--- a/crates/zakura-header-chain/src/transition/recovery/tests/authority.rs
+++ b/crates/zakura-header-chain/src/transition/recovery/tests/authority.rs
@@ -15,11 +15,11 @@ use super::super::{
 use super::{fixture, injected_store_error, violations, AuditRead, AuditStore};
 use crate::{
     AuxDelivery, BodyRuleId, BodySizeHint, BodyValidationState, BranchId, ChainScore,
-    CheckpointSet, ConsensusInvalidBodyTombstone, EligibilityReason, EligibilityState,
-    EngineConfig, EngineMode, EvidenceId, FinalityEpoch, FinalityRecord, FinalitySource, Frontier,
-    FullStateFinalityProvenance, HeaderGeneration, HeaderNode, HeaderValidationState,
-    HeaderWorkAuthority, HeaderWorkOwner, SourceId, StateVersion, StoreAuditSnapshot, StoreError,
-    SuffixWork, WorkCoordinate,
+    CheckpointSet, ConsensusInvalidBodyTombstone, DiskMigrationAuthentication, EligibilityReason,
+    EligibilityState, EngineConfig, EngineMode, EvidenceId, FinalityEpoch, FinalityRecord,
+    FinalitySource, Frontier, FullStateFinalityProvenance, HeaderChainDiskVersion,
+    HeaderGeneration, HeaderNode, HeaderValidationState, HeaderWorkAuthority, HeaderWorkOwner,
+    SourceId, StateVersion, StoreAuditSnapshot, StoreError, SuffixWork, WorkCoordinate,
 };
 
 #[test]
@@ -429,6 +429,80 @@ fn rebased_work_origin_requires_finality_history_and_canonical_authentication() 
     store
         .canonical
         .insert(child.height, block::Hash([0x92; 32]));
+    assert!(violations(&store, &config).contains(&AuditViolation::Configuration));
+}
+
+#[test]
+fn disk_migration_preserves_a_rebased_work_origin_below_the_migrated_frontier() {
+    let (mut store, config) = fixture();
+    let genesis_node = store.nodes[0].clone();
+    let child = store.metadata.frontiers.header_best;
+    let child_node = store.nodes[1].clone();
+    let mut grandchild_header = *child_node.header;
+    grandchild_header.previous_block_hash = child.hash;
+    grandchild_header.time += Duration::seconds(1);
+    grandchild_header.nonce = [2; 32].into();
+    let grandchild_header = Arc::new(grandchild_header);
+    let grandchild_hash = grandchild_header.hash();
+    let grandchild_work = grandchild_header
+        .difficulty_threshold
+        .to_work()
+        .expect("the fixture grandchild target has work");
+    let grandchild = Frontier::new(block::Height(2), grandchild_hash);
+    let grandchild_node = HeaderNode::from_durable_parts(
+        grandchild_header,
+        grandchild_hash,
+        child.hash,
+        grandchild.height,
+        grandchild_work,
+        WorkCoordinate::new(child.hash, grandchild_work.as_u256()),
+        HeaderValidationState::Valid,
+        EligibilityState::default(),
+        BodyValidationState::Verified {
+            evidence: EvidenceId::from_digest([0x61; 32]),
+        },
+        Vec::new(),
+    )
+    .expect("the canonical grandchild fields agree");
+
+    store.nodes = vec![grandchild_node];
+    store.children.clear();
+    store.selected = vec![grandchild];
+    store.verified = vec![grandchild];
+    store.contexts = vec![
+        ValidationContextRecord {
+            header: genesis_node.header,
+            height: genesis_node.height,
+        },
+        ValidationContextRecord {
+            header: child_node.header,
+            height: child.height,
+        },
+    ];
+    store.metadata.work_origin = child;
+    store.metadata.frontiers.finalized = grandchild;
+    store.metadata.frontiers.header_best = grandchild;
+    store.metadata.frontiers.verified_best = grandchild;
+    store.metadata.header_best_score = ChainScore::new(SuffixWork::zero(), grandchild.hash);
+    store.metadata.oldest_retained_height = grandchild.height;
+    store.finality = vec![FinalityRecord {
+        previous: grandchild,
+        current: grandchild,
+        source: FinalitySource::DiskMigration {
+            from_version: HeaderChainDiskVersion(3),
+            network_policy_digest: config.network_policy_digest(),
+            authentication: DiskMigrationAuthentication::FullState,
+        },
+        epoch: store.metadata.finality_epoch,
+    }];
+    store.canonical.insert(grandchild.height, grandchild.hash);
+    store.snapshot = store.metadata.snapshot();
+
+    audit_store(&store, &config).expect("a v3 disk migration keeps an earlier rebased work origin");
+
+    store
+        .canonical
+        .insert(child.height, block::Hash([0x93; 32]));
     assert!(violations(&store, &config).contains(&AuditViolation::Configuration));
 }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -19,14 +19,14 @@ use zakura_header_chain::{
     BodyWorkAuthority, BodyWorkOwner, ChangeSet, CommittedHeaderChainView, CommittedStallReceipt,
     CounterExhausted, EligibilityReason, EngineConfig, EngineMetadata, EngineMode, EngineSnapshot,
     EvidenceId, FinalityHistoryCheckpoint, FinalityRecord, FinalitySource, Frontier,
-    FullStateEvidenceAuthority, FullStateFinalityProvenance, FullStateFinalized, HeaderChainEngine,
-    HeaderInsertionFacts, HeaderLocator, HeaderNode, HeaderSyncWorkOwner, HeaderValidationFacts,
-    HeaderWorkAuthority, MemHeaderStore, NoChangeReceipt, RecoveryFailure, RecoveryPlan,
-    RecoveryRepair, RowLimit, SourceId, StaleReceipt, StateVersion, StoreAuditRead,
-    StoreAuditSnapshot, StoreCollection, StoreError, SystemClock, TransitionContext,
-    TransitionEffect, TransitionEvent, TransitionFailure, TransitionInput, TransitionRequest,
-    UntrustedAuxDeliveryRow, ValidationContextRecord, ValidationLease, VerifiedChainChanged,
-    VerifiedChangeCause, VerifiedHeaderRef,
+    FullStateEvidenceAuthority, FullStateFinalityProvenance, FullStateFinalized,
+    HeaderChainDiskVersion, HeaderChainEngine, HeaderInsertionFacts, HeaderLocator, HeaderNode,
+    HeaderSyncWorkOwner, HeaderValidationFacts, HeaderWorkAuthority, MemHeaderStore,
+    NoChangeReceipt, RecoveryFailure, RecoveryPlan, RecoveryRepair, RowLimit, SourceId,
+    StaleReceipt, StateVersion, StoreAuditRead, StoreAuditSnapshot, StoreCollection, StoreError,
+    SystemClock, TransitionContext, TransitionEffect, TransitionEvent, TransitionFailure,
+    TransitionInput, TransitionRequest, UntrustedAuxDeliveryRow, ValidationContextRecord,
+    ValidationLease, VerifiedChainChanged, VerifiedChangeCause, VerifiedHeaderRef,
 };
 
 use crate::{
@@ -3267,10 +3267,11 @@ impl HeaderChainStore {
         match self.metadata_row() {
             Ok(metadata) => Ok(metadata.is_some()),
             // Service construction classifies the durable runtime before the block writer
-            // migrates released version-one and version-two rows to the current format.
+            // migrates released legacy rows to the current format. Any older marker is a
+            // supported store; a newer marker stays fail-closed until a migrator exists.
             Err(HeaderChainStoreError::Codec(HeaderChainValueError::UnsupportedDiskFormat(
-                1 | 2,
-            ))) => Ok(true),
+                version,
+            ))) if version < HeaderChainDiskVersion::CURRENT.0 => Ok(true),
             Err(error) => Err(error),
         }
     }

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/startup.rs
@@ -1156,6 +1156,9 @@ fn version_three_integrated_migration_authenticates_the_full_state_frontier() {
     store.db.write(batch).expect("the legacy fixture commits");
 
     assert!(store
+        .is_initialized()
+        .expect("released version-three metadata identifies an initialized store"));
+    assert!(store
         .migrate_to_current(&engine_config)
         .expect("the version-three store migrates"));
     let migrated = store.metadata().expect("the migrated metadata is readable");
@@ -1183,6 +1186,31 @@ fn version_three_integrated_migration_authenticates_the_full_state_frontier() {
         .startup(&engine_config)
         .expect("startup audits the migrated store");
     assert!(report.publication_allowed);
+}
+
+#[test]
+fn a_newer_header_chain_disk_format_does_not_classify_as_initialized() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = mainnet_fixture();
+    let db = open(&db_config, engine_config.network());
+    let store = HeaderChainStore::new(db);
+    store
+        .initialize(metadata.clone(), anchor)
+        .expect("the current fixture initializes");
+    let mut newer = metadata.encode().expect("the metadata fixture encodes");
+    newer[..4].copy_from_slice(&(HeaderChainDiskVersion::CURRENT.0 + 1).to_be_bytes());
+    let mut batch = DiskWriteBatch::new();
+    store
+        .put_raw(&mut batch, HEADER_ENGINE_META, METADATA_KEY, &newer)
+        .expect("the newer metadata stages");
+    store.db.write(batch).expect("the newer fixture commits");
+
+    assert!(matches!(
+        store.is_initialized(),
+        Err(HeaderChainStoreError::Codec(
+            HeaderChainValueError::UnsupportedDiskFormat(version)
+        )) if version == HeaderChainDiskVersion::CURRENT.0 + 1
+    ));
 }
 
 #[test]
@@ -1327,6 +1355,9 @@ fn every_legacy_headers_only_version_migrates_with_a_complete_depth_proof() {
         let migrated_store = runtime.store.clone();
         drop(runtime);
 
+        assert!(migrated_store
+            .is_initialized()
+            .expect("released legacy metadata identifies an initialized store"));
         assert!(migrated_store
             .migrate_to_current(&engine_config)
             .expect("the headers-only store migrates"));

--- a/docs/changelog/unreleased/736.md
+++ b/docs/changelog/unreleased/736.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed startup of version-three header-chain databases so they migrate to the current
+  format without a resync
+  ([#736](https://github.com/zakura-core/zakura/pull/736)).

--- a/docs/changelog/unreleased/736.md
+++ b/docs/changelog/unreleased/736.md
@@ -1,5 +1,6 @@
 ## Fixed
 
 - Fixed startup of version-three header-chain databases so they migrate to the current
-  format without a resync
+  format without a resync, including nodes whose work origin is below the migrated
+  finalized frontier
   ([#736](https://github.com/zakura-core/zakura/pull/736)).


### PR DESCRIPTION
## Motivation

Deploying `f426979` (`#729`, which includes `#707`) panic-looped mainnet nodes that already had a version-three header-chain metadata row:

```text
the opened state database can classify its durable header runtime: Codec(UnsupportedDiskFormat(3))
```

`#707` bumped `HeaderChainDiskVersion::CURRENT` from 3 to 4 and added a v3→v4 migrator, but `StateService` calls `is_initialized()` during construction, before the block writer migrates. That probe still treated only formats 1 and 2 as released legacy stores, so a v3 row failed closed at `service.rs:469` and never reached `migrate_to_current()`.

`#710` and `#715` already taught this for v1 and v2. The v3 tests skipped `is_initialized()` and called the migrator directly, so CI stayed green.

After classification was fixed, `canada-0` migrated and came up. `europe-west-0` and `us-west-0` then failed:

```text
authoritative header-chain source rows failed startup audit
Store(Recovery(Source { violations: [Configuration] }))
```

`migrate_to_current()` replaces finality history with one `DiskMigration` row at the current finalized frontier and deletes the history checkpoint. Startup audit treated `work_origin` as missing unless it was genesis or equal to that migrated frontier. Nodes that initialized the header store at a later tip rebase `work_origin` there, so a later finality advance failed closed. Rolling those nodes back to `9ff94623b` then panic-looped on `UnsupportedDiskFormat(4)`.

## Solution

Classify any on-disk format older than `CURRENT` as an initialized store so the existing migrator can run. A newer marker still fails closed.

Treat a `DiskMigration` finality row as covering a rebased `work_origin` at or below the migrated frontier. Canonical authentication of that origin is unchanged.

The v3 integrated and headers-only fixtures now assert `is_initialized()` before migration, matching the v1/v2 tests. A newer-format fixture checks that classification stays fail-closed. A recovery test covers a rebased work origin below a v3 `DiskMigration` frontier.

Rolled-back mainnet nodes that already migrated to format 4 must run this binary, not `9ff94623b`. After this lands they should start in place; do not delete state.

## Testing

- `cargo test -p zakura-state --lib -- --test-threads=1 version_three_integrated_migration_authenticates_the_full_state_frontier a_newer_header_chain_disk_format_does_not_classify_as_initialized every_legacy_headers_only_version_migrates_with_a_complete_depth_proof` — 3 passed
- `cargo test -p zakura-header-chain --lib -- disk_migration_preserves_a_rebased_work_origin_below_the_migrated_frontier rebased_work_origin_requires_finality_history_and_canonical_authentication -- --test-threads=1` — 2 passed
- `./scripts/changelog.py check` — 39 fragments validated
- Draft CI in progress

The v3 tests now fail if construction-time classification panics on format 3, which is the production startup path.

## Changelog

- `docs/changelog/unreleased/736.md`

### Specifications & References

- `#707` introduced format 4 and the v3 migrator
- `#710` / `#715` added the construction-time classification for v1 / v2