### PR TITLE
perf(state): resume the frontier grid instead of rebuilding it

### DIFF
--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -47,8 +47,8 @@ use crate::{
 use super::super::{
     commitment_aux, export_frontier_grid_to, serve_block_roots,
     vct::validate_final_frontiers_bytes, verify_subtrees_against_stored, CheckpointVerifiedBlock,
-    DiskWriteBatch, FinalizedState, FrontierArtifact, FrontierEntry, GridSpacing,
-    VctAuxiliaryWindow, VctSuccessorWitness,
+    DiskWriteBatch, FinalizedState, FrontierArtifact, FrontierEntry, FrontierGridExportError,
+    GridSpacing, VctAuxiliaryWindow, VctSuccessorWitness,
 };
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -1658,6 +1658,7 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 &fast.db,
                 handoff,
                 GridSpacing::Uniform { blocks: 1 },
+                None,
                 |_, _| {},
             )
             .expect("a genesis-start VCT database exports its absent band");
@@ -2824,6 +2825,7 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 &legacy.db,
                 last_height,
                 GridSpacing::Uniform { blocks: 1 },
+                None,
                 |_, _| {},
             )
             .expect("a mid-chain VCT database exports from its stored predecessor");
@@ -2874,6 +2876,7 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 &legacy.db,
                 Height(last_height.0 - 2),
                 GridSpacing::Uniform { blocks: 1 },
+                None,
                 |_, _| {},
             )
             .expect("a lower target exports the same grid, minus its tail");
@@ -2895,6 +2898,58 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 );
             }
 
+            // Resuming reproduces the from-genesis walk exactly. That is the property the whole
+            // incremental path rests on: the cost accumulator resets at every emitted entry, so
+            // continuing at `last carried entry + 1` places the remainder identically.
+            let resumed_export = export_frontier_grid_to(
+                &legacy.db,
+                last_height,
+                GridSpacing::Uniform { blocks: 1 },
+                Some(&shorter_export.frontiers),
+                |_, _| {},
+            )
+            .expect("a published grid can be carried forward");
+            prop_assert_eq!(
+                resumed_export.frontiers.entries.len(),
+                anchored_export.frontiers.entries.len(),
+                "resuming publishes the same entries as a walk from genesis"
+            );
+            for (from_genesis, resumed) in anchored_export
+                .frontiers
+                .entries
+                .iter()
+                .zip(&resumed_export.frontiers.entries)
+            {
+                prop_assert_eq!(from_genesis.height, resumed.height);
+                prop_assert_eq!(from_genesis.sapling.root(), resumed.sapling.root());
+                prop_assert_eq!(from_genesis.orchard.root(), resumed.orchard.root());
+            }
+            prop_assert_eq!(
+                resumed_export.frontiers.encode(&network),
+                anchored_export.frontiers.encode(&network),
+                "a resumed artifact is byte-identical to the one a full walk produces"
+            );
+            prop_assert!(
+                resumed_export.replayed_blocks < anchored_export.replayed_blocks,
+                "resuming replays less than a walk from genesis"
+            );
+
+            // A grid that already reaches the requested checkpoint has nothing to extend, and
+            // carrying entries at or above it would describe heights the export does not cover.
+            prop_assert!(
+                matches!(
+                    export_frontier_grid_to(
+                        &legacy.db,
+                        Height(2),
+                        GridSpacing::Uniform { blocks: 1 },
+                        Some(&anchored_export.frontiers),
+                        |_, _| {},
+                    ),
+                    Err(FrontierGridExportError::ResumeAboveTarget { .. })
+                ),
+                "a grid reaching past the target is refused rather than truncated"
+            );
+
             // One export can draw on every source at once. Narrowing the handoff leaves this
             // database with stored trees on both sides of its absent band: entries below `U` and
             // at or above the handoff are read, and only the band between them is replayed.
@@ -2909,6 +2964,7 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 &legacy.db,
                 last_height,
                 GridSpacing::Uniform { blocks: 1 },
+                None,
                 |_, _| {},
             )
             .expect("a database with trees on both sides of its band exports every height");

--- a/crates/zakura-state/src/service/finalized_state/treestate_export.rs
+++ b/crates/zakura-state/src/service/finalized_state/treestate_export.rs
@@ -635,6 +635,18 @@ pub enum FrontierGridExportError {
     #[error("grid spacing and cost budget must be at least 1")]
     ZeroSpacing,
 
+    /// The grid being resumed from reaches at or above the requested checkpoint.
+    #[error(
+        "cannot resume from a grid whose last entry {seed:?} is not below the requested \
+         checkpoint {target:?}"
+    )]
+    ResumeAboveTarget {
+        /// The highest entry in the grid being resumed from.
+        seed: Height,
+        /// The requested checkpoint.
+        target: Height,
+    },
+
     /// A block body needed to place entries is not retained.
     #[error(
         "cannot place frontier grid entries: block body {missing:?} is not retained; generate \
@@ -733,12 +745,20 @@ fn next_grid_target(
 /// ([`produce_release_treestate_artifacts`]) owns that artifact, and it does not need historical
 /// block bodies to build it.
 ///
+/// `resume_from` carries an earlier grid's entries forward instead of recomputing them. Each
+/// carried entry is re-checked against this database's authenticated roots before it is accepted, so
+/// resuming inherits no trust from the file it came from. Placement is unaffected: the cost
+/// accumulator resets at every emitted entry, so continuing at `last carried entry + 1` puts the
+/// remaining entries exactly where a walk from genesis would. Resuming also makes the output a
+/// prefix-extension of the input by construction rather than by both runs agreeing on a budget.
+///
 /// `on_progress` is called with each emitted entry's height and the running replay count, for
 /// long runs.
 pub fn export_frontier_grid_to(
     db: &ZakuraDb,
     target_checkpoint: Height,
     spacing: GridSpacing,
+    resume_from: Option<&FrontierArtifact>,
     mut on_progress: impl FnMut(Height, u64),
 ) -> Result<FrontierGridExport, FrontierGridExportError> {
     match spacing {
@@ -780,6 +800,47 @@ pub fn export_frontier_grid_to(
 
     let mut next = Height(0);
     let mut accrued_cost: u64 = 0;
+
+    if let Some(seed) = resume_from {
+        if let Some(top) = seed.entries.last() {
+            if top.height > last {
+                return Err(FrontierGridExportError::ResumeAboveTarget {
+                    seed: top.height,
+                    target: target_checkpoint,
+                });
+            }
+        }
+
+        // Carried entries are re-checked here, so a stale, truncated, or hostile input costs a
+        // failed export rather than an unverified entry in the published artifact.
+        for entry in &seed.entries {
+            let frontiers = DerivedFrontiers {
+                sapling: entry.sapling.clone(),
+                orchard: entry.orchard.clone(),
+                ironwood: entry.ironwood.clone(),
+            };
+            verify_against_available_roots(db, entry.height, &frontiers).map_err(|source| {
+                FrontierGridExportError::Derivation {
+                    height: entry.height,
+                    source,
+                }
+            })?;
+
+            // A carried entry inside the absent band is a verified frontier at its height, which
+            // is a nearer replay anchor than the trees below `U`.
+            if absent_band
+                .is_some_and(|(upgrade, handoff)| entry.height >= upgrade && entry.height < handoff)
+            {
+                replay = Some((frontiers, entry.height.0 + 1));
+            }
+
+            entries.push(entry.clone());
+        }
+
+        if let Some(top) = entries.last() {
+            next = Height(top.height.0 + 1);
+        }
+    }
 
     // A pruned database answers the cost scan with a missing body, which would read as a free
     // block and space entries far too widely. The artifact would still be valid — every entry is

--- a/crates/zakura-utils/README.md
+++ b/crates/zakura-utils/README.md
@@ -52,6 +52,12 @@ in 4.8 MB, without replaying a single block. `--frontier-grid-target-cost-ms` tu
 grid's per-entry cost budget (default 2000); `--frontier-grid-spacing` produces a uniform grid
 and is not recommended.
 
+`--mainnet-frontier-grid-input <path>` resumes from a previously published grid instead of
+rebuilding it. Its entries are re-checked against the database and then carried forward verbatim,
+so the run scans only the blocks above the last carried entry and the output is a prefix-extension
+of the input by construction. Use it for every run after the first: a full walk stays O(chain)
+forever, while a resumed run costs only the new tail.
+
 To produce a grid for a checkpoint the binary already ships — backfilling the one artifact a
 committed release state is missing, without advancing the checkpoint list — run the grid
 alone:

--- a/crates/zakura-utils/src/bin/zakura-checkpoints/args.rs
+++ b/crates/zakura-utils/src/bin/zakura-checkpoints/args.rs
@@ -154,6 +154,17 @@ pub struct Args {
     #[arg(long)]
     pub mainnet_frontier_grid_output: Option<PathBuf>,
 
+    /// Offline mode: resume the frontier grid from a previously published one.
+    ///
+    /// Carries that grid's entries forward instead of recomputing them, so a run scans only the
+    /// blocks above its last entry rather than the whole chain. Every carried entry is re-checked
+    /// against this database's authenticated roots first, so the input is never trusted. Omit it
+    /// to build the grid from genesis, which is what the first run has to do.
+    ///
+    /// Requires `--mainnet-frontier-grid-output`.
+    #[arg(long)]
+    pub mainnet_frontier_grid_input: Option<PathBuf>,
+
     /// Offline mode: generate only the frontier grid, for an already-committed checkpoint.
     ///
     /// The normal export selects a new checkpoint above the embedded list and pins every
@@ -210,6 +221,14 @@ impl Args {
             return Err(
                 "--frontier-grid-spacing and --frontier-grid-target-cost-ms tune \
                  --mainnet-frontier-grid-output: add it, or remove them"
+                    .to_string(),
+            );
+        }
+        if self.mainnet_frontier_grid_output.is_none() && self.mainnet_frontier_grid_input.is_some()
+        {
+            return Err(
+                "--mainnet-frontier-grid-input resumes a grid that has nowhere to go: add \
+                 --mainnet-frontier-grid-output"
                     .to_string(),
             );
         }
@@ -418,6 +437,7 @@ mod tests {
             mainnet_frontier_output: None,
             mainnet_subtree_output: None,
             mainnet_frontier_grid_output: None,
+            mainnet_frontier_grid_input: None,
             mainnet_frontier_grid_checkpoint: None,
             frontier_grid_target_cost_ms: None,
             frontier_grid_spacing: None,
@@ -567,6 +587,17 @@ mod tests {
         assert!(
             full_list_without_grid.validate_mode().is_err(),
             "a replacement checkpoint list must ship with its frontier grid too"
+        );
+
+        let mut resume_without_grid_output = offline.clone();
+        resume_without_grid_output.mainnet_frontier_grid_output = None;
+        resume_without_grid_output.mainnet_frontier_output = None;
+        resume_without_grid_output.mainnet_subtree_output = None;
+        resume_without_grid_output.full_list = false;
+        resume_without_grid_output.mainnet_frontier_grid_input = Some(PathBuf::from("old.bin"));
+        assert!(
+            resume_without_grid_output.validate_mode().is_err(),
+            "resuming a grid needs somewhere to write the result"
         );
 
         let mut grid_tuning_without_grid_output = offline.clone();

--- a/crates/zakura-utils/src/bin/zakura-checkpoints/offline.rs
+++ b/crates/zakura-utils/src/bin/zakura-checkpoints/offline.rs
@@ -18,7 +18,7 @@
 // and argument invariants established by `Args::validate_mode` use `expect`.
 #![allow(clippy::print_stdout, clippy::print_stderr, clippy::unwrap_in_result)]
 
-use std::{io::Write, path::Path, time::Instant};
+use std::{fs, io::Write, path::Path, time::Instant};
 
 use color_eyre::eyre::{ensure, eyre, Context, Result};
 
@@ -251,6 +251,7 @@ pub fn run_offline(args: &Args) -> Result<()> {
             frontier_path,
             subtree_path,
             grid_path,
+            args.mainnet_frontier_grid_input.as_deref(),
             frontier_grid_spacing(args),
         )?;
     }
@@ -337,6 +338,7 @@ fn backfill_frontier_grid(
         network,
         checkpoint,
         grid_path,
+        args.mainnet_frontier_grid_input.as_deref(),
         frontier_grid_spacing(args),
     )
 }
@@ -366,6 +368,7 @@ fn write_release_treestate_artifacts(
     frontier_path: &Path,
     subtree_path: &Path,
     grid_path: &Path,
+    grid_resume_path: Option<&Path>,
     grid_spacing: zakura_state::GridSpacing,
 ) -> Result<()> {
     let artifacts = zakura_state::produce_release_treestate_artifacts(db, height)
@@ -394,7 +397,14 @@ fn write_release_treestate_artifacts(
         artifacts.verified_subtree_roots,
     );
 
-    write_frontier_grid(db, network, height, grid_path, grid_spacing)?;
+    write_frontier_grid(
+        db,
+        network,
+        height,
+        grid_path,
+        grid_resume_path,
+        grid_spacing,
+    )?;
 
     Ok(())
 }
@@ -409,6 +419,7 @@ fn write_frontier_grid(
     network: &Network,
     height: Height,
     grid_path: &Path,
+    resume_path: Option<&Path>,
     spacing: zakura_state::GridSpacing,
 ) -> Result<()> {
     match spacing {
@@ -423,24 +434,49 @@ fn write_frontier_grid(
         ),
     }
 
+    // Resuming carries a published grid's entries forward, so a run scans only the blocks above
+    // its last entry. Every carried entry is re-checked against this database before it is
+    // accepted, so the file supplies work already done, never trust.
+    let resume_from = match resume_path {
+        Some(path) => {
+            let bytes = fs::read(path).wrap_err_with(|| format!("reading {}", path.display()))?;
+            let grid = zakura_state::FrontierArtifact::decode(&bytes, network)
+                .map_err(|error| eyre!("reading {}: {error}", path.display()))?;
+            eprintln!(
+                "resuming from {}: {} entries through height {}",
+                path.display(),
+                grid.entries.len(),
+                grid.entries.last().map_or(0, |entry| entry.height.0),
+            );
+            Some(grid)
+        }
+        None => None,
+    };
+
     // Time each grid step. One step is exactly the replay a serving node performs for a cold
     // request at this spacing, so the run doubles as the measurement that sizes the grid.
     let mut entries = 0u64;
     let mut previous = Instant::now();
-    let export = zakura_state::export_frontier_grid_to(db, height, spacing, |entry, blocks| {
-        let step = previous.elapsed();
-        previous = Instant::now();
-        entries += 1;
+    let export = zakura_state::export_frontier_grid_to(
+        db,
+        height,
+        spacing,
+        resume_from.as_ref(),
+        |entry, blocks| {
+            let step = previous.elapsed();
+            previous = Instant::now();
+            entries += 1;
 
-        if entries.is_multiple_of(FRONTIER_GRID_PROGRESS_INTERVAL) {
-            eprintln!(
-                "  entry {entries:>7}  height {:>9}  {blocks:>9} blocks replayed  \
-                 last step {:>8.1}ms",
-                entry.0,
-                step.as_secs_f64() * 1e3,
-            );
-        }
-    })
+            if entries.is_multiple_of(FRONTIER_GRID_PROGRESS_INTERVAL) {
+                eprintln!(
+                    "  entry {entries:>7}  height {:>9}  {blocks:>9} blocks replayed  \
+                     last step {:>8.1}ms",
+                    entry.0,
+                    step.as_secs_f64() * 1e3,
+                );
+            }
+        },
+    )
     .map_err(|error| eyre!("producing the Mainnet historical frontier grid: {error}"))?;
 
     let grid_bytes = export.frontiers.encode(network);

--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -38,7 +38,7 @@ whole-band replay — hours on Mainnet.
 
 The importer requires every bundle to carry all four files and fails closed on one that does not,
 so the publisher has to be updated around the same time as the repository. It cannot be updated
-*first*: `deploy-snapshot-host.sh` refuses to install an exporter whose revision is not already an
+_first_: `deploy-snapshot-host.sh` refuses to install an exporter whose revision is not already an
 ancestor of `origin/main`, which is a supply-chain control worth keeping.
 
 So the order is:

--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -36,10 +36,22 @@ whole-band replay — hours on Mainnet.
 
 ## Cutover order
 
-The importer requires every bundle to carry all four files, and fails closed on one that does
-not. Deploy the publisher **before** merging the repository change that expects the frontier
-grid, or `update-release-state.yml` will reject the last bundle the old publisher produced until
-a new one appears.
+The importer requires every bundle to carry all four files and fails closed on one that does not,
+so the publisher has to be updated around the same time as the repository. It cannot be updated
+*first*: `deploy-snapshot-host.sh` refuses to install an exporter whose revision is not already an
+ancestor of `origin/main`, which is a supply-chain control worth keeping.
+
+So the order is:
+
+1. Merge the repository change.
+2. Run `deploy-snapshot-host.sh`, now buildable from `main`.
+3. Set `RELEASE_STATE_ARCHIVE_CACHE` and enable the timer.
+4. Dispatch `update-release-state.yml` once the first new bundle exists.
+
+Between 1 and 3 a scheduled import will fail with `meta.files is missing keys:
+mainnet-frontier-grid.bin`. Nothing is committed and nothing in production changes — it is a red
+scheduled job that clears as soon as the new publisher publishes — but prefer merging and
+deploying the same day over leaving it red for a week.
 
 ## One-time host setup
 
@@ -80,6 +92,11 @@ a new one appears.
 - A host-local lock serializes export, upload, pointer replacement, and
   retention. Run exactly one publisher host; multiple hosts require
   object-store conditional writes rather than the local lock.
+- Each run resumes the frontier grid from the previous bundle's copy, so it scans only the
+  blocks above that grid's last entry. Carried entries are re-checked against the database
+  before they are accepted, and are written out byte-for-byte, so a bundle is a prefix-extension
+  of its predecessor by construction. If the previous bundle has no grid, the run falls back to
+  a full walk from genesis and says so.
 - Exports continue the deterministic checkpoint selection grid from the
   binary's embedded list. Never hand-edit the Mainnet checkpoint file or
   publish RPC-mode Mainnet output: off-grid lines make every later bundle fail

--- a/deploy/release-state/publish-release-state.sh
+++ b/deploy/release-state/publish-release-state.sh
@@ -21,7 +21,9 @@
 #                             built with --features zakura-checkpoints-offline
 #   RELEASE_STATE_GRID_COST_MS
 #                             per-entry frontier grid cost budget in ms
-#                             (default: whatever the exporter defaults to)
+#                             (default: whatever the exporter defaults to). Only
+#                             affects entries added after the resumed prefix;
+#                             published entries are carried forward verbatim.
 #   RELEASE_STATE_KEEP        immutable bundles to retain (default 4)
 #   RELEASE_STATE_LOCK_FILE   host-local publisher lock
 #                             (default: /tmp/zakura-release-state-publish.lock)
@@ -93,6 +95,30 @@ list_remote_object() {
     fi
 }
 
+# Read the pointer before exporting. Its bundle carries the previously published
+# frontier grid, and resuming from that grid means this run scans only the blocks
+# above its last entry instead of the whole chain from genesis. The pointer height
+# is reused further down for the regression guard.
+POINTER_LISTING=$(list_remote_object "$REMOTE_PREFIX/latest.json")
+POINTER_HEIGHT=
+if [ -n "$POINTER_LISTING" ]; then
+    rclone copyto "$REMOTE_PREFIX/latest.json" "$STAGE/existing-latest.json"
+    POINTER_HEIGHT=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["height"])' \
+        "$STAGE/existing-latest.json")
+
+    # A bundle published before the grid joined the release state has no grid to
+    # resume from. That is not an error: the run falls back to a full walk, which
+    # is what the first grid-bearing export has to do anyway.
+    PREVIOUS_GRID="$REMOTE_PREFIX/v1/$POINTER_HEIGHT/mainnet-frontier-grid.bin"
+    if [ -n "$(list_remote_object "$PREVIOUS_GRID")" ]; then
+        rclone copyto "$PREVIOUS_GRID" "$STAGE/previous-frontier-grid.bin"
+        GRID_ARGS+=(--mainnet-frontier-grid-input "$STAGE/previous-frontier-grid.bin")
+        echo "resuming the frontier grid from bundle v1/$POINTER_HEIGHT" >&2
+    else
+        echo "bundle v1/$POINTER_HEIGHT has no frontier grid; building one from genesis" >&2
+    fi
+fi
+
 # One run, one coupled release state: the frontier, subtree roots, and frontier
 # grid are all generated for the checkpoint this run selects.
 "$BIN" \
@@ -108,18 +134,11 @@ HEIGHT=$(tail -1 "$STAGE/main-checkpoints.txt" | cut -d' ' -f1)
 BLOCK_HASH=$(tail -1 "$STAGE/main-checkpoints.txt" | cut -d' ' -f2)
 GENERATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Never move the pointer backwards: an export from stale stopped-node state
-# would regress latest.json, and retention could then purge the very bundle
-# it points at.
-POINTER_LISTING=$(list_remote_object "$REMOTE_PREFIX/latest.json")
-if [ -n "$POINTER_LISTING" ]; then
-    rclone copyto "$REMOTE_PREFIX/latest.json" "$STAGE/existing-latest.json"
-    POINTER_HEIGHT=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["height"])' \
-        "$STAGE/existing-latest.json")
-    if [ "$POINTER_HEIGHT" -gt "$HEIGHT" ]; then
-        echo "refusing to publish height $HEIGHT below the current pointer height $POINTER_HEIGHT; stale stopped-node state?" >&2
-        exit 1
-    fi
+# Never move the pointer backwards: an export from stale state would regress
+# latest.json, and retention could then purge the very bundle it points at.
+if [ -n "$POINTER_HEIGHT" ] && [ "$POINTER_HEIGHT" -gt "$HEIGHT" ]; then
+    echo "refusing to publish height $HEIGHT below the current pointer height $POINTER_HEIGHT; stale state?" >&2
+    exit 1
 fi
 
 HEIGHT="$HEIGHT" BLOCK_HASH="$BLOCK_HASH" GENERATED_AT="$GENERATED_AT" \

--- a/docs/changelog/unreleased/740.md
+++ b/docs/changelog/unreleased/740.md
@@ -1,0 +1,12 @@
+## Changed
+
+- The Mainnet frontier grid export now resumes from a previously published grid instead of
+  rebuilding it from genesis. `zakura-checkpoints` gained
+  `--mainnet-frontier-grid-input`, and the release-state publisher seeds each run from the
+  previous bundle's grid. Carried entries are re-checked against the generating database's
+  authenticated roots before they are accepted, so resuming inherits no trust from the file,
+  and they are then written out verbatim, so each bundle extends its predecessor by
+  construction rather than because two runs used the same cost budget. A routine export now
+  scans only the blocks added since the last one; the first Mainnet run, which had to walk
+  from genesis, took 81 minutes with no replay at all
+  ([#740](https://github.com/zakura-core/zakura/pull/740)).

--- a/docs/design/historical-treestate-serving.md
+++ b/docs/design/historical-treestate-serving.md
@@ -284,6 +284,15 @@ block bodies nor the grid's pass. `zakurad verify-historical-treestates` repeats
 offline for a candidate bundle, and also checks the bundle's grid for framing and for
 covering the same checkpoint as the rest of the bundle.
 
+**Resuming.** `--mainnet-frontier-grid-input` carries a published grid's entries forward instead
+of recomputing them. The cost accumulator resets at every emitted entry, so continuing at
+`last carried entry + 1` places the remainder exactly where a walk from genesis would — the same
+reset property that makes the checkpoint list resumable. Carried entries are re-checked against
+the generating database's authenticated roots before they are accepted, so resuming inherits no
+trust from the file. Two consequences: a routine run costs only the new tail rather than a scan
+of the whole chain, and the output is a prefix-extension of the input by construction rather than
+because two runs happened to agree on a cost budget.
+
 A grid for a checkpoint already committed is produced by
 `--mainnet-frontier-grid-checkpoint`, which emits nothing else. That is how the first grid is
 introduced for a release state that predates it, without a checkpoint advance riding along.
@@ -356,5 +365,9 @@ how many entries that budget buys.
 
 `0 blocks replayed` is the legacy-archive path in §5 confirmed end to end: every entry came
 from a stored per-height tree, and the 81 minutes is the cost-model scan reading each block
-body once, not replay. That is the floor for any archive node, and it is why the run is
-long even where no commitment is ever re-appended.
+body once, not replay. That is the floor for a run that walks from genesis, and it is why such
+a run is long even where no commitment is ever re-appended.
+
+That figure is therefore a one-off. A resumed run scans only the blocks above the previous
+grid's last entry, so the routine cost tracks how far the chain advanced since the last export
+rather than the length of the chain.

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -884,6 +884,10 @@ zakura-checkpoints \
   own boundaries, so exports from different databases and different tips are byte-prefix
   extensions of one another — the same grid contract the checkpoint list follows, which is
   what lets the importer verify grid updates as pure appends.
+- `--mainnet-frontier-grid-input` resumes the grid from the previously published one, so a
+  routine export scans only the blocks above its last entry instead of the whole chain. Carried
+  entries are re-checked against the database and then written verbatim, which makes each bundle
+  a prefix-extension of its predecessor by construction — the property the importer checks.
 - All artifacts are written before any checkpoint line reaches stdout, so a failure never
   leaves a caller's redirected output holding an advanced list without its coupled state.
 - `--mainnet-frontier-grid-checkpoint <height>` backfills the grid alone, for a checkpoint the


### PR DESCRIPTION
Stacks on #703's branch, which now carries #735 and #737.

## Motivation

Three of the four release-state artifacts update incrementally. The frontier grid does not:

| Artifact | Starts from |
| --- | --- |
| Checkpoint list | The last **embedded** checkpoint |
| Subtree roots | The **embedded** artifact, extended with newer rows |
| Frontier | A single read at the target checkpoint |
| Frontier grid | **Genesis, every run** |

The first full Mainnet run took 81 minutes and replayed **zero** blocks. All of it was the
cost-weighted placement scan reading every block body from genesis to decide where entries go. Left
alone, that runs daily and grows with the chain.

## Solution

The scan does not need repeating, because the cost accumulator resets at every emitted entry:

```rust
if *accrued_cost >= budget_us {
    *accrued_cost = 0;
    return Some(candidate);
}
```

So continuing at `last carried entry + 1` with a zeroed accumulator places the remaining entries
exactly where a walk from genesis would. It is the same reset property that lets the checkpoint
selector resume from the embedded list, and that the VCT design already calls the grid contract.

`export_frontier_grid_to` takes an optional grid to carry forward, exposed as
`--mainnet-frontier-grid-input`. The publisher seeds each run from the previous bundle's grid,
falling back to a full walk (with a log line) when the previous bundle predates the grid.

**Resuming inherits no trust.** Every carried entry is re-checked against the generating database's
authenticated roots before it is accepted, so a stale, truncated, or hostile input costs a failed
export rather than a bad artifact. A carried entry inside the absent band additionally becomes the
replay anchor, which is nearer than the trees below `U`.

## Two consequences beyond speed

**The prefix property becomes structural.** The importer requires each grid to be a byte-prefix
extension of the committed one. Previously that held only because every run happened to use the
same cost budget — change `RELEASE_STATE_GRID_COST_MS` and every entry moves, and the import fails
with `bundle rewrites committed frontier grid entries`, a message that does not point at the cause.
With resuming, carried entries are emitted verbatim, so the budget only affects entries added after
the prefix. The footgun is gone rather than documented.

**Routine cost tracks chain movement, not chain length.** A run now scans the blocks added since the
last export.

## Also in this PR

The cutover note in `deploy/release-state/README.md` told operators to deploy the publisher
*before* merging. That is impossible: `deploy-snapshot-host.sh` refuses an exporter revision that is
not already an ancestor of `origin/main`, which is a supply-chain control worth keeping. Replaced
with the achievable order and an explicit description of the transient — a red scheduled import
between merge and deploy, which commits nothing and clears itself.

## Testing

- `cargo test -p zakura-state --lib` — full suite green, including the extended
  `vct_db_produced_payload_round_trips_to_byte_identical_state`, which now asserts that a resumed
  export is **byte-identical** to a from-genesis walk over the same range, that it replays strictly
  less, and that a grid reaching past the target is refused with `ResumeAboveTarget` rather than
  silently truncated.
- `cargo test -p zakura-utils --features zakura-checkpoints-offline` — 13 passed, including the new
  guard that `--mainnet-frontier-grid-input` without an output path is rejected.
- `cargo fmt --all -- --check` clean; `cargo check` clean with no warnings on both crates.
- `bash -n` on the publisher.

Byte-identity is the assertion that matters: it is what proves the resumed artifact is
indistinguishable from the expensive one, so the optimization cannot quietly change what ships.

Not covered: the publisher's R2 seeding path, which needs a live bucket. Its fallback is exercised
by inspection only — if the previous bundle has no grid object, the run logs and walks from genesis.

## Changelog

`docs/changelog/unreleased/<this PR>.md`.

### Specifications & References

- `docs/design/historical-treestate-serving.md` §5 (resuming) and Appendix B (why the 81 minutes is
  a one-off), `docs/design/verified-commitment-trees.md` §16.1.

## AI Disclosure

Used Claude Code to implement this change and draft this description.
