### PR TITLE
fix(network): back off a bootstrap peer that closes every connection

### DIFF
--- a/crates/zakura-network/src/zakura/discovery/redial.rs
+++ b/crates/zakura-network/src/zakura/discovery/redial.rs
@@ -155,7 +155,7 @@ async fn run_dial_supervisor<F>(
             .iter()
             .any(|id| id == &peer_id);
 
-        let attempt = if already_registered {
+        let mut attempt = if already_registered {
             if !policy.redial_after_drop {
                 // Wait for it to deregister, then re-dial promptly.
                 tokio::select! {
@@ -187,16 +187,12 @@ async fn run_dial_supervisor<F>(
             // connection this loop just dialed often lands after the dial
             // future returns. Resetting the backoff on that registration made
             // every such peer re-dial at once, forever.
-            let registered_at = Instant::now();
-            loop {
-                if registered.changed().await.is_err() {
-                    return;
-                }
-                if !registered.borrow().iter().any(|id| id == &peer_id) {
-                    break;
-                }
-            }
-            if registered_at.elapsed() >= ZAKURA_REDIAL_HEALTHY_CONNECTION {
+            let Some(registered_for) =
+                wait_for_peer_deregistration(&mut registered, &peer_id).await
+            else {
+                return;
+            };
+            if registered_for >= ZAKURA_REDIAL_HEALTHY_CONNECTION {
                 DialResult::Healthy
             } else {
                 DialResult::Failed
@@ -204,6 +200,27 @@ async fn run_dial_supervisor<F>(
         } else {
             dial().await
         };
+
+        // The connection deregistration can land after the dial future returns.
+        // Wait for the watch to catch up before applying this attempt's result,
+        // so the residual registration does not become a second attempt on the
+        // next loop iteration. A concurrent registration that remains healthy
+        // can still upgrade a failed dial to a healthy connection.
+        if policy.redial_after_drop
+            && registered
+                .borrow_and_update()
+                .iter()
+                .any(|id| id == &peer_id)
+        {
+            let Some(registered_for) =
+                wait_for_peer_deregistration(&mut registered, &peer_id).await
+            else {
+                return;
+            };
+            if registered_for >= ZAKURA_REDIAL_HEALTHY_CONNECTION {
+                attempt = DialResult::Healthy;
+            }
+        }
 
         match attempt {
             DialResult::Healthy => {
@@ -242,6 +259,27 @@ async fn run_dial_supervisor<F>(
             }
         }
         backoff = backoff.saturating_mul(2).min(policy.max_backoff);
+    }
+}
+
+/// Wait until `peer_id` leaves the registration watch.
+///
+/// Returns how long the peer remained registered after this observer first saw
+/// it, or `None` when the sender closes while the peer remains registered.
+async fn wait_for_peer_deregistration(
+    registered: &mut tokio::sync::watch::Receiver<Vec<ZakuraPeerId>>,
+    peer_id: &ZakuraPeerId,
+) -> Option<Duration> {
+    let registered_at = Instant::now();
+    loop {
+        registered.changed().await.ok()?;
+        if !registered
+            .borrow_and_update()
+            .iter()
+            .any(|id| id == peer_id)
+        {
+            return Some(registered_at.elapsed());
+        }
     }
 }
 
@@ -411,6 +449,51 @@ mod tests {
         supervisor.abort();
     }
 
+    /// A lagging deregistration must not turn one healthy connection into a
+    /// second failed attempt.
+    #[tokio::test(start_paused = true)]
+    async fn dial_supervisor_maintain_preserves_healthy_result_while_deregistration_lags() {
+        let peer_id = redial_test_peer_id();
+        let (registered_tx, registered) = tokio::sync::watch::channel(Vec::<ZakuraPeerId>::new());
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let dial_calls = calls.clone();
+        let dial_peer_id = peer_id.clone();
+        let dial = move || {
+            let call = dial_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let registered_tx = registered_tx.clone();
+            let dial_peer_id = dial_peer_id.clone();
+            Box::pin(async move {
+                if call > 0 {
+                    return std::future::pending().await;
+                }
+
+                let _ = registered_tx.send(vec![dial_peer_id]);
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    let _ = registered_tx.send(Vec::new());
+                });
+                DialResult::Healthy
+            }) as Pin<Box<dyn Future<Output = DialResult> + Send>>
+        };
+
+        let supervisor = tokio::spawn(run_dial_supervisor(
+            peer_id,
+            registered,
+            RedialPolicy::maintain(Duration::from_secs(1), Duration::from_secs(30)),
+            dial,
+        ));
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        supervisor.abort();
+
+        assert_eq!(
+            dial_count(&calls),
+            2,
+            "a healthy connection must reset backoff after its registration disappears",
+        );
+    }
+
     /// A bootstrap peer that shares no service beyond discovery closes every
     /// connection as soon as the discovery exchange completes. The maintained
     /// dial must back off on that, not re-dial at once forever.
@@ -451,12 +534,12 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(60)).await;
         supervisor.abort();
 
-        // Backing off 1s, 2s, 4s, ... to the 30s ceiling allows a handful of
-        // dials per minute. Without backoff the loop re-dials every 51ms.
-        let dials = dial_count(&calls);
-        assert!(
-            dials <= 8,
-            "a peer that closes every connection must be backed off, but it was dialed {dials} times in 60s",
+        // Backing off 1s, 2s, 4s, ... to the 30s ceiling allows six dials in
+        // one minute. Without backoff the loop re-dials every 51ms.
+        assert_eq!(
+            dial_count(&calls),
+            6,
+            "a peer that closes every connection must use one backoff step per dial",
         );
     }
 }

--- a/crates/zakura-network/src/zakura/discovery/redial.rs
+++ b/crates/zakura-network/src/zakura/discovery/redial.rs
@@ -150,11 +150,12 @@ async fn run_dial_supervisor<F>(
 
     loop {
         // Already connected (possibly an inbound dial from the same peer).
-        if registered
+        let already_registered = registered
             .borrow_and_update()
             .iter()
-            .any(|id| id == &peer_id)
-        {
+            .any(|id| id == &peer_id);
+
+        let attempt = if already_registered {
             if !policy.redial_after_drop {
                 // Wait for it to deregister, then re-dial promptly.
                 tokio::select! {
@@ -171,15 +172,40 @@ async fn run_dial_supervisor<F>(
                     }
                 }
             }
-            if registered.changed().await.is_err() {
-                return;
-            }
-            backoff = policy.initial_backoff;
-            failures = 0;
-            continue;
-        }
 
-        match dial().await {
+            // A maintained dial owns this peer, so score the registration the
+            // same way a dial this loop drove is scored. Two things matter.
+            //
+            // Wait for *this* peer to deregister rather than for any peer-set
+            // change: on a busy node an unrelated peer connecting is not this
+            // connection ending.
+            //
+            // Then require the registration to have lasted before crediting it
+            // as healthy. A peer that shares no service beyond discovery is
+            // closed as soon as its discovery exchange completes
+            // (`discovery_exchange_complete`), and the deregistration for the
+            // connection this loop just dialed often lands after the dial
+            // future returns. Resetting the backoff on that registration made
+            // every such peer re-dial at once, forever.
+            let registered_at = Instant::now();
+            loop {
+                if registered.changed().await.is_err() {
+                    return;
+                }
+                if !registered.borrow().iter().any(|id| id == &peer_id) {
+                    break;
+                }
+            }
+            if registered_at.elapsed() >= ZAKURA_REDIAL_HEALTHY_CONNECTION {
+                DialResult::Healthy
+            } else {
+                DialResult::Failed
+            }
+        } else {
+            dial().await
+        };
+
+        match attempt {
             DialResult::Healthy => {
                 if !policy.redial_after_drop {
                     return;
@@ -383,5 +409,54 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         supervisor.abort();
+    }
+
+    /// A bootstrap peer that shares no service beyond discovery closes every
+    /// connection as soon as the discovery exchange completes. The maintained
+    /// dial must back off on that, not re-dial at once forever.
+    #[tokio::test(start_paused = true)]
+    async fn dial_supervisor_maintain_backs_off_a_peer_that_closes_every_connection() {
+        let peer_id = redial_test_peer_id();
+        let (registered_tx, registered) = tokio::sync::watch::channel(Vec::<ZakuraPeerId>::new());
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let dial_calls = calls.clone();
+        let dial_peer_id = peer_id.clone();
+        let dial = move || {
+            dial_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let registered_tx = registered_tx.clone();
+            let dial_peer_id = dial_peer_id.clone();
+            Box::pin(async move {
+                // The connection establishes and registers, serves the
+                // discovery exchange, and is then closed as discovery-only.
+                let _ = registered_tx.send(vec![dial_peer_id]);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                // The supervisor observes the deregistration only after this
+                // dial returns, so it sees the peer as still registered.
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                    let _ = registered_tx.send(Vec::new());
+                });
+                DialResult::Failed
+            }) as Pin<Box<dyn Future<Output = DialResult> + Send>>
+        };
+
+        let supervisor = tokio::spawn(run_dial_supervisor(
+            peer_id,
+            registered,
+            RedialPolicy::maintain(Duration::from_secs(1), Duration::from_secs(30)),
+            dial,
+        ));
+
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        supervisor.abort();
+
+        // Backing off 1s, 2s, 4s, ... to the 30s ceiling allows a handful of
+        // dials per minute. Without backoff the loop re-dials every 51ms.
+        let dials = dial_count(&calls);
+        assert!(
+            dials <= 8,
+            "a peer that closes every connection must be backed off, but it was dialed {dials} times in 60s",
+        );
     }
 }

--- a/docs/changelog/unreleased/741.md
+++ b/docs/changelog/unreleased/741.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Backed off repeated bootstrap dials when a peer closes short-lived Zakura
+  connections ([#741](https://github.com/zakura-core/zakura/pull/741)).


### PR DESCRIPTION
Found while smoke testing #594 on a four-node mainnet fleet. The bug is in `main`, independent of that PR.

## What happens

Two nodes whose only shared service is discovery reconnect about eleven times a second, forever. Handshakes per pair over ~13 minutes on the fleet:

| pair | shared service besides discovery | handshakes |
|---|---|---|
| `headers-0` ↔ `echo-only-0` | none | **8732** |
| `full-0` ↔ `echo-only-0` | none | **1144** |
| `full-0` ↔ `echo-full-0` | all native services | 10 |
| `echo-full-0` ↔ `echo-only-0` | one custom service | 6 |
| `full-0` ↔ `headers-0` | header sync | 4 |

The split is exact: every pair that shares a service holds one connection, every pair that shares only discovery churns. `headers-0` recorded 5714 closes with `reason: discovery_exchange_complete` and `echo-only-0` 9446, plus 3022 and 654 `accept_failed` on the inbound side of the same loop.

## Why

1. Discovery finishes its exchange, finds no other service owns the connection, and closes it (`closes_discovery_only_connection`, cause `discovery_exchange_complete`). Correct — there is nothing to keep it open for.
2. The peer is a configured bootstrap peer, so `RedialPolicy::maintain` owns the dial: `redial_after_drop: true`, `max_attempts: None`.
3. `run_dial_supervisor`'s already-registered branch waits for *any* peer-set change and then credits the peer with a healthy connection, resetting both `backoff` and `failures`.

Step 3 is the defect. The deregistration for the connection the loop just dialed usually lands *after* the dial future returns, so the loop takes that branch every cycle and the exponential backoff never applies. `DialResult::Failed` is computed correctly one line away and then thrown out.

The dampener meant for exactly this case, `entry_metadata_in_short_lived_exchange_backoff`, is only read by the discovery dialer's candidate selection. The bootstrap maintain loop never consults it, so the cost of a service-less bootstrap pairing is unbounded.

## The fix

Score the registration the way a dial the loop drove is scored:

- Wait for **this** peer to deregister rather than for any peer-set change. On a busy node an unrelated peer connecting is not this connection ending, and it should not restart the dial.
- Credit the registration as healthy only when it lasted `ZAKURA_REDIAL_HEALTHY_CONNECTION`. Anything shorter falls through to the same bounded backoff as a failed dial.

The `connect_once` path (legacy→Zakura upgrade hand-off) is untouched.

A bootstrap peer that shares no service still gets re-dialed — it may gain one — but at the 30s ceiling rather than continuously.

## Test

`dial_supervisor_maintain_backs_off_a_peer_that_closes_every_connection` models the observed sequence on paused time: the dial registers the peer, serves for 50ms, returns `Failed`, and the deregistration lands 1ms after the dial future returns.

- Before: **1177 dials in 60 seconds** (~20/s, matching the ~11/s measured on mainnet).
- After: **6**, which is 1s + 2s + 4s + 8s + 16s + 30s.

`cargo test -p zakura-network --lib`: 1088 passed, 0 failed. `cargo clippy -p zakura-network --all-targets` and `cargo fmt --check` clean.

## Why it matters more soon

Today most nodes run the same service set, so the mismatched pairing is rare. #594 makes partial-service and embedded nodes easy to run, and any operator whose bootstrap list mixes service sets then gets this storm between the mismatched pairs.

It is not only wasted work. On the fleet, `headers-0` (header sync only) sent **332** header requests to `echo-full-0`, which was syncing from genesis at height ~57k and answered every one with `busy` or `no_locator_intersection`, and **0** to `full-0`, which was at tip and had the headers. The reconnect loop consumed its dial capacity — 4 handshakes with `full-0` against 8732 with `echo-only-0`.

It is also not only wasted work in the sense of CPU. Over 67 minutes RSS tracked handshake count on both storm-hit nodes:

| node | RSS @4m | RSS @67m | handshakes @67m | growth | per handshake |
|---|---|---|---|---|---|
| `echo-only-0` | 130 MiB | **1077 MiB** | 271663 | +947 MiB | 3.8 KiB |
| `headers-0` | 589 MiB | **1300 MiB** | 238306 | +711 MiB | 3.3 KiB |
| `full-0` | 1054 MiB | 1089 MiB | 31606 | +35 MiB | 1.2 KiB |

`echo-only-0` runs discovery and one custom service against three peers, holds one session, keeps 26 file descriptors, and writes 1 MB to disk. The growth is anonymous heap (`RssAnon` 1069572 kB of `VmRSS` 1112220 kB) across 15 threads, so it is retained state rather than leaked sockets or tasks. At ~3.5 KiB per cycle and eleven cycles a second, a mismatched pairing costs about 3.4 GB a day; these 16 GB nodes would have been OOM-killed within a week.

`headers-0` also stopped syncing outright: 9 header-sync streams at four minutes, still 9 at 67 minutes, `peer_count` 0 throughout.

I have not identified what is retained per connection cycle. It may only be reachable at storm rates, in which case this PR is the whole fix; it may also be a leak that is invisible at normal connection rates. Either way the growth stops once the redial backs off, and the retention is worth a separate look.

## Follow-up, not in this PR

Service preference selects on *whether* a peer advertises `zakura.header_sync.v2`, not on whether its tip is ahead. `headers-0` had 9140 `advisory_header_summary` events carrying peer header tips, so the data to choose better is already flowing; selection does not use it.

Draft: I would like a second opinion on the healthy-registration threshold before this lands. Everything else is verified.
