### PR TITLE
fix(sync): harden checkpoint provenance and recovery

### DIFF
--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -62,7 +62,16 @@ struct QueuedBlock {
     /// The block, with additional precalculated data.
     block: CheckpointVerifiedBlock,
     /// The transmitting end of the oneshot channel for this block's result.
-    tx: oneshot::Sender<Result<block::Hash, VerifyCheckpointError>>,
+    tx: oneshot::Sender<QueuedBlockResult>,
+}
+
+/// The verification result and generation assigned when a queued block resolves.
+#[derive(Debug)]
+struct QueuedBlockResult {
+    /// The queued block's verification result.
+    result: Result<block::Hash, VerifyCheckpointError>,
+    /// The verifier generation that resolved the queued block.
+    reset_generation: u64,
 }
 
 /// The unverified block, with a receiver for the [`QueuedBlock`]'s result.
@@ -71,7 +80,7 @@ struct RequestBlock {
     /// The block, with additional precalculated data.
     block: CheckpointVerifiedBlock,
     /// The receiving end of the oneshot channel for this block's result.
-    rx: oneshot::Receiver<Result<block::Hash, VerifyCheckpointError>>,
+    rx: oneshot::Receiver<QueuedBlockResult>,
 }
 
 /// A list of unverified blocks at a particular height.
@@ -705,6 +714,7 @@ where
         let block = self.check_block(block)?;
         let height = block.height;
         let hash = block.hash;
+        let reset_generation = self.reset_generation;
 
         let new_qblock = QueuedBlock {
             block: block.clone(),
@@ -740,7 +750,10 @@ where
                 // even if the block hash is the same.
 
                 let old = std::mem::replace(qb, new_qblock);
-                let _ = old.tx.send(Err(e));
+                let _ = old.tx.send(QueuedBlockResult {
+                    result: Err(e),
+                    reset_generation,
+                });
                 return Ok(req_block);
             }
         }
@@ -810,12 +823,13 @@ where
             } else {
                 tracing::info!(?height, ?qblock.block.hash, ?expected_hash,
                                "Side chain hash at height in CheckpointVerifier");
-                let _ = qblock
-                    .tx
-                    .send(Err(VerifyCheckpointError::UnexpectedSideChain {
+                let _ = qblock.tx.send(QueuedBlockResult {
+                    result: Err(VerifyCheckpointError::UnexpectedSideChain {
                         found: qblock.block.hash,
                         expected: expected_hash,
-                    }));
+                    }),
+                    reset_generation: self.reset_generation,
+                });
             }
         }
 
@@ -947,9 +961,13 @@ where
 
         // All the blocks we've kept are valid, so let's verify them
         // in height order.
+        let reset_generation = self.reset_generation;
         for qblock in rev_valid_blocks.drain(..).rev() {
             // Sending can fail, but there's nothing we can do about it.
-            let _ = qblock.tx.send(Ok(qblock.block.hash));
+            let _ = qblock.tx.send(QueuedBlockResult {
+                result: Ok(qblock.block.hash),
+                reset_generation,
+            });
         }
 
         // Finally, update the checkpoint bounds
@@ -1007,7 +1025,10 @@ where
                 .expect("each entry is only removed once");
             for qblock in qblocks.drain(..) {
                 // Sending can fail, but there's nothing we can do about it.
-                let _ = qblock.tx.send(Err(VerifyCheckpointError::Dropped));
+                let _ = qblock.tx.send(QueuedBlockResult {
+                    result: Err(VerifyCheckpointError::Dropped),
+                    reset_generation: self.reset_generation,
+                });
             }
         }
     }
@@ -1200,7 +1221,6 @@ where
         // Reset the verifier back to the state tip if requested
         // (e.g. due to an error when committing a block to the state)
         self.apply_pending_reset();
-        let reset_generation = self.reset_generation;
 
         // Immediately reject all incoming blocks that arrive after we've finished.
         if let FinalCheckpoint = self.previous_checkpoint_height() {
@@ -1243,44 +1263,53 @@ where
         let state_service = self.state_service.clone();
         let network = self.network.clone();
         let commit_checkpoint_verified = tokio::spawn(async move {
-            let hash = req_block
+            let queued_result = req_block
                 .rx
                 .await
                 .map_err(Into::into)
                 .map_err(VerifyCheckpointError::CommitCheckpointVerified)
-                .expect("CheckpointVerifier does not leave dangling receivers")?;
+                .expect("CheckpointVerifier does not leave dangling receivers");
+            let reset_generation = queued_result.reset_generation;
 
-            if req_block.block.auth_data_root.is_none()
-                && NetworkUpgrade::current(&network, req_block.block.height) >= NetworkUpgrade::Nu5
-            {
-                let block = req_block.block.clone();
-                if let Ok(block) =
-                    tokio::task::spawn_blocking(move || block.with_precomputed_auth_data_root())
-                        .await
+            let result: Result<block::Hash, VerifyCheckpointError> = async move {
+                let hash = queued_result.result?;
+
+                if req_block.block.auth_data_root.is_none()
+                    && NetworkUpgrade::current(&network, req_block.block.height)
+                        >= NetworkUpgrade::Nu5
                 {
-                    req_block.block = block;
+                    let block = req_block.block.clone();
+                    if let Ok(block) =
+                        tokio::task::spawn_blocking(move || block.with_precomputed_auth_data_root())
+                            .await
+                    {
+                        req_block.block = block;
+                    }
                 }
-            }
 
-            // We use a `ServiceExt::oneshot`, so that every state service
-            // `poll_ready` has a corresponding `call`. See #1593.
-            match state_service
-                .oneshot(zs::Request::CommitCheckpointVerifiedBlock(req_block.block))
-                .map_err(VerifyCheckpointError::CommitCheckpointVerified)
-                .await?
-            {
-                zs::Response::Committed(committed_hash) => {
-                    assert_eq!(committed_hash, hash, "state must commit correct hash");
-                    Ok(hash)
+                // We use a `ServiceExt::oneshot`, so that every state service
+                // `poll_ready` has a corresponding `call`. See #1593.
+                match state_service
+                    .oneshot(zs::Request::CommitCheckpointVerifiedBlock(req_block.block))
+                    .map_err(VerifyCheckpointError::CommitCheckpointVerified)
+                    .await?
+                {
+                    zs::Response::Committed(committed_hash) => {
+                        assert_eq!(committed_hash, hash, "state must commit correct hash");
+                        Ok(hash)
+                    }
+                    _ => unreachable!("wrong response for CommitCheckpointVerifiedBlock"),
                 }
-                _ => unreachable!("wrong response for CommitCheckpointVerifiedBlock"),
             }
+            .await;
+
+            (result, reset_generation)
         });
 
         let state_service = self.state_service.clone();
         let reset_sender = self.reset_sender.clone();
         async move {
-            let result = commit_checkpoint_verified.await;
+            let commit_result = commit_checkpoint_verified.await;
             // Avoid a panic on shutdown
             //
             // When `zakurad` is terminated using Ctrl-C, the `commit_checkpoint_verified` task
@@ -1288,11 +1317,11 @@ where
             // so we don't need to panic here. The persistent state is correct even when the
             // task is cancelled, because block data is committed inside transactions, in
             // height order.
-            let result = if zakura_chain::shutdown::is_shutting_down() {
-                Err(VerifyCheckpointError::ShuttingDown)
-            } else {
-                result.expect("commit_checkpoint_verified should not panic")
-            };
+            if zakura_chain::shutdown::is_shutting_down() {
+                return Err(VerifyCheckpointError::ShuttingDown);
+            }
+            let (result, reset_generation) =
+                commit_result.expect("commit_checkpoint_verified should not panic");
             // Only reset on real commit/state desyncs. Duplicate / NewerRequest
             // failures are expected when sync resubmits in-queue bodies; resetting
             // for them rewinds progress behind the already-verified checkpoint and

--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -82,6 +82,15 @@ struct RequestBlock {
 /// The CheckpointVerifier avoids creating zero-block lists.
 type QueuedBlockList = Vec<QueuedBlock>;
 
+/// A state-tip reset requested by a checkpoint commit from one verifier generation.
+#[derive(Copy, Clone, Debug)]
+struct CheckpointReset {
+    /// The verifier generation that submitted the failed commit.
+    generation: u64,
+    /// The durable state tip observed after the commit failed.
+    tip: Option<(block::Height, block::Hash)>,
+}
+
 /// The maximum number of queued blocks at any one height.
 ///
 /// This value is a tradeoff between:
@@ -152,10 +161,12 @@ where
 
     /// A channel to receive requests to reset the verifier,
     /// receiving the tip of the state.
-    reset_receiver: mpsc::Receiver<Option<(block::Height, block::Hash)>>,
+    reset_receiver: mpsc::Receiver<CheckpointReset>,
     /// A channel to send requests to reset the verifier,
     /// passing the tip of the state.
-    reset_sender: mpsc::Sender<Option<(block::Height, block::Hash)>>,
+    reset_sender: mpsc::Sender<CheckpointReset>,
+    /// The generation assigned to new checkpoint commits.
+    reset_generation: u64,
 
     /// Queued block height progress transmitter.
     #[cfg(feature = "progress-bar")]
@@ -286,6 +297,7 @@ where
             verifier_progress,
             reset_receiver: receiver,
             reset_sender: sender,
+            reset_generation: 0,
             #[cfg(feature = "progress-bar")]
             queued_blocks_bar,
             #[cfg(feature = "progress-bar")]
@@ -372,6 +384,42 @@ where
         self.verifier_progress = verifier_progress;
 
         self.verified_checkpoint_diagnostics(verifier_progress.height());
+    }
+
+    /// Apply one reset for the current generation and discard older reset requests.
+    ///
+    /// One checkpoint-range failure can make every sibling commit future fail.
+    /// Each sibling then requests a reset for the same generation.
+    /// The first recovery call drains those requests and advances the generation.
+    /// A late sibling request cannot rewind progress after recovery.
+    fn apply_pending_reset(&mut self) {
+        let generation = self.reset_generation;
+        let mut highest_tip = None;
+
+        while let Ok(reset) = self.reset_receiver.try_recv() {
+            if reset.generation != generation {
+                continue;
+            }
+
+            highest_tip = Some(match (highest_tip, reset.tip) {
+                (None, tip) => tip,
+                (Some(None), tip) => tip,
+                (Some(Some(current)), None) => Some(current),
+                (Some(Some(current)), Some(candidate)) => Some(if candidate.0 >= current.0 {
+                    candidate
+                } else {
+                    current
+                }),
+            });
+        }
+
+        if let Some(tip) = highest_tip {
+            self.reset_progress(tip);
+            self.reset_generation = self
+                .reset_generation
+                .checked_add(1)
+                .expect("checkpoint reset generation cannot exhaust u64");
+        }
     }
 
     /// Return the current verifier's progress.
@@ -1151,9 +1199,8 @@ where
     fn call(&mut self, block: Arc<Block>) -> Self::Future {
         // Reset the verifier back to the state tip if requested
         // (e.g. due to an error when committing a block to the state)
-        if let Ok(tip) = self.reset_receiver.try_recv() {
-            self.reset_progress(tip);
-        }
+        self.apply_pending_reset();
+        let reset_generation = self.reset_generation;
 
         // Immediately reject all incoming blocks that arrive after we've finished.
         if let FinalCheckpoint = self.previous_checkpoint_height() {
@@ -1267,7 +1314,10 @@ where
                     };
                     // Ignore errors since send() can fail only when the verifier
                     // is being dropped, and then it doesn't matter anymore.
-                    let _ = reset_sender.send(tip);
+                    let _ = reset_sender.send(CheckpointReset {
+                        generation: reset_generation,
+                        tip,
+                    });
                 }
             }
             result

--- a/crates/zakura-consensus/src/checkpoint/tests.rs
+++ b/crates/zakura-consensus/src/checkpoint/tests.rs
@@ -1098,6 +1098,129 @@ async fn stale_commit_reset_must_not_rewind_recovered_checkpoint_progress() -> R
     Ok(())
 }
 
+/// Blocks queued before a reset must use the generation that verifies their range.
+#[tokio::test(flavor = "multi_thread")]
+async fn queued_commit_failure_after_reset_must_reset_recovered_progress() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+
+    let blockchain: Vec<_> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .iter()
+        .map(|(height, bytes)| {
+            let block = Arc::<Block>::zcash_deserialize(*bytes).expect("block deserializes");
+            let hash = block.hash();
+            let coinbase_height = block.coinbase_height().expect("block has a height");
+            assert_eq!(*height, coinbase_height.0);
+            (block, coinbase_height, hash)
+        })
+        .collect();
+    assert!(blockchain.len() > 10);
+
+    let checkpoint_list: BTreeMap<_, _> = [0usize, 3, 6, 10]
+        .into_iter()
+        .map(|index| {
+            let (_block, height, hash) = &blockchain[index];
+            (*height, *hash)
+        })
+        .collect();
+    let initial_tip = (blockchain[3].1, blockchain[3].2);
+    let (tip_sender, _tip_receiver) = tokio::sync::watch::channel(Some(initial_tip));
+    let state_service = tower::service_fn(move |request: zs::Request| {
+        let tip_sender = tip_sender.clone();
+
+        async move {
+            match request {
+                zs::Request::CommitCheckpointVerifiedBlock(block) => {
+                    if block.height == block::Height(4) {
+                        tip_sender.send_replace(Some((block.height, block.hash)));
+                        Ok(zs::Response::Committed(block.hash))
+                    } else {
+                        let mut tip_receiver = tip_sender.subscribe();
+                        loop {
+                            let height_four_is_committed = tip_receiver
+                                .borrow()
+                                .is_some_and(|(height, _hash)| height >= block::Height(4));
+                            if height_four_is_committed {
+                                break;
+                            }
+                            tip_receiver
+                                .changed()
+                                .await
+                                .expect("the test retains the tip sender");
+                        }
+
+                        Err::<zs::Response, BoxError>(
+                            std::io::Error::other("injected checkpoint commit failure").into(),
+                        )
+                    }
+                }
+                zs::Request::Tip => Ok(zs::Response::Tip(*tip_sender.borrow())),
+                _ => unreachable!("checkpoint verifier test uses only commit and tip requests"),
+            }
+        }
+    });
+    let mut checkpoint_verifier =
+        CheckpointVerifier::from_list(checkpoint_list, &Mainnet, Some(initial_tip), state_service)
+            .map_err(|error| eyre!(error))?;
+
+    let ready = checkpoint_verifier
+        .ready()
+        .map_err(|error| eyre!(error))
+        .await?;
+    let height_5 = ready.call(blockchain[5].0.clone());
+    let ready = checkpoint_verifier
+        .ready()
+        .map_err(|error| eyre!(error))
+        .await?;
+    let height_6 = ready.call(blockchain[6].0.clone());
+
+    checkpoint_verifier
+        .reset_sender
+        .send(CheckpointReset {
+            generation: 0,
+            tip: Some(initial_tip),
+        })
+        .expect("the verifier owns the reset receiver");
+
+    let ready = checkpoint_verifier
+        .ready()
+        .map_err(|error| eyre!(error))
+        .await?;
+    let height_4 = ready.call(blockchain[4].0.clone());
+    assert_eq!(checkpoint_verifier.reset_generation, 1);
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        PreviousCheckpoint(block::Height(6)),
+        "the recovered range must verify before its commits finish"
+    );
+
+    height_4.await.expect("height 4 must commit");
+    height_5
+        .await
+        .expect_err("the test state must reject height 5");
+    height_6
+        .await
+        .expect_err("the test state must reject height 6");
+
+    let ready = checkpoint_verifier
+        .ready()
+        .map_err(|error| eyre!(error))
+        .await?;
+    let retry_height_5 = ready.call(blockchain[5].0.clone());
+
+    assert_eq!(checkpoint_verifier.reset_generation, 2);
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        InitialTip(block::Height(4)),
+        "a failed recovered commit must reset optimistic verifier progress"
+    );
+    assert!(
+        retry_height_5.now_or_never().is_none(),
+        "the verifier must queue the retry instead of returning AlreadyVerified"
+    );
+
+    Ok(())
+}
+
 /// Duplicate block errors must stay classified as duplicate requests after the
 /// state wraps them, so they don't restart the syncer during checkpoint sync.
 #[test]

--- a/crates/zakura-consensus/src/checkpoint/tests.rs
+++ b/crates/zakura-consensus/src/checkpoint/tests.rs
@@ -1025,6 +1025,79 @@ async fn newer_request_must_not_rewind_verified_checkpoint_progress() -> Result<
     Ok(())
 }
 
+/// A late reset from an earlier commit generation must not rewind recovered progress.
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_commit_reset_must_not_rewind_recovered_checkpoint_progress() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+
+    let blockchain: Vec<_> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .iter()
+        .map(|(height, bytes)| {
+            let block = Arc::<Block>::zcash_deserialize(*bytes).expect("block deserializes");
+            let hash = block.hash();
+            let coinbase_height = block.coinbase_height().expect("block has a height");
+            assert_eq!(*height, coinbase_height.0);
+            (coinbase_height, hash)
+        })
+        .collect();
+    assert!(blockchain.len() > 10);
+
+    let checkpoint_list: BTreeMap<_, _> = [0usize, 3, 6, 10]
+        .into_iter()
+        .map(|index| blockchain[index])
+        .collect();
+    let state_service = zakura_state::init_test(&Mainnet).await;
+    let mut checkpoint_verifier = CheckpointVerifier::from_list(
+        checkpoint_list,
+        &Mainnet,
+        Some(blockchain[3]),
+        state_service,
+    )
+    .map_err(|e| eyre!(e))?;
+
+    checkpoint_verifier
+        .reset_sender
+        .send(CheckpointReset {
+            generation: 0,
+            tip: Some(blockchain[3]),
+        })
+        .expect("the verifier owns the reset receiver");
+    checkpoint_verifier
+        .reset_sender
+        .send(CheckpointReset {
+            generation: 0,
+            tip: Some(blockchain[6]),
+        })
+        .expect("the verifier owns the reset receiver");
+    checkpoint_verifier.apply_pending_reset();
+
+    assert_eq!(checkpoint_verifier.reset_generation, 1);
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        InitialTip(block::Height(6)),
+        "one reset generation must use its highest durable tip"
+    );
+
+    checkpoint_verifier.verifier_progress = PreviousCheckpoint(block::Height(6));
+    checkpoint_verifier
+        .reset_sender
+        .send(CheckpointReset {
+            generation: 0,
+            tip: Some(blockchain[3]),
+        })
+        .expect("the verifier owns the reset receiver");
+    checkpoint_verifier.apply_pending_reset();
+
+    assert_eq!(checkpoint_verifier.reset_generation, 1);
+    assert_eq!(
+        checkpoint_verifier.previous_checkpoint_height(),
+        PreviousCheckpoint(block::Height(6)),
+        "a late reset from the failed generation must not reopen a committed gap"
+    );
+
+    Ok(())
+}
+
 /// Duplicate block errors must stay classified as duplicate requests after the
 /// state wraps them, so they don't restart the syncer during checkpoint sync.
 #[test]

--- a/crates/zakura-header-chain/src/transition/authority.rs
+++ b/crates/zakura-header-chain/src/transition/authority.rs
@@ -2,7 +2,9 @@
 
 use chrono::{DateTime, Utc};
 
-use crate::{EngineConfig, InsertHeaders, OperatorBodyRetry, TransitionEvent, ValidationLease};
+use crate::{
+    EngineConfig, InsertHeaders, OperatorBodyRetry, StateVersion, TransitionEvent, ValidationLease,
+};
 
 /// The consensus-local clock supplies time to transition events.
 /// Transition events cannot supply time.
@@ -39,6 +41,11 @@ impl Clock for SystemClock {
 pub trait FullStateEvidenceAuthority: Send + Sync {
     /// Return true only when the complete event is the writer's staged mutation.
     fn authorizes_full_state(&self, event: &TransitionEvent) -> bool;
+
+    /// Return the header-engine version that the writer consumed to authorize this event.
+    fn full_state_authorization_version(&self, _event: &TransitionEvent) -> Option<StateVersion> {
+        None
+    }
 
     /// Return true only when the serialized scheduler staged this exact retry action.
     fn authorizes_scheduler_retry(&self, _retry: &OperatorBodyRetry) -> bool {

--- a/crates/zakura-header-chain/src/transition/planner.rs
+++ b/crates/zakura-header-chain/src/transition/planner.rs
@@ -153,6 +153,7 @@ fn derive_plan_candidate(
     }
     let event = bound_request.event;
     let domain = bound_request.domain;
+    let full_state_authorization_version = bound_request.full_state_authorization_version;
 
     // Phase 3: project event evidence
     let old_selected = engine.selected_projection();
@@ -181,6 +182,7 @@ fn derive_plan_candidate(
         context,
         old_selected,
         old_verified,
+        full_state_authorization_version,
     })?;
     let settled = match settlement {
         FinalityRetentionOutcome::ResourceStalled => {

--- a/crates/zakura-header-chain/src/transition/planner/admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/admission.rs
@@ -21,6 +21,8 @@ pub(super) struct AdmittedRequest {
     pub(super) event: TransitionEvent,
     /// Caller-observed durable version when the input is version-qualified.
     pub(super) expected_version: Option<crate::StateVersion>,
+    /// Durable version whose snapshot authorized full-state evidence.
+    pub(super) full_state_authorization_version: Option<crate::StateVersion>,
 }
 
 /// How a pure header insertion related to newer monotone finality.
@@ -73,12 +75,16 @@ pub(super) fn authenticate_and_admit(
     let event = input.event();
     validate_event_resource_bounds(engine, &event, context.config.limits)?;
     validate_authority(&event, context)?;
+    let full_state_authorization_version = context
+        .full_state_authority
+        .and_then(|authority| authority.full_state_authorization_version(&event));
     Ok((
         snapshot_before_commit,
         metadata,
         AdmittedRequest {
             event,
             expected_version: input.expected_version(),
+            full_state_authorization_version,
         },
     ))
 }

--- a/crates/zakura-header-chain/src/transition/planner/replay.rs
+++ b/crates/zakura-header-chain/src/transition/planner/replay.rs
@@ -16,6 +16,7 @@ pub(super) struct BoundRequest {
     pub(super) domain: TransitionDomain,
     pub(super) header_rebase: HeaderInsertionRebase,
     pub(super) no_change_effect: Option<TransitionEffect>,
+    pub(super) full_state_authorization_version: Option<crate::StateVersion>,
 }
 
 /// Check replay identity, async ownership, and version freshness for an admitted request.
@@ -33,6 +34,7 @@ pub(super) fn bind_replay_and_freshness(
     let AdmittedRequest {
         mut event,
         expected_version,
+        full_state_authorization_version,
     } = request;
     let domain = event.domain();
     let header_rebase =
@@ -62,6 +64,7 @@ pub(super) fn bind_replay_and_freshness(
             domain,
             header_rebase,
             no_change_effect: Some(TransitionEffect::header_work_already_applied()),
+            full_state_authorization_version,
         });
     }
     if fingerprint.is_some() && metadata.last_transition == fingerprint {
@@ -70,6 +73,7 @@ pub(super) fn bind_replay_and_freshness(
             domain,
             header_rebase,
             no_change_effect: Some(TransitionEffect::event()),
+            full_state_authorization_version,
         });
     }
     let has_async_authority = event.header_sync_owner().is_some() || event.body_owner().is_some();
@@ -90,5 +94,6 @@ pub(super) fn bind_replay_and_freshness(
         domain,
         header_rebase,
         no_change_effect: None,
+        full_state_authorization_version,
     })
 }

--- a/crates/zakura-header-chain/src/transition/planner/settlement.rs
+++ b/crates/zakura-header-chain/src/transition/planner/settlement.rs
@@ -28,6 +28,7 @@ pub(super) struct SettlementInputs<'engine, 'ctx> {
     pub(super) context: &'ctx TransitionContext<'ctx>,
     pub(super) old_selected: &'engine [Frontier],
     pub(super) old_verified: &'engine [Frontier],
+    pub(super) full_state_authorization_version: Option<crate::StateVersion>,
 }
 
 /// Evidence that an appended finality record continues the prior projections.
@@ -87,6 +88,7 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
         context,
         old_selected,
         old_verified,
+        full_state_authorization_version,
     } = inputs;
     let work_rebased = projected.work_coordinates_rebased();
     if work_rebased {
@@ -133,7 +135,8 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
             FinalitySource::FullState {
                 provenance: FullStateFinalityProvenance {
                     evidence,
-                    state_version: snapshot_before_commit.state_version,
+                    state_version: full_state_authorization_version
+                        .unwrap_or(snapshot_before_commit.state_version),
                     kind,
                 },
             },

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -2308,6 +2308,14 @@ impl HeaderChainRuntime {
             .map_err(|_| HeaderChainStoreError::WriterPoisoned)?
             .active_references(Instant::now());
 
+        // The state writer binds checkpoint finality evidence to the durable version it read,
+        // and the auxiliary transition below advances that version. Provenance therefore has
+        // to be checked against the pre-auxiliary snapshot the writer actually authorized.
+        let before = transition_engine.snapshot();
+        if checkpoint_request.expected_version == before.state_version {
+            validate_full_state_finality_provenance(&checkpoint_request.event, &before)?;
+        }
+
         let first_authority = StateIssuedAuthority {
             inner: first_context.full_state_authority,
             validation_leases: &[],
@@ -2390,10 +2398,6 @@ impl HeaderChainRuntime {
         }
 
         let expected_version = transition_engine.snapshot().state_version;
-        validate_full_state_finality_provenance(
-            &checkpoint_request.event,
-            &transition_engine.snapshot(),
-        )?;
         let TransitionEvent::VerifiedChainChanged(checkpoint_event) = checkpoint_request.event
         else {
             return Err(HeaderChainStoreError::Incoherent(

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -296,12 +296,21 @@ struct StateIssuedAuthority<'a> {
     inner: Option<&'a dyn FullStateEvidenceAuthority>,
     validation_leases: &'a [ValidationLease],
     active_retention_references: &'a [block::Hash],
+    full_state_authorization_version: Option<StateVersion>,
 }
 
 impl FullStateEvidenceAuthority for StateIssuedAuthority<'_> {
     fn authorizes_full_state(&self, event: &TransitionEvent) -> bool {
         self.inner
             .is_some_and(|inner| inner.authorizes_full_state(event))
+    }
+
+    fn full_state_authorization_version(&self, event: &TransitionEvent) -> Option<StateVersion> {
+        if self.authorizes_full_state(event) {
+            self.full_state_authorization_version
+        } else {
+            None
+        }
     }
 
     fn authorizes_scheduler_retry(&self, retry: &zakura_header_chain::OperatorBodyRetry) -> bool {
@@ -2335,6 +2344,7 @@ impl HeaderChainRuntime {
             inner: first_context.full_state_authority,
             validation_leases: &[],
             active_retention_references: lease_references.as_ref(),
+            full_state_authorization_version: None,
         };
         let first_context = TransitionContext {
             config: first_context.config,
@@ -2374,6 +2384,7 @@ impl HeaderChainRuntime {
             inner: checkpoint_context.full_state_authority,
             validation_leases: validation_leases.as_slice(),
             active_retention_references: lease_references.as_ref(),
+            full_state_authorization_version: Some(before.state_version),
         };
         let checkpoint_context = TransitionContext {
             config: checkpoint_context.config,
@@ -2698,6 +2709,7 @@ impl HeaderChainRuntime {
             inner: base_context.full_state_authority,
             validation_leases: &validation_leases,
             active_retention_references: lease_references.as_deref().unwrap_or_default(),
+            full_state_authorization_version: Some(before.state_version),
         };
         let transition_context = TransitionContext {
             config: base_context.config,

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -2312,9 +2312,24 @@ impl HeaderChainRuntime {
         // and the auxiliary transition below advances that version. Provenance therefore has
         // to be checked against the pre-auxiliary snapshot the writer actually authorized.
         let before = transition_engine.snapshot();
-        if checkpoint_request.expected_version == before.state_version {
-            validate_full_state_finality_provenance(&checkpoint_request.event, &before)?;
+        if checkpoint_request.expected_version != before.state_version {
+            let branch = checkpoint_request
+                .event
+                .header_sync_owner()
+                .map(HeaderSyncWorkOwner::header_authority)
+                .map(|authority| authority.branch)
+                .or_else(|| {
+                    checkpoint_request
+                        .event
+                        .body_owner()
+                        .map(|owner| owner.branch)
+                });
+            return Ok(ApplyResult::Stale(StaleReceipt {
+                current_version: before.state_version,
+                branch,
+            }));
         }
+        validate_full_state_finality_provenance(&checkpoint_request.event, &before)?;
 
         let first_authority = StateIssuedAuthority {
             inner: first_context.full_state_authority,

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -1481,7 +1481,13 @@ fn repeated_compatible_finality_publications_preserve_body_work_epoch() {
 
 #[test]
 fn combined_checkpoint_rejects_stale_version_and_accepts_pre_auxiliary_evidence() {
-    let db_config = Config::ephemeral();
+    let cache = tempfile::tempdir().expect("the test cache directory is created");
+    let db_config = Config {
+        cache_dir: cache.path().to_owned(),
+        ephemeral: false,
+        debug_skip_non_finalized_state_backup_task: true,
+        ..Config::default()
+    };
     let (engine_config, anchor, metadata) = fixture();
     let store = HeaderChainStore::new(open(&db_config, engine_config.network()));
     store
@@ -1698,6 +1704,13 @@ fn combined_checkpoint_rejects_stale_version_and_accepts_pre_auxiliary_evidence(
         before.state_version.get() + 2,
         "the auxiliary transition must advance the version the checkpoint evidence was bound to"
     );
+
+    drop(runtime);
+    let (reopened, report) = HeaderChainStore::new(open(&db_config, engine_config.network()))
+        .startup(&engine_config)
+        .expect("recovery authenticates the pre-auxiliary checkpoint provenance");
+    assert_eq!(report.current, after);
+    assert_eq!(reopened.publisher().snapshot(), after);
 }
 
 #[test]

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -1480,7 +1480,7 @@ fn repeated_compatible_finality_publications_preserve_body_work_epoch() {
 }
 
 #[test]
-fn combined_checkpoint_accepts_evidence_bound_to_the_pre_auxiliary_version() {
+fn combined_checkpoint_rejects_stale_version_and_accepts_pre_auxiliary_evidence() {
     let db_config = Config::ephemeral();
     let (engine_config, anchor, metadata) = fixture();
     let store = HeaderChainStore::new(open(&db_config, engine_config.network()));
@@ -1612,6 +1612,53 @@ fn combined_checkpoint_accepts_evidence_bound_to_the_pre_auxiliary_version() {
             .expect("the auxiliary observation has an identity"),
     );
     let checkpoint_authority = Authority(checkpoint_evidence);
+
+    let stale_version = StateVersion::new(
+        before
+            .state_version
+            .get()
+            .checked_sub(1)
+            .expect("header insertion advanced the initial version"),
+    );
+    let mut stale_full_state_batch = DiskWriteBatch::new();
+    stage_full_state_canonical_hash(&runtime.store, &mut stale_full_state_batch, child);
+    let mut stale_memory_swapped = false;
+    let stale_result = runtime
+        .apply_aux_then_checkpoint_combined(
+            TransitionRequest {
+                expected_version: before.state_version,
+                event: aux_event.clone(),
+            },
+            &TransitionContext {
+                config: &engine_config,
+                clock: &SystemClock,
+                full_state_authority: Some(&aux_authority),
+                retention_references: &[],
+            },
+            TransitionRequest {
+                expected_version: stale_version,
+                event: checkpoint_event.clone(),
+            },
+            &TransitionContext {
+                config: &engine_config,
+                clock: &SystemClock,
+                full_state_authority: Some(&checkpoint_authority),
+                retention_references: &[],
+            },
+            stale_full_state_batch,
+            || stale_memory_swapped = true,
+        )
+        .expect("a stale checkpoint request returns a typed result");
+
+    assert_eq!(
+        stale_result,
+        ApplyResult::Stale(StaleReceipt {
+            current_version: before.state_version,
+            branch: None,
+        })
+    );
+    assert!(!stale_memory_swapped);
+    assert_eq!(runtime.publisher().snapshot(), before);
 
     let mut full_state_batch = DiskWriteBatch::new();
     stage_full_state_canonical_hash(&runtime.store, &mut full_state_batch, child);

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/transition.rs
@@ -1405,6 +1405,18 @@ fn checkpoint_auxiliary_staging_does_not_clone_the_retained_engine() {
         implementation.contains("transition_engine.graph().header_node(header.hash).is_some()"),
         "the predecessor-lease fast path must be justified by the coherent retained graph"
     );
+    let validated = implementation
+        .find("validate_full_state_finality_provenance")
+        .expect("the combined checkpoint path validates full-state finality provenance");
+    let staged = implementation
+        .find("install_committed_transition")
+        .expect("the combined checkpoint path stages the auxiliary transition");
+    assert!(
+        validated < staged,
+        "checkpoint provenance must be validated against the pre-auxiliary snapshot, \
+         because staging the auxiliary transition advances the state version the \
+         state writer bound its evidence to"
+    );
 }
 
 #[test]
@@ -1464,5 +1476,218 @@ fn repeated_compatible_finality_publications_preserve_body_work_epoch() {
         publisher.view().body_work_epoch,
         zakura_header_chain::BodyWorkEpoch::default(),
         "compatible checkpoint publications must not advance the cumulative epoch"
+    );
+}
+
+#[test]
+fn combined_checkpoint_accepts_evidence_bound_to_the_pre_auxiliary_version() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let store = HeaderChainStore::new(open(&db_config, engine_config.network()));
+    store
+        .initialize(metadata, anchor.clone())
+        .expect("the empty schema initializes");
+    let (runtime, _) = store
+        .startup(&engine_config)
+        .expect("the initial store audits");
+    let initial = runtime.publisher().snapshot();
+    let anchor_frontier = Frontier::new(anchor.height, anchor.hash);
+
+    let lease = runtime
+        .reader()
+        .validation_context(anchor.hash)
+        .expect("the anchor validation context is coherent")
+        .expect("the initialized anchor is retained");
+    let rules = HeaderRules::for_validation_lease(&lease)
+        .expect("the authenticated regtest policy is valid");
+    let mut child_header = *anchor.header;
+    child_header.previous_block_hash = anchor.hash;
+    child_header.time += chrono::Duration::seconds(1);
+    child_header.nonce.0[0] = 0x81;
+    let child_header = Arc::new(child_header);
+    // Authenticating a VCT delivery reads the delivery's direct successor on the owned
+    // branch, so the fixture admits one header past the checkpoint target.
+    let mut successor_header = *child_header;
+    successor_header.previous_block_hash = child_header.hash();
+    successor_header.time += chrono::Duration::seconds(1);
+    successor_header.nonce.0[0] = 0x85;
+    let successor_header = Arc::new(successor_header);
+    let headers = [child_header.clone(), successor_header.clone()];
+    let insertion_batch = zakura_header_chain::prepare_headers(
+        HeaderBatchInput::new(&headers),
+        lease.parent(),
+        &rules,
+        &SystemClock,
+    )
+    .expect("the checkpoint fixture passes production validation");
+    let child = Frontier::new(
+        anchor
+            .height
+            .next()
+            .expect("the genesis anchor has a next height"),
+        child_header.hash(),
+    );
+    let successor = Frontier::new(
+        child.height.next().expect("the child has a next height"),
+        successor_header.hash(),
+    );
+
+    // The unauthenticated delivery gives the auxiliary transition real durable work, which is
+    // what advances the state version between the writer's read and the checkpoint plan.
+    let source = SourceId::from_digest([0x82; 32]);
+    // The admission rule requires the delivery and its insertion to share one owner.
+    let insertion_owner = header_owner(&initial, successor.hash, 63, 64);
+    let delivery = zakura_header_chain::AuxDelivery::new(
+        EvidenceId::from_digest([0x83; 32]),
+        child.hash,
+        source,
+        insertion_owner,
+        zakura_header_chain::BodySizeHint::Unknown,
+        Some(zakura_header_chain::TreeAuxRecordV1 {
+            height: child.height,
+            sapling_root: Default::default(),
+            orchard_root: Default::default(),
+            ironwood_root: Default::default(),
+            sapling_tx_count: 4,
+            orchard_tx_count: 5,
+            ironwood_tx_count: 6,
+            auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from([0x84; 32]),
+        }),
+    );
+    runtime
+        .apply(
+            TransitionRequest {
+                expected_version: initial.state_version,
+                event: TransitionEvent::InsertHeaders(Box::new(InsertHeaders {
+                    owner: insertion_owner,
+                    source,
+                    parent_hash: anchor.hash,
+                    target_tip_hash: successor.hash,
+                    completion: TargetCompletion::TargetComplete {
+                        common_ancestor: anchor_frontier,
+                    },
+                    batch: insertion_batch,
+                    aux: vec![delivery],
+                })),
+            },
+            &TransitionContext {
+                config: &engine_config,
+                clock: &SystemClock,
+                full_state_authority: None,
+                retention_references: &[],
+            },
+        )
+        .expect("the checkpoint header inserts with its unauthenticated delivery");
+
+    let before = runtime.publisher().snapshot();
+    assert_eq!(before.frontiers.verified_best, anchor_frontier);
+
+    // The state writer binds checkpoint finality evidence to the version it read.
+    let checkpoint_evidence =
+        zakura_header_chain::checkpoint_finality_evidence(before.state_version, child);
+    let checkpoint_event = TransitionEvent::VerifiedChainChanged(VerifiedChainChanged {
+        full_state_transition_id: checkpoint_evidence,
+        old_tip: before.frontiers.verified_best,
+        new_path: vec![zakura_header_chain::VerifiedHeaderRef {
+            height: child.height,
+            hash: child.hash,
+            header: child_header,
+        }],
+        cause: VerifiedChangeCause::CheckpointFinalizedGrow,
+    });
+
+    let observation = zakura_header_chain::AuxObservationV1::from_vct(
+        body_owner(&before, 63, 64),
+        vec![delivery],
+        zakura_header_chain::AuxVerificationFactV1::current_delivery_verified(),
+        Some(zakura_chain::block::merkle::AuthDataRoot::from([0x84; 32])),
+    )
+    .expect("the VCT authentication observation is well formed");
+    let aux_event = TransitionEvent::AuxEvidence(Box::new(
+        zakura_header_chain::AuxEvidence::observed(observation),
+    ));
+    let aux_authority = Authority(
+        aux_event
+            .idempotency_key()
+            .expect("the auxiliary observation has an identity"),
+    );
+    let checkpoint_authority = Authority(checkpoint_evidence);
+
+    let mut full_state_batch = DiskWriteBatch::new();
+    stage_full_state_canonical_hash(&runtime.store, &mut full_state_batch, child);
+
+    let result = runtime
+        .apply_aux_then_checkpoint_combined(
+            TransitionRequest {
+                expected_version: before.state_version,
+                event: aux_event,
+            },
+            &TransitionContext {
+                config: &engine_config,
+                clock: &SystemClock,
+                full_state_authority: Some(&aux_authority),
+                retention_references: &[],
+            },
+            TransitionRequest {
+                expected_version: before.state_version,
+                event: checkpoint_event,
+            },
+            &TransitionContext {
+                config: &engine_config,
+                clock: &SystemClock,
+                full_state_authority: Some(&checkpoint_authority),
+                retention_references: &[],
+            },
+            full_state_batch,
+            || {},
+        )
+        .expect("the checkpoint commits against evidence bound to the pre-auxiliary version");
+
+    assert!(matches!(result, ApplyResult::Committed));
+    let after = runtime.publisher().snapshot();
+    assert_eq!(after.frontiers.verified_best, child);
+    assert_eq!(
+        after.state_version.get(),
+        before.state_version.get() + 2,
+        "the auxiliary transition must advance the version the checkpoint evidence was bound to"
+    );
+}
+
+#[test]
+fn checkpoint_grow_provenance_is_bound_to_one_state_version() {
+    let (_, anchor, metadata) = fixture();
+    let snapshot = metadata.snapshot();
+    let current = Frontier::new(
+        anchor
+            .height
+            .next()
+            .expect("the anchor has a successor height"),
+        block::Hash([0x95; 32]),
+    );
+    let event = TransitionEvent::VerifiedChainChanged(VerifiedChainChanged {
+        full_state_transition_id: zakura_header_chain::checkpoint_finality_evidence(
+            snapshot.state_version,
+            current,
+        ),
+        old_tip: metadata.frontiers.verified_best,
+        new_path: vec![zakura_header_chain::VerifiedHeaderRef {
+            height: current.height,
+            hash: current.hash,
+            header: anchor.header.clone(),
+        }],
+        cause: VerifiedChangeCause::CheckpointFinalizedGrow,
+    });
+    assert!(validate_full_state_finality_provenance(&event, &snapshot).is_ok());
+
+    let mut advanced = snapshot.clone();
+    advanced.state_version = StateVersion::new(snapshot.state_version.get() + 1);
+    assert!(
+        matches!(
+            validate_full_state_finality_provenance(&event, &advanced),
+            Err(HeaderChainStoreError::Incoherent(
+                "full-state finality provenance does not match the authorized transition"
+            ))
+        ),
+        "checkpoint evidence must not validate against a version the state writer never read"
     );
 }

--- a/docs/changelog/unreleased/746.md
+++ b/docs/changelog/unreleased/746.md
@@ -2,12 +2,12 @@
 
 - Fixed a sync halt on nodes running the Zakura header chain. Checkpoint finality
   evidence is bound to the state version the state writer read, but the combined
-  auxiliary-then-checkpoint path recomputed that evidence after installing the
-  auxiliary transition, which had already advanced the version. Every checkpoint
-  commit bundled with a VCT authentication that changed durable state was
-  therefore rejected as incoherent. Provenance is now validated against the
-  pre-auxiliary snapshot. The combined path now returns `Stale` before staging the
-  auxiliary transition when the checkpoint request names an old state version
+  auxiliary-then-checkpoint path installed the auxiliary transition before it
+  planned finality. The auxiliary transition advanced the version and caused the
+  planner to persist mismatched checkpoint provenance. The combined path now
+  validates and records provenance against the pre-auxiliary snapshot. The
+  combined path returns `Stale` before staging the auxiliary transition when the
+  checkpoint request names an old state version
   ([#746](https://github.com/zakura-core/zakura/pull/746)).
 - Fixed checkpoint recovery after a hard state commit error. Sibling checkpoint
   commits could queue late reset requests that rewound the recovered verifier and

--- a/docs/changelog/unreleased/746.md
+++ b/docs/changelog/unreleased/746.md
@@ -1,0 +1,11 @@
+## Fixed
+
+- Fixed a sync halt on nodes running the Zakura header chain. Checkpoint finality
+  evidence is bound to the state version the state writer read, but the combined
+  auxiliary-then-checkpoint path recomputed that evidence after installing the
+  auxiliary transition, which had already advanced the version. Every checkpoint
+  commit bundled with a VCT authentication that changed durable state was
+  therefore rejected as incoherent, and the resulting state-queue reset left the
+  block-sync driver with no work to request, so the node stopped making progress
+  without exiting. Provenance is now validated against the pre-auxiliary snapshot
+  ([#746](https://github.com/zakura-core/zakura/pull/746)).

--- a/docs/changelog/unreleased/746.md
+++ b/docs/changelog/unreleased/746.md
@@ -5,7 +5,12 @@
   auxiliary-then-checkpoint path recomputed that evidence after installing the
   auxiliary transition, which had already advanced the version. Every checkpoint
   commit bundled with a VCT authentication that changed durable state was
-  therefore rejected as incoherent, and the resulting state-queue reset left the
-  block-sync driver with no work to request, so the node stopped making progress
-  without exiting. Provenance is now validated against the pre-auxiliary snapshot
+  therefore rejected as incoherent. Provenance is now validated against the
+  pre-auxiliary snapshot. The combined path now returns `Stale` before staging the
+  auxiliary transition when the checkpoint request names an old state version
+  ([#746](https://github.com/zakura-core/zakura/pull/746)).
+- Fixed checkpoint recovery after a hard state commit error. Sibling checkpoint
+  commits could queue late reset requests that rewound the recovered verifier and
+  reopened a permanent block gap. The verifier now coalesces resets by commit
+  generation and ignores late resets from an earlier generation
   ([#746](https://github.com/zakura-core/zakura/pull/746)).


### PR DESCRIPTION
## Motivation

Both continuous-sync nodes halted on `8d38b584`. The controller reported no
height progress for 600 seconds, but the first failure occurred earlier in the
checkpoint commit path:

```text
08:10:17.85  state commit fails provenance validation at height 1723542
08:10:18.65  recovery commits checkpoint range through height 1723596
08:20:24     controller halts after no further verified progress
```

The run exposed three related correctness defects.

## Root causes

### Provenance used the wrong state version

`checkpoint_finality_evidence` hashes `state_version`. The state writer created
checkpoint evidence from the version it read before the combined transition.
The combined path installed the auxiliary transition first, advanced the version,
and then validated the checkpoint evidence against that newer version.

Every checkpoint commit bundled with a state-changing VCT authentication therefore
failed provenance validation. A no-change auxiliary transition did not advance the
version, which made the failure appear intermittent.

### Late reset requests rewound recovered verifier progress

The block-sync driver did retry the failed height. The final `no_work` trace only
described its network work queue. At shutdown, node 1 still held 3,591 applying
bodies. The checkpoint verifier owned 401 submitted applies, and 3,190 bodies
waited behind them. Node 2 ended in the same state shape.

One hard state commit error made the sibling checkpoint commit futures fail. Each
failed future queried the state tip and queued a verifier reset. The verifier
consumed one reset per later call. A late reset could therefore rewind progress
after recovery had already committed a newer checkpoint. The verifier then waited
for an earlier range that the driver would not submit again.

### The combined path accepted a stale checkpoint request

The combined path skipped provenance validation when
`checkpoint_request.expected_version` did not match the current version. It then
discarded that expected version and planned the checkpoint against the
post-auxiliary version. The plain path preserves the request version and can return
`ApplyResult::Stale`.

## Solution

- Validate checkpoint provenance against the pre-auxiliary snapshot that produced
  the evidence.
- Return `ApplyResult::Stale` before staging the auxiliary transition when the
  checkpoint request names an old state version.
- Assign each checkpoint commit to a reset generation.
- Drain reset requests for the current generation and reset to their highest
  durable tip.
- Advance the generation after that reset so late sibling failures cannot rewind
  recovered progress.

The existing driver retry remains unchanged. The verifier now preserves the
progress that retry produces.

## Testing

`combined_checkpoint_rejects_stale_version_and_accepts_pre_auxiliary_evidence`
first submits a stale checkpoint request. It asserts that the combined path returns
`Stale`, does not swap memory, and does not publish any state. The test then submits
evidence bound to the pre-auxiliary version. It asserts that the atomic commit
succeeds and advances the durable version twice.

`checkpoint_grow_provenance_is_bound_to_one_state_version` proves that checkpoint
evidence validates only against the version that produced it.

`stale_commit_reset_must_not_rewind_recovered_checkpoint_progress` queues multiple
resets for one failed generation. It asserts that recovery uses the highest tip.
It then delivers a late reset from that generation and asserts that verified
progress does not rewind.

The existing `newer_request_must_not_rewind_verified_checkpoint_progress`
regression continues to pass.

Validation:

- `cargo test -p zakura-consensus checkpoint::tests:: --lib` — 13 passed
- `cargo test -p zakura-state service::finalized_state::header_chain::tests:: --lib`
  — 52 passed
- `cargo clippy -p zakura-consensus -p zakura-state --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `git diff --check`

## Changelog

`docs/changelog/unreleased/746.md` now describes the provenance fix, stale-request
result, and reset-generation recovery.
