### PR TITLE
chore(deps): use Zakura cryptography forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "addchain"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,27 +406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
-name = "bellman"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afceed28bac7f9f5a508bca8aeeff51cdfa4770c0b967ac55c621e2ddfd6171"
-dependencies = [
- "bitvec",
- "blake2s_simd",
- "byteorder",
- "crossbeam-channel",
- "ff",
- "group",
- "lazy_static",
- "log",
- "num_cpus",
- "pairing",
- "rand_core 0.6.4",
- "rayon",
- "subtle",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,19 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "ff",
- "group",
- "pairing",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1830,13 +1807,29 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
  "bitvec",
- "rand_core 0.6.4",
+ "ff_derive",
+ "rand_core 0.10.1",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241afe8c15ffa21933eaefe8a563af36fd9fc98a3e8a044e8f7db52eb1fae3d8"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2217,13 +2210,13 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
  "memuse",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2255,61 +2248,6 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
-]
-
-[[package]]
-name = "halo2_gadgets"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
-dependencies = [
- "arrayvec",
- "bitvec",
- "ff",
- "group",
- "halo2_poseidon",
- "halo2_proofs",
- "lazy_static",
- "pasta_curves",
- "rand 0.8.6",
- "sinsemilla",
- "subtle",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "halo2_legacy_pdqsort"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
-
-[[package]]
-name = "halo2_poseidon"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
-dependencies = [
- "bitvec",
- "ff",
- "group",
- "pasta_curves",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "halo2_legacy_pdqsort",
- "indexmap 1.9.3",
- "maybe-rayon",
- "pasta_curves",
- "rand_core 0.6.4",
- "tracing",
 ]
 
 [[package]]
@@ -3390,20 +3328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jubjub"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
-dependencies = [
- "bitvec",
- "bls12_381",
- "ff",
- "group",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "known-folders"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,42 +4322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "orchard"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
-dependencies = [
- "aes",
- "bitvec",
- "blake2b_simd",
- "corez",
- "ff",
- "fpe",
- "getset",
- "group",
- "halo2_gadgets",
- "halo2_poseidon",
- "halo2_proofs",
- "hex",
- "incrementalmerkletree",
- "lazy_static",
- "memuse",
- "nonempty",
- "pasta_curves",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "reddsa",
- "serde",
- "sinsemilla",
- "subtle",
- "tracing",
- "visibility",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
 name = "os_info"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4454,15 +4342,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
-]
 
 [[package]]
 name = "parity-scale-codec"
@@ -4519,21 +4398,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -5262,6 +5126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5348,38 +5222,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "reddsa"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "frost-rerandomized",
- "group",
- "hex",
- "jubjub",
- "pasta_curves",
- "rand_core 0.6.4",
- "serde",
- "thiserror 2.0.18",
- "zeroize",
-]
-
-[[package]]
-name = "redjubjub"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
-dependencies = [
- "rand_core 0.6.4",
- "reddsa",
- "serde",
- "thiserror 1.0.69",
- "zeroize",
 ]
 
 [[package]]
@@ -5782,39 +5624,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "sapling-crypto"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
-dependencies = [
- "aes",
- "bellman",
- "bitvec",
- "blake2b_simd",
- "blake2s_simd",
- "bls12_381",
- "corez",
- "document-features",
- "ff",
- "fpe",
- "getset",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "lazy_static",
- "memuse",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "redjubjub",
- "subtle",
- "tracing",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
 ]
 
 [[package]]
@@ -6297,17 +6106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "sinsemilla"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
-dependencies = [
- "group",
- "pasta_curves",
- "subtle",
 ]
 
 [[package]]
@@ -8323,6 +8121,7 @@ dependencies = [
  "zakura-consensus",
  "zakura-header-chain",
  "zakura-jsonl-trace",
+ "zakura-keys",
  "zakura-network",
  "zakura-node-services",
  "zakura-rpc",
@@ -8330,8 +8129,42 @@ dependencies = [
  "zakura-state",
  "zakura-test",
  "zakura-utils",
- "zcash_keys",
  "zcash_script",
+]
+
+[[package]]
+name = "zakura-bellman"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ab38ed765a77fe39545be96028e0122d03fc9987bfcb0db77dd6a77a1be4f1"
+dependencies = [
+ "bitvec",
+ "blake2s_simd",
+ "byteorder",
+ "crossbeam-channel",
+ "ff",
+ "group",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rayon",
+ "subtle",
+ "zakura-pairing",
+]
+
+[[package]]
+name = "zakura-bls12-381"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73462d28b889c0430135dfcc633d9b79ca282d0b1e2089e697b9a60e58e0240e"
+dependencies = [
+ "ff",
+ "group",
+ "rand_core 0.10.1",
+ "subtle",
+ "zakura-pairing",
 ]
 
 [[package]]
@@ -8356,26 +8189,23 @@ dependencies = [
  "equihash",
  "futures",
  "group",
- "halo2_proofs",
  "hex",
  "humantime",
  "incrementalmerkletree",
  "itertools 0.14.0",
- "jubjub",
  "lazy_static",
  "num-integer",
- "orchard",
  "primitive-types",
  "proptest",
  "proptest-derive",
+ "rand 0.10.2",
  "rand 0.8.6",
+ "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rayon",
- "reddsa",
- "redjubjub",
  "ripemd 0.1.3",
- "sapling-crypto",
  "schemars 1.2.1",
  "secp256k1",
  "serde",
@@ -8383,7 +8213,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sinsemilla",
  "spandoc",
  "static_assertions",
  "strum",
@@ -8393,12 +8222,19 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
+ "zakura-halo2-proofs",
+ "zakura-jubjub",
+ "zakura-orchard",
+ "zakura-primitives",
+ "zakura-reddsa",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+ "zakura-sinsemilla",
  "zakura-test",
  "zcash_address",
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -8408,31 +8244,26 @@ dependencies = [
 name = "zakura-consensus"
 version = "7.0.0"
 dependencies = [
- "bellman",
  "blake2b_simd",
- "bls12_381",
  "chrono",
  "color-eyre",
  "criterion",
  "derive-getters",
  "futures",
  "futures-util",
- "halo2_proofs",
  "hex",
  "howudoin",
- "jubjub",
  "lazy_static",
  "libzcash_script",
  "metrics",
  "mset",
  "num-integer",
  "once_cell",
- "orchard",
  "proptest",
  "proptest-derive",
+ "rand 0.10.2",
  "rand 0.8.6",
  "rayon",
- "sapling-crypto",
  "serde",
  "spandoc",
  "thiserror 2.0.18",
@@ -8443,19 +8274,81 @@ dependencies = [
  "tracing-error",
  "tracing-futures",
  "tracing-subscriber",
+ "zakura-bellman",
+ "zakura-bls12-381",
  "zakura-chain",
+ "zakura-halo2-proofs",
  "zakura-header-chain",
+ "zakura-jubjub",
  "zakura-node-services",
+ "zakura-orchard",
+ "zakura-primitives",
+ "zakura-proofs",
+ "zakura-sapling-crypto",
  "zakura-script",
  "zakura-state",
  "zakura-test",
  "zakura-tower-batch-control",
  "zakura-tower-fallback",
- "zcash_primitives",
- "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-halo2-gadgets"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdd0b9b46a028c2985cb370abc896d453a5426bf213327a2797973b31f8d3bc"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.10.2",
+ "subtle",
+ "uint 0.9.5",
+ "zakura-halo2-poseidon",
+ "zakura-halo2-proofs",
+ "zakura-pasta-curves",
+ "zakura-sinsemilla",
+]
+
+[[package]]
+name = "zakura-halo2-legacy-pdqsort"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1da6314d8d65892181973c06ee2f086fc2b9a8d869c5d69bc0d9abe2bb9bb7db"
+
+[[package]]
+name = "zakura-halo2-poseidon"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0b274860c7f6a67492d8f7036b64cd1b17ce2fcd1e5f6e6689bfe39d348ad3"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "zakura-pasta-curves",
+]
+
+[[package]]
+name = "zakura-halo2-proofs"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae837badc975e154609b06fbb5d0e7fb2bc02917573dd85d5d3853cad48f5a4"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "indexmap 1.9.3",
+ "maybe-rayon",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "tracing",
+ "zakura-halo2-legacy-pdqsort",
+ "zakura-pasta-curves",
 ]
 
 [[package]]
@@ -8483,6 +8376,48 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "zakura-jubjub"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5a2da7e032f0d65d6f41826d465e682b3e8a7ba130f53eb3f0f785986a448e"
+dependencies = [
+ "bitvec",
+ "ff",
+ "group",
+ "rand_core 0.10.1",
+ "subtle",
+ "zakura-bls12-381",
+]
+
+[[package]]
+name = "zakura-keys"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0ba8ff30917252863dde03a0a2ff89522006e72682eff5f87de1d457f028f7"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bs58",
+ "corez",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zakura-bls12-381",
+ "zakura-orchard",
+ "zakura-sapling-crypto",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_protocol",
+ "zcash_transparent",
+ "zip32",
 ]
 
 [[package]]
@@ -8551,6 +8486,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "zakura-orchard"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9526028dd6510821e6198494d3822416b67fa1053005c4937460717570a004"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "corez",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "nonempty",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "tracing",
+ "visibility",
+ "zakura-halo2-gadgets",
+ "zakura-halo2-poseidon",
+ "zakura-halo2-proofs",
+ "zakura-pasta-curves",
+ "zakura-reddsa",
+ "zakura-sinsemilla",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zakura-pairing"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b705189d9b0c993a7d0628643fbc65775e4c1e65bf1d9252b3f0ba3a4a92b3fa"
+dependencies = [
+ "group",
+]
+
+[[package]]
+name = "zakura-pasta-curves"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e778e0af70387b9f1e988d9a280f936350340c509e5dc26ed32a962c4a708c42"
+dependencies = [
+ "blake2b_simd",
+ "cc",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.10.2",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "zakura-primitives"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a4076fe985fe29818a33b389ff42fd373408cdcd0921c9574336a9ed9c58fc"
+dependencies = [
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "corez",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash",
+ "ff",
+ "hex",
+ "incrementalmerkletree",
+ "memuse",
+ "nonempty",
+ "rand_core 0.10.1",
+ "secp256k1",
+ "sha2 0.10.9",
+ "zakura-jubjub",
+ "zakura-orchard",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol",
+ "zcash_script",
+ "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-proofs"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d81423433e74114f8ca34e3656d24f46450426621b9e0d8c49e747b8f06f89"
+dependencies = [
+ "blake2b_simd",
+ "document-features",
+ "group",
+ "home",
+ "known-folders",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "tracing",
+ "wagyu-zcash-parameters",
+ "xdg",
+ "zakura-bellman",
+ "zakura-bls12-381",
+ "zakura-jubjub",
+ "zakura-primitives",
+ "zakura-redjubjub",
+ "zakura-sapling-crypto",
+]
+
+[[package]]
+name = "zakura-reddsa"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0620f5a6b2297d2a2d211d3e31e6906619b0f7756c7a919f3ab40fbc65dbfe"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+ "frost-rerandomized",
+ "group",
+ "hex",
+ "rand_core 0.10.1",
+ "serde",
+ "thiserror 2.0.18",
+ "zakura-jubjub",
+ "zakura-pasta-curves",
+ "zeroize",
+]
+
+[[package]]
+name = "zakura-redjubjub"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367add8b8f3c1c3b0d2e92b1677a86d5d6141a8c21c76652c8515dcb3702fd2"
+dependencies = [
+ "rand_core 0.10.1",
+ "serde",
+ "thiserror 1.0.69",
+ "zakura-reddsa",
+ "zeroize",
+]
+
+[[package]]
 name = "zakura-rpc"
 version = "8.0.0"
 dependencies = [
@@ -8576,13 +8660,12 @@ dependencies = [
  "metrics",
  "nix",
  "openrpsee",
- "orchard",
  "phf",
  "proptest",
  "prost",
+ "rand 0.10.2",
  "rand 0.8.6",
  "rustls",
- "sapling-crypto",
  "schemars 1.2.1",
  "semver",
  "serde",
@@ -8606,18 +8689,54 @@ dependencies = [
  "which",
  "zakura-chain",
  "zakura-consensus",
+ "zakura-keys",
  "zakura-network",
  "zakura-node-services",
+ "zakura-orchard",
+ "zakura-primitives",
+ "zakura-proofs",
+ "zakura-sapling-crypto",
  "zakura-script",
  "zakura-state",
  "zakura-test",
  "zcash_address",
- "zcash_keys",
- "zcash_primitives",
- "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+]
+
+[[package]]
+name = "zakura-sapling-crypto"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b149d61f100b0d91e6631b99da7c0ab99def11ad45888e4b7816e29d6facd458"
+dependencies = [
+ "aes",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "corez",
+ "document-features",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "lazy_static",
+ "memuse",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "subtle",
+ "tracing",
+ "zakura-bellman",
+ "zakura-bls12-381",
+ "zakura-jubjub",
+ "zakura-redjubjub",
+ "zcash_note_encryption",
+ "zcash_spec",
+ "zip32",
 ]
 
 [[package]]
@@ -8633,9 +8752,21 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "zakura-chain",
+ "zakura-primitives",
  "zakura-test",
- "zcash_primitives",
  "zcash_script",
+]
+
+[[package]]
+name = "zakura-sinsemilla"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06816174cb74c80d2cec794dae218e32cd7fcd488450ed149707a124681b97a0"
+dependencies = [
+ "group",
+ "lazy_static",
+ "subtle",
+ "zakura-pasta-curves",
 ]
 
 [[package]]
@@ -8650,7 +8781,6 @@ dependencies = [
  "derive-new",
  "dirs",
  "futures",
- "halo2_proofs",
  "hex",
  "hex-literal",
  "howudoin",
@@ -8659,12 +8789,10 @@ dependencies = [
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
- "jubjub",
  "lazy_static",
  "metrics",
  "mset",
  "once_cell",
- "orchard",
  "proptest",
  "proptest-derive",
  "rand 0.8.6",
@@ -8672,7 +8800,6 @@ dependencies = [
  "regex",
  "rlimit",
  "rocksdb",
- "sapling-crypto",
  "semver",
  "serde",
  "serde-big-array",
@@ -8686,8 +8813,12 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "zakura-chain",
+ "zakura-halo2-proofs",
  "zakura-header-chain",
+ "zakura-jubjub",
  "zakura-node-services",
+ "zakura-orchard",
+ "zakura-sapling-crypto",
  "zakura-test",
 ]
 
@@ -8768,8 +8899,8 @@ dependencies = [
  "tracing-subscriber",
  "zakura-chain",
  "zakura-node-services",
+ "zakura-primitives",
  "zakura-state",
- "zcash_primitives",
  "zcash_protocol",
 ]
 
@@ -8823,34 +8954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_keys"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
-dependencies = [
- "bech32",
- "blake2b_simd",
- "bls12_381",
- "bs58",
- "corez",
- "document-features",
- "group",
- "memuse",
- "nonempty",
- "orchard",
- "rand_core 0.6.4",
- "sapling-crypto",
- "secrecy",
- "subtle",
- "tracing",
- "zcash_address",
- "zcash_encoding",
- "zcash_protocol",
- "zcash_transparent",
- "zip32",
-]
-
-[[package]]
 name = "zcash_note_encryption"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8864,64 +8967,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_primitives"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
-dependencies = [
- "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
- "corez",
- "crypto-common 0.2.0-rc.1",
- "document-features",
- "equihash",
- "ff",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "secp256k1",
- "sha2 0.10.9",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_protocol",
- "zcash_script",
- "zcash_transparent",
-]
-
-[[package]]
-name = "zcash_proofs"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
-dependencies = [
- "bellman",
- "blake2b_simd",
- "bls12_381",
- "document-features",
- "group",
- "home",
- "jubjub",
- "known-folders",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "tracing",
- "wagyu-zcash-parameters",
- "xdg",
- "zcash_primitives",
-]
-
-[[package]]
 name = "zcash_protocol"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
+checksum = "314329b91ec4bbb517441840e47d0b2029bf0b946f086980c96c889c2d92dc5d"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2117,7 +2117,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2608,7 +2608,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3128,7 +3128,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3333,7 +3333,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3921,7 +3921,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4992,7 +4992,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5031,9 +5031,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5504,7 +5504,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5563,7 +5563,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6442,7 +6442,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7585,7 +7585,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,27 +32,27 @@ edition = "2021"
 
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.15.4"
-sapling-crypto = "0.7"
+orchard = { version = "1.0.0-rc.2", package = "zakura-orchard" }
+sapling-crypto = { version = "1.0.0-rc.2", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
 zcash_encoding = "0.4"
 zcash_history = "0.5.0"
-zcash_keys = "0.16.0"
-zcash_primitives = "0.30.0"
-zcash_proofs = "0.30.0"
+zcash_keys = { version = "1.0.0-rc.2", package = "zakura-keys" }
+zcash_primitives = { version = "1.0.0-rc.2", package = "zakura-primitives" }
+zcash_proofs = { version = "1.0.0-rc.2", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
 abscissa_core = "0.7"
 base64 = "0.22.1"
 bech32 = "0.11.0"
-bellman = "0.14"
+bellman = { version = "1.0.0-rc.2", package = "zakura-bellman" }
 bincode = "1.3"
 bitflags = "2.9"
 bitflags-serde-legacy = "0.1.1"
 bitvec = "1.0"
 blake2b_simd = "1.0"
 blake2s_simd = "1.0"
-bls12_381 = "0.8"
+bls12_381 = { version = "1.0.0-rc.2", package = "zakura-bls12-381" }
 bs58 = "0.5"
 byteorder = "1.5"
 bytes = "1.10"
@@ -70,8 +70,8 @@ equihash = "0.3"
 futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
-group = "0.13"
-halo2 = "0.3"
+group = "0.14"
+halo2 = { version = "1.0.0-rc.2", package = "zakura-halo2-proofs" }
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -91,7 +91,7 @@ itertools = "0.14"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
-jubjub = "0.10"
+jubjub = { version = "1.0.0-rc.2", package = "zakura-jubjub" }
 lazy_static = "1.4"
 libzcash_script = "0.1"
 log = "0.4.27"
@@ -112,9 +112,12 @@ prost = "0.14"
 rand = "0.8.5"
 rand_chacha = "0.3"
 rand_core = "0.6"
+rand_10 = { package = "rand", version = "0.10" }
+rand_chacha_10 = { package = "rand_chacha", version = "0.10" }
+rand_core_10 = { package = "rand_core", version = "0.10" }
 rayon = "1.10"
-reddsa = "0.5"
-redjubjub = "0.8"
+reddsa = { version = "1.0.0-rc.2", package = "zakura-reddsa" }
+redjubjub = { version = "1.0.0-rc.2", package = "zakura-redjubjub" }
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false }
 ripemd = "0.1"
@@ -129,6 +132,7 @@ serde_json = "1.0.140"
 serde_with = "3.12"
 sha2 = "0.10"
 schemars = "1"
+sinsemilla = { version = "1.0.0-rc.2", package = "zakura-sinsemilla" }
 spandoc = "0.2"
 static_assertions = "1.1"
 anyhow = "1.0"
@@ -240,28 +244,28 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.pasta_curves]
+[profile.dev.package.zakura-pasta-curves]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.halo2_proofs]
+[profile.dev.package.zakura-halo2-proofs]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.halo2_gadgets]
+[profile.dev.package.zakura-halo2-gadgets]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.bls12_381]
+[profile.dev.package.zakura-bls12-381]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false
@@ -282,7 +286,7 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
-[profile.dev.package.zcash_proofs]
+[profile.dev.package.zakura-proofs]
 opt-level = 3
 debug-assertions = false
 overflow-checks = false

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -68,6 +68,9 @@ dirs = { workspace = true }
 num-integer = { workspace = true }
 primitive-types = { workspace = true }
 rand_core = { workspace = true }
+rand_10 = { workspace = true }
+rand_chacha_10 = { workspace = true }
+rand_core_10 = { workspace = true }
 ripemd = { workspace = true }
 # Matches version used by hdwallet
 secp256k1 = { workspace = true, features = ["serde"] }
@@ -79,7 +82,7 @@ bech32 = { workspace = true }
 zcash_script.workspace = true
 
 # ECC deps
-halo2 = { package = "halo2_proofs", version = "0.3" }
+halo2 = { workspace = true }
 orchard.workspace = true
 zcash_encoding.workspace = true
 zcash_history.workspace = true
@@ -89,7 +92,7 @@ sapling-crypto.workspace = true
 zcash_protocol.workspace = true
 zcash_address.workspace = true
 zcash_transparent = { workspace = true }
-sinsemilla = { version = "0.1" }
+sinsemilla = { workspace = true }
 
 # Time
 chrono = { workspace = true, features = ["clock", "std", "serde"] }

--- a/crates/zakura-chain/benches/redpallas.rs
+++ b/crates/zakura-chain/benches/redpallas.rs
@@ -9,7 +9,7 @@
 #![allow(missing_docs)]
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use rand::{thread_rng, Rng};
+use rand_10::{rng as thread_rng, RngExt};
 use reddsa::{
     batch,
     orchard::{Binding, SpendAuth},
@@ -42,7 +42,7 @@ enum Item {
 fn sigs_with_distinct_keys() -> impl Iterator<Item = Item> {
     std::iter::repeat_with(|| {
         let mut rng = thread_rng();
-        match rng.gen::<u8>() % 2 {
+        match rng.random::<u8>() % 2 {
             0 => {
                 let sk = SigningKey::<SpendAuth>::new(thread_rng());
                 let vk_bytes = VerificationKey::from(&sk).into();

--- a/crates/zakura-chain/src/orchard/arbitrary.rs
+++ b/crates/zakura-chain/src/orchard/arbitrary.rs
@@ -2,7 +2,7 @@
 
 use group::{
     ff::{FromUniformBytes, PrimeField},
-    prime::PrimeCurveAffine,
+    CurveAffine,
 };
 use halo2::pasta::pallas;
 use reddsa::{orchard::SpendAuth, Signature, SigningKey, VerificationKey, VerificationKeyBytes};

--- a/crates/zakura-chain/src/orchard/commitment.rs
+++ b/crates/zakura-chain/src/orchard/commitment.rs
@@ -4,8 +4,7 @@ use std::{fmt, io};
 
 use group::{
     ff::{FromUniformBytes, PrimeField},
-    prime::PrimeCurveAffine,
-    GroupEncoding,
+    CurveAffine as _, GroupEncoding,
 };
 use halo2::{
     arithmetic::{Coordinates, CurveAffine},

--- a/crates/zakura-chain/src/orchard/keys.rs
+++ b/crates/zakura-chain/src/orchard/keys.rs
@@ -6,7 +6,7 @@
 
 use std::{fmt, io};
 
-use group::{ff::PrimeField, prime::PrimeCurveAffine, Group, GroupEncoding};
+use group::{ff::PrimeField, CurveAffine as _, Group, GroupEncoding};
 use halo2::{
     arithmetic::{Coordinates, CurveAffine},
     pasta::pallas,

--- a/crates/zakura-chain/src/primitives/zcash_note_encryption.rs
+++ b/crates/zakura-chain/src/primitives/zcash_note_encryption.rs
@@ -82,7 +82,7 @@ fn ironwood_action_decrypts_successfully<A>(act: &orchard::Action<A>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use group::{ff::PrimeField, prime::PrimeCurveAffine, GroupEncoding};
+    use group::{ff::PrimeField, CurveAffine, GroupEncoding};
     use halo2::pasta::pallas;
     use orchard::{
         note::{

--- a/crates/zakura-chain/src/sapling/arbitrary.rs
+++ b/crates/zakura-chain/src/sapling/arbitrary.rs
@@ -2,8 +2,8 @@
 
 use group::Group;
 use jubjub::ExtendedPoint;
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
+use rand_chacha_10::ChaChaRng;
+use rand_core_10::SeedableRng;
 
 use proptest::{collection::vec, prelude::*};
 

--- a/crates/zakura-chain/src/subtree_verify.rs
+++ b/crates/zakura-chain/src/subtree_verify.rs
@@ -183,7 +183,9 @@ fn fold_to_level<H: Hashable + Clone>(block: &[H], level: u8) -> H {
 
     for current in TRACKED_SUBTREE_HEIGHT..level {
         nodes = nodes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| H::combine(Level::from(current), &pair[0], &pair[1]))
             .collect();
     }

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -2331,7 +2331,7 @@ fn assert_noncanonical_shielded_protocol_proof_size(error: SerializationError) {
 /// pattern.
 #[test]
 fn orchard_rk_identity_point_rejected_during_deserialization() {
-    use group::prime::PrimeCurveAffine;
+    use group::CurveAffine;
     use reddsa::Signature;
 
     use crate::{

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -36,9 +36,10 @@ proptest-impl = ["proptest", "proptest-derive", "zakura-chain/proptest-impl", "z
 blake2b_simd = { workspace = true }
 bellman = { workspace = true }
 bls12_381 = { workspace = true }
-halo2 = { package = "halo2_proofs", version = "0.3" }
+halo2 = { workspace = true }
 jubjub = { workspace = true }
 rand = { workspace = true }
+rand_10 = { workspace = true }
 rayon = { workspace = true }
 mset.workspace = true
 

--- a/crates/zakura-consensus/benches/sapling.rs
+++ b/crates/zakura-consensus/benches/sapling.rs
@@ -26,7 +26,7 @@ mod common;
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use rand::thread_rng;
+use rand_10::rng as thread_rng;
 
 use zakura_chain::{
     block::{self, Block},

--- a/crates/zakura-consensus/src/primitives/halo2.rs
+++ b/crates/zakura-consensus/src/primitives/halo2.rs
@@ -15,7 +15,7 @@ use orchard::{
     bundle::{BatchError, BatchValidator},
     circuit::{OrchardCircuitVersion, VerifyingKey},
 };
-use rand::thread_rng;
+use rand_10::rng as thread_rng;
 use zakura_chain::{
     parameters::NetworkUpgrade,
     transaction::{SigHash, UnminedTxId, WtxId},

--- a/crates/zakura-consensus/src/primitives/redjubjub.rs
+++ b/crates/zakura-consensus/src/primitives/redjubjub.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
-use rand::thread_rng;
+use rand_10::rng as thread_rng;
 
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};

--- a/crates/zakura-consensus/src/primitives/redpallas.rs
+++ b/crates/zakura-consensus/src/primitives/redpallas.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
-use rand::thread_rng;
+use rand_10::rng as thread_rng;
 
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};

--- a/crates/zakura-consensus/src/primitives/sapling.rs
+++ b/crates/zakura-consensus/src/primitives/sapling.rs
@@ -10,7 +10,7 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
-use rand::thread_rng;
+use rand_10::rng as thread_rng;
 use tokio::sync::watch;
 use tower::{util::ServiceFn, Service};
 use tower_batch_control::{Batch, BatchControl, RequestWeight};

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -2169,7 +2169,7 @@ impl Drop for PeerRoutine {
     /// The reactor owns entry insert (on connect) and remove (on disconnect/
     /// admission-reject); see `handle_peer_disconnected`.
     fn drop(&mut self) {
-        let outstanding_ranges: Vec<_> = self.window.outstanding.drain(..).collect();
+        let outstanding_ranges = std::mem::take(&mut self.window.outstanding);
         for outstanding in outstanding_ranges {
             let unreceived: Vec<_> = outstanding
                 .request

--- a/crates/zakura-network/src/zakura/header_sync/fuzz.rs
+++ b/crates/zakura-network/src/zakura/header_sync/fuzz.rs
@@ -911,7 +911,7 @@ impl PursuitHarness {
 /// Replay one bounded byte stream through the production queue and ownership gate.
 pub fn replay_header_pursuit_bytes(data: &[u8]) -> HeaderPursuitReplaySummary {
     let mut harness = PursuitHarness::new();
-    for operation in data[..data.len().min(MAX_INPUT_BYTES)].chunks_exact(4) {
+    for operation in data[..data.len().min(MAX_INPUT_BYTES)].as_chunks::<4>().0 {
         harness.apply(operation);
     }
     harness.summary

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -66,6 +66,7 @@ strum_macros = { workspace = true }
 # RPC endpoint basic auth
 base64 = { workspace = true }
 rand = { workspace = true }
+rand_10 = { workspace = true }
 # Constant-time cookie comparison to prevent a timing oracle on RPC auth.
 subtle = { workspace = true }
 

--- a/crates/zakura-rpc/src/methods/tests/snapshot.rs
+++ b/crates/zakura-rpc/src/methods/tests/snapshot.rs
@@ -511,7 +511,8 @@ async fn test_rpc_response_data_for_network(network: &Network) {
 
     let rpc_req = rpc.get_raw_transaction(txid.clone(), Some(0u8), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
-    settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_verbosity=0"), rsp));
+    settings
+        .bind(|| insta::assert_json_snapshot!("getrawtransaction_verbosity=0".to_string(), rsp));
 
     // `getrawtransaction` verbosity=1
     let mempool_req = mempool
@@ -524,7 +525,8 @@ async fn test_rpc_response_data_for_network(network: &Network) {
 
     let rpc_req = rpc.get_raw_transaction(txid, Some(1u8), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
-    settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_verbosity=1"), rsp));
+    settings
+        .bind(|| insta::assert_json_snapshot!("getrawtransaction_verbosity=1".to_string(), rsp));
 
     // `getrawtransaction` with unknown txid
     let mempool_req = mempool
@@ -538,13 +540,15 @@ async fn test_rpc_response_data_for_network(network: &Network) {
     let rpc_req =
         rpc.get_raw_transaction(transaction::Hash::from([0; 32]).encode_hex(), Some(1), None);
     let (rsp, _) = futures::join!(rpc_req, mempool_req);
-    settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_unknown_txid"), rsp));
+    settings
+        .bind(|| insta::assert_json_snapshot!("getrawtransaction_unknown_txid".to_string(), rsp));
 
     // `getrawtransaction` with an invalid TXID
     let rsp = rpc
         .get_raw_transaction("aBadC0de".to_owned(), Some(1), None)
         .await;
-    settings.bind(|| insta::assert_json_snapshot!(format!("getrawtransaction_invalid_txid"), rsp));
+    settings
+        .bind(|| insta::assert_json_snapshot!("getrawtransaction_invalid_txid".to_string(), rsp));
 
     // Each awaited RPC has finished all of its causal mempool work, and each
     // expected request above was consumed by its paired handler. One absence
@@ -666,7 +670,7 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
 
     // Check the response.
     settings.bind(|| {
-        insta::assert_json_snapshot!(format!("z_get_subtrees_by_index_for_sapling"), subtrees)
+        insta::assert_json_snapshot!("z_get_subtrees_by_index_for_sapling".to_string(), subtrees)
     });
 
     // Test the response format from `z_getsubtreesbyindex` for Orchard.
@@ -694,7 +698,7 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
 
     // Check the response.
     settings.bind(|| {
-        insta::assert_json_snapshot!(format!("z_get_subtrees_by_index_for_orchard"), subtrees)
+        insta::assert_json_snapshot!("z_get_subtrees_by_index_for_orchard".to_string(), subtrees)
     });
 }
 
@@ -704,7 +708,7 @@ fn snapshot_rpc_getinfo(info: GetInfoResponse, settings: &insta::Settings) {
         insta::assert_json_snapshot!("get_info", info, {
             ".subversion" => dynamic_redaction(|value, _path| {
                 // assert that the subversion value is user agent
-                assert_eq!(value.as_str().unwrap(), format!("RPC test"));
+                assert_eq!(value.as_str().unwrap(), "RPC test");
                 // replace with:
                 "[SubVersion]"
             }),

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -245,7 +245,7 @@ async fn rpc_getinfo() {
 
     // make sure there is a `subversion` field,
     // and that is equal to the Zebra user agent.
-    assert_eq!(get_info.subversion, format!("RPC test"));
+    assert_eq!(get_info.subversion, "RPC test");
 
     mempool.expect_no_requests().await;
     read_state.expect_no_requests().await;

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -7,7 +7,6 @@ use chrono::{DateTime, Utc};
 use derive_getters::Getters;
 use derive_new::new;
 use hex::ToHex;
-use rand::rngs::OsRng;
 use zcash_script::script::Asm;
 
 use zakura_chain::{
@@ -254,7 +253,7 @@ impl TransactionTemplate<NegativeOrZero> {
             &Default::default(),
             Default::default(),
             Default::default(),
-            OsRng,
+            rand_10::rng(),
             sapling_prover,
             sapling_prover,
             &FeeRule::non_standard(Zatoshis::ZERO),

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -105,7 +105,7 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rand = { workspace = true }
 
-halo2 = { package = "halo2_proofs", version = "0.3" }
+halo2 = { workspace = true }
 jubjub = { workspace = true }
 orchard = { workspace = true }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain/fuzz.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/fuzz.rs
@@ -81,14 +81,10 @@ pub fn replay_recovery_rows_bytes(data: &[u8]) -> RecoveryRowsReplaySummary {
     let mut rows = logical_dump(&store);
     let mut mutations = 0;
     let mut mode_operations = Vec::new();
-    for operation in data[..data.len().min(MAX_INPUT_BYTES)].chunks_exact(4) {
+    for operation in data[..data.len().min(MAX_INPUT_BYTES)].as_chunks::<4>().0 {
         if recovery_opcode(operation[0]) == 8 {
             if mode_operations.len() < 2 {
-                mode_operations.push(
-                    operation
-                        .try_into()
-                        .expect("chunks_exact yields four-byte operations"),
-                );
+                mode_operations.push(*operation);
             }
             continue;
         }

--- a/deny.toml
+++ b/deny.toml
@@ -89,7 +89,11 @@ deny = [
 #
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-
+    # Zakura's cryptography forks use Rand 0.10, while the remaining ecosystem
+    # still resolves Rand 0.9. Remove these when the workspace converges.
+    { name = "chacha20", version = "=0.9.1" },
+    { name = "rand", version = "=0.9.4" },
+    { name = "rand_chacha", version = "=0.9.0" },
 ]
 
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/docs/changelog/unreleased/749.md
+++ b/docs/changelog/unreleased/749.md
@@ -1,5 +1,6 @@
-<!-- changelog: none -->
+## Changed
 
-This PR switches internal cryptography dependencies to the coordinated Zakura
-fork releases before the initial release, with no separately released
-operator-visible change.
+- Changed the published dependency graph to use the coordinated Zakura
+  cryptography forks, so crate consumers resolve the Zakura implementations
+  instead of their upstream equivalents
+  ([#749](https://github.com/zakura-core/zakura/pull/749)).

--- a/docs/changelog/unreleased/749.md
+++ b/docs/changelog/unreleased/749.md
@@ -1,0 +1,5 @@
+<!-- changelog: none -->
+
+This PR switches internal cryptography dependencies to the coordinated Zakura
+fork releases before the initial release, with no separately released
+operator-visible change.

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -70,6 +70,11 @@ audit-as-crates-io = false
 [policy.zakura-utils]
 audit-as-crates-io = false
 
+[[exemptions.addchain]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+
 [[exemptions.addr2line]]
 version = "0.21.0"
 criteria = "safe-to-deploy"
@@ -122,6 +127,16 @@ version = "0.2.3"
 criteria = "safe-to-deploy"
 notes = "Audit deferred: the safe single-sink wrappers preserve the documented exclusivity contract and ordinary tests pass, but the crate's core is a custom unsafe lock-free two-slot Waker state machine. Its published higher-bound Loom slot-reuse exploration did not complete within the batch review window; retain the exemption pending a dedicated concurrency review or completed model run."
 
+[[exemptions.ff]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+
+[[exemptions.ff_derive]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+
 [[exemptions.fixedbitset]]
 version = "0.5.7"
 criteria = "safe-to-deploy"
@@ -132,6 +147,16 @@ version = "1.3.0"
 criteria = "safe-to-deploy"
 suggest = false
 notes = "Audit hold: recursive directory enumeration follows directory symlinks, and move_dir then moves and deletes files reached through them. A local reproduction with source/link pointing outside the source tree returned success, removed the external sentinel, and copied it under the destination. Retain the exemption until traversal uses symlink_metadata or otherwise confines moves to the requested tree."
+
+[[exemptions.group]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+
+[[exemptions.h2]]
+version = "0.4.16"
+criteria = "safe-to-deploy"
+notes = "Patched release for RUSTSEC-2026-0258; retain this exact-version exemption pending delta audit from 0.4.15."
 
 [[exemptions.hash32]]
 version = "0.2.1"
@@ -240,6 +265,11 @@ notes = "Audit hold: validator.rs explicitly notes that empty-stack PEEK_ALL is 
 version = "5.2.0"
 criteria = "safe-to-deploy"
 notes = "Audit hold: the UEFI protocol tables expose firmware operations that accept and dereference raw pointers as safe extern function pointers. Safe Rust can therefore invoke them with invalid pointers; version 6.0.0 corrected this by making every firmware callback unsafe. Retain the 5.2.0 exemption until its dependents upgrade."
+
+[[exemptions.rand_chacha]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.redox_users]]
 version = "0.4.5"
@@ -360,6 +390,91 @@ criteria = "safe-to-deploy"
 [[exemptions.windows_x86_64_msvc]]
 version = "0.52.5"
 criteria = "safe-to-deploy"
+
+[[exemptions.zakura-bellman]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-bls12-381]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-halo2-gadgets]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-halo2-legacy-pdqsort]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-halo2-poseidon]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-halo2-proofs]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-jubjub]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-keys]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-orchard]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-pairing]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-pasta-curves]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-primitives]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-proofs]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-reddsa]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-redjubjub]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-sapling-crypto]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
+
+[[exemptions.zakura-sinsemilla]]
+version = "1.0.0-rc.2"
+criteria = "safe-to-deploy"
+notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zerovec]]
 version = "0.11.6"

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -90,30 +90,9 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
-[[publisher.zcash_keys]]
-version = "0.16.0"
-when = "2026-07-25"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_primitives]]
-version = "0.30.0"
-when = "2026-07-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
-[[publisher.zcash_proofs]]
-version = "0.30.0"
-when = "2026-07-24"
-user-id = 169181
-user-login = "nuttycom"
-user-name = "Kris Nuttycombe"
-
 [[publisher.zcash_protocol]]
-version = "0.10.1"
-when = "2026-07-24"
+version = "0.10.5"
+when = "2026-08-19"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"


### PR DESCRIPTION
## Motivation

Zakura still resolved the upstream Zcash cryptography crates, allowing the original packages to coexist with the coordinated Zakura fork stack.

## Solution

- Replace all direct cryptography dependencies with the `1.0.0-rc.2` Zakura crates.io packages.
- Keep the full 17-crate fork closure on the coordinated release.
- Align `group` traits and use Rand 0.10 at APIs exposed by the fork crates while retaining Rand 0.8 where existing dependencies require it.
- Rename development profile package selectors so cryptography optimizations continue to apply.
- Document narrow Rand duplicate and Cargo Vet exemptions introduced by the migration.
- Update `h2` to 0.4.16, which fixes RUSTSEC-2026-0258.

## Testing

- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p zakura-chain -p zakura-consensus -p zakura-rpc --lib` (715 passed, 1 ignored)
- `cargo deny` default, release-feature, all-feature, and advisory checks
- `cargo vet check --store-path ./qa/supply-chain/`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- Markdown lint for `docs/changelog/unreleased/749.md`

A full `cargo test --workspace` run reached the network-dependent acceptance suite; 43 acceptance tests passed, 40 were ignored, and `activate_mempool_mainnet` timed out waiting for live Mainnet synchronization.

## Changelog

- Added a user-facing `Changed` entry for crate consumers in `docs/changelog/unreleased/749.md`.

### Specifications & References

- https://github.com/zakura-core/libraries
- https://rustsec.org/advisories/RUSTSEC-2026-0258

### Follow-up Work

Replace the exact-version Cargo Vet exemptions with direct or delta audits as those reviews are completed.