### PR TITLE
feat(state): generate historical frontier grids

### DIFF
--- a/.github/scripts/fetch-release-state.py
+++ b/.github/scripts/fetch-release-state.py
@@ -38,6 +38,13 @@ FILE_LIMITS = {
     "mainnet-frontier.bin": 1 * 1024 * 1024,
     "mainnet-treestate-subtrees.bin": 8 * 1024 * 1024,
 }
+# Produced by the archive publisher once generation lands; still optional here so existing
+# three-file bundles keep fetching until the import follow-up requires the grid.
+OPTIONAL_FILE_LIMITS = {
+    # The cost-weighted grid measures ~3.3 MB on Mainnet. The cap leaves room for a
+    # uniform-spacing run, which is larger, without accepting an unbounded download.
+    "mainnet-frontier-grid.bin": 32 * 1024 * 1024,
+}
 LATEST_REQUIRED_KEYS = {
     "schema_version",
     "network",
@@ -234,9 +241,11 @@ def resolve_bundle(
         raise BundleError(f"release-state bundle is older than {max_age_hours} hours")
 
     files = _object(meta["files"], "meta.files")
-    _check_keys(files, set(FILE_LIMITS), set(), "meta.files")
+    _check_keys(files, set(FILE_LIMITS), set(OPTIONAL_FILE_LIMITS), "meta.files")
     validated: dict[str, dict[str, Any]] = {}
-    for name, max_size in FILE_LIMITS.items():
+    for name, max_size in {**FILE_LIMITS, **OPTIONAL_FILE_LIMITS}.items():
+        if name not in files:
+            continue
         entry = _object(files[name], f"meta.files.{name}")
         _check_keys(entry, {"size", "sha256"}, set(), f"meta.files.{name}")
         size = _integer(entry["size"], f"meta.files.{name}.size", maximum=max_size)
@@ -296,12 +305,16 @@ def _self_test() -> int:
         meta_mutate: Callable[[dict[str, Any]], None] = lambda meta: None,
         latest_mutate: Callable[[dict[str, Any]], None] = lambda latest: None,
         file_overrides: dict[str, bytes] | None = None,
+        include_frontier_grid: bool = False,
     ) -> dict[str, bytes]:
+        frontier_grid = b"frontier grid"
         data_files = {
             "main-checkpoints.txt": checkpoints,
             "mainnet-frontier.bin": frontier,
             "mainnet-treestate-subtrees.bin": subtrees,
         }
+        if include_frontier_grid:
+            data_files["mainnet-frontier-grid.bin"] = frontier_grid
         meta = {
             "schema_version": 1,
             "network": "Mainnet",
@@ -336,6 +349,8 @@ def _self_test() -> int:
             f"{base}mainnet-frontier.bin": frontier,
             f"{base}mainnet-treestate-subtrees.bin": subtrees,
         }
+        if include_frontier_grid:
+            responses[f"{base}mainnet-frontier-grid.bin"] = frontier_grid
         responses.update(file_overrides or {})
         return responses
 
@@ -374,6 +389,45 @@ def _self_test() -> int:
 
             with self.assertRaisesRegex(BundleError, "missing keys"):
                 self.resolve(build(meta_mutate=remove_subtrees))
+
+        def test_frontier_grid_is_optional(self):
+            resolution = self.resolve(build())
+            self.assertEqual(resolution["height"], 3415600)
+
+        def test_frontier_grid_is_accepted_when_present(self):
+            with tempfile.TemporaryDirectory() as scratch:
+                responses = build(include_frontier_grid=True)
+
+                def fake_fetch(fetch_url: str, max_bytes: int) -> bytes:
+                    data = responses.get(fetch_url)
+                    if data is None:
+                        raise BundleError(f"unexpected fetch of {fetch_url}")
+                    if len(data) > max_bytes:
+                        raise BundleError(f"{fetch_url} exceeds its maximum allowed size")
+                    return data
+
+                resolution = resolve_bundle(
+                    latest_url,
+                    Path(scratch) / "bundle",
+                    Path(scratch) / "resolution.json",
+                    48,
+                    fetch=fake_fetch,
+                    now=now,
+                )
+                self.assertEqual(resolution["height"], 3415600)
+                self.assertEqual(
+                    (Path(scratch) / "bundle" / "mainnet-frontier-grid.bin").read_bytes(),
+                    b"frontier grid",
+                )
+
+        def test_frontier_grid_digest_is_checked(self):
+            responses = build(include_frontier_grid=True)
+            tampered = b"frontier griD"
+            responses[
+                f"https://{host}/release-state/v1/3415600/mainnet-frontier-grid.bin"
+            ] = tampered
+            with self.assertRaisesRegex(BundleError, "digest does not match"):
+                self.resolve(responses)
 
         def test_wrong_host_rejected(self):
             with self.assertRaisesRegex(BundleError, "host"):

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -96,6 +96,12 @@ pub use service::finalized_state::{
     VctTreestateInventory,
 };
 pub use service::finalized_state::{
+    export_frontier_grid_to, produce_release_treestate_artifacts, verify_subtree_artifact,
+    FrontierArtifact, FrontierEntry, FrontierGridExport, FrontierGridExportError, GridSpacing,
+    ReleaseTreestateArtifacts, ReleaseTreestateArtifactsError, SubtreeArtifact, SubtreeRecord,
+    TreestateArtifactError, VerifiedSubtreeCounts,
+};
+pub use service::finalized_state::{
     preview_prune_finalized_state, prune_finalized_state, PruneFinalizedStateError,
     PruneFinalizedStateOptions, PruneFinalizedStateSummary,
 };
@@ -106,12 +112,6 @@ pub use service::finalized_state::{
 pub use service::finalized_state::{
     produce_final_frontiers_bytes, produce_settled_final_frontiers_bytes,
     validate_final_frontiers_bytes, FinalFrontiersGenerationError, FinalFrontiersValidationError,
-};
-pub use service::finalized_state::{
-    export_frontier_grid_to, produce_release_treestate_artifacts, verify_subtree_artifact,
-    FrontierArtifact, FrontierEntry, FrontierGridExport, FrontierGridExportError, GridSpacing,
-    ReleaseTreestateArtifacts, ReleaseTreestateArtifactsError, SubtreeArtifact, SubtreeRecord,
-    TreestateArtifactError, VerifiedSubtreeCounts,
 };
 pub use service::read::{
     derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -108,7 +108,8 @@ pub use service::finalized_state::{
     validate_final_frontiers_bytes, FinalFrontiersGenerationError, FinalFrontiersValidationError,
 };
 pub use service::finalized_state::{
-    produce_release_treestate_artifacts, verify_subtree_artifact, FrontierArtifact, FrontierEntry,
+    export_frontier_grid_to, produce_release_treestate_artifacts, verify_subtree_artifact,
+    FrontierArtifact, FrontierEntry, FrontierGridExport, FrontierGridExportError, GridSpacing,
     ReleaseTreestateArtifacts, ReleaseTreestateArtifactsError, SubtreeArtifact, SubtreeRecord,
     TreestateArtifactError, VerifiedSubtreeCounts,
 };

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -123,7 +123,9 @@ pub use treestate_artifact::{
     TreestateArtifactError, VerifiedSubtreeCounts,
 };
 pub use treestate_export::{
-    produce_release_treestate_artifacts, ReleaseTreestateArtifacts, ReleaseTreestateArtifactsError,
+    export_frontier_grid_to, produce_release_treestate_artifacts, FrontierGridExport,
+    FrontierGridExportError, GridSpacing, ReleaseTreestateArtifacts,
+    ReleaseTreestateArtifactsError,
 };
 pub use vct::{validate_final_frontiers_bytes, FinalFrontiersValidationError, VctSuccessorWitness};
 pub(crate) use vct::{VctAuthenticationProof, VctAuxiliaryFailureAttribution, VctAuxiliaryWindow};

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -35,8 +35,9 @@ use crate::{
         check::anchors::tx_anchors_refer_to_final_treestates,
         non_finalized_state::Chain,
         read::{
-            derive_historical_frontiers, historical_tree::HistoricalTreeDerivationError,
-            sapling_subtrees, sapling_tree, HistoricalTreeCache,
+            derive_historical_frontiers, historical_tree::stored_frontier_before_absent_band,
+            historical_tree::HistoricalTreeDerivationError, sapling_subtrees, sapling_tree,
+            HistoricalTreeCache,
         },
     },
     tests::FakeChainHelper,
@@ -44,9 +45,10 @@ use crate::{
 };
 
 use super::super::{
-    commitment_aux, serve_block_roots, vct::validate_final_frontiers_bytes,
-    verify_subtrees_against_stored, CheckpointVerifiedBlock, DiskWriteBatch, FinalizedState,
-    VctAuxiliaryWindow, VctSuccessorWitness,
+    commitment_aux, export_frontier_grid_to, serve_block_roots,
+    vct::validate_final_frontiers_bytes, verify_subtrees_against_stored, CheckpointVerifiedBlock,
+    DiskWriteBatch, FinalizedState, FrontierGridExportError, GridSpacing, VctAuxiliaryWindow,
+    VctSuccessorWitness,
 };
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -1646,6 +1648,34 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
             // range is the absent band and every request is served from the index.
             prop_assert_eq!(fast.vct_fast_synced_below(), Some(handoff), "fast-sync marker is set to the handoff height");
             prop_assert_eq!(fast.db.vct_upgrade_height(), Some(Height(0)), "genesis fast sync records the upgrade height at genesis");
+            prop_assert!(
+                stored_frontier_before_absent_band(&fast.db, Height(0))
+                    .expect("a genesis-start database does not need a stored predecessor")
+                    .is_none(),
+                "U = 0 starts frontier replay from empty genesis trees"
+            );
+            let genesis_export = export_frontier_grid_to(
+                &fast.db,
+                handoff,
+                GridSpacing::Uniform { blocks: 1 },
+                None,
+                |_, _| {},
+            )
+            .expect("a genesis-start VCT database exports its absent band");
+            let last_published = genesis_export
+                .frontiers
+                .entries
+                .last()
+                .expect("a genesis-start band of this length publishes at least one on-grid entry");
+            prop_assert!(
+                last_published.height < handoff,
+                "published heights stay inside the absent band [0, H)"
+            );
+            prop_assert_eq!(
+                genesis_export.replayed_blocks,
+                u64::from(last_published.height.0) + 1,
+                "a genesis-start export replays from empty frontiers through the last on-grid entry"
+            );
 
             // Consensus state (anchor sets + history root) matches the legacy recompute.
             prop_assert_eq!(fast.db.vct_anchor_digest(), golden_anchors, "fast anchors must match legacy");
@@ -1829,12 +1859,12 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 );
             }
 
-            // The replay bound is a serving limit: with the memo primed by the loop above, the
-            // last height is already derived, so it costs nothing. A cold height below every memo
+            // The replay bound is a serving limit: with the cache primed by the loop above, the
+            // last height is already derived, so it costs nothing. A cold height below every cache
             // entry still has to replay, and refuses rather than running unbounded.
             prop_assert!(
                 derive_historical_frontiers(&fast.db, &cache, Height(last as u32 - 1), 0).is_ok(),
-                "a memoized height is served without replaying, whatever the bound"
+                "a cached height is served without replaying, whatever the bound"
             );
             let cold_cache = Mutex::new(HistoricalTreeCache::default());
             let cold_height = Height(last as u32 - 1);
@@ -2011,6 +2041,25 @@ fn vct_fast_sync_handoff_marks_database_and_resumes() -> Result<()> {
                 verify_subtrees_against_stored(&legacy.db, Height(seed as u32), handoff),
                 Err(HistoricalTreeDerivationError::RootMismatch { height: handoff }),
                 "the subtree audit rejects a replay whose final frontiers are unauthenticated"
+            );
+
+            // Re-label the genesis-start fast database as a mid-chain upgrade only after all its
+            // other assertions. It has no per-height trees below the handoff, so the shared
+            // fallback must reject the missing U - 1 frontier rather than silently replay genesis.
+            let missing_anchor_upgrade = Height(1);
+            let mut batch = DiskWriteBatch::new();
+            batch.delete_sapling_tree(&fast.db, &Height(0));
+            batch.update_vct_upgrade_marker(&fast.db, missing_anchor_upgrade);
+            fast.db
+                .write_batch(batch)
+                .expect("simulating a missing pre-band frontier succeeds");
+            prop_assert_eq!(
+                stored_frontier_before_absent_band(&fast.db, missing_anchor_upgrade).err(),
+                Some(HistoricalTreeDerivationError::MissingAnchor {
+                    height: missing_anchor_upgrade,
+                    anchor: Height(0),
+                }),
+                "a missing stored U - 1 frontier is rejected"
             );
     });
 
@@ -2718,6 +2767,7 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
             let mut batch = DiskWriteBatch::new();
             batch.delete_range_commitment_roots_by_height(&legacy.db, &Height(0), &upgrade);
             batch.update_vct_upgrade_marker(&legacy.db, upgrade);
+            batch.update_vct_sync_marker(&legacy.db, last_height);
             legacy
                 .db
                 .write_batch(batch)
@@ -2758,6 +2808,204 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 }),
                 "a zero-replay database fallback is not served without an authenticated root"
             );
+            let (stored_anchor_height, stored_anchor) =
+                stored_frontier_before_absent_band(&legacy.db, upgrade)
+                    .expect("the pre-upgrade trees provide an export anchor")
+                    .expect("a mid-chain upgrade has a stored predecessor");
+            prop_assert_eq!(stored_anchor_height, fallback_anchor);
+            prop_assert_eq!(
+                stored_anchor.sapling.root(),
+                legacy
+                    .db
+                    .latest_stored_sapling_tree(&fallback_anchor)
+                    .expect("the pre-upgrade Sapling tree is stored")
+                    .root()
+            );
+            let anchored_export = export_frontier_grid_to(
+                &legacy.db,
+                last_height,
+                GridSpacing::Uniform { blocks: 1 },
+                None,
+                |_, _| {},
+            )
+            .expect("a mid-chain VCT database exports from its stored predecessor");
+            let last_published = anchored_export
+                .frontiers
+                .entries
+                .last()
+                .expect("a grid over this chain publishes at least one on-grid entry");
+            prop_assert!(
+                last_published.height < last_height,
+                "published heights stay below the target checkpoint"
+            );
+            prop_assert!(
+                anchored_export
+                    .frontiers
+                    .entries
+                    .first()
+                    .is_some_and(|first| first.height < upgrade),
+                "coverage starts at genesis, not at this database's own upgrade height"
+            );
+            prop_assert_eq!(
+                anchored_export.replayed_blocks,
+                u64::from(last_published.height.0 - upgrade.0) + 1,
+                "only the absent band [U, last on-grid entry] is replayed; below U is read"
+            );
+            prop_assert_eq!(
+                anchored_export.frontiers.last_checkpoint,
+                last_height,
+                "the artifact records the checkpoint it was generated for, not this database's handoff"
+            );
+            for entry in &anchored_export.frontiers.entries {
+                // Unchanged trees are deduplicated, so the newest row at or below the height is
+                // the state there.
+                let stored = legacy
+                    .db
+                    .latest_stored_sapling_tree(&entry.height)
+                    .expect("the legacy pass stored a tree at or below every height");
+                prop_assert_eq!(
+                    entry.sapling.root(),
+                    stored.root(),
+                    "every published entry reproduces the tree the legacy pass stored"
+                );
+            }
+
+            // A shorter export is a prefix of a longer one. That is what lets the release
+            // pipeline check an incoming grid against the committed one entry by entry.
+            let shorter_export = export_frontier_grid_to(
+                &legacy.db,
+                Height(last_height.0 - 2),
+                GridSpacing::Uniform { blocks: 1 },
+                None,
+                |_, _| {},
+            )
+            .expect("a lower target exports the same grid, minus its tail");
+            prop_assert!(
+                shorter_export.frontiers.entries.len() < anchored_export.frontiers.entries.len(),
+                "a lower target publishes fewer entries"
+            );
+            for (earlier, later) in shorter_export
+                .frontiers
+                .entries
+                .iter()
+                .zip(&anchored_export.frontiers.entries)
+            {
+                prop_assert_eq!(earlier.height, later.height, "grid heights do not move");
+                prop_assert_eq!(
+                    earlier.sapling.root(),
+                    later.sapling.root(),
+                    "an entry's contents do not change as the target advances"
+                );
+            }
+
+            // Resuming reproduces the from-genesis walk exactly. That is the property the whole
+            // incremental path rests on: the cost accumulator resets at every emitted entry, so
+            // continuing at `last carried entry + 1` places the remainder identically.
+            let resumed_export = export_frontier_grid_to(
+                &legacy.db,
+                last_height,
+                GridSpacing::Uniform { blocks: 1 },
+                Some(&shorter_export.frontiers),
+                |_, _| {},
+            )
+            .expect("a published grid can be carried forward");
+            prop_assert_eq!(
+                resumed_export.frontiers.entries.len(),
+                anchored_export.frontiers.entries.len(),
+                "resuming publishes the same entries as a walk from genesis"
+            );
+            for (from_genesis, resumed) in anchored_export
+                .frontiers
+                .entries
+                .iter()
+                .zip(&resumed_export.frontiers.entries)
+            {
+                prop_assert_eq!(from_genesis.height, resumed.height);
+                prop_assert_eq!(from_genesis.sapling.root(), resumed.sapling.root());
+                prop_assert_eq!(from_genesis.orchard.root(), resumed.orchard.root());
+            }
+            prop_assert_eq!(
+                resumed_export.frontiers.encode(&network),
+                anchored_export.frontiers.encode(&network),
+                "a resumed artifact is byte-identical to the one a full walk produces"
+            );
+            prop_assert!(
+                resumed_export.replayed_blocks < anchored_export.replayed_blocks,
+                "resuming replays less than a walk from genesis"
+            );
+
+            // A grid that already reaches the requested checkpoint has nothing to extend, and
+            // carrying entries at or above it would describe heights the export does not cover.
+            prop_assert!(
+                matches!(
+                    export_frontier_grid_to(
+                        &legacy.db,
+                        Height(2),
+                        GridSpacing::Uniform { blocks: 1 },
+                        Some(&anchored_export.frontiers),
+                        |_, _| {},
+                    ),
+                    Err(FrontierGridExportError::ResumeAboveTarget { .. })
+                ),
+                "a grid reaching past the target is refused rather than truncated"
+            );
+
+            // One export can draw on every source at once. Narrowing the handoff leaves this
+            // database with stored trees on both sides of its absent band: entries below `U` and
+            // at or above the handoff are read, and only the band between them is replayed.
+            let narrow_handoff = Height(upgrade.0 + 2);
+            let mut batch = DiskWriteBatch::new();
+            batch.update_vct_sync_marker(&legacy.db, narrow_handoff);
+            legacy
+                .db
+                .write_batch(batch)
+                .expect("narrowing the absent band succeeds");
+            let mixed_export = export_frontier_grid_to(
+                &legacy.db,
+                last_height,
+                GridSpacing::Uniform { blocks: 1 },
+                None,
+                |_, _| {},
+            )
+            .expect("a database with trees on both sides of its band exports every height");
+            prop_assert!(
+                mixed_export.replayed_blocks
+                    <= u64::from(narrow_handoff.0 - upgrade.0),
+                "replay is confined to the absent band"
+            );
+            prop_assert!(
+                mixed_export.replayed_blocks < anchored_export.replayed_blocks,
+                "a narrower band means less replay for the same coverage"
+            );
+            prop_assert!(
+                mixed_export
+                    .frontiers
+                    .entries
+                    .last()
+                    .is_some_and(|entry| entry.height >= narrow_handoff),
+                "coverage continues above the handoff, where the trees are stored again"
+            );
+            for (band_generated, read_generated) in anchored_export
+                .frontiers
+                .entries
+                .iter()
+                .zip(&mixed_export.frontiers.entries)
+            {
+                prop_assert_eq!(band_generated.height, read_generated.height);
+                prop_assert_eq!(
+                    band_generated.sapling.root(),
+                    read_generated.sapling.root(),
+                    "a replayed entry and a read entry at the same height are the same frontier"
+                );
+            }
+
+            // Restore the fixture's handoff for the assertions that follow.
+            let mut batch = DiskWriteBatch::new();
+            batch.update_vct_sync_marker(&legacy.db, last_height);
+            legacy
+                .db
+                .write_batch(batch)
+                .expect("restoring the fixture handoff succeeds");
             let stitched = serve_block_roots(&legacy.db, serve_range);
             prop_assert_eq!(
                 stitched,
@@ -2776,6 +3024,14 @@ fn vct_db_produced_payload_round_trips_to_byte_identical_state() -> Result<()> {
                 .db
                 .write_batch(batch)
                 .expect("simulating a stale post-rollback upgrade marker succeeds");
+            prop_assert_eq!(
+                stored_frontier_before_absent_band(&legacy.db, stale_anchor).err(),
+                Some(HistoricalTreeDerivationError::MissingAnchor {
+                    height: stale_anchor,
+                    anchor: stale_anchor,
+                }),
+                "the shared stored-tree anchor rejects a stale upgrade marker"
+            );
             prop_assert_eq!(
                 derive_historical_frontiers(
                     &legacy.db,

--- a/crates/zakura-state/src/service/finalized_state/treestate_export.rs
+++ b/crates/zakura-state/src/service/finalized_state/treestate_export.rs
@@ -5,7 +5,10 @@
 //! those two sources works for both legacy and verified-commitment-trees databases, and does not
 //! need historical block bodies or per-height frontiers from the skipped range.
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 
 use thiserror::Error;
 
@@ -14,12 +17,18 @@ use zakura_chain::{
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex, TRACKED_SUBTREE_HEIGHT},
 };
 
+use crate::service::read::historical_tree::{
+    replay_with_subtrees, stored_frontier_before_absent_band, stored_frontiers_at,
+    verify_against_available_roots, DerivedFrontiers, HistoricalTreeDerivationError,
+};
+
 use super::{
     commitment_aux::{
         produce_settled_final_frontiers, FinalFrontiers, FinalFrontiersGenerationError,
     },
     treestate_artifact::{
-        embedded_historical_subtrees, SubtreeArtifact, SubtreeRecord, TreestateArtifactError,
+        embedded_historical_subtrees, FrontierArtifact, FrontierEntry, SubtreeArtifact,
+        SubtreeRecord, TreestateArtifactError,
     },
     ZakuraDb,
 };
@@ -558,6 +567,481 @@ mod tests {
                 expected: 2,
                 found: 1,
             })
+        );
+    }
+}
+
+/// Estimated replay cost of one block, in microseconds, independent of its shielded activity.
+///
+/// Covers reading the block and walking its transactions. Blocks with no shielded outputs cost
+/// about this much, which is what the constant is fitted to.
+const COST_PER_BLOCK_US: u64 = 1_500;
+
+/// Estimated replay cost of appending one note commitment, in microseconds.
+///
+/// Fitted so the model reproduces the measured whole-band replay time (6,879 s over 3,358,006
+/// blocks and ~124M Sapling and Orchard commitments) given [`COST_PER_BLOCK_US`]. Appending
+/// dominates wherever there is shielded activity.
+const COST_PER_COMMITMENT_US: u64 = 47;
+
+/// How the frontier grid's height spacing is chosen.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GridSpacing {
+    /// One entry every `blocks` heights.
+    Uniform {
+        /// The height spacing.
+        blocks: u32,
+    },
+
+    /// One entry per `budget_us` of estimated replay cost.
+    ///
+    /// Replay cost varies by more than an order of magnitude across Mainnet, so a uniform grid
+    /// either wastes entries where blocks are cheap or leaves a long tail where they are not.
+    /// Spacing by estimated cost instead bounds the worst cold request rather than the average.
+    ///
+    /// The estimate is a deterministic function of the chain — block and commitment counts, not
+    /// wall-clock timing — so two generator runs on different hardware still produce byte-identical
+    /// artifacts.
+    Adaptive {
+        /// The per-entry cost budget, in microseconds.
+        budget_us: u64,
+    },
+}
+
+/// Why frontier grid generation could not complete.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum FrontierGridExportError {
+    /// The database has no finalized tip, so it holds nothing to generate from.
+    #[error("this database has no finalized tip to generate a frontier grid from")]
+    NoFinalizedTip,
+
+    /// The requested checkpoint is above what the database has finalized.
+    #[error("cannot generate a grid for {target:?}: this database is only finalized to {tip:?}")]
+    TargetAboveTip {
+        /// The requested checkpoint.
+        target: Height,
+        /// The database's finalized tip.
+        tip: Height,
+    },
+
+    /// The grid would cover no heights at all.
+    #[error("a grid at {target:?} covers no heights")]
+    EmptyRange {
+        /// The requested checkpoint.
+        target: Height,
+    },
+
+    /// The grid spacing or cost budget was zero, which would produce an entry at every height.
+    #[error("grid spacing and cost budget must be at least 1")]
+    ZeroSpacing,
+
+    /// The grid being resumed from reaches at or above the requested checkpoint.
+    #[error(
+        "cannot resume from a grid whose last entry {seed:?} is not below the requested \
+         checkpoint {target:?}"
+    )]
+    ResumeAboveTarget {
+        /// The highest entry in the grid being resumed from.
+        seed: Height,
+        /// The requested checkpoint.
+        target: Height,
+    },
+
+    /// A block body needed to place entries is not retained.
+    #[error(
+        "cannot place frontier grid entries: block body {missing:?} is not retained; generate \
+         from an archive database"
+    )]
+    UnretainedBlockBody {
+        /// The first height whose body was missing.
+        missing: Height,
+    },
+
+    /// A replay or its root check failed.
+    #[error("generation failed at height {height:?}: {source}")]
+    Derivation {
+        /// The height being produced when generation failed.
+        height: Height,
+        /// The underlying failure.
+        #[source]
+        source: HistoricalTreeDerivationError,
+    },
+}
+
+/// What one frontier grid generation run produced.
+#[derive(Clone, Debug)]
+pub struct FrontierGridExport {
+    /// The frontier grid.
+    pub frontiers: FrontierArtifact,
+
+    /// How long generation took.
+    pub elapsed: Duration,
+
+    /// How many blocks were replayed.
+    pub replayed_blocks: u64,
+}
+
+/// Next on-grid height at or below `last`, or `None` if only a partial cell remains.
+///
+/// A partial cell is not published. Clamping it to `last` would place a tip-local entry that a
+/// later export, at a higher `last`, would replace with the unclamped grid point — rewriting the
+/// seam and breaking the append-only prefix contract. Serving still covers that tail: it replays
+/// from the previous on-grid entry, which is already within one grid step.
+fn next_grid_target(
+    spacing: GridSpacing,
+    next: Height,
+    last: Height,
+    accrued_cost: &mut u64,
+    mut block_commitments: impl FnMut(Height) -> usize,
+) -> Option<Height> {
+    match spacing {
+        GridSpacing::Uniform { blocks } => {
+            let target = Height(next.0.saturating_add(blocks));
+            (target <= last).then_some(target)
+        }
+        GridSpacing::Adaptive { budget_us } => {
+            let mut candidate = next;
+            while candidate <= last {
+                let counts = block_commitments(candidate);
+                *accrued_cost = accrued_cost
+                    .saturating_add(COST_PER_BLOCK_US)
+                    // The count is bounded by a block's own commitments, so it fits in u64.
+                    .saturating_add(COST_PER_COMMITMENT_US.saturating_mul(counts as u64));
+                if *accrued_cost >= budget_us {
+                    *accrued_cost = 0;
+                    return Some(candidate);
+                }
+                if candidate == last {
+                    return None;
+                }
+                candidate = Height(candidate.0 + 1);
+            }
+            None
+        }
+    }
+}
+
+/// Generates the frontier grid covering `[0, target_checkpoint)` at the given `spacing`.
+///
+/// Each entry's frontiers come from whichever source the database actually holds at that height.
+/// Per-height trees are read wherever they exist; retained block bodies are replayed only across
+/// a verified-commitment-trees database's absent band `[U, H)`, where no tree was ever written.
+/// A legacy archive database has trees at every height, so it generates the whole grid from reads
+/// and never replays.
+///
+/// The walk always starts at genesis and its entry heights are a function of chain data alone, so
+/// databases of different shapes, and the same database at different tips, produce grids that are
+/// byte-prefix extensions of one another. That is the append-only contract the release-state
+/// pipeline checks, and it is why the walk does not start at whatever boundary this particular
+/// database happens to have.
+///
+/// A partial cell at `target_checkpoint` is omitted, so a later export at a higher checkpoint is
+/// a prefix of this one plus new on-grid entries. Each emitted entry is root-checked against the
+/// authenticated roots the database already holds, and generation stops at the first height that
+/// fails, so a returned artifact is one whose every entry matched. That is what lets the grid
+/// ship without trust: a consumer re-runs the same check before anchoring on an entry.
+///
+/// Completed subtree roots are not collected here. The release pipeline
+/// ([`produce_release_treestate_artifacts`]) owns that artifact, and it does not need historical
+/// block bodies to build it.
+///
+/// `resume_from` carries an earlier grid's entries forward instead of recomputing them. Each
+/// carried entry is re-checked against this database's authenticated roots before it is accepted, so
+/// resuming inherits no trust from the file it came from. Placement is unaffected: the cost
+/// accumulator resets at every emitted entry, so continuing at `last carried entry + 1` puts the
+/// remaining entries exactly where a walk from genesis would. Resuming also makes the output a
+/// prefix-extension of the input by construction rather than by both runs agreeing on a budget.
+///
+/// `on_progress` is called with each emitted entry's height and the running replay count, for
+/// long runs.
+pub fn export_frontier_grid_to(
+    db: &ZakuraDb,
+    target_checkpoint: Height,
+    spacing: GridSpacing,
+    resume_from: Option<&FrontierArtifact>,
+    mut on_progress: impl FnMut(Height, u64),
+) -> Result<FrontierGridExport, FrontierGridExportError> {
+    match spacing {
+        GridSpacing::Uniform { blocks: 0 } | GridSpacing::Adaptive { budget_us: 0 } => {
+            return Err(FrontierGridExportError::ZeroSpacing)
+        }
+        _ => {}
+    }
+
+    let tip = db
+        .finalized_tip_height()
+        .ok_or(FrontierGridExportError::NoFinalizedTip)?;
+    if target_checkpoint > tip {
+        return Err(FrontierGridExportError::TargetAboveTip {
+            target: target_checkpoint,
+            tip,
+        });
+    }
+    // The covered range is half-open, so the last height the grid can publish is `target - 1`.
+    let last = target_checkpoint.0.checked_sub(1).map(Height).ok_or(
+        FrontierGridExportError::EmptyRange {
+            target: target_checkpoint,
+        },
+    )?;
+
+    // Only a fast-synced database has heights with no stored tree. Everything outside that band
+    // is read rather than replayed, including the pre-upgrade range below `U`.
+    let absent_band = db
+        .vct_synced_below()
+        .map(|handoff| (db.vct_upgrade_height().unwrap_or(Height(0)), handoff));
+
+    let start = Instant::now();
+    let mut entries: Vec<FrontierEntry> = Vec::new();
+    let mut replayed_blocks = 0u64;
+
+    // The replay cursor, carried across grid steps so the band is covered by one contiguous pass
+    // anchored on the previous root-checked endpoint rather than restarted at every entry.
+    let mut replay: Option<(DerivedFrontiers, u32)> = None;
+
+    let mut next = Height(0);
+    let mut accrued_cost: u64 = 0;
+
+    if let Some(seed) = resume_from {
+        if let Some(top) = seed.entries.last() {
+            if top.height > last {
+                return Err(FrontierGridExportError::ResumeAboveTarget {
+                    seed: top.height,
+                    target: target_checkpoint,
+                });
+            }
+        }
+
+        // Carried entries are re-checked here, so a stale, truncated, or hostile input costs a
+        // failed export rather than an unverified entry in the published artifact.
+        for entry in &seed.entries {
+            let frontiers = DerivedFrontiers {
+                sapling: entry.sapling.clone(),
+                orchard: entry.orchard.clone(),
+                ironwood: entry.ironwood.clone(),
+            };
+            verify_against_available_roots(db, entry.height, &frontiers).map_err(|source| {
+                FrontierGridExportError::Derivation {
+                    height: entry.height,
+                    source,
+                }
+            })?;
+
+            // A carried entry inside the absent band is a verified frontier at its height, which
+            // is a nearer replay anchor than the trees below `U`.
+            if absent_band
+                .is_some_and(|(upgrade, handoff)| entry.height >= upgrade && entry.height < handoff)
+            {
+                replay = Some((frontiers, entry.height.0 + 1));
+            }
+
+            entries.push(entry.clone());
+        }
+
+        if let Some(top) = entries.last() {
+            next = Height(top.height.0 + 1);
+        }
+    }
+
+    // A pruned database answers the cost scan with a missing body, which would read as a free
+    // block and space entries far too widely. The artifact would still be valid — every entry is
+    // root-checked — but it would not bound cold requests, which is the only reason it exists.
+    // Record the first such height and fail instead.
+    let mut unretained: Option<Height> = None;
+
+    // Under a uniform grid the next entry is a fixed number of blocks ahead. Under an adaptive
+    // one it is wherever the estimated cost budget runs out, which needs a block-by-block scan
+    // of the commitment counts to find. Either way, a target past `last` is a partial cell and
+    // is not published.
+    while let Some(target) = next_grid_target(spacing, next, last, &mut accrued_cost, |height| {
+        match db.block(height.into()) {
+            Some(block) => {
+                block.sapling_note_commitments().count()
+                    + block.orchard_note_commitments().count()
+                    + block.ironwood_note_commitments().count()
+            }
+            None => {
+                unretained.get_or_insert(height);
+                0
+            }
+        }
+    }) {
+        if let Some(missing) = unretained {
+            return Err(FrontierGridExportError::UnretainedBlockBody { missing });
+        }
+
+        let in_absent_band =
+            absent_band.is_some_and(|(upgrade, handoff)| target >= upgrade && target < handoff);
+
+        let frontiers = if in_absent_band {
+            let (carried, replay_from) = match replay.take() {
+                Some(cursor) => cursor,
+                // Entering the band: anchor on the trees stored just below it, or on empty
+                // frontiers when the band starts at genesis.
+                None => {
+                    let upgrade = absent_band
+                        .expect("a height inside the band implies the band exists")
+                        .0;
+                    match stored_frontier_before_absent_band(db, upgrade).map_err(|source| {
+                        FrontierGridExportError::Derivation {
+                            height: upgrade,
+                            source,
+                        }
+                    })? {
+                        Some((anchor, frontiers)) => (frontiers, anchor.0 + 1),
+                        None => (DerivedFrontiers::empty(), 0),
+                    }
+                }
+            };
+
+            let derived = replay_with_subtrees(db, target, replay_from, carried, |_, _| {})
+                .map_err(|source| FrontierGridExportError::Derivation {
+                    height: target,
+                    source,
+                })?;
+            replayed_blocks += u64::from(target.0 - replay_from) + 1;
+            derived
+        } else {
+            stored_frontiers_at(db, target).map_err(|source| {
+                FrontierGridExportError::Derivation {
+                    height: target,
+                    source,
+                }
+            })?
+        };
+
+        // The root check is what makes this entry safe to publish.
+        verify_against_available_roots(db, target, &frontiers).map_err(|source| {
+            FrontierGridExportError::Derivation {
+                height: target,
+                source,
+            }
+        })?;
+
+        entries.push(FrontierEntry {
+            height: target,
+            sapling: frontiers.sapling.clone(),
+            orchard: frontiers.orchard.clone(),
+            ironwood: frontiers.ironwood.clone(),
+        });
+        on_progress(target, replayed_blocks);
+
+        if in_absent_band {
+            replay = Some((frontiers, target.0 + 1));
+        }
+
+        if target == last {
+            break;
+        }
+
+        next = Height(target.0 + 1);
+    }
+
+    if let Some(missing) = unretained {
+        return Err(FrontierGridExportError::UnretainedBlockBody { missing });
+    }
+
+    Ok(FrontierGridExport {
+        frontiers: FrontierArtifact {
+            spacing: match spacing {
+                GridSpacing::Uniform { blocks } => blocks,
+                // Recorded as provenance only; consumers locate entries by searching.
+                GridSpacing::Adaptive { .. } => 0,
+            },
+            last_checkpoint: target_checkpoint,
+            entries,
+        },
+        elapsed: start.elapsed(),
+        replayed_blocks,
+    })
+}
+
+#[cfg(test)]
+mod grid_target_tests {
+    use super::*;
+
+    fn published_grid_heights(
+        spacing: GridSpacing,
+        start: Height,
+        last: Height,
+        mut commitments: impl FnMut(Height) -> usize,
+    ) -> Vec<u32> {
+        let mut heights = Vec::new();
+        let mut next = start;
+        let mut accrued_cost = 0;
+        while let Some(target) =
+            next_grid_target(spacing, next, last, &mut accrued_cost, &mut commitments)
+        {
+            heights.push(target.0);
+            if target == last {
+                break;
+            }
+            next = Height(target.0 + 1);
+        }
+        heights
+    }
+
+    #[test]
+    fn uniform_grid_omits_a_partial_final_cell() {
+        let spacing = GridSpacing::Uniform { blocks: 10 };
+
+        assert_eq!(
+            published_grid_heights(spacing, Height(0), Height(25), |_| 0),
+            vec![10, 21],
+            "the cell that would clamp to 25 is not published"
+        );
+        assert_eq!(
+            published_grid_heights(spacing, Height(0), Height(10), |_| 0),
+            vec![10],
+            "a target that lands exactly on last is on-grid and is published"
+        );
+        assert!(
+            published_grid_heights(spacing, Height(0), Height(9), |_| 0).is_empty(),
+            "a band shorter than one step publishes nothing rather than a clamped entry"
+        );
+    }
+
+    #[test]
+    fn uniform_grid_heights_are_prefix_compatible_across_tips() {
+        let spacing = GridSpacing::Uniform { blocks: 10 };
+        let earlier = published_grid_heights(spacing, Height(0), Height(25), |_| 0);
+        let later = published_grid_heights(spacing, Height(0), Height(35), |_| 0);
+
+        assert_eq!(&later[..earlier.len()], earlier.as_slice());
+        assert_eq!(later, vec![10, 21, 32]);
+        assert!(
+            !later.contains(&25),
+            "the height a clamp would have published at the earlier tip is not a later grid point"
+        );
+    }
+
+    #[test]
+    fn adaptive_grid_omits_a_partial_final_cell() {
+        // Three empty blocks cost 4_500 µs, so a 4_000 µs budget fires every third height.
+        let spacing = GridSpacing::Adaptive { budget_us: 4_000 };
+
+        assert_eq!(
+            published_grid_heights(spacing, Height(0), Height(10), |_| 0),
+            vec![2, 5, 8],
+            "the incomplete cell ending at last is omitted"
+        );
+        assert_eq!(
+            published_grid_heights(spacing, Height(0), Height(11), |_| 0),
+            vec![2, 5, 8, 11],
+            "last is published when it is a real budget boundary"
+        );
+    }
+
+    #[test]
+    fn adaptive_grid_heights_are_prefix_compatible_across_tips() {
+        let spacing = GridSpacing::Adaptive { budget_us: 4_000 };
+        let earlier = published_grid_heights(spacing, Height(0), Height(10), |_| 0);
+        let later = published_grid_heights(spacing, Height(0), Height(11), |_| 0);
+
+        assert_eq!(&later[..earlier.len()], earlier.as_slice());
+        assert_eq!(later, vec![2, 5, 8, 11]);
+        assert!(
+            !later.contains(&10),
+            "the height a clamp would have published at the earlier tip is not a later grid point"
         );
     }
 }

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -377,7 +377,6 @@ fn anchor_for(
     )))
 }
 
-
 /// Returns the stored frontier immediately before the absent band, if the band starts above
 /// genesis.
 ///
@@ -605,7 +604,6 @@ pub fn verify_against_index(
     }
 }
 
-
 /// Checks `frontiers` against the best roots the database can produce for `height`.
 ///
 /// Generation-only. It differs from [`verify_against_index`] in one place: below the upgrade
@@ -644,7 +642,6 @@ fn authenticated_roots(
         .filter(|roots| roots.height == height)
         .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -30,7 +30,7 @@ use zakura_chain::{
 
 use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
 
-use crate::service::finalized_state::{TransactionLocation, ZakuraDb};
+use crate::service::finalized_state::{serve_block_roots, TransactionLocation, ZakuraDb};
 
 /// The most derived frontiers to keep memoized per node.
 ///
@@ -377,6 +377,69 @@ fn anchor_for(
     )))
 }
 
+
+/// Returns the stored frontier immediately before the absent band, if the band starts above
+/// genesis.
+///
+/// `height` identifies the derivation or export that needs the anchor in any returned error.
+/// `None` means the absent band starts at genesis, so replay must start from empty frontiers.
+pub(crate) fn stored_frontier_before_absent_band(
+    db: &ZakuraDb,
+    height: Height,
+) -> Result<Option<(Height, DerivedFrontiers)>, HistoricalTreeDerivationError> {
+    // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
+    // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
+    let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
+        return Ok(None);
+    };
+
+    let anchor = Height(upgrade.0 - 1);
+    // Rollback can move the tip below the write-once upgrade marker. In that case a backwards tree
+    // lookup would return a retained row below the rollback target and mislabel it as `anchor`.
+    if db
+        .finalized_tip_height()
+        .is_none_or(|tip_height| anchor > tip_height)
+    {
+        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+    }
+
+    // The tip check above establishes that the chain still reaches `anchor`, so the newest stored
+    // row at or below it is its state rather than a pre-rollback leftover.
+    let frontiers = stored_frontiers_at(db, anchor)
+        .map_err(|_| HistoricalTreeDerivationError::MissingAnchor { height, anchor })?;
+
+    Ok(Some((anchor, frontiers)))
+}
+
+/// Returns the per-height trees the database stores at `height`.
+///
+/// Unchanged trees are deduplicated, so the newest stored row at or below `height` is the state
+/// at `height`. That holds only where the database actually stores trees: callers must not use
+/// this inside a fast-synced database's absent band, where the newest row below the requested
+/// height belongs to a different stretch of the chain entirely. Genesis writes a row for every
+/// pool, so a pool with no activity yet still resolves to its empty tree.
+pub(crate) fn stored_frontiers_at(
+    db: &ZakuraDb,
+    height: Height,
+) -> Result<DerivedFrontiers, HistoricalTreeDerivationError> {
+    let (Some(sapling), Some(orchard), Some(ironwood)) = (
+        db.latest_stored_sapling_tree(&height),
+        db.latest_stored_orchard_tree(&height),
+        db.latest_stored_ironwood_tree(&height),
+    ) else {
+        return Err(HistoricalTreeDerivationError::MissingAnchor {
+            height,
+            anchor: height,
+        });
+    };
+
+    Ok(DerivedFrontiers {
+        sapling,
+        orchard,
+        ironwood,
+    })
+}
+
 /// Appends the note commitments of blocks `replay_from..=height` to `frontiers`, reporting every
 /// subtree that completes along the way.
 ///
@@ -542,6 +605,34 @@ pub fn verify_against_index(
     }
 }
 
+
+/// Checks `frontiers` against the best roots the database can produce for `height`.
+///
+/// Generation-only. It differs from [`verify_against_index`] in one place: below the upgrade
+/// marker, where the serving index has no rows because an older binary committed those blocks,
+/// it falls back to roots derived from the per-height trees. There the check is a consistency
+/// check rather than an independent one, since the roots come from the same trees the entry does.
+/// That is acceptable precisely because the artifact carries no trust of its own — the consumer
+/// re-checks every entry against roots authenticated by its own header chain before anchoring on
+/// it, and a consumer's absent band never overlaps a range where it has trees of its own.
+pub(crate) fn verify_against_available_roots(
+    db: &ZakuraDb,
+    height: Height,
+    frontiers: &DerivedFrontiers,
+) -> Result<(), HistoricalTreeDerivationError> {
+    let roots = serve_block_roots(db, height..=height)
+        .into_iter()
+        .next()
+        .filter(|roots| roots.height == height)
+        .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })?;
+
+    if frontiers.matches(&roots) {
+        Ok(())
+    } else {
+        Err(HistoricalTreeDerivationError::RootMismatch { height })
+    }
+}
+
 /// Returns the authenticated per-pool roots stored for `height`.
 fn authenticated_roots(
     db: &ZakuraDb,
@@ -552,4 +643,52 @@ fn authenticated_roots(
         .next()
         .filter(|roots| roots.height == height)
         .ok_or(HistoricalTreeDerivationError::MissingAuthenticatedRoot { height })
+}
+
+
+#[cfg(test)]
+mod tests {
+    use zakura_chain::{block::Height, parameters::Network};
+
+    use crate::{
+        config::Config,
+        constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
+        service::finalized_state::{DiskWriteBatch, STATE_COLUMN_FAMILIES_IN_CODE},
+    };
+
+    use super::*;
+
+    fn ephemeral_db() -> ZakuraDb {
+        ZakuraDb::new(
+            &Config::ephemeral(),
+            STATE_DATABASE_KIND,
+            &state_database_format_version_in_code(),
+            &Network::Mainnet,
+            true,
+            STATE_COLUMN_FAMILIES_IN_CODE
+                .iter()
+                .map(ToString::to_string),
+            false,
+        )
+        .expect("opening an ephemeral database should succeed")
+    }
+
+    #[test]
+    fn genesis_absent_band_has_no_stored_predecessor() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+
+        assert!(stored_frontier_before_absent_band(&db, Height(0))
+            .expect("an unset upgrade marker starts replay at genesis")
+            .is_none());
+
+        let mut batch = DiskWriteBatch::new();
+        batch.update_vct_upgrade_marker(&db, Height(0));
+        db.write_batch(batch)
+            .expect("seeding a genesis upgrade marker succeeds");
+
+        assert!(stored_frontier_before_absent_band(&db, Height(0))
+            .expect("a genesis upgrade starts replay at genesis")
+            .is_none());
+    }
 }

--- a/crates/zakura-utils/README.md
+++ b/crates/zakura-utils/README.md
@@ -17,26 +17,62 @@ This command generates a list of zebra checkpoints, and writes them to standard 
 #### Offline Mainnet export (release-state pipeline)
 
 Mainnet checkpoint updates flow through the release-state pipeline: the publisher host runs
-offline mode against a quiesced copy of a synced Mainnet state database. The same run produces
-the matching VCT frontier and completed-subtree artifacts for the last emitted checkpoint. Build
-with the offline feature and run:
+offline mode against a synced Mainnet **archive** state database. One run produces the whole
+coupled release state for the last emitted checkpoint — the checkpoint list, the VCT frontier,
+the completed-subtree roots, and the historical frontier grid. Build with the offline feature
+and run:
 
 ```sh
 cargo install --locked --features zakura-checkpoints-offline --git https://github.com/zakura-core/zakura zakura-utils
 
 zakura-checkpoints \
-  --state-cache-dir /path/to/quiesced-zakura-cache \
+  --state-cache-dir /path/to/archive-zakura-cache \
   --full-list \
   --mainnet-frontier-output /out/mainnet-frontier.bin \
   --mainnet-subtree-output /out/mainnet-treestate-subtrees.bin \
+  --mainnet-frontier-grid-output /out/mainnet-frontier-grid.bin \
   > /out/main-checkpoints.txt
 ```
 
 Offline mode reads canonical hashes and `BlockInfo` sizes straight from the finalized
-database, so it works on pruned state and needs no running node. `--full-list` prints the
-embedded checkpoint list before the new entries, making stdout a complete replacement
-`main-checkpoints.txt`. The subtree export keeps the roots already embedded in the binary and
-adds later roots retained by the database, so it works with the production pruned VCT state.
+database, which it opens as a read-only RocksDB secondary, so the node does not have to be
+stopped. `--full-list` prints the embedded checkpoint list before the new entries, making
+stdout a complete replacement `main-checkpoints.txt`. The subtree export keeps the roots
+already embedded in the binary and adds later roots retained by the database.
+
+The three artifact output flags are one set: supply all of them or none, so a replacement
+checkpoint list can never ship without its coupled state. Checkpoints, the frontier, and the
+subtree roots come out of pruned state too, but the frontier grid covers the heights below the
+checkpoint, which a pruned database no longer holds — hence the archive requirement. A legacy
+archive node generates the grid entirely from stored trees; a fast-synced one replays its
+absent band instead, which takes hours on Mainnet. Either way the default cost-weighted
+spacing reads every block body once to place its entries, so expect a long batch run: the
+first full Mainnet run took 81 minutes on a legacy archive node and produced 5,472 entries
+in 4.8 MB, without replaying a single block. `--frontier-grid-target-cost-ms` tunes the
+grid's per-entry cost budget (default 2000); `--frontier-grid-spacing` produces a uniform grid
+and is not recommended.
+
+`--mainnet-frontier-grid-input <path>` resumes from a previously published grid instead of
+rebuilding it. Its entries are re-checked against the database and then carried forward verbatim,
+so the run scans only the blocks above the last carried entry and the output is a prefix-extension
+of the input by construction. Use it for every run after the first: a full walk stays O(chain)
+forever, while a resumed run costs only the new tail.
+
+To produce a grid for a checkpoint the binary already ships — backfilling the one artifact a
+committed release state is missing, without advancing the checkpoint list — run the grid
+alone:
+
+```sh
+zakura-checkpoints \
+  --state-cache-dir /path/to/archive-zakura-cache \
+  --mainnet-frontier-grid-output /out/mainnet-frontier-grid.bin \
+  --mainnet-frontier-grid-checkpoint <embedded checkpoint height>
+```
+
+That mode emits no checkpoints and refuses the other artifact outputs, which only exist for a
+newly selected checkpoint. The height must be one of the embedded checkpoints, and the database
+must agree with the embedded list at it.
+
 Do not hand-append RPC-mode output to the Mainnet list: pipeline
 updates must stay on the deterministic selection grid (see
 `docs/design/verified-commitment-trees.md`, "Mainnet release-state pipeline").

--- a/crates/zakura-utils/src/bin/zakura-checkpoints/args.rs
+++ b/crates/zakura-utils/src/bin/zakura-checkpoints/args.rs
@@ -141,16 +141,65 @@ pub struct Args {
     /// Offline mode: write the completed-subtree artifact for the last emitted
     /// checkpoint height to this path.
     ///
-    /// Requires `--state-cache-dir` and `--mainnet-frontier-output`.
+    /// Requires `--state-cache-dir` and the other artifact output flags.
     #[arg(long)]
     pub mainnet_subtree_output: Option<PathBuf>,
+
+    /// Offline mode: write the historical note commitment frontier grid covering
+    /// everything below the last emitted checkpoint to this path.
+    ///
+    /// Serving nodes anchor on this grid to answer `z_gettreestate` across the
+    /// heights a fast sync skipped. Requires `--state-cache-dir` and the other
+    /// artifact output flags.
+    #[arg(long)]
+    pub mainnet_frontier_grid_output: Option<PathBuf>,
+
+    /// Offline mode: resume the frontier grid from a previously published one.
+    ///
+    /// Carries that grid's entries forward instead of recomputing them, so a run scans only the
+    /// blocks above its last entry rather than the whole chain. Every carried entry is re-checked
+    /// against this database's authenticated roots first, so the input is never trusted. Omit it
+    /// to build the grid from genesis, which is what the first run has to do.
+    ///
+    /// Requires `--mainnet-frontier-grid-output`.
+    #[arg(long)]
+    pub mainnet_frontier_grid_input: Option<PathBuf>,
+
+    /// Offline mode: generate only the frontier grid, for an already-committed checkpoint.
+    ///
+    /// The normal export selects a new checkpoint above the embedded list and pins every
+    /// artifact to it. This backfills a grid for a checkpoint the repository already ships,
+    /// so the artifact can be committed without advancing `main-checkpoints.txt`. The height
+    /// must be one of the embedded checkpoints.
+    ///
+    /// Requires `--state-cache-dir` and `--mainnet-frontier-grid-output`, and excludes the
+    /// other artifact outputs, which would be generated for a newly selected checkpoint.
+    #[arg(long)]
+    pub mainnet_frontier_grid_checkpoint: Option<Height>,
+
+    /// Offline mode: per-entry replay budget for the frontier grid, in milliseconds.
+    ///
+    /// Defaults to 2000 ms. The grid is spaced by estimated replay cost rather than
+    /// evenly, so it bounds the slowest cold request a consumer can make rather than
+    /// the average one. The estimate is a function of the chain, not of wall-clock
+    /// timing, so generator runs stay byte-identical.
+    #[arg(long, conflicts_with = "frontier_grid_spacing")]
+    pub frontier_grid_target_cost_ms: Option<u64>,
+
+    /// Offline mode: uniform height spacing for the frontier grid, in blocks.
+    ///
+    /// Not recommended. Replay cost varies by more than an order of magnitude across
+    /// Mainnet, so a uniform grid cannot bound the worst-case cold request at a sane
+    /// size. Prefer the default cost-weighted grid.
+    #[arg(long, conflicts_with = "frontier_grid_target_cost_ms")]
+    pub frontier_grid_spacing: Option<u32>,
 
     /// Offline mode: print the embedded Mainnet checkpoint list before the
     /// newly generated checkpoints, so stdout is a complete replacement
     /// `main-checkpoints.txt`.
     ///
-    /// Requires `--state-cache-dir`, `--mainnet-frontier-output`, and
-    /// `--mainnet-subtree-output`; incompatible with `--last-checkpoint`.
+    /// Requires `--state-cache-dir` and every artifact output flag; incompatible
+    /// with `--last-checkpoint`.
     #[arg(long)]
     pub full_list: bool,
 
@@ -166,6 +215,28 @@ impl Args {
     /// Offline and RPC modes are mutually exclusive, and the full-list output
     /// only makes sense when extending the embedded checkpoint list.
     pub fn validate_mode(&self) -> Result<(), String> {
+        if self.mainnet_frontier_grid_output.is_none()
+            && (self.frontier_grid_spacing.is_some() || self.frontier_grid_target_cost_ms.is_some())
+        {
+            return Err(
+                "--frontier-grid-spacing and --frontier-grid-target-cost-ms tune \
+                 --mainnet-frontier-grid-output: add it, or remove them"
+                    .to_string(),
+            );
+        }
+        if self.mainnet_frontier_grid_output.is_none() && self.mainnet_frontier_grid_input.is_some()
+        {
+            return Err(
+                "--mainnet-frontier-grid-input resumes a grid that has nowhere to go: add \
+                 --mainnet-frontier-grid-output"
+                    .to_string(),
+            );
+        }
+
+        if self.state_cache_dir.is_some() && self.mainnet_frontier_grid_checkpoint.is_some() {
+            return self.validate_grid_backfill_mode();
+        }
+
         if self.state_cache_dir.is_some() {
             if self.addr.is_some() {
                 return Err(
@@ -185,44 +256,123 @@ impl Args {
                         .to_string(),
                 );
             }
-            if self.mainnet_frontier_output.is_some() != self.mainnet_subtree_output.is_some() {
+            let supplied = self
+                .artifact_outputs()
+                .iter()
+                .filter(|(_, path)| path.is_some())
+                .count();
+            if supplied != 0 && supplied != self.artifact_outputs().len() {
                 return Err(
-                    "release-state frontiers and subtree roots are one pair: provide both \
-                     --mainnet-frontier-output and --mainnet-subtree-output"
+                    "release-state frontiers, subtree roots, and the frontier grid are one \
+                     artifact set: provide --mainnet-frontier-output, --mainnet-subtree-output, \
+                     and --mainnet-frontier-grid-output together"
                         .to_string(),
                 );
             }
-            let artifact_output_paths_match =
-                match (&self.mainnet_frontier_output, &self.mainnet_subtree_output) {
-                    (Some(frontier), Some(subtrees)) => {
-                        resolved_output_destination(frontier)?
-                            == resolved_output_destination(subtrees)?
-                    }
-                    _ => false,
-                };
-            if artifact_output_paths_match {
-                return Err(
-                    "--mainnet-frontier-output and --mainnet-subtree-output must use different paths"
-                        .to_string(),
-                );
-            }
-            if self.full_list && self.mainnet_frontier_output.is_none() {
+            self.reject_aliased_artifact_outputs()?;
+            if self.full_list && supplied == 0 {
                 return Err(
                     "--full-list emits a replacement main-checkpoints.txt, which must ship with \
-                     its coupled frontier and subtree roots: add both artifact output flags"
+                     its coupled release state: add every artifact output flag"
                         .to_string(),
                 );
             }
         } else {
-            if self.mainnet_frontier_output.is_some() {
-                return Err("--mainnet-frontier-output requires --state-cache-dir".to_string());
-            }
-            if self.mainnet_subtree_output.is_some() {
-                return Err("--mainnet-subtree-output requires --state-cache-dir".to_string());
+            for (flag, path) in self.artifact_outputs() {
+                if path.is_some() {
+                    return Err(format!("{flag} requires --state-cache-dir"));
+                }
             }
             if self.full_list {
                 return Err("--full-list requires --state-cache-dir".to_string());
             }
+            if self.mainnet_frontier_grid_checkpoint.is_some() {
+                return Err(
+                    "--mainnet-frontier-grid-checkpoint requires --state-cache-dir".to_string(),
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check the flags of a grid-only backfill run.
+    ///
+    /// This mode exists to produce a grid for a checkpoint the repository already ships, so it
+    /// emits no checkpoints and writes no other artifact. Pairing it with the flags that do
+    /// either would silently pin those outputs to a different, newly selected checkpoint.
+    fn validate_grid_backfill_mode(&self) -> Result<(), String> {
+        if self.mainnet_frontier_grid_output.is_none() {
+            return Err(
+                "--mainnet-frontier-grid-checkpoint needs somewhere to write: add \
+                 --mainnet-frontier-grid-output"
+                    .to_string(),
+            );
+        }
+        if self.mainnet_frontier_output.is_some() || self.mainnet_subtree_output.is_some() {
+            return Err(
+                "--mainnet-frontier-grid-checkpoint backfills the grid alone: remove \
+                 --mainnet-frontier-output and --mainnet-subtree-output, which are only \
+                 produced for a newly selected checkpoint"
+                    .to_string(),
+            );
+        }
+        if self.full_list {
+            return Err(
+                "--mainnet-frontier-grid-checkpoint emits no checkpoints: remove --full-list"
+                    .to_string(),
+            );
+        }
+        if self.last_checkpoint.is_some() {
+            return Err(
+                "--mainnet-frontier-grid-checkpoint selects no checkpoints: remove \
+                 --last-checkpoint"
+                    .to_string(),
+            );
+        }
+        if self.addr.is_some() {
+            return Err("--state-cache-dir reads the database directly: remove --addr".to_string());
+        }
+        if !self.zcli_args.is_empty() {
+            return Err(
+                "--state-cache-dir reads the database directly: remove zcash-cli passthrough \
+                 arguments"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// The artifact output flags and their paths, in the order errors report them.
+    fn artifact_outputs(&self) -> [(&'static str, &Option<PathBuf>); 3] {
+        [
+            ("--mainnet-frontier-output", &self.mainnet_frontier_output),
+            ("--mainnet-subtree-output", &self.mainnet_subtree_output),
+            (
+                "--mainnet-frontier-grid-output",
+                &self.mainnet_frontier_grid_output,
+            ),
+        ]
+    }
+
+    /// Rejects two artifact outputs that resolve to the same destination.
+    ///
+    /// The artifacts are written independently, so two flags naming one file — directly, or
+    /// through a symlinked or relative parent — would silently publish one artifact where the
+    /// bundle expects two.
+    fn reject_aliased_artifact_outputs(&self) -> Result<(), String> {
+        let mut resolved: Vec<(&'static str, PathBuf)> = Vec::new();
+        for (flag, path) in self.artifact_outputs() {
+            let Some(path) = path else { continue };
+            let destination = resolved_output_destination(path)?;
+            if let Some((earlier, _)) = resolved
+                .iter()
+                .find(|(_, existing)| existing == &destination)
+            {
+                return Err(format!("{earlier} and {flag} must use different paths"));
+            }
+            resolved.push((flag, destination));
         }
 
         Ok(())
@@ -286,9 +436,76 @@ mod tests {
             state_cache_dir: None,
             mainnet_frontier_output: None,
             mainnet_subtree_output: None,
+            mainnet_frontier_grid_output: None,
+            mainnet_frontier_grid_input: None,
+            mainnet_frontier_grid_checkpoint: None,
+            frontier_grid_target_cost_ms: None,
+            frontier_grid_spacing: None,
             full_list: false,
             zcli_args: Vec::new(),
         }
+    }
+
+    /// A baseline offline-mode `Args` value with the complete artifact output set.
+    fn offline_args() -> Args {
+        Args {
+            state_cache_dir: Some(PathBuf::from("state")),
+            mainnet_frontier_output: Some(PathBuf::from("frontier.bin")),
+            mainnet_subtree_output: Some(PathBuf::from("subtrees.bin")),
+            mainnet_frontier_grid_output: Some(PathBuf::from("grid.bin")),
+            full_list: true,
+            ..rpc_args()
+        }
+    }
+
+    /// A baseline grid-backfill `Args` value.
+    fn backfill_args() -> Args {
+        Args {
+            state_cache_dir: Some(PathBuf::from("state")),
+            mainnet_frontier_grid_output: Some(PathBuf::from("grid.bin")),
+            mainnet_frontier_grid_checkpoint: Some(Height(3_449_371)),
+            ..rpc_args()
+        }
+    }
+
+    #[test]
+    fn grid_backfill_flag_combinations() {
+        assert_eq!(backfill_args().validate_mode(), Ok(()));
+
+        let mut without_output = backfill_args();
+        without_output.mainnet_frontier_grid_output = None;
+        assert!(
+            without_output.validate_mode().is_err(),
+            "a backfill needs somewhere to write"
+        );
+
+        let mut with_frontier = backfill_args();
+        with_frontier.mainnet_frontier_output = Some(PathBuf::from("frontier.bin"));
+        assert!(
+            with_frontier.validate_mode().is_err(),
+            "the other artifacts belong to a newly selected checkpoint"
+        );
+
+        let mut with_full_list = backfill_args();
+        with_full_list.full_list = true;
+        assert!(
+            with_full_list.validate_mode().is_err(),
+            "a backfill emits no checkpoint list"
+        );
+
+        let mut with_last_checkpoint = backfill_args();
+        with_last_checkpoint.last_checkpoint = Some(Height(100));
+        assert!(
+            with_last_checkpoint.validate_mode().is_err(),
+            "a backfill selects no checkpoints"
+        );
+
+        let mut without_state = backfill_args();
+        without_state.state_cache_dir = None;
+        assert!(
+            without_state.validate_mode().is_err(),
+            "a backfill reads a state database"
+        );
     }
 
     #[test]
@@ -325,6 +542,10 @@ mod tests {
         subtrees_without_state.mainnet_subtree_output = Some(PathBuf::from("subtrees.bin"));
         assert!(subtrees_without_state.validate_mode().is_err());
 
+        let mut grid_without_state = rpc_args();
+        grid_without_state.mainnet_frontier_grid_output = Some(PathBuf::from("grid.bin"));
+        assert!(grid_without_state.validate_mode().is_err());
+
         let mut full_list_without_state = rpc_args();
         full_list_without_state.full_list = true;
         assert!(full_list_without_state.validate_mode().is_err());
@@ -332,11 +553,7 @@ mod tests {
 
     #[test]
     fn offline_mode_flag_combinations() {
-        let mut offline = rpc_args();
-        offline.state_cache_dir = Some(PathBuf::from("state"));
-        offline.mainnet_frontier_output = Some(PathBuf::from("frontier.bin"));
-        offline.mainnet_subtree_output = Some(PathBuf::from("subtrees.bin"));
-        offline.full_list = true;
+        let offline = offline_args();
         assert_eq!(offline.validate_mode(), Ok(()));
 
         let mut offline_with_addr = offline.clone();
@@ -355,14 +572,43 @@ mod tests {
         full_list_without_frontier.mainnet_frontier_output = None;
         assert!(
             full_list_without_frontier.validate_mode().is_err(),
-            "a replacement checkpoint list must ship with both coupled artifacts"
+            "a replacement checkpoint list must ship with every coupled artifact"
         );
 
         let mut full_list_without_subtrees = offline.clone();
         full_list_without_subtrees.mainnet_subtree_output = None;
         assert!(
             full_list_without_subtrees.validate_mode().is_err(),
-            "a replacement checkpoint list must ship with both coupled artifacts"
+            "a replacement checkpoint list must ship with every coupled artifact"
+        );
+
+        let mut full_list_without_grid = offline.clone();
+        full_list_without_grid.mainnet_frontier_grid_output = None;
+        assert!(
+            full_list_without_grid.validate_mode().is_err(),
+            "a replacement checkpoint list must ship with its frontier grid too"
+        );
+
+        let mut resume_without_grid_output = offline.clone();
+        resume_without_grid_output.mainnet_frontier_grid_output = None;
+        resume_without_grid_output.mainnet_frontier_output = None;
+        resume_without_grid_output.mainnet_subtree_output = None;
+        resume_without_grid_output.full_list = false;
+        resume_without_grid_output.mainnet_frontier_grid_input = Some(PathBuf::from("old.bin"));
+        assert!(
+            resume_without_grid_output.validate_mode().is_err(),
+            "resuming a grid needs somewhere to write the result"
+        );
+
+        let mut grid_tuning_without_grid_output = offline.clone();
+        grid_tuning_without_grid_output.mainnet_frontier_grid_output = None;
+        grid_tuning_without_grid_output.mainnet_frontier_output = None;
+        grid_tuning_without_grid_output.mainnet_subtree_output = None;
+        grid_tuning_without_grid_output.full_list = false;
+        grid_tuning_without_grid_output.frontier_grid_target_cost_ms = Some(1_500);
+        assert!(
+            grid_tuning_without_grid_output.validate_mode().is_err(),
+            "grid tuning flags without the grid output are a silent no-op"
         );
 
         let mut matching_artifact_paths = offline.clone();
@@ -384,9 +630,7 @@ mod tests {
 
     #[test]
     fn rejects_artifact_output_path_aliases() {
-        let mut offline = rpc_args();
-        offline.state_cache_dir = Some(PathBuf::from("state"));
-        offline.mainnet_frontier_output = Some(PathBuf::from("frontier.bin"));
+        let mut offline = offline_args();
         offline.mainnet_subtree_output = Some(
             env::current_dir()
                 .expect("current directory is available")
@@ -403,6 +647,17 @@ mod tests {
                 .join("frontier.bin"),
         );
         assert!(offline.validate_mode().is_err());
+
+        let mut aliased_grid = offline_args();
+        aliased_grid.mainnet_frontier_grid_output = aliased_grid.mainnet_subtree_output.clone();
+        assert_eq!(
+            aliased_grid.validate_mode(),
+            Err(
+                "--mainnet-subtree-output and --mainnet-frontier-grid-output must use different \
+                 paths"
+                    .to_string()
+            )
+        );
     }
 
     #[cfg(unix)]
@@ -416,8 +671,7 @@ mod tests {
         let alias_directory = temp.path().join("alias");
         symlink(&real_directory, &alias_directory).expect("directory symlink is created");
 
-        let mut offline = rpc_args();
-        offline.state_cache_dir = Some(PathBuf::from("state"));
+        let mut offline = offline_args();
         offline.mainnet_frontier_output = Some(real_directory.join("artifact.bin"));
         offline.mainnet_subtree_output = Some(alias_directory.join("artifact.bin"));
 

--- a/crates/zakura-utils/src/bin/zakura-checkpoints/offline.rs
+++ b/crates/zakura-utils/src/bin/zakura-checkpoints/offline.rs
@@ -1,17 +1,24 @@
-//! Offline checkpoint and VCT-frontier export from a quiesced Zakura state.
+//! Offline release-state export from a Zakura state database.
 //!
 //! Reads canonical block hashes and `BlockInfo` sizes straight from a finalized
-//! state database, so it works on pruned databases and needs no running node.
-//! The emitted checkpoints continue the deterministic selection sequence started
-//! at the embedded Mainnet checkpoint list. The optional frontier and completed-subtree
-//! artifacts are produced together at the last emitted checkpoint height. See the
-//! "Mainnet release-state" section of `docs/design/verified-commitment-trees.md`.
+//! state database, so it needs no running node: the database is opened as a
+//! read-only RocksDB secondary. The emitted checkpoints continue the
+//! deterministic selection sequence started at the embedded Mainnet checkpoint
+//! list. The optional frontier, completed-subtree, and historical frontier grid
+//! artifacts are produced together at the last emitted checkpoint height, so one
+//! run yields one coupled release state. See the "Mainnet release-state" section
+//! of `docs/design/verified-commitment-trees.md`.
+//!
+//! Checkpoints, the final frontier, and the subtree roots come out of a pruned
+//! database too. The frontier grid does not: it covers the heights below the
+//! checkpoint, which a pruned database no longer holds. Generate from an archive
+//! database.
 
 // This is a CLI module: checkpoint lines go to stdout, status goes to stderr,
 // and argument invariants established by `Args::validate_mode` use `expect`.
 #![allow(clippy::print_stdout, clippy::print_stderr, clippy::unwrap_in_result)]
 
-use std::{io::Write, path::Path};
+use std::{fs, io::Write, path::Path, time::Instant};
 
 use color_eyre::eyre::{ensure, eyre, Context, Result};
 
@@ -23,6 +30,15 @@ use zakura_chain::{
 use zakura_node_services::constants::{MAX_CHECKPOINT_BYTE_COUNT, MAX_CHECKPOINT_HEIGHT_GAP};
 
 use crate::args::Args;
+
+/// Default per-entry replay budget for the cost-weighted frontier grid.
+///
+/// Matches the 2 s budget measured in the historical-treestate serving design: a uniform
+/// 50,000-block grid leaves a cold request that runs into minutes.
+const DEFAULT_FRONTIER_GRID_TARGET_COST_MS: u64 = 2_000;
+
+/// How often a long grid run reports progress, in entries.
+const FRONTIER_GRID_PROGRESS_INTERVAL: u64 = 100;
 
 /// One candidate block row read from the finalized state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -103,9 +119,10 @@ fn validate_header_link(
 /// Run the offline export selected by `--state-cache-dir`.
 ///
 /// Prints checkpoint lines to stdout (optionally prefixed with the embedded
-/// Mainnet list under `--full-list`) and writes the frontier and completed-subtree
-/// artifacts for the last emitted checkpoint when their output paths are supplied.
-/// All status output goes to stderr so stdout stays a clean checkpoint list.
+/// Mainnet list under `--full-list`) and writes the frontier, completed-subtree,
+/// and frontier grid artifacts for the last emitted checkpoint when their output
+/// paths are supplied. All status output goes to stderr so stdout stays a clean
+/// checkpoint list.
 pub fn run_offline(args: &Args) -> Result<()> {
     let state_cache_dir = args
         .state_cache_dir
@@ -128,6 +145,10 @@ pub fn run_offline(args: &Args) -> Result<()> {
     let (_read_state, db, _non_finalized_sender) =
         zakura_state::init_read_only(state_config, &network)
             .wrap_err("opening the Mainnet state database read-only")?;
+
+    if let Some(checkpoint) = args.mainnet_frontier_grid_checkpoint {
+        return backfill_frontier_grid(args, &db, &network, checkpoint);
+    }
 
     let (tip_height, tip_hash) = db
         .tip()
@@ -216,12 +237,23 @@ pub fn run_offline(args: &Args) -> Result<()> {
         .last()
         .expect("selection was checked to be non-empty");
 
-    // Produce and persist both artifacts before any checkpoint output. A failure must not leave a
+    // Produce and persist every artifact before any checkpoint output. A failure must not leave a
     // caller's redirected stdout holding an advanced list without its coupled release state.
-    if let (Some(frontier_path), Some(subtree_path)) =
-        (&args.mainnet_frontier_output, &args.mainnet_subtree_output)
-    {
-        write_release_treestate_artifacts(&db, last_height, frontier_path, subtree_path)?;
+    if let (Some(frontier_path), Some(subtree_path), Some(grid_path)) = (
+        &args.mainnet_frontier_output,
+        &args.mainnet_subtree_output,
+        &args.mainnet_frontier_grid_output,
+    ) {
+        write_release_treestate_artifacts(
+            &db,
+            &network,
+            last_height,
+            frontier_path,
+            subtree_path,
+            grid_path,
+            args.mainnet_frontier_grid_input.as_deref(),
+            frontier_grid_spacing(args),
+        )?;
     }
 
     // Lock stdout once: the full list is ~14k lines and per-line locking is slow.
@@ -246,12 +278,98 @@ pub fn run_offline(args: &Args) -> Result<()> {
     Ok(())
 }
 
+/// Generate only the frontier grid, for a checkpoint the binary already ships.
+///
+/// The normal export pins every artifact to a checkpoint it selects above the embedded list.
+/// That is right for an advancing release, and wrong for backfilling the one artifact a
+/// committed release state is missing: it would advance `main-checkpoints.txt` as a side effect
+/// of producing a file for a checkpoint already reviewed and merged.
+fn backfill_frontier_grid(
+    args: &Args,
+    db: &zakura_state::ZakuraDb,
+    network: &Network,
+    checkpoint: Height,
+) -> Result<()> {
+    let grid_path = args
+        .mainnet_frontier_grid_output
+        .as_ref()
+        .expect("backfill mode is only entered with --mainnet-frontier-grid-output");
+
+    // Only an embedded checkpoint can be backfilled. A height off the reviewed list would
+    // produce an artifact no committed release state can be coupled to.
+    let embedded_hash = network.checkpoint_list().hash(checkpoint).ok_or_else(|| {
+        eyre!(
+            "{} is not an embedded Mainnet checkpoint; backfill targets a checkpoint this \
+             binary already ships",
+            checkpoint.0,
+        )
+    })?;
+
+    let (tip_height, tip_hash) = db
+        .tip()
+        .ok_or_else(|| eyre!("Mainnet state database has no finalized tip"))?;
+    ensure!(
+        tip_height >= checkpoint,
+        "state tip {} is below checkpoint {}; sync further before backfilling",
+        tip_height.0,
+        checkpoint.0,
+    );
+
+    // Same anchor check as the checkpoint export: a database that disagrees with the embedded
+    // list at this height is a different chain, and its grid would be silently wrong.
+    let database_hash = db
+        .hash(checkpoint)
+        .ok_or_else(|| eyre!("state database has no block at checkpoint {}", checkpoint.0))?;
+    ensure!(
+        database_hash == embedded_hash,
+        "state database hash at checkpoint {} is {database_hash}, but the embedded checkpoint \
+         list has {embedded_hash}; refusing to export from a mismatched chain",
+        checkpoint.0,
+    );
+
+    eprintln!(
+        "backfilling the frontier grid for embedded checkpoint {} from finalized tip {} \
+         ({tip_hash}); no checkpoints are emitted",
+        checkpoint.0, tip_height.0,
+    );
+
+    write_frontier_grid(
+        db,
+        network,
+        checkpoint,
+        grid_path,
+        args.mainnet_frontier_grid_input.as_deref(),
+        frontier_grid_spacing(args),
+    )
+}
+
+/// Chooses the frontier grid layout from the CLI flags.
+///
+/// Cost-weighted at [`DEFAULT_FRONTIER_GRID_TARGET_COST_MS`] is the default: a uniform grid
+/// cannot bound the worst-case cold request at a sane artifact size.
+fn frontier_grid_spacing(args: &Args) -> zakura_state::GridSpacing {
+    match args.frontier_grid_spacing {
+        Some(blocks) => zakura_state::GridSpacing::Uniform { blocks },
+        None => zakura_state::GridSpacing::Adaptive {
+            budget_us: args
+                .frontier_grid_target_cost_ms
+                .unwrap_or(DEFAULT_FRONTIER_GRID_TARGET_COST_MS)
+                .saturating_mul(1000),
+        },
+    }
+}
+
 /// Produce and atomically write the coupled treestate artifacts for `height`.
+#[allow(clippy::too_many_arguments)]
 fn write_release_treestate_artifacts(
     db: &zakura_state::ZakuraDb,
+    network: &Network,
     height: Height,
     frontier_path: &Path,
     subtree_path: &Path,
+    grid_path: &Path,
+    grid_resume_path: Option<&Path>,
+    grid_spacing: zakura_state::GridSpacing,
 ) -> Result<()> {
     let artifacts = zakura_state::produce_release_treestate_artifacts(db, height)
         .wrap_err("producing the Mainnet release treestate artifacts")?;
@@ -278,6 +396,105 @@ fn write_release_treestate_artifacts(
         artifacts.added_subtree_roots,
         artifacts.verified_subtree_roots,
     );
+
+    write_frontier_grid(
+        db,
+        network,
+        height,
+        grid_path,
+        grid_resume_path,
+        grid_spacing,
+    )?;
+
+    Ok(())
+}
+
+/// Produce and atomically write the historical frontier grid covering `[0, height)`.
+///
+/// Generated for the checkpoint the other two artifacts describe, so all three files pin one
+/// release state. A consuming node refuses to start when its own fast-sync handoff is above the
+/// grid's checkpoint, which is why the coupling has to hold rather than merely usually hold.
+fn write_frontier_grid(
+    db: &zakura_state::ZakuraDb,
+    network: &Network,
+    height: Height,
+    grid_path: &Path,
+    resume_path: Option<&Path>,
+    spacing: zakura_state::GridSpacing,
+) -> Result<()> {
+    match spacing {
+        zakura_state::GridSpacing::Adaptive { budget_us } => eprintln!(
+            "generating the frontier grid below checkpoint {}, cost-weighted at {} ms per entry",
+            height.0,
+            budget_us / 1000,
+        ),
+        zakura_state::GridSpacing::Uniform { blocks } => eprintln!(
+            "generating the frontier grid below checkpoint {}, uniform spacing {blocks}",
+            height.0,
+        ),
+    }
+
+    // Resuming carries a published grid's entries forward, so a run scans only the blocks above
+    // its last entry. Every carried entry is re-checked against this database before it is
+    // accepted, so the file supplies work already done, never trust.
+    let resume_from = match resume_path {
+        Some(path) => {
+            let bytes = fs::read(path).wrap_err_with(|| format!("reading {}", path.display()))?;
+            let grid = zakura_state::FrontierArtifact::decode(&bytes, network)
+                .map_err(|error| eyre!("reading {}: {error}", path.display()))?;
+            eprintln!(
+                "resuming from {}: {} entries through height {}",
+                path.display(),
+                grid.entries.len(),
+                grid.entries.last().map_or(0, |entry| entry.height.0),
+            );
+            Some(grid)
+        }
+        None => None,
+    };
+
+    // Time each grid step. One step is exactly the replay a serving node performs for a cold
+    // request at this spacing, so the run doubles as the measurement that sizes the grid.
+    let mut entries = 0u64;
+    let mut previous = Instant::now();
+    let export = zakura_state::export_frontier_grid_to(
+        db,
+        height,
+        spacing,
+        resume_from.as_ref(),
+        |entry, blocks| {
+            let step = previous.elapsed();
+            previous = Instant::now();
+            entries += 1;
+
+            if entries.is_multiple_of(FRONTIER_GRID_PROGRESS_INTERVAL) {
+                eprintln!(
+                    "  entry {entries:>7}  height {:>9}  {blocks:>9} blocks replayed  \
+                     last step {:>8.1}ms",
+                    entry.0,
+                    step.as_secs_f64() * 1e3,
+                );
+            }
+        },
+    )
+    .map_err(|error| eyre!("producing the Mainnet historical frontier grid: {error}"))?;
+
+    let grid_bytes = export.frontiers.encode(network);
+    atomic_write(grid_path.to_path_buf(), &grid_bytes)
+        .wrap_err_with(|| format!("writing {}", grid_path.display()))?
+        .wrap_err_with(|| format!("persisting {}", grid_path.display()))?;
+
+    eprintln!(
+        "wrote {}-byte frontier grid to {}: {} entries below checkpoint {}, {} blocks replayed \
+         in {:.1}s",
+        grid_bytes.len(),
+        grid_path.display(),
+        export.frontiers.entries.len(),
+        height.0,
+        export.replayed_blocks,
+        export.elapsed.as_secs_f64(),
+    );
+
     Ok(())
 }
 

--- a/crates/zakurad/src/commands/verify_historical_treestates.rs
+++ b/crates/zakurad/src/commands/verify_historical_treestates.rs
@@ -8,6 +8,13 @@
 //! This command runs that check with no database and no network, against the frontier embedded in
 //! this binary or one supplied on the command line. It exists so a bundle from the release-state
 //! publisher can be checked before it is committed, rather than only after it ships.
+//!
+//! It optionally checks the bundle's frontier grid too. Every grid entry is root-checked by the
+//! node that loads it, so nothing here has to prove the entries themselves. What a bundle can get
+//! wrong without any node noticing until startup is the coupling: a grid generated for a
+//! different checkpoint than the rest of the bundle makes a node whose fast-sync handoff sits
+//! above the grid fail closed. So the grid is checked for framing and for agreeing with the
+//! bundle it arrived in.
 
 use std::{fs, path::PathBuf};
 
@@ -15,7 +22,7 @@ use abscissa_core::{Command, Runnable};
 use clap::Parser;
 use color_eyre::eyre::{eyre, Result, WrapErr};
 
-use zakura_chain::parameters::Network;
+use zakura_chain::{block::Height, parameters::Network};
 
 /// Prove a historical subtree-root artifact against a note commitment frontier
 #[derive(Command, Debug, Default, Parser)]
@@ -42,6 +49,16 @@ pub struct VerifyHistoricalTreestatesCmd {
         help = "path to a frontier artifact; defaults to the one embedded in this binary"
     )]
     frontier_input: Option<PathBuf>,
+
+    /// The historical frontier grid from the same bundle.
+    ///
+    /// Checked for framing and for covering the same checkpoint as the subtree artifact. Its
+    /// entries are not proven here: a node re-derives and root-checks every one before use.
+    #[clap(
+        long,
+        help = "path to a frontier grid artifact from the same release-state bundle"
+    )]
+    frontier_grid_input: Option<PathBuf>,
 }
 
 impl Runnable for VerifyHistoricalTreestatesCmd {
@@ -83,6 +100,140 @@ impl VerifyHistoricalTreestatesCmd {
             counts.ironwood,
         );
 
+        if let Some(grid_path) = &self.frontier_grid_input {
+            let checkpoint = zakura_state::SubtreeArtifact::decode(&subtrees, &self.network)
+                .map_err(|error| eyre!("{error}"))?
+                .last_checkpoint;
+            self.verify_frontier_grid(grid_path, checkpoint)?;
+        }
+
         Ok(())
+    }
+
+    /// Checks a frontier grid's framing, and that it belongs to this bundle.
+    #[allow(clippy::print_stdout)]
+    fn verify_frontier_grid(&self, grid_path: &PathBuf, checkpoint: Height) -> Result<()> {
+        let bytes =
+            fs::read(grid_path).wrap_err_with(|| format!("reading {}", grid_path.display()))?;
+        let grid = zakura_state::FrontierArtifact::decode(&bytes, &self.network)
+            .map_err(|error| eyre!("{error}"))?;
+
+        if grid.last_checkpoint != checkpoint {
+            return Err(eyre!(
+                "{} covers checkpoint {}, but this bundle's subtree roots are for checkpoint {}",
+                grid_path.display(),
+                grid.last_checkpoint.0,
+                checkpoint.0,
+            ));
+        }
+
+        // The format orders entries but does not bound them, and an entry at or above the
+        // checkpoint describes a height the grid does not claim to cover.
+        if let Some(entry) = grid.entries.last() {
+            if entry.height >= grid.last_checkpoint {
+                return Err(eyre!(
+                    "{} has an entry at height {}, at or above its own checkpoint {}",
+                    grid_path.display(),
+                    entry.height.0,
+                    grid.last_checkpoint.0,
+                ));
+            }
+        }
+
+        println!(
+            "frontier grid {} covers checkpoint {} with {} entries",
+            grid_path.display(),
+            grid.last_checkpoint.0,
+            grid.entries.len(),
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use zakura_state::{FrontierArtifact, FrontierEntry};
+
+    use super::*;
+
+    /// A grid artifact at `checkpoint` with one entry per height in `heights`.
+    fn grid_bytes(checkpoint: u32, heights: &[u32]) -> Vec<u8> {
+        FrontierArtifact {
+            spacing: 1,
+            last_checkpoint: Height(checkpoint),
+            entries: heights
+                .iter()
+                .map(|height| FrontierEntry {
+                    height: Height(*height),
+                    sapling: Arc::default(),
+                    orchard: Arc::default(),
+                    ironwood: Arc::default(),
+                })
+                .collect(),
+        }
+        .encode(&Network::Mainnet)
+    }
+
+    fn command_with_grid(bytes: &[u8]) -> (tempfile::TempDir, VerifyHistoricalTreestatesCmd) {
+        let directory = tempfile::tempdir().expect("temporary directory is created");
+        let path = directory.path().join("mainnet-frontier-grid.bin");
+        std::fs::write(&path, bytes).expect("writing the grid succeeds");
+
+        let command = VerifyHistoricalTreestatesCmd {
+            network: Network::Mainnet,
+            subtree_input: PathBuf::new(),
+            frontier_input: None,
+            frontier_grid_input: Some(path),
+        };
+
+        (directory, command)
+    }
+
+    fn check(bytes: &[u8], checkpoint: u32) -> Result<()> {
+        let (_directory, command) = command_with_grid(bytes);
+        let path = command
+            .frontier_grid_input
+            .clone()
+            .expect("the fixture sets a grid path");
+
+        command.verify_frontier_grid(&path, Height(checkpoint))
+    }
+
+    #[test]
+    fn accepts_a_grid_for_the_bundle_checkpoint() {
+        check(&grid_bytes(100, &[10, 20, 30]), 100).expect("a matching grid is accepted");
+    }
+
+    #[test]
+    fn rejects_a_grid_for_another_checkpoint() {
+        let error = check(&grid_bytes(90, &[10, 20]), 100)
+            .expect_err("a grid from a different bundle is rejected");
+
+        assert!(
+            error.to_string().contains("covers checkpoint 90"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_entry_at_or_above_the_checkpoint() {
+        let error = check(&grid_bytes(100, &[10, 100]), 100)
+            .expect_err("an entry outside the covered range is rejected");
+
+        assert!(
+            error.to_string().contains("at or above its own checkpoint"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_bytes_that_are_not_a_grid() {
+        let error =
+            check(b"ZKVCTST1 not a frontier grid", 100).expect_err("bad framing is rejected");
+
+        assert!(!error.to_string().is_empty(), "the parse error is reported");
     }
 }

--- a/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -46,13 +46,14 @@ use crate::{
 
 use InventoryResponse::*;
 
-/// Maximum time to wait for a network service request.
+/// How long the mock peer set waits for an expected request before panicking.
 ///
-/// The default [`MockService`] value can be too short for some of these tests that take a little
-/// longer than expected to actually send the network request.
-///
-/// Increasing this value causes the tests to take longer to complete, so it can't be too large.
-const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_millis(500);
+/// Must comfortably exceed [`PEER_GOSSIP_DELAY`]: after that sleep the gossip task still needs a tip
+/// change notification and a short submission delay before it advertises. A tight 500ms bound
+/// races under CI scheduling and fails with `timeout while waiting for a request` even though the
+/// advertise would arrive a moment later. The dedicated gossip tests use the same 30s budget;
+/// with a paused runtime the extra headroom does not slow the happy path.
+const MAX_PEER_SET_REQUEST_DELAY: Duration = Duration::from_secs(30);
 
 async fn wait_for_gossip() {
     // Let background gossip tasks arm their timers before this paused runtime

--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -36,22 +36,17 @@ whole-band replay — hours on Mainnet.
 
 ## Cutover order
 
-The importer requires every bundle to carry all four files and fails closed on one that does not,
-so the publisher has to be updated around the same time as the repository. It cannot be updated
-_first_: `deploy-snapshot-host.sh` refuses to install an exporter whose revision is not already an
-ancestor of `origin/main`, which is a supply-chain control worth keeping.
+This change makes the publisher emit `mainnet-frontier-grid.bin`. Import and provenance checks that
+*require* the fourth file land in a follow-up, so today's importer still accepts a three-file
+bundle and a four-file one alike. Deploy when convenient after merge:
 
-So the order is:
-
-1. Merge the repository change.
+1. Merge this repository change.
 2. Run `deploy-snapshot-host.sh`, now buildable from `main`.
 3. Set `RELEASE_STATE_ARCHIVE_CACHE` and enable the timer.
-4. Dispatch `update-release-state.yml` once the first new bundle exists.
 
-Between 1 and 3 a scheduled import will fail with `meta.files is missing keys:
-mainnet-frontier-grid.bin`. Nothing is committed and nothing in production changes — it is a red
-scheduled job that clears as soon as the new publisher publishes — but prefer merging and
-deploying the same day over leaving it red for a week.
+Until the import follow-up merges, scheduled imports ignore the new grid file. Once that follow-up
+lands, prefer deploying the publisher the same day so the first required four-file bundle already
+exists.
 
 ## One-time host setup
 

--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -1,25 +1,57 @@
 # Release-state publisher
 
 Publishes Mainnet release-state bundles — the coupled checkpoint list, VCT
-frontier, and completed-subtree roots — from the snapshot host to R2, where the
-`update-release-state.yml` workflow imports them into reviewable draft PRs.
+frontier, completed-subtree roots, and historical frontier grid — from an
+archive host to R2, where the `update-release-state.yml` workflow imports them
+into reviewable draft PRs.
 Design: `docs/design/verified-commitment-trees.md`, section 16.
 Production host wiring, operations, and rollback:
 [`SNAPSHOT_HOST.md`](SNAPSHOT_HOST.md).
 
 ## What runs where
 
-- **This host (snapshot service):** while the snapshot job holds its lock and
-  has stopped its synced Mainnet node,
-  `publish-release-state.sh <stopped-node-cache-dir>` runs
-  the offline export and uploads one immutable bundle
-  (`meta.json`, `main-checkpoints.txt`, `mainnet-frontier.bin`, and
-  `mainnet-treestate-subtrees.bin`),
+- **This host (archive node):** `publish-release-state.sh <archive-cache-dir>`
+  runs the offline export and uploads one immutable bundle
+  (`meta.json`, `main-checkpoints.txt`, `mainnet-frontier.bin`,
+  `mainnet-treestate-subtrees.bin`, and `mainnet-frontier-grid.bin`),
   then atomically replaces `release-state/latest.json`. Bundles are retained
   newest-4 by default (`RELEASE_STATE_KEEP`).
 - **GitHub (repository):** the workflow resolves `latest.json` over a pinned
   HTTPS host, verifies every digest, and opens a draft PR. Humans review and
   merge; releases build only committed source.
+
+## Why an archive node, and why it need not be stopped
+
+The exporter opens the state database as a read-only RocksDB secondary, so it
+reads a consistent view of a _running_ node and does not need the stopped-node
+window the pruned snapshot job used to provide.
+
+It must be an archive node. Checkpoints, the frontier, and the subtree roots
+come out of pruned state, but the frontier grid covers the heights below the
+checkpoint, which a pruned database no longer holds. A **legacy** archive node
+(one that never fast-synced) is the best generator: it has per-height trees
+everywhere, so the grid is built from reads with no replay at all, and its
+coverage follows its tip. A fast-synced archive node also works, but pays one
+whole-band replay — hours on Mainnet.
+
+## Cutover order
+
+The importer requires every bundle to carry all four files and fails closed on one that does not,
+so the publisher has to be updated around the same time as the repository. It cannot be updated
+_first_: `deploy-snapshot-host.sh` refuses to install an exporter whose revision is not already an
+ancestor of `origin/main`, which is a supply-chain control worth keeping.
+
+So the order is:
+
+1. Merge the repository change.
+2. Run `deploy-snapshot-host.sh`, now buildable from `main`.
+3. Set `RELEASE_STATE_ARCHIVE_CACHE` and enable the timer.
+4. Dispatch `update-release-state.yml` once the first new bundle exists.
+
+Between 1 and 3 a scheduled import will fail with `meta.files is missing keys:
+mainnet-frontier-grid.bin`. Nothing is committed and nothing in production changes — it is a red
+scheduled job that clears as soon as the new publisher publishes — but prefer merging and
+deploying the same day over leaving it red for a week.
 
 ## One-time host setup
 
@@ -37,12 +69,12 @@ Production host wiring, operations, and rollback:
    in the fetch script's allowed-host list
    (`.github/scripts/fetch-release-state.py`).
 
-3. Hook the script into the snapshot job with its environment, e.g.:
+3. Run the script from a timer with its environment, e.g.:
 
    ```sh
    RELEASE_STATE_R2_REMOTE=r2:zakura-artifacts \
    RELEASE_STATE_PUBLIC_BASE=https://zakura-release.valargroup.dev/release-state \
-   /opt/zakura/publish-release-state.sh /mnt/data/stopped-node-zakura-cache
+   /opt/zakura/publish-release-state.sh /var/lib/zakura/archive-cache
    ```
 
 4. Set the repository variable `MAINNET_RELEASE_STATE_LATEST_URL` to
@@ -52,26 +84,39 @@ Production host wiring, operations, and rollback:
 
 - Bundle directories are immutable: an existing height is only ever reused
   when its data-file digests match the fresh export byte-for-byte (a same-state
-  re-run); different contents at the same height abort loudly.
+  re-run); different contents at the same height abort loudly. Two runs that
+  select the same checkpoint read the same chain prefix, so this holds even
+  though the node keeps syncing underneath the secondary.
 - Data files upload before `meta.json`, and `latest.json` moves last, so a
   partial upload is never resolvable.
 - A host-local lock serializes export, upload, pointer replacement, and
   retention. Run exactly one publisher host; multiple hosts require
   object-store conditional writes rather than the local lock.
+- Each run resumes the frontier grid from the previous bundle's copy, so it scans only the
+  blocks above that grid's last entry. Carried entries are re-checked against the database
+  before they are accepted, and are written out byte-for-byte, so a bundle is a prefix-extension
+  of its predecessor by construction. If the previous bundle has no grid, the run falls back to
+  a full walk from genesis and says so.
 - Exports continue the deterministic checkpoint selection grid from the
   binary's embedded list. Never hand-edit the Mainnet checkpoint file or
   publish RPC-mode Mainnet output: off-grid lines make every later bundle fail
   the workflow's byte-for-byte prefix check.
+- Every artifact in a bundle describes the checkpoint that run selected. The
+  frontier grid in particular must not lag: a node whose fast-sync handoff is
+  above the grid's checkpoint refuses to start with derivation enabled.
 
 ## Failure modes
 
-- `state tip ... is not above the last checkpoint`: the stopped-node state
+- `state tip ... is not above the last checkpoint`: the exported state
   predates the embedded checkpoint list of the installed tool; sync further
   or update the tool.
+- `cannot derive the note commitment tree at ...: block body ... is not
+  retained`: the grid export ran against a pruned database. Point it at an
+  archive one.
 - `Sprout note commitments were appended at ...`: a v4 JoinSplit landed just
   below the state tip; the next day's export self-heals once the checkpoint
   grid passes that block.
 - `existing bundle at this height has different contents`: determinism broke
   (or the bucket was tampered with) — investigate before deleting anything.
 - `another release-state publisher is already running`: wait for the active
-  snapshot/manual publication to finish before retrying.
+  timer or manual publication to finish before retrying.

--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -37,7 +37,7 @@ whole-band replay — hours on Mainnet.
 ## Cutover order
 
 This change makes the publisher emit `mainnet-frontier-grid.bin`. Import and provenance checks that
-*require* the fourth file land in a follow-up, so today's importer still accepts a three-file
+_require_ the fourth file land in a follow-up, so today's importer still accepts a three-file
 bundle and a four-file one alike. Deploy when convenient after merge:
 
 1. Merge this repository change.

--- a/deploy/release-state/SNAPSHOT_HOST.md
+++ b/deploy/release-state/SNAPSHOT_HOST.md
@@ -1,29 +1,43 @@
-# Production snapshot-host publisher
+# Production release-state publisher host
 
 ## Purpose and topology
 
 The production release-state publisher generates a trusted, coupled Mainnet checkpoint list, VCT
-frontier, and completed-subtree artifact from Zakura's finalized pruned database. It runs on the
-production snapshot host against:
+frontier, completed-subtree artifact, and historical frontier grid from Zakura's finalized
+**archive** database. It runs on the production snapshot host against:
 
-- container: `zakura-pruned`
-- cache: `/mnt/zec_snapshot/zakura-cache-pruned`
+- container: `zakura` (the archive node, not `zakura-pruned`)
+- cache: the archive container's cache directory, supplied as
+  `RELEASE_STATE_ARCHIVE_CACHE` in `/etc/zakura-release-state.env`
 - R2 endpoint:
   `https://152e2a8834283136c2f0575782b1b7aa.r2.cloudflarestorage.com`
 - bucket: `zakura-release-state`
 - public prefix:
   `https://zakura-release.valargroup.dev/release-state`
 
-The exporter is a stopped-node phase of `zakura-snapshot-pruned.service`, after
-that service stops `zakura-pruned` and before it starts the `tar | zstd`
-archive pipeline. It is not a separate timer. This ordering gives the exporter
-a consistent RocksDB view and keeps the existing parent lock,
-`/run/zakura-snapshot-pruned-publish.lock`, held for the entire operation.
-The exporter also retains its own
-`/run/zakura-release-state-publish.lock`, which rejects duplicate hook or
-manual invocations. It never takes the independent archive publisher lock.
+The exporter is its own `zakura-release-state.timer`, not a phase of any snapshot job. Two
+changes made that possible, and one made it necessary:
 
-The existing automation remains in place:
+- The exporter opens the state database as a read-only RocksDB **secondary**, so it reads a
+  consistent view of a running node. It never needed the stopped-node window for correctness,
+  only for convenience.
+- It therefore takes no snapshot lock and cannot delay a snapshot. Its own
+  `/run/zakura-release-state-publish.lock` still rejects overlapping timer or manual runs.
+- The frontier grid covers the heights below the checkpoint, which the pruned database no
+  longer holds. That is why the source moved from `zakura-pruned` to `zakura`.
+
+Grid generation cost depends on which kind of archive node the cache belongs to. A **legacy**
+archive node — one that never fast-synced — has per-height trees everywhere, so every entry is a
+read and no note commitment is ever re-appended. A fast-synced archive node has to replay its
+absent band instead, which is hours on Mainnet.
+
+Neither is quick. The default cost-weighted spacing decides where entries go by scanning every
+block body from genesis for its commitment counts, so both kinds of node read the whole chain
+once per run; the legacy node just skips the append work on top. `TimeoutStartSec=6h` on the unit
+covers the slower case. Measure one run before trusting the daily schedule, and consider
+`RELEASE_STATE_GRID_COST_MS` or a longer `OnCalendar` interval if it does not comfortably fit.
+
+The existing automation remains in place and is untouched by this publisher:
 
 - `zakura-snapshot-pruned-check.timer` runs at minute `:17` with up to 120
   seconds of randomized delay.
@@ -42,9 +56,23 @@ deploy/release-state/deploy-snapshot-host.sh <snapshot-host-ssh-target>
 
 The script builds `zakura-checkpoints` with `zakura-checkpoints-offline` at the commit checked out
 in the trusted source tree. It verifies that commit is on `origin/main`, then installs the binary
-and publisher scripts under `/opt/zakura-release-state`, installs the
-`zakura-snapshot-pruned.service` drop-in, runs `systemctl daemon-reload`, and verifies the unit. It
-refuses to install while either snapshot publisher is active and does not restart either live node.
+and publisher scripts under `/opt/zakura-release-state`, removes any leftover
+`zakura-snapshot-pruned.service` drop-in from the previous topology, installs
+`zakura-release-state.{service,timer}`, runs `systemctl daemon-reload`, and verifies the units. It
+refuses to install while any publisher is active, does not restart either live node, and does not
+enable the timer.
+
+Then supply the archive cache path and enable the timer:
+
+```sh
+printf 'RELEASE_STATE_ARCHIVE_CACHE=%s\n' /path/to/archive-cache \
+  > /etc/zakura-release-state.env
+chmod 0644 /etc/zakura-release-state.env
+systemctl enable --now zakura-release-state.timer
+```
+
+The publisher refuses to run without `RELEASE_STATE_ARCHIVE_CACHE`. There is deliberately no
+default: falling back to the pruned cache would publish a bundle the grid export cannot complete.
 
 The host's existing Infisical Universal Auth identity uses project
 `c57a6889-6a7c-4d05-a54a-e4a4c0b14ee7`, environment `prod`.
@@ -66,41 +94,39 @@ Verify presence without printing either value:
 
 ## Operation and verification
 
-Normal and manual publication both use the existing service:
+Normal and manual publication both use the publisher service:
 
 ```sh
-systemctl start zakura-snapshot-pruned.service
-journalctl -fu zakura-snapshot-pruned.service
+systemctl start zakura-release-state.service
+journalctl -fu zakura-release-state.service
 ```
 
-Expected journal order is: stop `zakura-pruned`, run and complete the
-release-state hook, archive the pruned state, restart `zakura-pruned`, then
-verify and upload the snapshot. A hook failure or 30-minute timeout emits a
-Sentry error tagged `alert:zakura_release_state` and `check:release_state`,
-but snapshot creation continues and the parent EXIT trap still restarts the
-container.
+The run reads the archive cache through a secondary and touches no container, so nothing has to
+be stopped or restarted around it. Expected journal order is: checkpoint selection, the frontier
+and subtree artifacts, the frontier grid (with periodic entry progress), then the bundle upload
+and pointer replacement.
 
 After a run:
 
 ```sh
-systemctl is-active zakura-snapshot-pruned.service
-docker inspect --format '{{.State.Running}}' zakura-pruned
+systemctl is-active zakura-release-state.service
+docker inspect --format '{{.State.Running}}' zakura
 curl -fsS https://zakura-release.valargroup.dev/release-state/latest.json | jq .
 ```
 
 Confirm the pointer height advanced, fetch its `meta_url`, verify
 `meta_sha256`, and verify the listed size and SHA-256 for
-`main-checkpoints.txt`, `mainnet-frontier.bin`, and `mainnet-treestate-subtrees.bin`. The publisher
-keeps the newest four immutable `release-state/v1/<height>/` bundles by default.
+`main-checkpoints.txt`, `mainnet-frontier.bin`, `mainnet-treestate-subtrees.bin`, and
+`mainnet-frontier-grid.bin`. The publisher keeps the newest four immutable
+`release-state/v1/<height>/` bundles by default.
 
-Direct hook invocation is an incident diagnostic only. First ensure both
-snapshot publishers are inactive, stop `zakura-pruned`, invoke the hook
-through `with-secrets.sh`, and always restart and verify the container:
+Direct invocation is available for diagnostics. It takes the same publisher lock as the timer,
+so it is safe alongside a scheduled run, and it leaves both containers alone:
 
 ```sh
 /usr/local/bin/with-secrets.sh \
-  /opt/zakura-release-state/bin/publish-from-snapshot-host.sh \
-  /mnt/zec_snapshot/zakura-cache-pruned
+  /opt/zakura-release-state/bin/publish-from-archive-host.sh \
+  /path/to/archive-cache
 ```
 
 ## CI consumers
@@ -112,8 +138,10 @@ In `zakura-core/zakura`:
   gate, frontier and Sprout tests, a strict diff allowlist, then mints a
   short-lived GitHub App token and opens a signed draft
   `adam/update-release-state` PR.
-- `.github/workflows/tests-unit.yml` includes the checkpoint, frontier, and
+- `.github/workflows/tests-unit.yml` includes the checkpoint, frontier, grid, and
   provenance paths, so generated update PRs run Unit Tests.
+- `.github/workflows/history-growth.yml` raises its packed-growth allowance for a change
+  confined to the release-state files, because the committed frontier grid is a few megabytes.
 - `.github/workflows/create-release.yml` and `scripts/make/release.mk` validate only
   committed release state before creating a tag.
 - `scripts/check-release-state.sh` is the non-Cargo release gate and rejects
@@ -129,16 +157,15 @@ credential. Never print, journal, or persist either secret.
 
 ## Rollback
 
-Remove only the hook drop-in and reload systemd:
+Disable only the publisher timer:
 
 ```sh
-rm /etc/systemd/system/zakura-snapshot-pruned.service.d/release-state.conf
+systemctl disable --now zakura-release-state.timer
 systemctl daemon-reload
-systemd-analyze verify zakura-snapshot-pruned.service
 ```
 
-Do not remove or disable either snapshot timer and do not delete the publisher
-script during an incident. Keep bootstrap and current R2 objects intact, so
-GitHub safely takes the no-op path when no newer bundle is available. If a run
-was interrupted, verify `zakura-pruned` is running and syncing before closing
-the incident. Preserve the service journal and dedicated Sentry event.
+Do not remove or disable either snapshot timer, and do not delete the publisher script during an
+incident. Keep bootstrap and current R2 objects intact, so GitHub safely takes the no-op path
+when no newer bundle is available. A publisher run mutates nothing on the host beyond its own
+lock file and a temporary staging directory, so an interrupted run needs no container recovery.
+Preserve the service journal.

--- a/deploy/release-state/SNAPSHOT_HOST.md
+++ b/deploy/release-state/SNAPSHOT_HOST.md
@@ -138,10 +138,9 @@ In `zakura-core/zakura`:
   gate, frontier and Sprout tests, a strict diff allowlist, then mints a
   short-lived GitHub App token and opens a signed draft
   `adam/update-release-state` PR.
-- `.github/workflows/tests-unit.yml` includes the checkpoint, frontier, grid, and
-  provenance paths, so generated update PRs run Unit Tests.
-- `.github/workflows/history-growth.yml` raises its packed-growth allowance for a change
-  confined to the release-state files, because the committed frontier grid is a few megabytes.
+- `.github/workflows/tests-unit.yml` includes the checkpoint, frontier, and
+  provenance paths, so generated update PRs run Unit Tests. A follow-up adds the
+  frontier-grid path once the binary is committed.
 - `.github/workflows/create-release.yml` and `scripts/make/release.mk` validate only
   committed release state before creating a tag.
 - `scripts/check-release-state.sh` is the non-Cargo release gate and rejects

--- a/deploy/release-state/deploy-snapshot-host.sh
+++ b/deploy/release-state/deploy-snapshot-host.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Build the offline exporter from this checkout's pinned commit and install the snapshot-host hook.
-# This script does not restart either Zakura container or start a snapshot job.
+# Build the offline exporter from this checkout's pinned commit and install the release-state
+# publisher timer. This script does not restart either Zakura container, start a snapshot job,
+# or enable the timer.
 set -euo pipefail
 
 TARGET=${1:-root@45.55.96.29}
@@ -31,6 +32,7 @@ ssh -o BatchMode=yes "$TARGET" "
     [ \"\$(hostname -s)\" = \"$EXPECTED_HOST\" ]
     ! systemctl is-active --quiet zakura-snapshot-pruned.service
     ! systemctl is-active --quiet zakura-snapshot.service
+    ! systemctl is-active --quiet zakura-release-state.service
     [ \"\$(docker inspect --format '{{.State.Running}}' zakura-pruned)\" = true ]
     [ \"\$(docker inspect --format '{{.State.Running}}' zakura)\" = true ]
 " || die "host identity or inactive-publisher preflight failed"
@@ -50,10 +52,12 @@ install -m 0755 "$BUILD_TARGET/release/zakura-checkpoints" \
     "$WORK/stage/bin/zakura-checkpoints"
 install -m 0755 "$WORK/source/deploy/release-state/publish-release-state.sh" \
     "$WORK/stage/bin/publish-release-state.sh"
-install -m 0755 "$WORK/source/deploy/release-state/publish-from-snapshot-host.sh" \
-    "$WORK/stage/bin/publish-from-snapshot-host.sh"
-install -m 0644 "$WORK/source/deploy/release-state/zakura-snapshot-pruned-release-state.conf" \
-    "$WORK/stage/systemd/release-state.conf"
+install -m 0755 "$WORK/source/deploy/release-state/publish-from-archive-host.sh" \
+    "$WORK/stage/bin/publish-from-archive-host.sh"
+install -m 0644 "$WORK/source/deploy/release-state/zakura-release-state.service" \
+    "$WORK/stage/systemd/zakura-release-state.service"
+install -m 0644 "$WORK/source/deploy/release-state/zakura-release-state.timer" \
+    "$WORK/stage/systemd/zakura-release-state.timer"
 printf '%s\n' "$EXPORTER_REVISION" > "$WORK/stage/EXPORTER_REVISION"
 
 ssh -o BatchMode=yes "$TARGET" "install -d -m 0700 '$REMOTE_STAGE'"
@@ -64,6 +68,7 @@ ssh -o BatchMode=yes "$TARGET" "
     [ \"\$(hostname -s)\" = \"$EXPECTED_HOST\" ]
     ! systemctl is-active --quiet zakura-snapshot-pruned.service
     ! systemctl is-active --quiet zakura-snapshot.service
+    ! systemctl is-active --quiet zakura-release-state.service
     [ \"\$(docker inspect --format '{{.State.Running}}' zakura-pruned)\" = true ]
     [ \"\$(docker inspect --format '{{.State.Running}}' zakura)\" = true ]
 
@@ -77,21 +82,33 @@ ssh -o BatchMode=yes "$TARGET" "
         /opt/zakura-release-state/bin/zakura-checkpoints
     install -m 0755 '$REMOTE_STAGE/bin/publish-release-state.sh' \
         /opt/zakura-release-state/bin/publish-release-state.sh
-    install -m 0755 '$REMOTE_STAGE/bin/publish-from-snapshot-host.sh' \
-        /opt/zakura-release-state/bin/publish-from-snapshot-host.sh
+    install -m 0755 '$REMOTE_STAGE/bin/publish-from-archive-host.sh' \
+        /opt/zakura-release-state/bin/publish-from-archive-host.sh
     install -m 0644 '$REMOTE_STAGE/EXPORTER_REVISION' \
         /opt/zakura-release-state/EXPORTER_REVISION
 
-    install -d -m 0755 \
-        /etc/systemd/system/zakura-snapshot-pruned.service.d
-    install -m 0644 '$REMOTE_STAGE/systemd/release-state.conf' \
-        /etc/systemd/system/zakura-snapshot-pruned.service.d/release-state.conf
+    # The publisher used to run as a stopped-node hook on the pruned snapshot
+    # service. Remove that drop-in so a host mid-cutover cannot run both.
+    rm -f /etc/systemd/system/zakura-snapshot-pruned.service.d/release-state.conf
+    rmdir --ignore-fail-on-non-empty \
+        /etc/systemd/system/zakura-snapshot-pruned.service.d 2>/dev/null || true
+    install -m 0644 '$REMOTE_STAGE/systemd/zakura-release-state.service' \
+        /etc/systemd/system/zakura-release-state.service
+    install -m 0644 '$REMOTE_STAGE/systemd/zakura-release-state.timer' \
+        /etc/systemd/system/zakura-release-state.timer
     systemctl daemon-reload
     systemd-analyze verify zakura-snapshot-pruned.service
+    systemd-analyze verify zakura-release-state.timer
+
+    # The unit reads the archive cache path from here. Installing without it
+    # leaves the timer inert rather than exporting from the wrong database.
+    if [ ! -e /etc/zakura-release-state.env ]; then
+        echo 'note: create /etc/zakura-release-state.env with RELEASE_STATE_ARCHIVE_CACHE=... before enabling the timer' >&2
+    fi
 
     /opt/zakura-release-state/bin/zakura-checkpoints --help >/dev/null
     bash -n /opt/zakura-release-state/bin/publish-release-state.sh
-    bash -n /opt/zakura-release-state/bin/publish-from-snapshot-host.sh
+    bash -n /opt/zakura-release-state/bin/publish-from-archive-host.sh
 "
 
-echo "Installed release-state hook on $TARGET without starting either publisher."
+echo "Installed the release-state publisher on $TARGET without enabling its timer."

--- a/deploy/release-state/publish-from-archive-host.sh
+++ b/deploy/release-state/publish-from-archive-host.sh
@@ -1,35 +1,43 @@
 #!/usr/bin/env bash
-# Stopped-node hook for zakura-snapshot-pruned.service.
+# Host wrapper for the release-state publisher timer.
+#
+# Exports from the archive node's live cache directory: the exporter opens it as
+# a read-only RocksDB secondary, so the container keeps running throughout. The
+# pruned cache is not a valid source — the frontier grid covers heights a pruned
+# database no longer holds.
 set -euo pipefail
 
 EXPECTED_HOST=zakura-snapshot
-EXPECTED_CACHE=/mnt/zec_snapshot/zakura-cache-pruned
-CONTAINER=zakura-pruned
+CONTAINER=zakura
 INSTALL_ROOT=/opt/zakura-release-state
 R2_ENDPOINT=https://152e2a8834283136c2f0575782b1b7aa.r2.cloudflarestorage.com
 R2_BUCKET=zakura-release-state
 PUBLIC_BASE=https://zakura-release.valargroup.dev/release-state
 
 die() {
-    echo "release-state snapshot hook: $*" >&2
+    echo "release-state publisher: $*" >&2
     exit 1
 }
 
 main() {
     local state_dir running
-    state_dir=${1:?usage: publish-from-snapshot-host.sh <stopped-node-zakura-cache-dir>}
+
+    # No default: the archive cache path is host configuration, and silently
+    # falling back to the wrong directory would publish a bundle from a database
+    # that cannot produce a complete one.
+    state_dir=${1:-${RELEASE_STATE_ARCHIVE_CACHE:-}}
+    [ -n "$state_dir" ] \
+        || die "set RELEASE_STATE_ARCHIVE_CACHE to the archive node's cache directory"
 
     [ "$(hostname -s)" = "$EXPECTED_HOST" ] \
         || die "must run on $EXPECTED_HOST"
-    [ "$state_dir" = "$EXPECTED_CACHE" ] \
-        || die "expected cache $EXPECTED_CACHE, got $state_dir"
     [ -d "$state_dir" ] \
         || die "cache directory does not exist: $state_dir"
 
     running=$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null) \
         || die "cannot inspect container $CONTAINER"
-    [ "$running" = false ] \
-        || die "container $CONTAINER must be stopped before export"
+    [ "$running" = true ] \
+        || die "container $CONTAINER must be running so its cache is a live archive node"
 
     : "${R2_ACCESS_KEY_ID:?R2 access key was not injected}"
     : "${R2_SECRET_ACCESS_KEY:?R2 secret key was not injected}"

--- a/deploy/release-state/publish-release-state.sh
+++ b/deploy/release-state/publish-release-state.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-# Export a Mainnet release-state bundle from a stopped-node state copy and publish
+# Export a Mainnet release-state bundle from an archive node's state and publish
 # it to R2: an immutable release-state/v1/<height>/ bundle plus the mutable
 # latest.json pointer consumed by the update-release-state workflow.
-# Run after the snapshot job stops the node, against the same state directory.
-# See README.md in this directory for host wiring, and
+#
+# The exporter opens the database as a read-only RocksDB secondary, so the node
+# does not have to be stopped. It must be an *archive* node: the frontier grid
+# covers the heights below the checkpoint, which a pruned database no longer
+# holds. See README.md in this directory for host wiring, and
 # docs/design/verified-commitment-trees.md, section 16, for the design.
 #
-# Usage: publish-release-state.sh <stopped-node-zakura-cache-dir>
+# Usage: publish-release-state.sh <archive-node-zakura-cache-dir>
 #
 # Required environment:
 #   RELEASE_STATE_R2_REMOTE   rclone destination, e.g. "r2:zakura-artifacts"
@@ -16,13 +19,18 @@
 # Optional environment:
 #   ZAKURA_CHECKPOINTS_BIN    zakura-checkpoints binary (default: on PATH),
 #                             built with --features zakura-checkpoints-offline
+#   RELEASE_STATE_GRID_COST_MS
+#                             per-entry frontier grid cost budget in ms
+#                             (default: whatever the exporter defaults to). Only
+#                             affects entries added after the resumed prefix;
+#                             published entries are carried forward verbatim.
 #   RELEASE_STATE_KEEP        immutable bundles to retain (default 4)
 #   RELEASE_STATE_LOCK_FILE   host-local publisher lock
 #                             (default: /tmp/zakura-release-state-publish.lock)
 
 set -euo pipefail
 
-STATE_DIR=${1:?usage: publish-release-state.sh <stopped-node-zakura-cache-dir>}
+STATE_DIR=${1:?usage: publish-release-state.sh <archive-node-zakura-cache-dir>}
 : "${RELEASE_STATE_R2_REMOTE:?set RELEASE_STATE_R2_REMOTE to an rclone destination}"
 : "${RELEASE_STATE_PUBLIC_BASE:?set RELEASE_STATE_PUBLIC_BASE to the public HTTPS base URL}"
 BIN=${ZAKURA_CHECKPOINTS_BIN:-zakura-checkpoints}
@@ -35,6 +43,16 @@ if ! [[ "$KEEP" =~ ^[1-9][0-9]*$ ]]; then
     exit 1
 fi
 REMOTE_PREFIX="${RELEASE_STATE_R2_REMOTE%/}/release-state"
+# Left empty by default so the exporter's own budget applies, rather than pinning
+# a second copy of it here that would drift when the exporter's default changes.
+GRID_ARGS=()
+if [ -n "${RELEASE_STATE_GRID_COST_MS:-}" ]; then
+    if ! [[ "$RELEASE_STATE_GRID_COST_MS" =~ ^[1-9][0-9]*$ ]]; then
+        echo "RELEASE_STATE_GRID_COST_MS must be a positive integer, got: ${RELEASE_STATE_GRID_COST_MS@Q}" >&2
+        exit 1
+    fi
+    GRID_ARGS+=(--frontier-grid-target-cost-ms "$RELEASE_STATE_GRID_COST_MS")
+fi
 
 # The publisher is intentionally single-host. Serializing the complete
 # export/upload/pointer/retention transaction prevents overlapping snapshot or
@@ -77,29 +95,50 @@ list_remote_object() {
     fi
 }
 
+# Read the pointer before exporting. Its bundle carries the previously published
+# frontier grid, and resuming from that grid means this run scans only the blocks
+# above its last entry instead of the whole chain from genesis. The pointer height
+# is reused further down for the regression guard.
+POINTER_LISTING=$(list_remote_object "$REMOTE_PREFIX/latest.json")
+POINTER_HEIGHT=
+if [ -n "$POINTER_LISTING" ]; then
+    rclone copyto "$REMOTE_PREFIX/latest.json" "$STAGE/existing-latest.json"
+    POINTER_HEIGHT=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["height"])' \
+        "$STAGE/existing-latest.json")
+
+    # A bundle published before the grid joined the release state has no grid to
+    # resume from. That is not an error: the run falls back to a full walk, which
+    # is what the first grid-bearing export has to do anyway.
+    PREVIOUS_GRID="$REMOTE_PREFIX/v1/$POINTER_HEIGHT/mainnet-frontier-grid.bin"
+    if [ -n "$(list_remote_object "$PREVIOUS_GRID")" ]; then
+        rclone copyto "$PREVIOUS_GRID" "$STAGE/previous-frontier-grid.bin"
+        GRID_ARGS+=(--mainnet-frontier-grid-input "$STAGE/previous-frontier-grid.bin")
+        echo "resuming the frontier grid from bundle v1/$POINTER_HEIGHT" >&2
+    else
+        echo "bundle v1/$POINTER_HEIGHT has no frontier grid; building one from genesis" >&2
+    fi
+fi
+
+# One run, one coupled release state: the frontier, subtree roots, and frontier
+# grid are all generated for the checkpoint this run selects.
 "$BIN" \
     --state-cache-dir "$STATE_DIR" \
     --full-list \
     --mainnet-frontier-output "$STAGE/mainnet-frontier.bin" \
     --mainnet-subtree-output "$STAGE/mainnet-treestate-subtrees.bin" \
+    --mainnet-frontier-grid-output "$STAGE/mainnet-frontier-grid.bin" \
+    ${GRID_ARGS[@]+"${GRID_ARGS[@]}"} \
     > "$STAGE/main-checkpoints.txt"
 
 HEIGHT=$(tail -1 "$STAGE/main-checkpoints.txt" | cut -d' ' -f1)
 BLOCK_HASH=$(tail -1 "$STAGE/main-checkpoints.txt" | cut -d' ' -f2)
 GENERATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Never move the pointer backwards: an export from stale stopped-node state
-# would regress latest.json, and retention could then purge the very bundle
-# it points at.
-POINTER_LISTING=$(list_remote_object "$REMOTE_PREFIX/latest.json")
-if [ -n "$POINTER_LISTING" ]; then
-    rclone copyto "$REMOTE_PREFIX/latest.json" "$STAGE/existing-latest.json"
-    POINTER_HEIGHT=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["height"])' \
-        "$STAGE/existing-latest.json")
-    if [ "$POINTER_HEIGHT" -gt "$HEIGHT" ]; then
-        echo "refusing to publish height $HEIGHT below the current pointer height $POINTER_HEIGHT; stale stopped-node state?" >&2
-        exit 1
-    fi
+# Never move the pointer backwards: an export from stale state would regress
+# latest.json, and retention could then purge the very bundle it points at.
+if [ -n "$POINTER_HEIGHT" ] && [ "$POINTER_HEIGHT" -gt "$HEIGHT" ]; then
+    echo "refusing to publish height $HEIGHT below the current pointer height $POINTER_HEIGHT; stale state?" >&2
+    exit 1
 fi
 
 HEIGHT="$HEIGHT" BLOCK_HASH="$BLOCK_HASH" GENERATED_AT="$GENERATED_AT" \
@@ -112,6 +151,7 @@ for name in (
     "main-checkpoints.txt",
     "mainnet-frontier.bin",
     "mainnet-treestate-subtrees.bin",
+    "mainnet-frontier-grid.bin",
 ):
     data = open(os.path.join(stage, name), "rb").read()
     files[name] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
@@ -158,6 +198,7 @@ else
     rclone copyto "$STAGE/main-checkpoints.txt" "$BUNDLE_REMOTE/main-checkpoints.txt"
     rclone copyto "$STAGE/mainnet-frontier.bin" "$BUNDLE_REMOTE/mainnet-frontier.bin"
     rclone copyto "$STAGE/mainnet-treestate-subtrees.bin" "$BUNDLE_REMOTE/mainnet-treestate-subtrees.bin"
+    rclone copyto "$STAGE/mainnet-frontier-grid.bin" "$BUNDLE_REMOTE/mainnet-frontier-grid.bin"
     rclone copyto "$STAGE/meta.json" "$BUNDLE_REMOTE/meta.json"
     echo "published bundle v1/$HEIGHT ($BLOCK_HASH)" >&2
 fi

--- a/deploy/release-state/zakura-release-state.service
+++ b/deploy/release-state/zakura-release-state.service
@@ -1,0 +1,22 @@
+# Publishes one Mainnet release-state bundle from the archive node's live cache.
+#
+# Independent of the snapshot services: the exporter reads a RocksDB secondary,
+# so it needs no stopped-node window and takes no snapshot lock. Its own
+# /run/zakura-release-state-publish.lock rejects overlapping runs.
+[Unit]
+Description=Publish Mainnet release-state bundle
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Supplies RELEASE_STATE_ARCHIVE_CACHE, and optionally RELEASE_STATE_KEEP or
+# RELEASE_STATE_GRID_COST_MS. The publisher refuses to run without the cache path.
+EnvironmentFile=/etc/zakura-release-state.env
+ExecStart=/usr/local/bin/with-secrets.sh /opt/zakura-release-state/bin/publish-from-archive-host.sh
+# A whole-band frontier grid replay takes hours on a fast-synced archive
+# database. A legacy archive database reads the grid instead and finishes in
+# minutes, but the ceiling has to cover both.
+TimeoutStartSec=6h
+Nice=10
+IOSchedulingClass=idle

--- a/deploy/release-state/zakura-release-state.timer
+++ b/deploy/release-state/zakura-release-state.timer
@@ -1,0 +1,12 @@
+# Daily release-state publication. The import side is weekly, so a missed run
+# costs nothing beyond a slightly older bundle.
+[Unit]
+Description=Daily Mainnet release-state publication
+
+[Timer]
+OnCalendar=*-*-* 05:40:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/release-state/zakura-snapshot-pruned-release-state.conf
+++ b/deploy/release-state/zakura-snapshot-pruned-release-state.conf
@@ -1,3 +1,0 @@
-[Service]
-Environment=STOPPED_NODE_HOOK=/opt/zakura-release-state/bin/publish-from-snapshot-host.sh
-Environment=STOPPED_NODE_HOOK_TIMEOUT=1800

--- a/docs/changelog/unreleased/751.md
+++ b/docs/changelog/unreleased/751.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+Internal-only frontier grid generation, `zakura-checkpoints` wiring, and archive
+publisher support. Nothing consumes the grid at runtime yet.

--- a/docs/design/verified-commitment-trees.md
+++ b/docs/design/verified-commitment-trees.md
@@ -818,11 +818,14 @@ asserts to prove roots actually came over the wire rather than a silent legacy s
 
 ## 16. Mainnet release-state pipeline
 
-The embedded Mainnet frontier and completed-subtree roots are release artifacts coupled to the
-terminal Mainnet checkpoint. Whenever `main-checkpoints.txt`'s max height advances, the matching
-`mainnet-frontier.bin` and `mainnet-subtrees.bin` must advance to the same height, and all three
-must land in the same PR. The offline exporter below produces the coupled set; the publisher,
-refresh workflow, and release gate below consume it.
+The Mainnet release-state export couples a terminal checkpoint to its final frontier,
+completed-subtree roots, and historical frontier grid. The exporter and publisher produce four
+data files as one set: `main-checkpoints.txt`, `mainnet-frontier.bin`,
+`mainnet-treestate-subtrees.bin`, and `mainnet-frontier-grid.bin`. The checkpoint, final frontier,
+and subtree roots are committed together; the root-checked grid carries no trust weight and is
+distributed from the release-state bundle for historical serving. The offline exporter below
+produces the coupled set; the publisher, refresh workflow, and release gate below consume the
+parts they own.
 
 ### 16.1 Offline export (`zakura-checkpoints --state-cache-dir`)
 
@@ -835,13 +838,17 @@ zakura-checkpoints \
   --full-list \
   --mainnet-frontier-output /out/mainnet-frontier.bin \
   --mainnet-subtree-output /out/mainnet-treestate-subtrees.bin \
+  --mainnet-frontier-grid-output /out/mainnet-frontier-grid.bin \
   > /out/main-checkpoints.txt
 ```
 
 - Offline mode reads canonical hashes and `BlockInfo` sizes straight from the finalized
-  database (read-only), so it works on pruned state and needs no RPC or running node. The
-  quiesced database tip is by construction `MAX_BLOCK_REORG_HEIGHT` (1000) blocks behind the
-  network tip, which keeps every emitted checkpoint reorg-safe.
+  database (read-only) and needs no RPC or running node. Checkpoint selection and the
+  final-frontier/subtree pair can operate on pruned state, but the required historical frontier
+  grid scans retained block bodies to place adaptive entries and replays bodies across the VCT
+  absent band. The coupled command therefore requires a quiesced **archive** database. Its tip is
+  by construction `MAX_BLOCK_REORG_HEIGHT` (1000) blocks behind the network tip, which keeps every
+  emitted checkpoint reorg-safe.
 - New checkpoints continue the same cumulative byte-count / 400-block height-gap selection as
   the RPC mode, starting from the embedded Mainnet max checkpoint. Selection state fully
   resets at every selected checkpoint, so exports taken at different tips are byte-for-byte
@@ -861,8 +868,9 @@ zakura-checkpoints \
 - Frontier correctness inherits the finalized database's trust boundary: the exporter reads
   trees produced by Zakura's validated, atomic finalized-state commits rather than replaying
   historical transaction bodies. The parser validates framing and height, not the tree roots'
-  provenance. This deliberate trust model keeps the exporter compatible with pruned databases;
-  operators must only export from a quiesced state produced by a trusted Zakura node.
+  provenance. This keeps final-frontier generation itself compatible with pruned databases, but
+  does not remove the coupled frontier grid's archive-body requirement. Operators must only
+  export from a quiesced state produced by a trusted Zakura node.
 - The subtree artifact starts with the reviewed roots already embedded in the binary, then appends
   subtree rows the database retained after that checkpoint. Any overlapping database row must
   match the embedded record. The new frontier supplies the exact number of roots needed, and the
@@ -874,11 +882,11 @@ zakura-checkpoints \
 ### 16.2 Bundle, pointer, and refresh workflow
 
 The publisher (`deploy/release-state/`) uploads each export to R2 as an immutable bundle containing
-`meta.json`, `main-checkpoints.txt`, `mainnet-frontier.bin`, and
-`mainnet-treestate-subtrees.bin`. `meta.json` binds the network, terminal height/hash, an RFC 3339
-generation time, and each file's size and SHA-256. The publisher then atomically replaces the
-mutable `release-state/latest.json` pointer (height, hash, `meta_url`, `meta_sha256`), keeping the
-newest few bundles.
+`meta.json`, `main-checkpoints.txt`, `mainnet-frontier.bin`,
+`mainnet-treestate-subtrees.bin`, and `mainnet-frontier-grid.bin`. `meta.json` binds the network,
+terminal height/hash, an RFC 3339 generation time, and each data file's size and SHA-256. The
+publisher then atomically replaces the mutable `release-state/latest.json` pointer (height, hash,
+`meta_url`, `meta_sha256`), keeping the newest few bundles.
 
 The `update-release-state.yml` workflow (manual dispatch plus a weekly cron) and
 `prepare-release-pr.yml` both resolve the pointer once over a pinned HTTPS host with no
@@ -886,8 +894,11 @@ redirects, bounded reads, digest verification at every hop, and a maximum bundle
 exit green without release-state changes when the bundle does not advance the committed
 list. Otherwise their shared importer verifies the committed `main-checkpoints.txt` is a
 byte-identical prefix of the bundle's list, requires each pool's subtree bytes to retain the
-committed prefix, replaces all three artifacts, and writes `vct/mainnet-vct-manifest.json`
-provenance (source `release-state-bundle`, heights, digests, bundle binding).
+committed prefix, replaces the three committed release-state data files, and writes
+`vct/mainnet-vct-manifest.json` provenance (source `release-state-bundle`, heights, digests, bundle
+binding). During the frontier-grid cutover, the fetcher accepts both legacy bundles without a grid
+and new four-data-file bundles; the historical-serving path consumes the grid separately rather
+than embedding it as consensus-critical source.
 
 The standalone update workflow also floors `ESTIMATED_RELEASE_HEIGHT`, validates everything
 — including proving the candidate subtree roots against its frontier — restricts the diff to


### PR DESCRIPTION
## Motivation

Historical treestate serving needs a generator for sparse note-commitment frontier grids before the grid can be published, embedded, or used at runtime. Part 1 (#750) defined the artifact format; this PR produces grids and ships them from the archive release-state publisher without consuming them on the serving path.

## Solution

- Add `GridSpacing`, `export_frontier_grid_to`, adaptive cost-weighted placement, resume-from-previous-grid, and prefix-extension behavior.
- Add only the dormant replay/storage helpers generation needs (`stored_frontiers_at`, `stored_frontier_before_absent_band`, `verify_against_available_roots`).
- Extend `zakura-checkpoints` with frontier-grid output, spacing/budget flags, resume input, and embedded-checkpoint backfill.
- Move generation onto the archive-node publisher (`zakura-release-state.timer`), which emits `mainnet-frontier-grid.bin` in the R2 bundle.
- Teach `fetch-release-state.py` to accept the grid as an **optional** digest-verified file so four-file publisher bundles do not break today's three-file importer.
- Add `zakurad verify-historical-treestates --frontier-grid-input` for offline framing/coupling checks.

This PR intentionally excludes embedding, config, service caches, RPC serving, provenance/import enforcement, and the Mainnet grid binary.

## Testing

- `cargo test -p zakura-state --lib grid_target_tests` — 4 passed (uniform/adaptive placement and tip-prefix compatibility)
- `cargo test -p zakura-state --lib historical_tree::tests::genesis_absent_band` — 1 passed
- `cargo test -p zakura-utils --features zakura-checkpoints-offline --bin zakura-checkpoints` — 13 passed
- `python3 .github/scripts/fetch-release-state.py --self-test` — 17 passed (optional grid accept/digest)
- `./scripts/changelog.py check` — passed
- Additional clippy/fmt/`bash -n` and generation property coverage are running locally against this draft

## Changelog

`docs/changelog/unreleased/751.md` explicitly excludes this internal-only generation plumbing from operator-facing release notes.

### Specifications & References

- Builds on #750 (`FrontierArtifact` format).
- Follows the historical treestate serving design's independently root-checked frontier model.
- Stack slice 2 of the #703 split.

### Follow-up Work

- Import/provenance/workflows that *require* the fourth file (part 3).
- Commit the Mainnet grid binary in a release-state-only PR (part 4).
- Runtime serving integration (part 5) and RPC coverage (part 6).

## AI Disclosure

Used Cursor to extract generation from the #703 stack onto current `main` after #750.
