### PR TITLE
build(zakurad): replace vergen metadata generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,43 +630,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "cast"
@@ -1307,36 +1274,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1354,22 +1297,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -1442,37 +1374,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -4001,15 +3902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5976,7 +5868,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6525,9 +6417,7 @@ checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -7282,46 +7172,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
- "rustc_version",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
 
 [[package]]
 name = "version_check"
@@ -8116,7 +7966,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
- "vergen-gitcl",
  "zakura-chain",
  "zakura-consensus",
  "zakura-header-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,6 @@ opentelemetry = "0.32"
 opentelemetry_sdk = "0.32.1"
 opentelemetry-otlp = "0.32"
 uint = "0.10"
-vergen-gitcl = { version = "9", default-features = false }
 x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -281,8 +281,6 @@ derive-new.workspace = true
 hex.workspace = true
 
 [build-dependencies]
-vergen-gitcl = { workspace = true, features = ["cargo", "rustc"] }
-
 # test feature lightwalletd-grpc-tests
 tonic-prost-build = { workspace = true, optional = true }
 

--- a/crates/zakurad/build.rs
+++ b/crates/zakurad/build.rs
@@ -6,74 +6,20 @@
 //! When compiling the `lightwalletd` gRPC tests, also builds a gRPC client
 //! Rust API for `lightwalletd`.
 
-use vergen_gitcl::{CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
+#[path = "build/metadata.rs"]
+mod metadata;
 
-/// Process entry point for `zakurad`'s build script
-#[allow(clippy::print_stderr)]
+#[cfg(feature = "lightwalletd-grpc-tests")]
+#[path = "build/lightwalletd.rs"]
+mod lightwalletd;
+
+/// Process entry point for `zakurad`'s build script.
 fn main() {
-    let mut emitter = Emitter::default();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build");
 
-    // Configures an [`Emitter`] for everything except for `git` env vars.
-    // This builder fails the build on error.
-    //
-    // The cargo instructions are listed explicitly instead of using
-    // `all_cargo()`: its `dependencies` instruction (whose output nothing
-    // consumes) runs `cargo metadata` at compile time, which resolves the
-    // dependency graph against the registry index — that fails in the
-    // `cargo package`/`cargo publish` verify build of the packaged crate
-    // (before the zakura-* dependencies are published) and in offline builds.
-    let cargo_instructions = CargoBuilder::default()
-        .debug(true)
-        .features(true)
-        .opt_level(true)
-        .target_triple(true)
-        .build()
-        .expect("cargo instruction builder should build successfully");
-
-    emitter
-        .fail_on_error()
-        .add_instructions(&cargo_instructions)
-        .expect("adding cargo instructions should succeed")
-        .add_instructions(
-            &RustcBuilder::all_rustc().expect("all_rustc() should build successfully"),
-        )
-        .expect("adding all_rustc() instructions should succeed");
-
-    // Get git information. This is used by e.g. ZakuradApp::register_components()
-    // to log the commit hash
-    let all_git = GitclBuilder::default()
-        .branch(true)
-        .commit_author_email(true)
-        .commit_author_name(true)
-        .commit_count(true)
-        .commit_date(true)
-        .commit_message(true)
-        .commit_timestamp(true)
-        .describe(false, false, None)
-        .sha(true)
-        .dirty(false)
-        .describe(true, true, Some("v*.*.*"))
-        .build()
-        .expect("all_git + describe + sha should build successfully");
-
-    if let Err(e) = emitter.add_instructions(&all_git) {
-        // The most common failure here is due to a missing `.git` directory,
-        // e.g., when building from `cargo install zakurad`. We simply
-        // proceed with the build.
-        // Note that this won't be printed unless in cargo very verbose mode (-vv).
-        // We could emit a build warning, but that might scare users.
-        eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);
-    }
-
-    emitter.emit().expect("base emit should succeed");
+    metadata::emit();
 
     #[cfg(feature = "lightwalletd-grpc-tests")]
-    tonic_prost_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile_protos(
-            &["tests/common/lightwalletd/proto/service.proto"],
-            &["tests/common/lightwalletd/proto"],
-        )
-        .expect("Failed to generate lightwalletd gRPC files");
+    lightwalletd::generate_client();
 }

--- a/crates/zakurad/build/lightwalletd.rs
+++ b/crates/zakurad/build/lightwalletd.rs
@@ -1,0 +1,12 @@
+//! Generates the lightwalletd gRPC test client.
+
+pub fn generate_client() {
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(false)
+        .compile_protos(
+            &["tests/common/lightwalletd/proto/service.proto"],
+            &["tests/common/lightwalletd/proto"],
+        )
+        .expect("lightwalletd test protobufs should compile");
+}

--- a/crates/zakurad/build/metadata.rs
+++ b/crates/zakurad/build/metadata.rs
@@ -1,0 +1,158 @@
+//! Emits Cargo, Rust compiler, and Git metadata for `zakurad`.
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Emits all metadata consumed by `zakurad` diagnostics.
+#[allow(clippy::print_stderr)]
+pub fn emit() {
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    emit_cargo_metadata();
+    emit_rustc_metadata();
+
+    if let Err(error) = emit_git_metadata() {
+        // Source archives and `cargo install` builds do not have a `.git`
+        // directory, so Git metadata is intentionally optional.
+        eprintln!("git metadata unavailable: skipping git env vars: {error}");
+    }
+}
+
+fn emit_cargo_metadata() {
+    let mut features: Vec<_> = env::vars()
+        .filter_map(|(name, _)| {
+            name.strip_prefix("CARGO_FEATURE_")
+                .map(|feature| feature.to_lowercase())
+        })
+        .collect();
+    features.sort_unstable();
+
+    emit_env("VERGEN_CARGO_FEATURES", features.join(","));
+    emit_env("VERGEN_CARGO_TARGET_TRIPLE", required_env("TARGET"));
+    emit_env("VERGEN_CARGO_OPT_LEVEL", required_env("OPT_LEVEL"));
+    emit_env("VERGEN_CARGO_DEBUG", required_env("DEBUG"));
+}
+
+fn emit_rustc_metadata() {
+    let rustc = env::var_os("RUSTC").expect("Cargo always sets RUSTC for build scripts");
+    let output = Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .expect("rustc must be executable to compile zakurad");
+    assert!(output.status.success(), "rustc -vV must succeed");
+
+    let version = String::from_utf8(output.stdout).expect("rustc -vV output must be UTF-8");
+    emit_env("VERGEN_RUSTC_SEMVER", rustc_field(&version, "release"));
+    emit_env(
+        "VERGEN_RUSTC_COMMIT_DATE",
+        rustc_field(&version, "commit-date"),
+    );
+}
+
+fn emit_git_metadata() -> Result<(), String> {
+    if git(&["rev-parse", "--is-inside-work-tree"])? != "true" {
+        return Err("not inside a Git worktree".to_string());
+    }
+
+    emit_git_rerun_triggers()?;
+
+    let branch = git(&["rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD"])?;
+    let sha = git(&["rev-parse", "HEAD"])?;
+    let timestamp = match env::var("SOURCE_DATE_EPOCH") {
+        Ok(epoch) => format_source_date_epoch(&epoch)?,
+        Err(env::VarError::NotPresent) => git(&["log", "-1", "--pretty=format:%cI"])?,
+        Err(error) => return Err(format!("invalid SOURCE_DATE_EPOCH: {error}")),
+    };
+
+    let mut describe = git(&["describe", "--always", "--tags", "--match", "v*.*.*"])?;
+    if !git(&["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        describe.push_str("-dirty");
+    }
+
+    emit_env("VERGEN_GIT_BRANCH", branch);
+    emit_env("VERGEN_GIT_COMMIT_TIMESTAMP", timestamp);
+    emit_env("VERGEN_GIT_DESCRIBE", describe);
+    emit_env("VERGEN_GIT_SHA", sha);
+
+    Ok(())
+}
+
+fn emit_git_rerun_triggers() -> Result<(), String> {
+    let git_dir = PathBuf::from(git(&["rev-parse", "--git-dir"])?);
+    emit_rerun_if_exists(&git_dir.join("HEAD"));
+
+    if let Ok(reference) = git(&["symbolic-ref", "HEAD"]) {
+        emit_rerun_if_exists(&git_dir.join(reference));
+    }
+
+    Ok(())
+}
+
+fn emit_rerun_if_exists(path: &Path) {
+    if path.exists() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn git(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .output()
+        .map_err(|error| format!("could not run git: {error}"))?;
+
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn format_source_date_epoch(epoch: &str) -> Result<String, String> {
+    let seconds: i64 = epoch
+        .parse()
+        .map_err(|error| format!("SOURCE_DATE_EPOCH must be an integer: {error}"))?;
+    let days = seconds.div_euclid(86_400);
+    let seconds_of_day = seconds.rem_euclid(86_400);
+    let (year, month, day) = civil_date(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = seconds_of_day % 3_600 / 60;
+    let second = seconds_of_day % 60;
+
+    Ok(format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.000000000Z"
+    ))
+}
+
+fn civil_date(days_since_unix_epoch: i64) -> (i64, i64, i64) {
+    let days = days_since_unix_epoch + 719_468;
+    let era = days.div_euclid(146_097);
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}
+
+fn rustc_field<'a>(version: &'a str, field: &str) -> &'a str {
+    version
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{field}: ")))
+        .unwrap_or_else(|| panic!("rustc -vV output must contain {field}"))
+}
+
+fn required_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("Cargo always sets {name} for build scripts"))
+}
+
+fn emit_env(name: &str, value: impl AsRef<str>) {
+    println!("cargo:rustc-env={name}={}", value.as_ref());
+}

--- a/docs/changelog/unreleased/755.md
+++ b/docs/changelog/unreleased/755.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only changes internal build metadata generation and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

Zakurad compiles a large build-time dependency subtree to emit a small set of diagnostic metadata values.

## Solution

Replace `vergen-gitcl` with focused standard-library Cargo, rustc, and Git metadata emitters behind a thin build-script entrypoint.

## Testing

- `cargo check -p zakura --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/755.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/755.md` marks this internal-only change as excluded.