### PR TITLE
build(rpc): pre-generate RPC artifacts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Check locked all-feature build
         if: ${{ !cancelled() }}
         run: cargo check --locked --all-features --all-targets
+      - name: Check generated RPC artifacts
+        if: ${{ !cancelled() }}
+        run: cargo xtask check-rpc-artifacts
 
   # NOTE: per-crate default / no-default-features checks moved to
   # `test-crates.yml`, which runs `cargo hack check --workspace` (and again with

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Run Codex
         id: codex
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 #v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 #v1.11
         with:
           openai-api-key: ${{ secrets.CODEX_API_KEY }}
           prompt-file: .github/upstream-sync/prompts/adapt-pr.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7549,15 +7549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8006,10 +7997,12 @@ dependencies = [
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "openrpsee",
  "serde",
  "sha2 0.10.9",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -8682,11 +8675,9 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "tonic-reflection",
  "tower 0.4.13",
  "tracing",
- "which",
  "zakura-chain",
  "zakura-consensus",
  "zakura-keys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,6 @@ x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"
 config = { version = "0.15.14", default-features = false, features = ["toml"] }
-which = "8.0.0"
 
 # All cargo-release configuration lives in this table. Do not add a root
 # release.toml: it would silently shadow every setting here (cargo-release

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -15,9 +15,9 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
+openrpsee.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
-toml.workspace = true
-
-[dev-dependencies]
 tempfile.workspace = true
+toml.workspace = true
+tonic-prost-build.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 
 mod header_conformance;
 mod header_fuzz;
+mod rpc_artifacts;
 
 const DEFAULT_FEATURES: &str = "default-release-binaries";
 const DEFAULT_UBUNTU_IMAGE: &str = "ubuntu:22.04";
@@ -61,6 +62,24 @@ fn try_main() -> Result<(), BoxError> {
                 )));
             }
             header_fuzz::minimize(&repo_root()?, Path::new(&artifact))
+        }
+        Some("generate-rpc-artifacts") => {
+            if args.next().is_some() {
+                return Err(Box::new(UsageError(
+                    "`cargo xtask generate-rpc-artifacts` does not accept arguments",
+                )));
+            }
+
+            rpc_artifacts::update(&repo_root()?)
+        }
+        Some("check-rpc-artifacts") => {
+            if args.next().is_some() {
+                return Err(Box::new(UsageError(
+                    "`cargo xtask check-rpc-artifacts` does not accept arguments",
+                )));
+            }
+
+            rpc_artifacts::check(&repo_root()?)
         }
         Some("-h" | "--help") | None => {
             if args.next().is_some() {
@@ -263,6 +282,8 @@ fn print_usage(output: &mut impl fmt::Write) -> fmt::Result {
     writeln!(output, "  cargo xtask package ubuntu")?;
     writeln!(output, "  cargo xtask header-conformance [LC-…]")?;
     writeln!(output, "  cargo xtask minimize-header-fuzz <artifact>")?;
+    writeln!(output, "  cargo xtask generate-rpc-artifacts")?;
+    writeln!(output, "  cargo xtask check-rpc-artifacts")?;
     writeln!(output)?;
     writeln!(
         output,
@@ -286,5 +307,11 @@ fn print_usage(output: &mut impl fmt::Write) -> fmt::Result {
     writeln!(
         output,
         "its SHA-256, decoded bounded operations, and a deterministic Rust regression."
-    )
+    )?;
+    writeln!(output)?;
+    writeln!(
+        output,
+        "Regenerates deterministic protobuf and OpenRPC source artifacts, or checks that"
+    )?;
+    writeln!(output, "the checked-in artifacts are current.")
 }

--- a/crates/xtask/src/rpc_artifacts.rs
+++ b/crates/xtask/src/rpc_artifacts.rs
@@ -1,0 +1,94 @@
+use std::{fs, path::Path};
+
+use crate::BoxError;
+
+const INDEXER_PROTO: &str = "crates/zakura-rpc/proto/indexer.proto";
+const RPC_CRATE: &str = "crates/zakura-rpc";
+const METHODS_SOURCE: &str = "crates/zakura-rpc/src/methods.rs";
+const OPENRPC_ARTIFACT: &str = "crates/zakura-rpc/src/methods/rpc_openrpc.rs";
+
+const GENERATED_FILES: [(&str, &str); 3] = [
+    (
+        "indexer_descriptor.bin",
+        "crates/zakura-rpc/proto/__generated__/indexer_descriptor.bin",
+    ),
+    (
+        "zebra.indexer.rpc.rs",
+        "crates/zakura-rpc/proto/__generated__/zebra.indexer.rpc.rs",
+    ),
+    ("rpc_openrpc.rs", OPENRPC_ARTIFACT),
+];
+
+pub fn update(repo_root: &Path) -> Result<(), BoxError> {
+    compare_generated_artifacts(repo_root, true)
+}
+
+pub fn check(repo_root: &Path) -> Result<(), BoxError> {
+    compare_generated_artifacts(repo_root, false)
+}
+
+fn compare_generated_artifacts(repo_root: &Path, update: bool) -> Result<(), BoxError> {
+    let first_dir = tempfile::tempdir()?;
+    let second_dir = tempfile::tempdir()?;
+
+    generate(repo_root, first_dir.path())?;
+    generate(repo_root, second_dir.path())?;
+
+    for (file_name, checked_in_path) in GENERATED_FILES {
+        let first = fs::read(first_dir.path().join(file_name))?;
+        let second = fs::read(second_dir.path().join(file_name))?;
+
+        if first != second {
+            return Err(
+                format!("RPC artifact generation is not deterministic: {file_name}").into(),
+            );
+        }
+
+        let checked_in_path = repo_root.join(checked_in_path);
+        if fs::read(&checked_in_path).ok().as_deref() == Some(first.as_slice()) {
+            println!("unchanged {}", checked_in_path.display());
+        } else if !update {
+            return Err(format!(
+                "checked-in RPC artifact is stale: {}; run `cargo xtask generate-rpc-artifacts`",
+                checked_in_path.display()
+            )
+            .into());
+        } else {
+            fs::write(&checked_in_path, first)?;
+            println!("updated {}", checked_in_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn generate(repo_root: &Path, output_dir: &Path) -> Result<(), BoxError> {
+    let proto_file = repo_root.join(INDEXER_PROTO);
+    let rpc_crate = repo_root.join(RPC_CRATE);
+
+    tonic_prost_build::configure()
+        .emit_rerun_if_changed(false)
+        .out_dir(output_dir)
+        .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
+        .file_descriptor_set_path(output_dir.join("indexer_descriptor.bin"))
+        .compile_protos(&[proto_file], &[rpc_crate])?;
+
+    let methods_source = repo_root.join(METHODS_SOURCE);
+    let methods_source = methods_source
+        .to_str()
+        .ok_or("RPC methods source path should be valid UTF-8")?;
+    openrpsee::generate_openrpc(methods_source, &["Rpc"], false, output_dir)?;
+
+    verify_generated_files(output_dir)
+}
+
+fn verify_generated_files(output_dir: &Path) -> Result<(), BoxError> {
+    for (file_name, _) in GENERATED_FILES {
+        let path = output_dir.join(file_name);
+        if !path.is_file() {
+            return Err(format!("generator did not produce {}", path.display()).into());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -128,11 +128,6 @@ tokio-rustls = "0.26.4"
 # Only used to read the validity dates of the configured RPC TLS certificates.
 der = "0.7.10"
 
-[build-dependencies]
-openrpsee = { workspace = true }
-tonic-prost-build = { workspace = true }
-which = { workspace = true }
-
 [dev-dependencies]
 bytes = { workspace = true }
 http-body = { workspace = true }

--- a/crates/zakura-rpc/build.rs
+++ b/crates/zakura-rpc/build.rs
@@ -1,59 +1,17 @@
-//! Compile proto files
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+//! Copy checked-in protobuf artifacts into Cargo's output directory.
+use std::{env, fs, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_or_copy_proto()?;
-    build_rpc_schema()?;
-
-    Ok(())
-}
-
-fn build_or_copy_proto() -> Result<(), Box<dyn std::error::Error>> {
-    const PROTO_FILE_PATH: &str = "proto/indexer.proto";
-
     let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
     let file_names = ["indexer_descriptor.bin", "zebra.indexer.rpc.rs"];
 
-    let is_proto_file_available = Path::new(PROTO_FILE_PATH).exists();
-    let is_protoc_available = env::var_os("PROTOC")
-        .map(PathBuf::from)
-        .or_else(|| which::which("protoc").ok())
-        .is_some();
-
-    if is_proto_file_available && is_protoc_available {
-        tonic_prost_build::configure()
-            .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
-            .file_descriptor_set_path(out_dir.join("indexer_descriptor.bin"))
-            .compile_protos(&[PROTO_FILE_PATH], &[""])?;
-
-        for file_name in file_names {
-            let out_path = out_dir.join(file_name);
-            let generated_path = format!("proto/__generated__/{file_name}");
-            if fs::read(&out_path).ok() != fs::read(&generated_path).ok() {
-                fs::copy(out_path, generated_path)?;
-            }
-        }
-    } else {
-        for file_name in file_names {
-            let out_path = out_dir.join(file_name);
-            let generated_path = format!("proto/__generated__/{file_name}");
-            if fs::read(&out_path).ok() != Some(fs::read(&generated_path)?) {
-                fs::copy(generated_path, out_path)?;
-            }
+    for file_name in file_names {
+        let out_path = out_dir.join(file_name);
+        let generated_path = PathBuf::from("proto/__generated__").join(file_name);
+        if fs::read(&out_path).ok() != Some(fs::read(&generated_path)?) {
+            fs::copy(generated_path, out_path)?;
         }
     }
-
-    Ok(())
-}
-
-fn build_rpc_schema() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
-    let json_rpc_methods_rs = "src/methods.rs";
-    let trait_names = ["Rpc"];
-    openrpsee::generate_openrpc(json_rpc_methods_rs, &trait_names, false, &out_dir)?;
 
     Ok(())
 }

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -148,7 +148,7 @@ where
     service.oneshot(request).await.map_misc_error()
 }
 
-include!(concat!(env!("OUT_DIR"), "/rpc_openrpc.rs"));
+include!("methods/rpc_openrpc.rs");
 
 // TODO: Review the parameter descriptions below, and update them as needed:
 // https://github.com/ZcashFoundation/zebra/issues/10320

--- a/crates/zakura-rpc/src/methods/rpc_openrpc.rs
+++ b/crates/zakura-rpc/src/methods/rpc_openrpc.rs
@@ -1,0 +1,307 @@
+/// Lookup table for JSON-RPC methods.
+#[allow(unused_qualifications)]
+pub static METHODS: ::phf::Map<&str, openrpsee::openrpc::RpcMethod> = ::phf::phf_map! {
+"getinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns software information from the RPC server, as a\n[`GetInfoResponse`] JSON struct.\n\nzcashd reference: [`getinfo`](https://zcash.github.io/rpc/getinfo.html)\nmethod: post\ntags: control\n\n# Notes\n\n[The zcashd reference](https://zcash.github.io/rpc/getinfo.html) might not show some fields\nin Zebra\'s [`GetInfoResponse`]. Zebra uses the field names and formats\nfrom the [zcashd\ncode](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).\n\nSome fields from the zcashd reference are missing from Zebra\'s\n[`GetInfoResponse`]. It only contains the fields\n[required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getinfo_result"),
+    deprecated: false,
+},
+"getdeprecationinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns end-of-support information for this node release, as a\n[`GetDeprecationInfoResponse`] JSON struct.\n\nzcashd reference:\n[`getdeprecationinfo`](https://zcash.github.io/rpc/getdeprecationinfo.html)\nmethod: post\ntags: network\n\n# Notes\n\nAs in zcashd, the `end_of_service` object is only present on Mainnet,\nwhere end of support is enforced. Zakura reports the estimated last\nheight this release supports in `end_of_service.block_height`; the node\nhalts when the tip goes past it.\n\nSome fields from the zcashd response are missing from Zakura\'s response:\n`version` and `subversion` are available from `getinfo`,\n`deprecationheight` is deprecated in zcashd, and Zakura does not have\nzcashd\'s feature deprecation framework.\n\nThe estimate assumes the node is synced to the network tip; during\ninitial sync it is significantly overestimated.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getdeprecationinfo_result"),
+    deprecated: false,
+},
+"getblockchaininfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns blockchain state information, as a [`GetBlockchainInfoResponse`] JSON struct.\n\nzcashd reference: [`getblockchaininfo`](https://zcash.github.io/rpc/getblockchaininfo.html)\nmethod: post\ntags: blockchain\n\n# Notes\n\nSome fields from the zcashd reference are missing from Zebra\'s [`GetBlockchainInfoResponse`]. It only contains the fields\n[required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L72-L89)\n\nZebra includes an `ironwood` value pool entry. Like other value pool\nentries, it can be present with a zero balance.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockchaininfo_result"),
+    deprecated: false,
+},
+"getaddressbalance" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the total balance of provided `addresses` in a\n[`GetAddressBalanceResponse`] instance.\n\nzcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `address_strings`: (object, example={\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"]}) A JSON map with a single entry\n    - `addresses`: (array of strings) A list of base-58 encoded addresses.\n\n# Notes\n\nzcashd also accepts a single string parameter instead of an array of strings, but Zebra\ndoesn\'t because lightwalletd always calls this RPC with an array of addresses.\n\nzcashd also returns the total amount of Zatoshis received by the addresses, but Zebra\ndoesn\'t because lightwalletd doesn\'t use that information.\n\nThe RPC documentation says that the returned object has a string `balance` field, but\nzcashd actually [returns an\ninteger](https://github.com/zcash/lightwalletd/blob/bdaac63f3ee0dbef62bde04f6817a9f90d483b00/common/common.go#L128-L130).\n",
+    params: |_g| vec![
+        _g.param::<GetAddressBalanceRequest>("address_strings", crate::methods::PARAM_ADDRESS_STRINGS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddressbalance_result"),
+    deprecated: false,
+},
+"sendrawtransaction" => openrpsee::openrpc::RpcMethod {
+    description: "Sends the raw bytes of a signed transaction to the local node\'s mempool, if the transaction is valid.\nReturns the [`SendRawTransactionResponse`] for the transaction, as a\nJSON string.\n\nzcashd reference: [`sendrawtransaction`](https://zcash.github.io/rpc/sendrawtransaction.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `raw_transaction_hex`: (string, required, example=\"signedhex\") The hex-encoded raw transaction bytes.\n- `allow_high_fees`: (bool, optional) A legacy parameter accepted by zcashd but ignored by Zebra.\n\n# Notes\n\nzcashd accepts an optional `allowhighfees` parameter. Zebra doesn\'t support this parameter,\nbecause lightwalletd doesn\'t use it.\n",
+    params: |_g| vec![
+        _g.param::<String>("raw_transaction_hex", crate::methods::PARAM_RAW_TRANSACTION_HEX_DESC, true),
+        _g.param::<bool>("_allow_high_fees", crate::methods::PARAM__ALLOW_HIGH_FEES_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("sendrawtransaction_result"),
+    deprecated: false,
+},
+"getblock" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the requested block by hash or height, as a\n[`GetBlockResponse`] JSON string.\nIf the block is not in Zebra\'s state, returns\n[error code `-8`.](https://github.com/zcash/zcash/issues/5758) if a height was\npassed or -5 if a hash was passed.\n\nzcashd reference: [`getblock`](https://zcash.github.io/rpc/getblock.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash_or_height`: (string, required, example=\"1\") The hash or height for the block to be returned.\n- `verbosity`: (number, optional, default=1, example=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.\n\n# Notes\n\nThe `size` field is only returned with verbosity=2.\n\nThe undocumented `chainwork` field is not returned.\n\nWith verbosity=2, transaction objects include `ironwood` only when the\ntransaction contains Ironwood shielded data. Block `trees` can include an\nIronwood tree entry when the state has one for the requested block.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+        _g.param::<u8>("verbosity", crate::methods::PARAM_VERBOSITY_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblock_result"),
+    deprecated: false,
+},
+"getblockheader" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the requested block header by hash or height, as a\n[`GetBlockHeaderResponse`] JSON string.\nIf the block is not in Zebra\'s state,\nreturns [error code `-8`.](https://github.com/zcash/zcash/issues/5758)\nif a height was passed or -5 if a hash was passed.\n\nzcashd reference: [`getblockheader`](https://zcash.github.io/rpc/getblockheader.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash_or_height`: (string, required, example=\"1\") The hash or height for the block to be returned.\n- `verbose`: (bool, optional, default=false, example=true) false for hex encoded data, true for a json object\n\n# Notes\n\nThe undocumented `chainwork` field is not returned.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+        _g.param::<bool>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockheader_result"),
+    deprecated: false,
+},
+"getbestblockhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the hash of the current best blockchain tip block, as a\n[`GetBlockHashResponse`] JSON string.\n\nzcashd reference: [`getbestblockhash`](https://zcash.github.io/rpc/getbestblockhash.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getbestblockhash_result"),
+    deprecated: false,
+},
+"getbestblockheightandhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the height and hash of the current best blockchain tip block, as a [`GetBlockHeightAndHashResponse`] JSON struct.\n\nzcashd reference: none\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getbestblockheightandhash_result"),
+    deprecated: false,
+},
+"getmempoolinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns details on the active state of the TX memory pool.\n\nzcash reference: [`getmempoolinfo`](https://zcash.github.io/rpc/getmempoolinfo.html)\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getmempoolinfo_result"),
+    deprecated: false,
+},
+"getrawmempool" => openrpsee::openrpc::RpcMethod {
+    description: "Returns all transaction ids in the memory pool, as a JSON array.\n\n# Parameters\n\n- `verbose`: (boolean, optional, default=false) true for a json object, false for array of transaction ids.\n\nzcashd reference: [`getrawmempool`](https://zcash.github.io/rpc/getrawmempool.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+        _g.param::<bool>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getrawmempool_result"),
+    deprecated: false,
+},
+"z_gettreestate" => openrpsee::openrpc::RpcMethod {
+    description: "Returns information about the given block\'s Sapling, Orchard, and when\navailable Ironwood tree state.\n\nzcashd reference: [`z_gettreestate`](https://zcash.github.io/rpc/z_gettreestate.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash | height`: (string, required, example=\"00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5\") The block hash or height.\n\n# Notes\n\nThe zcashd doc reference above says that the parameter \"`height` can be\nnegative where -1 is the last known valid block\". On the other hand,\n`lightwalletd` only uses positive heights, so Zebra does not support\nnegative heights.\n\nThe `ironwood` field contains empty commitments unless Ironwood tree\nstate is available for the requested block.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_gettreestate_result"),
+    deprecated: false,
+},
+"z_getsubtreesbyindex" => openrpsee::openrpc::RpcMethod {
+    description: "Returns information about a range of shielded subtrees.\n\nzcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `pool`: (string, required) The pool from which subtrees should be returned.\n  Either \"sapling\", \"orchard\", or \"ironwood\".\n- `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.\n- `limit`: (number, optional) The maximum number of subtree values to return.\n\n# Notes\n\nWhile Zebra is doing its initial subtree index rebuild, subtrees will become available\nstarting at the chain tip. This RPC will return an empty list if the `start_index` subtree\nexists, but has not been rebuilt yet. This matches `zcashd`\'s behaviour when subtrees aren\'t\navailable yet. (But `zcashd` does its rebuild before syncing any blocks.)\n",
+    params: |_g| vec![
+        _g.param::<String>("pool", crate::methods::PARAM_POOL_DESC, true),
+        _g.param::<NoteCommitmentSubtreeIndex>("start_index", crate::methods::PARAM_START_INDEX_DESC, true),
+        _g.param::<NoteCommitmentSubtreeIndex>("limit", crate::methods::PARAM_LIMIT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_getsubtreesbyindex_result"),
+    deprecated: false,
+},
+"getrawtransaction" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the raw transaction data, as a [`GetRawTransactionResponse`]\nJSON string or structure.\n\nzcashd reference: [`getrawtransaction`](https://zcash.github.io/rpc/getrawtransaction.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `txid`: (string, required, example=\"mytxid\") The transaction ID of the transaction to be returned.\n- `verbose`: (number, optional, default=0, example=1) If 0, return a string of hex-encoded data, otherwise return a JSON object.\n- `blockhash` (string, optional) The block in which to look for the transaction\n\n# Notes\n\nVerbose transaction output includes `ironwood` only when the transaction\ncontains Ironwood shielded data.\n",
+    params: |_g| vec![
+        _g.param::<String>("txid", crate::methods::PARAM_TXID_DESC, true),
+        _g.param::<u8>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getrawtransaction_result"),
+    deprecated: false,
+},
+"getaddresstxids" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the transaction ids made by the provided transparent addresses.\n\nzcashd reference: [`getaddresstxids`](https://zcash.github.io/rpc/getaddresstxids.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `request`: (required) Either:\n    - A single address string (e.g., `\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"`), or\n    - An object with the following named fields:\n        - `addresses`: (array of strings, required) The addresses to get transactions from.\n        - `start`: (numeric, optional) The lower height to start looking for transactions (inclusive).\n        - `end`: (numeric, optional) The upper height to stop looking for transactions (inclusive).\n\nExample of the object form:\n```json\n{\n  \"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"],\n  \"start\": 1000,\n  \"end\": 2000\n}\n```\n\n# Notes\n\n- Only the multi-argument format is used by lightwalletd and this is what we currently support:\n<https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L97-L102>\n- It is recommended that users call the method with start/end heights such that the response can\'t be too large.\n",
+    params: |_g| vec![
+        _g.param::<GetAddressTxIdsRequest>("request", crate::methods::PARAM_REQUEST_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddresstxids_result"),
+    deprecated: false,
+},
+"getaddressutxos" => openrpsee::openrpc::RpcMethod {
+    description: "Returns all unspent outputs for a list of addresses.\n\nzcashd reference: [`getaddressutxos`](https://zcash.github.io/rpc/getaddressutxos.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `request`: (required) Either:\n    - A single address string (e.g., `\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"`), or\n    - An object with the following named fields:\n        - `addresses`: (array, required, example=[\\\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\\\"]) The addresses to get outputs from.\n        - `chaininfo`: (boolean, optional, default=false) Include chain info with results\n\n# Notes\n\nlightwalletd always uses the multi-address request, without chaininfo:\n<https://github.com/zcash/lightwalletd/blob/master/frontend/service.go#L402>\n",
+    params: |_g| vec![
+        _g.param::<GetAddressUtxosRequest>("request", crate::methods::PARAM_REQUEST_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddressutxos_result"),
+    deprecated: false,
+},
+"stop" => openrpsee::openrpc::RpcMethod {
+    description: "Stop the running zakurad process.\n\n# Notes\n\n- Works for non windows targets only.\n- Works only if the network of the running zakurad process is `Regtest`.\n\nzcashd reference: [`stop`](https://zcash.github.io/rpc/stop.html)\nmethod: post\ntags: control\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("stop_result"),
+    deprecated: false,
+},
+"getblockcount" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the height of the most recent block in the best valid block chain (equivalently,\nthe number of blocks in this chain excluding the genesis block).\n\nzcashd reference: [`getblockcount`](https://zcash.github.io/rpc/getblockcount.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockcount_result"),
+    deprecated: false,
+},
+"getblockhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the hash of the block of a given height iff the index argument correspond\nto a block in the best chain.\n\nzcashd reference: [`getblockhash`](https://zcash-rpc.github.io/getblockhash.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `index`: (numeric, required, example=1) The block index.\n\n# Notes\n\n- If `index` is positive then index = block height.\n- If `index` is negative then -1 is the last known valid block.\n",
+    params: |_g| vec![
+        _g.param::<i32>("index", crate::methods::PARAM_INDEX_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockhash_result"),
+    deprecated: false,
+},
+"getblocktemplate" => openrpsee::openrpc::RpcMethod {
+    description: "Returns a block template for mining new Zcash blocks.\n\n# Parameters\n\n- `jsonrequestobject`: (string, optional) A JSON object containing arguments.\n\nzcashd reference: [`getblocktemplate`](https://zcash-rpc.github.io/getblocktemplate.html)\nmethod: post\ntags: mining\n\n# Notes\n\nArguments to this RPC are currently ignored.\nLong polling, block proposals, server lists, and work IDs are not supported.\n\nMiners can make arbitrary changes to blocks, as long as:\n- the data sent to `submitblock` is a valid Zcash block, and\n- the parent block is a valid block that Zebra already has, or will receive soon.\n\nZebra verifies blocks in parallel, and keeps recent chains in parallel,\nso moving between chains and forking chains is very cheap.\n",
+    params: |_g| vec![
+        _g.param::<GetBlockTemplateParameters>("parameters", crate::methods::PARAM_PARAMETERS_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblocktemplate_result"),
+    deprecated: false,
+},
+"submitblock" => openrpsee::openrpc::RpcMethod {
+    description: "Submits block to the node to be validated and committed.\nReturns the [`SubmitBlockResponse`] for the operation, as a JSON string.\n\nzcashd reference: [`submitblock`](https://zcash.github.io/rpc/submitblock.html)\nmethod: post\ntags: mining\n\n# Parameters\n\n- `hexdata`: (string, required)\n- `jsonparametersobject`: (string, optional) - currently ignored\n\n# Notes\n\n - `jsonparametersobject` holds a single field, workid, that must be included in submissions if provided by the server.\n",
+    params: |_g| vec![
+        _g.param::<HexData>("hex_data", crate::methods::PARAM_HEX_DATA_DESC, true),
+        _g.param::<SubmitBlockParameters>("_parameters", crate::methods::PARAM__PARAMETERS_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("submitblock_result"),
+    deprecated: false,
+},
+"getmininginfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns mining-related information.\n\nzcashd reference: [`getmininginfo`](https://zcash.github.io/rpc/getmininginfo.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getmininginfo_result"),
+    deprecated: false,
+},
+"getnetworksolps" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the estimated network solutions per second based on the last `num_blocks` before\n`height`.\n\nIf `num_blocks` is not supplied, uses 120 blocks. If it is 0 or -1, uses the difficulty\naveraging window.\nIf `height` is not supplied or is -1, uses the tip height.\n\nzcashd reference: [`getnetworksolps`](https://zcash.github.io/rpc/getnetworksolps.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+        _g.param::<i32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, false),
+        _g.param::<i32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworksolps_result"),
+    deprecated: false,
+},
+"getnetworkhashps" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the estimated network solutions per second based on the last `num_blocks` before\n`height`.\n\nThis method name is deprecated, use [`getnetworksolps`](Self::get_network_sol_ps) instead.\nSee that method for details.\n\nzcashd reference: [`getnetworkhashps`](https://zcash.github.io/rpc/getnetworkhashps.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+        _g.param::<i32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, false),
+        _g.param::<i32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworkhashps_result"),
+    deprecated: false,
+},
+"getnetworkinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns an object containing various state info regarding P2P networking.\n\nzcashd reference: [`getnetworkinfo`](https://zcash.github.io/rpc/getnetworkinfo.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworkinfo_result"),
+    deprecated: false,
+},
+"getpeerinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns data about each connected network node.\n\nzcashd reference: [`getpeerinfo`](https://zcash.github.io/rpc/getpeerinfo.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getpeerinfo_result"),
+    deprecated: false,
+},
+"ping" => openrpsee::openrpc::RpcMethod {
+    description: "Requests that a ping be sent to all other nodes, to measure ping time.\n\nResults provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\nPing command is handled in queue with all other commands, so it measures processing backlog, not just network ping.\n\nzcashd reference: [`ping`](https://zcash.github.io/rpc/ping.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("ping_result"),
+    deprecated: false,
+},
+"validateaddress" => openrpsee::openrpc::RpcMethod {
+    description: "Checks if a zcash transparent address of type P2PKH, P2SH or TEX is valid.\nReturns information about the given address if valid.\n\nzcashd reference: [`validateaddress`](https://zcash.github.io/rpc/validateaddress.html)\nmethod: post\ntags: util\n\n# Parameters\n\n- `address`: (string, required) The zcash address to validate.\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("validateaddress_result"),
+    deprecated: false,
+},
+"z_validateaddress" => openrpsee::openrpc::RpcMethod {
+    description: "Checks if a zcash address of type P2PKH, P2SH, TEX, SAPLING or UNIFIED is valid.\nReturns information about the given address if valid.\n\nzcashd reference: [`z_validateaddress`](https://zcash.github.io/rpc/z_validateaddress.html)\nmethod: post\ntags: util\n\n# Parameters\n\n- `address`: (string, required) The zcash address to validate.\n\n# Notes\n\n- No notes\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_validateaddress_result"),
+    deprecated: false,
+},
+"getblocksubsidy" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.\nReturns an error if `height` is less than the height of the first halving for the current network.\n\nzcashd reference: [`getblocksubsidy`](https://zcash.github.io/rpc/getblocksubsidy.html)\nmethod: post\ntags: mining\n\n# Parameters\n\n- `height`: (numeric, optional, example=1) Can be any valid current or future height.\n\n# Notes\n\nIf `height` is not supplied, uses the tip height.\n",
+    params: |_g| vec![
+        _g.param::<u32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblocksubsidy_result"),
+    deprecated: false,
+},
+"getdifficulty" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the proof-of-work difficulty as a multiple of the minimum difficulty.\n\nzcashd reference: [`getdifficulty`](https://zcash.github.io/rpc/getdifficulty.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getdifficulty_result"),
+    deprecated: false,
+},
+"z_listunifiedreceivers" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the list of individual payment addresses given a unified address.\n\nzcashd reference: [`z_listunifiedreceivers`](https://zcash.github.io/rpc/z_listunifiedreceivers.html)\nmethod: post\ntags: wallet\n\n# Parameters\n\n- `address`: (string, required) The zcash unified address to get the list from.\n\n# Notes\n\n- No notes\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_listunifiedreceivers_result"),
+    deprecated: false,
+},
+"invalidateblock" => openrpsee::openrpc::RpcMethod {
+    description: "Invalidates a block if it is not yet finalized, removing it from the non-finalized\nstate if it is present and rejecting it during contextual validation if it is submitted.\n\n# Parameters\n\n- `block_hash`: (hex-encoded block hash, required) The block hash to invalidate.\n",
+    params: |_g| vec![
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("invalidateblock_result"),
+    deprecated: false,
+},
+"reconsiderblock" => openrpsee::openrpc::RpcMethod {
+    description: "Reconsiders a previously invalidated block if it exists in the cache of previously invalidated blocks.\n\n# Parameters\n\n- `block_hash`: (hex-encoded block hash, required) The block hash to reconsider.\n",
+    params: |_g| vec![
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("reconsiderblock_result"),
+    deprecated: false,
+},
+"generate" => openrpsee::openrpc::RpcMethod {
+    description: "Mine blocks immediately. Returns the block hashes of the generated blocks.\n\n# Parameters\n\n- `num_blocks`: (numeric, required, example=1) Number of blocks to be generated.\n\n# Notes\n\nOnly works if the network of the running zakurad process is `Regtest`.\n\nzcashd reference: [`generate`](https://zcash.github.io/rpc/generate.html)\nmethod: post\ntags: generating\n",
+    params: |_g| vec![
+        _g.param::<u32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("generate_result"),
+    deprecated: false,
+},
+"addnode" => openrpsee::openrpc::RpcMethod {
+    description: "Add or remove a node from the address book.\n\n# Parameters\n\n- `addr`: (string, required) The address of the node to add or remove.\n- `command`: (string, required) The command to execute, either \"add\", \"onetry\", or \"remove\".\n\n# Notes\n\nOnly the \"add\" command is currently supported.\n\nzcashd reference: [`addnode`](https://zcash.github.io/rpc/addnode.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+        _g.param::<PeerSocketAddr>("addr", crate::methods::PARAM_ADDR_DESC, true),
+        _g.param::<AddNodeCommand>("command", crate::methods::PARAM_COMMAND_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("addnode_result"),
+    deprecated: false,
+},
+"rpc.discover" => openrpsee::openrpc::RpcMethod {
+    description: "Returns an OpenRPC schema as a description of this service.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("rpc.discover_result"),
+    deprecated: false,
+},
+"gettxout" => openrpsee::openrpc::RpcMethod {
+    description: "Returns details about an unspent transaction output.\n\nzcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `txid`: (string, required, example=\"mytxid\") The transaction ID that contains the output.\n- `n`: (number, required) The output index number.\n- `include_mempool` (bool, optional, default=true) Whether to include the mempool in the search.\n",
+    params: |_g| vec![
+        _g.param::<String>("txid", crate::methods::PARAM_TXID_DESC, true),
+        _g.param::<u32>("n", crate::methods::PARAM_N_DESC, true),
+        _g.param::<bool>("include_mempool", crate::methods::PARAM_INCLUDE_MEMPOOL_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("gettxout_result"),
+    deprecated: false,
+},
+};

--- a/docs/changelog/unreleased/756.md
+++ b/docs/changelog/unreleased/756.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only changes internal RPC artifact generation and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

Normal RPC builds compile protobuf and OpenRPC generators even though their outputs can be checked in and reviewed.

## Solution

Move regeneration to `cargo xtask generate-rpc-artifacts`, include generated OpenRPC source directly, and add a non-mutating CI drift check.

## Testing

- `cargo check -p zakura-rpc -p xtask`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/756.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/756.md` marks this internal-only change as excluded.