### PR TITLE
build(rpc): standardize TLS on ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ tokio-stream = "0.1.17"
 tokio-test = "0.4"
 tokio-util = "0.7.14"
 toml = "1.0"
-tonic = { version = "0.14", features = ["tls-aws-lc"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tonic-reflection = "0.14"

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -123,8 +123,8 @@ zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0"
 ] }
 zakura-script = { path = "../zakura-script", version = "3.2.1-rc0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0" }
-rustls = "0.23.40"
-tokio-rustls = "0.26.4"
+rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
 der = "0.7.10"
 

--- a/crates/zakura-rpc/src/indexer/server.rs
+++ b/crates/zakura-rpc/src/indexer/server.rs
@@ -212,7 +212,7 @@ fn load_mtls_config(tls: IndexerTlsConfig) -> Result<ServerTlsConfig, BoxError> 
 
 /// Ensures tonic TLS connections have a rustls crypto provider.
 pub(crate) fn install_tls_crypto_provider() {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 /// Reads an indexer TLS file with its role included in any error.

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -330,7 +330,7 @@ fn load_tls_config(
         )
     })?;
 
-    let crypto_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let crypto_provider = Arc::new(rustls::crypto::ring::default_provider());
     let config = RustlsServerConfig::builder_with_provider(crypto_provider)
         .with_safe_default_protocol_versions()
         .map_err(|error| format!("could not configure RPC TLS protocol versions: {error}"))?

--- a/docs/changelog/unreleased/758.md
+++ b/docs/changelog/unreleased/758.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only changes the internal TLS provider dependency and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

RPC TLS currently selects AWS-LC while Ring is already required elsewhere, adding a second cryptographic provider and native build toolchain.

## Solution

Select Ring consistently for Tonic, Rustls, and Tokio-Rustls and initialize that provider at both RPC server entrypoints.

## Testing

- `cargo check -p zakura-rpc`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/758.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/758.md` marks this internal-only change as excluded.