### PR TITLE
refactor(state): replace human-bytes formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,12 +2510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
-
-[[package]]
 name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8784,7 +8778,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "howudoin",
- "human_bytes",
  "humantime-serde",
  "indexmap 2.14.0",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ hex-literal = "0.4"
 howudoin = "0.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
-human_bytes = { version = "0.4", default-features = false }
 humantime = "2.2"
 humantime-serde = "1.1"
 hyper = "1.6"

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -51,7 +51,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 humantime-serde = { workspace = true }
-human_bytes = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -47,6 +47,33 @@ use super::{TypedColumnFamily, WriteTypedBatch};
 #[cfg(test)]
 mod tests;
 
+/// Decimal byte units used by database size logs.
+const DECIMAL_BYTE_UNITS: [&str; 7] = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+
+/// Formats an integer byte count with one optional decimal digit.
+fn format_bytes(bytes: u64) -> String {
+    const UNIT_SCALE: u64 = 1_000;
+
+    let mut unit_index = 0;
+    let mut unit_size = 1;
+    while unit_index + 1 < DECIMAL_BYTE_UNITS.len() && bytes >= unit_size * UNIT_SCALE {
+        unit_index += 1;
+        unit_size *= UNIT_SCALE;
+    }
+
+    let rounded_tenths =
+        (u128::from(bytes) * 10 + u128::from(unit_size) / 2) / u128::from(unit_size);
+    let whole_units = rounded_tenths / 10;
+    let fractional_tenth = rounded_tenths % 10;
+    let unit = DECIMAL_BYTE_UNITS[unit_index];
+
+    if fractional_tenth == 0 {
+        format!("{whole_units} {unit}")
+    } else {
+        format!("{whole_units}.{fractional_tenth} {unit}")
+    }
+}
+
 /// The [`rocksdb::ThreadMode`] used by the database.
 pub type DBThreadMode = rocksdb::SingleThreaded;
 
@@ -645,8 +672,8 @@ impl DiskDb {
                 column_families_log_string,
                 "{} (Disk: {}, Memory: {})",
                 cf_name,
-                human_bytes::human_bytes(cf_disk_size as f64),
-                human_bytes::human_bytes(mem_table_size.unwrap_or(0) as f64)
+                format_bytes(cf_disk_size),
+                format_bytes(mem_table_size.unwrap_or(0))
             )
             .unwrap();
         }
@@ -654,15 +681,15 @@ impl DiskDb {
         debug!("{}", column_families_log_string);
         info!(
             "Total Database Disk Size: {}",
-            human_bytes::human_bytes(total_size_on_disk as f64)
+            format_bytes(total_size_on_disk)
         );
         info!(
             "Total Live Data Disk Size: {}",
-            human_bytes::human_bytes(total_live_size_on_disk as f64)
+            format_bytes(total_live_size_on_disk)
         );
         info!(
             "Total Database Memory Size: {}",
-            human_bytes::human_bytes(total_size_in_mem as f64)
+            format_bytes(total_size_in_mem)
         );
     }
 

--- a/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Deref;
 
-use crate::service::finalized_state::disk_db::{DiskDb, DB};
+use crate::service::finalized_state::disk_db::{format_bytes, DiskDb, DB};
 
 // Enable older test code to automatically access the inner database via Deref coercion.
 impl Deref for DiskDb {
@@ -24,6 +24,19 @@ impl DiskDb {
 
         rocksdb::DB::list_cf(&opts, path)
     }
+}
+
+#[test]
+fn format_bytes_preserves_decimal_unit_boundaries() {
+    assert_eq!(format_bytes(0), "0 B");
+    assert_eq!(format_bytes(999), "999 B");
+    assert_eq!(format_bytes(1_000), "1 KB");
+    assert_eq!(format_bytes(1_049), "1 KB");
+    assert_eq!(format_bytes(1_050), "1.1 KB");
+    assert_eq!(format_bytes(999_949), "999.9 KB");
+    assert_eq!(format_bytes(999_950), "1000 KB");
+    assert_eq!(format_bytes(1_000_000), "1 MB");
+    assert_eq!(format_bytes(u64::MAX), "18.4 EB");
 }
 
 /// Check that zs_iter_opts returns an upper bound one greater than provided inclusive end bounds.

--- a/docs/changelog/unreleased/759.md
+++ b/docs/changelog/unreleased/759.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR preserves existing database metric output while replacing an internal formatter.


### PR DESCRIPTION
## Motivation

Database metric logging depends on a floating-point formatting crate for a handful of byte counts.

## Solution

Use a private integer-safe decimal byte formatter and preserve existing operator-visible rounding at unit boundaries.

## Testing

- Focused byte-format boundary test
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/759.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/759.md` marks this output-preserving internal change as excluded.