### PR TITLE
refactor: replace mset with local collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,12 +3640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mset"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c4d16a3d2b0e89ec6e7d509cf791545fcb48cbc8fc2fb2e96a492defda9140"
-
-[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8256,7 +8250,6 @@ dependencies = [
  "lazy_static",
  "libzcash_script",
  "metrics",
- "mset",
  "num-integer",
  "once_cell",
  "proptest",
@@ -8791,7 +8784,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "metrics",
- "mset",
  "once_cell",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,6 @@ libzcash_script = "0.1"
 log = "0.4.27"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
-mset = "0.1"
 nix = "0.31"
 num-integer = "0.1.46"
 once_cell = "1.21"

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -41,8 +41,6 @@ jubjub = { workspace = true }
 rand = { workspace = true }
 rand_10 = { workspace = true }
 rayon = { workspace = true }
-mset.workspace = true
-
 chrono = { workspace = true, features = ["clock", "std"] }
 lazy_static = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -4,7 +4,6 @@ use std::{collections::HashSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
-use mset::MultiSet;
 use zakura_chain::{
     amount::{
         Amount, DeferredPoolBalanceChange, Error as AmountError, NegativeAllowed, NonNegative,
@@ -24,6 +23,32 @@ use zakura_chain::{
 use zakura_header_chain::{CompactTargetError, PowPolicy};
 
 use crate::{error::*, funding_stream_address};
+
+/// Coinbase outputs that have not yet matched a required subsidy payment.
+///
+/// The source transaction bounds this vector through its serialized size limit.
+struct UnmatchedCoinbaseOutputs {
+    outputs: Vec<Output>,
+}
+
+impl UnmatchedCoinbaseOutputs {
+    /// Copies the bounded outputs from a coinbase transaction.
+    fn new(outputs: &[Output]) -> Self {
+        Self {
+            outputs: outputs.to_vec(),
+        }
+    }
+
+    /// Removes one matching output, preserving duplicate output multiplicity.
+    fn remove(&mut self, expected: &Output) -> bool {
+        let Some(index) = self.outputs.iter().position(|output| output == expected) else {
+            return false;
+        };
+
+        self.outputs.remove(index);
+        true
+    }
+}
 
 /// Checks if there is exactly one coinbase transaction in `Block`,
 /// and if that coinbase transaction is the first transaction in the block.
@@ -155,14 +180,13 @@ pub fn subsidy_is_valid(
 
     let height = block.coinbase_height().ok_or(SubsidyError::NoCoinbase)?;
 
-    let mut coinbase_outputs: MultiSet<Output> = block
-        .transactions
-        .first()
-        .ok_or(SubsidyError::NoCoinbase)?
-        .outputs()
-        .iter()
-        .cloned()
-        .collect();
+    let mut coinbase_outputs = UnmatchedCoinbaseOutputs::new(
+        block
+            .transactions
+            .first()
+            .ok_or(SubsidyError::NoCoinbase)?
+            .outputs(),
+    );
 
     let mut has_amount = |addr: &Address, amount| {
         assert!(addr.is_script_hash(), "address must be P2SH");
@@ -439,4 +463,35 @@ pub fn merkle_root_validity(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use zakura_chain::{
+        amount::{Amount, NonNegative},
+        transparent::{Output, Script},
+    };
+
+    use super::UnmatchedCoinbaseOutputs;
+
+    fn output(value: u64) -> Output {
+        let value = Amount::<NonNegative>::try_from(value).expect("test value is a valid amount");
+        Output::new(value, Script::new(&[]))
+    }
+
+    #[test]
+    fn unmatched_coinbase_outputs_remove_one_duplicate_at_a_time() {
+        let repeated_output = output(1);
+        let distinct_output = output(2);
+        let mut outputs = UnmatchedCoinbaseOutputs::new(&[
+            repeated_output.clone(),
+            repeated_output.clone(),
+            distinct_output.clone(),
+        ]);
+
+        assert!(outputs.remove(&repeated_output));
+        assert!(outputs.remove(&repeated_output));
+        assert!(!outputs.remove(&repeated_output));
+        assert!(outputs.remove(&distinct_output));
+    }
 }

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -56,7 +56,6 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
-mset = { workspace = true }
 regex = { workspace = true }
 rlimit = { workspace = true }
 rocksdb = { workspace = true, features = ["lz4"] }

--- a/crates/zakura-state/src/service/non_finalized_state/chain.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use mset::MultiSet;
 use tracing::instrument;
 
 use zakura_chain::{
@@ -43,8 +42,9 @@ use crate::{
 #[cfg(feature = "indexer")]
 use crate::request::Spend;
 
-use self::index::TransparentTransfers;
+use self::{counted_set::CountedSet, index::TransparentTransfers};
 
+mod counted_set;
 pub mod index;
 
 /// A single non-finalized partial chain, from the child of the finalized tip,
@@ -166,7 +166,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) sprout_anchors: MultiSet<sprout::tree::Root>,
+    pub(crate) sprout_anchors: CountedSet<sprout::tree::Root>,
     /// The Sprout anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -177,7 +177,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) sapling_anchors: MultiSet<sapling::tree::Root>,
+    pub(crate) sapling_anchors: CountedSet<sapling::tree::Root>,
     /// The Sapling anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -191,7 +191,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) orchard_anchors: MultiSet<orchard::tree::Root>,
+    pub(crate) orchard_anchors: CountedSet<orchard::tree::Root>,
     /// The Orchard anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -209,7 +209,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) ironwood_anchors: MultiSet<ironwood::tree::Root>,
+    pub(crate) ironwood_anchors: CountedSet<ironwood::tree::Root>,
 
     /// The Ironwood anchors created by each block in `blocks`.
     ///
@@ -278,19 +278,19 @@ impl Chain {
             tx_loc_by_hash: Default::default(),
             created_utxos: Default::default(),
             spent_utxos: Default::default(),
-            sprout_anchors: MultiSet::new(),
+            sprout_anchors: CountedSet::new(),
             sprout_anchors_by_height: Default::default(),
             sprout_trees_by_anchor: Default::default(),
             sprout_trees_by_height: Default::default(),
-            sapling_anchors: MultiSet::new(),
+            sapling_anchors: CountedSet::new(),
             sapling_anchors_by_height: Default::default(),
             sapling_trees_by_height: Default::default(),
             sapling_subtrees: Default::default(),
-            orchard_anchors: MultiSet::new(),
+            orchard_anchors: CountedSet::new(),
             orchard_anchors_by_height: Default::default(),
             orchard_trees_by_height: Default::default(),
             orchard_subtrees: Default::default(),
-            ironwood_anchors: MultiSet::new(),
+            ironwood_anchors: CountedSet::new(),
             ironwood_anchors_by_height: Default::default(),
             ironwood_trees_by_height: Default::default(),
             ironwood_subtrees: Default::default(),

--- a/crates/zakura-state/src/service/non_finalized_state/chain/counted_set.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain/counted_set.rs
@@ -1,0 +1,101 @@
+//! A set that tracks the multiplicity of each distinct value.
+
+use std::{collections::HashMap, hash::Hash};
+
+/// Stores one count for each distinct value.
+///
+/// Removing a value decrements its count and only removes the distinct value
+/// after its final occurrence is removed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CountedSet<T: Eq + Hash> {
+    counts: HashMap<T, usize>,
+}
+
+impl<T> CountedSet<T>
+where
+    T: Eq + Hash,
+{
+    /// Creates an empty counted set.
+    pub(crate) fn new() -> Self {
+        Self {
+            counts: HashMap::new(),
+        }
+    }
+
+    /// Adds one occurrence of `value`.
+    pub(crate) fn insert(&mut self, value: T) {
+        let count = self.counts.entry(value).or_default();
+        *count = count
+            .checked_add(1)
+            .expect("a counted set cannot contain more values than usize::MAX");
+    }
+
+    /// Removes one occurrence of `value`, returning whether it was present.
+    pub(crate) fn remove(&mut self, value: &T) -> bool {
+        let Some(count) = self.counts.get_mut(value) else {
+            return false;
+        };
+
+        if *count > 1 {
+            *count -= 1;
+            return true;
+        }
+
+        self.counts.remove(value);
+        true
+    }
+
+    /// Returns whether at least one occurrence of `value` is present.
+    pub(crate) fn contains(&self, value: &T) -> bool {
+        self.counts.contains_key(value)
+    }
+
+    /// Returns whether the set contains no values.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    /// Iterates over each distinct value once.
+    pub(crate) fn distinct_values(&self) -> impl Iterator<Item = &T> {
+        self.counts.keys()
+    }
+}
+
+impl<T> Default for CountedSet<T>
+where
+    T: Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::CountedSet;
+
+    #[test]
+    fn removal_preserves_multiplicity() {
+        let mut values = CountedSet::new();
+
+        values.insert("repeated");
+        values.insert("repeated");
+        values.insert("distinct");
+
+        assert!(values.remove(&"repeated"));
+        assert!(values.contains(&"repeated"));
+        assert!(values.remove(&"repeated"));
+        assert!(!values.contains(&"repeated"));
+        assert!(!values.remove(&"repeated"));
+
+        assert_eq!(
+            values.distinct_values().copied().collect::<HashSet<_>>(),
+            HashSet::from(["distinct"])
+        );
+        assert!(!values.is_empty());
+        assert!(values.remove(&"distinct"));
+        assert!(values.is_empty());
+    }
+}

--- a/crates/zakura-state/src/service/non_finalized_state/chain/index.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain/index.rs
@@ -5,8 +5,6 @@ use std::{
     ops::RangeInclusive,
 };
 
-use mset::MultiSet;
-
 use zakura_chain::{
     amount::{Amount, NegativeAllowed},
     block::Height,
@@ -15,7 +13,7 @@ use zakura_chain::{
 
 use crate::{OutputLocation, TransactionLocation, ValidateContextError};
 
-use super::{RevertPosition, UpdateWith};
+use super::{counted_set::CountedSet, RevertPosition, UpdateWith};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransparentTransfers {
@@ -30,7 +28,7 @@ pub struct TransparentTransfers {
     /// inconsistencies.
     ///
     /// The `getaddresstxids` RPC needs these transaction IDs to be sorted in chain order.
-    tx_ids: MultiSet<transaction::Hash>,
+    tx_ids: CountedSet<transaction::Hash>,
 
     /// The partial list of UTXOs received by a transparent address.
     ///
@@ -257,7 +255,7 @@ impl TransparentTransfers {
         query_height_range: RangeInclusive<Height>,
     ) -> BTreeMap<TransactionLocation, transaction::Hash> {
         self.tx_ids
-            .distinct_elements()
+            .distinct_values()
             .filter_map(|tx_hash| {
                 let tx_loc = *chain_tx_loc_by_hash
                     .get(tx_hash)

--- a/docs/changelog/unreleased/761.md
+++ b/docs/changelog/unreleased/761.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR preserves collection semantics while replacing an internal dependency.


### PR DESCRIPTION
## Motivation

Consensus and non-finalized state use a single-purpose multiset dependency for small, bounded operations.

## Solution

Use a bounded coinbase-output matcher and a domain-named counted set that preserves duplicate insertion and removal semantics.

## Testing

- Focused consensus duplicate-output test
- Focused state multiplicity test
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/761.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/761.md` marks this semantics-preserving internal change as excluded.