### PR TITLE
build: remove stale dependencies and narrow features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,7 +4243,6 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -8046,7 +8045,6 @@ name = "zakura"
 version = "1.3.0-rc0"
 dependencies = [
  "abscissa_core",
- "anyhow",
  "bytes",
  "chrono",
  "clap",
@@ -8076,7 +8074,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "nix",
  "num-integer",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -8093,8 +8090,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "strum",
- "strum_macros",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -8121,7 +8116,6 @@ dependencies = [
  "zakura-consensus",
  "zakura-header-chain",
  "zakura-jsonl-trace",
- "zakura-keys",
  "zakura-network",
  "zakura-node-services",
  "zakura-rpc",
@@ -8201,7 +8195,6 @@ dependencies = [
  "rand 0.10.2",
  "rand 0.8.6",
  "rand_chacha 0.10.0",
- "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rayon",
@@ -8232,7 +8225,6 @@ dependencies = [
  "zakura-sinsemilla",
  "zakura-test",
  "zcash_address",
- "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
  "zcash_protocol",
@@ -8257,7 +8249,6 @@ dependencies = [
  "libzcash_script",
  "metrics",
  "mset",
- "num-integer",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -8271,15 +8262,12 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tower 0.4.13",
  "tracing",
- "tracing-error",
  "tracing-futures",
- "tracing-subscriber",
  "zakura-bellman",
  "zakura-bls12-381",
  "zakura-chain",
  "zakura-halo2-proofs",
  "zakura-header-chain",
- "zakura-jubjub",
  "zakura-node-services",
  "zakura-orchard",
  "zakura-primitives",
@@ -8424,7 +8412,6 @@ dependencies = [
 name = "zakura-network"
 version = "7.0.0-rc0"
 dependencies = [
- "anyhow",
  "bitflags",
  "blake2b_simd",
  "byteorder",
@@ -8474,7 +8461,6 @@ dependencies = [
 name = "zakura-node-services"
 version = "3.2.1-rc0"
 dependencies = [
- "color-eyre",
  "jsonrpsee-types",
  "reqwest 0.12.28",
  "serde",
@@ -8694,7 +8680,6 @@ dependencies = [
  "zakura-node-services",
  "zakura-orchard",
  "zakura-primitives",
- "zakura-proofs",
  "zakura-sapling-crypto",
  "zakura-script",
  "zakura-state",
@@ -8779,7 +8764,6 @@ dependencies = [
  "crossbeam-channel",
  "derive-getters",
  "derive-new",
- "dirs",
  "futures",
  "hex",
  "hex-literal",
@@ -8815,7 +8799,6 @@ dependencies = [
  "zakura-chain",
  "zakura-halo2-proofs",
  "zakura-header-chain",
- "zakura-jubjub",
  "zakura-node-services",
  "zakura-orchard",
  "zakura-sapling-crypto",
@@ -8899,9 +8882,7 @@ dependencies = [
  "tracing-subscriber",
  "zakura-chain",
  "zakura-node-services",
- "zakura-primitives",
  "zakura-state",
- "zcash_protocol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8882,6 +8882,7 @@ dependencies = [
  "tracing-subscriber",
  "zakura-chain",
  "zakura-node-services",
+ "zakura-primitives",
  "zakura-state",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,13 @@ incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = { version = "1.0.0-rc.2", package = "zakura-orchard" }
 sapling-crypto = { version = "1.0.0-rc.2", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
-zcash_encoding = "0.4"
 zcash_history = "0.5.0"
 zcash_keys = { version = "1.0.0-rc.2", package = "zakura-keys" }
 zcash_primitives = { version = "1.0.0-rc.2", package = "zakura-primitives" }
 zcash_proofs = { version = "1.0.0-rc.2", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
-abscissa_core = "0.7"
+abscissa_core = { version = "0.7", default-features = false }
 base64 = "0.22.1"
 bech32 = "0.11.0"
 bellman = { version = "1.0.0-rc.2", package = "zakura-bellman" }
@@ -162,9 +161,9 @@ tracing-journald = "0.3"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.4"
 tracing-opentelemetry = "0.33"
-opentelemetry = "0.32"
-opentelemetry_sdk = "0.32.1"
-opentelemetry-otlp = "0.32"
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false }
 uint = "0.10"
 vergen-gitcl = { version = "9", default-features = false }
 x25519-dalek = "2.0.1"

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -27,7 +27,7 @@ json-conversion = [
 
 # Async error handling convenience traits
 async-error = [
-    "tokio",
+    "tokio/rt",
 ]
 
 # Experimental internal miner support
@@ -38,8 +38,8 @@ internal-miner = ["equihash/solver"]
 proptest-impl = [
     "proptest",
     "proptest-derive",
-    "rand",
-    "rand_chacha",
+    "rand_chacha_10",
+    "rand_core_10",
     "tokio/tracing",
     "zakura-test",
 ]
@@ -68,9 +68,8 @@ dirs = { workspace = true }
 num-integer = { workspace = true }
 primitive-types = { workspace = true }
 rand_core = { workspace = true }
-rand_10 = { workspace = true }
-rand_chacha_10 = { workspace = true }
-rand_core_10 = { workspace = true }
+rand_chacha_10 = { workspace = true, optional = true }
+rand_core_10 = { workspace = true, optional = true }
 ripemd = { workspace = true }
 # Matches version used by hdwallet
 secp256k1 = { workspace = true, features = ["serde"] }
@@ -84,7 +83,6 @@ zcash_script.workspace = true
 # ECC deps
 halo2 = { workspace = true }
 orchard.workspace = true
-zcash_encoding.workspace = true
 zcash_history.workspace = true
 zcash_note_encryption = { workspace = true }
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
@@ -113,7 +111,7 @@ serde-big-array = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 rayon = { workspace = true }
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
 
 # ZF deps
 ed25519-zebra = { workspace = true }
@@ -130,9 +128,6 @@ tokio = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-rand = { workspace = true, optional = true }
-rand_chacha = { workspace = true, optional = true }
-
 zakura-test = { path = "../zakura-test/", version = "2.1.0", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
@@ -143,14 +138,15 @@ criterion = { workspace = true, features = ["html_reports"] }
 # Error Handling & Formatting
 color-eyre = { workspace = true }
 spandoc = { workspace = true }
-tracing = { workspace = true }
 
 # Make the optional testing dependencies required
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
 rand = { workspace = true }
-rand_chacha = { workspace = true }
+rand_10 = { workspace = true }
+rand_chacha_10 = { workspace = true }
+rand_core_10 = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -37,7 +37,6 @@ blake2b_simd = { workspace = true }
 bellman = { workspace = true }
 bls12_381 = { workspace = true }
 halo2 = { workspace = true }
-jubjub = { workspace = true }
 rand = { workspace = true }
 rand_10 = { workspace = true }
 rayon = { workspace = true }
@@ -88,15 +87,12 @@ proptest-derive = { workspace = true, optional = true }
 color-eyre = { workspace = true }
 
 hex = { workspace = true }
-num-integer = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 spandoc = { workspace = true }
 toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
-tracing-error = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0", features = ["proptest-impl"] }
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = ["proptest-impl"] }

--- a/crates/zakura-consensus/src/primitives/groth16.rs
+++ b/crates/zakura-consensus/src/primitives/groth16.rs
@@ -137,7 +137,7 @@ impl Item {
     /// Encodes the primary input for the JoinSplit proof statement as Bls12_381 base
     /// field elements, to match [`bellman::groth16::verify_proof()`].
     ///
-    /// NB: [`jubjub::Fq`] is a type alias for [`bls12_381::Scalar`].
+    /// NB: Jubjub's base field is a type alias for [`bls12_381::Scalar`].
     ///
     /// `joinsplit_pub_key`: the JoinSplit public validation key for this JoinSplit, from
     /// the transaction. (All JoinSplits in a transaction share the same validation key.)

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -64,7 +64,6 @@ regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 futures = { workspace = true }
@@ -91,11 +90,11 @@ zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0-rc0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 criterion = { workspace = true }
 
+tempfile = { workspace = true }
 static_assertions = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -22,7 +22,11 @@ default = []
 
 # Tool and test features
 
+# Retain the published feature name after removing its unused dependency.
+color-eyre = []
+
 rpc-client = [
+    "color-eyre",
     "jsonrpsee-types",
     "reqwest",
     "serde",

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -23,7 +23,6 @@ default = []
 # Tool and test features
 
 rpc-client = [
-    "color-eyre",
     "jsonrpsee-types",
     "reqwest",
     "serde",
@@ -38,7 +37,6 @@ tower = { workspace = true }
 # Optional dependencies
 
 # Tool and test feature rpc-client
-color-eyre = { workspace = true, optional = true }
 jsonrpsee-types = { workspace = true, optional = true }
 # Security: avoid default dependency on openssl
 reqwest = { workspace = true, features = ["rustls-tls"], optional = true }
@@ -48,7 +46,6 @@ tokio = { workspace = true, features = ["time", "sync"] }
 
 [dev-dependencies]
 
-color-eyre = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -35,7 +35,6 @@ internal-miner = []
 
 # Test-only features
 proptest-impl = [
-    "proptest",
     "zakura-consensus/proptest-impl",
     "zakura-state/proptest-impl",
     "zakura-network/proptest-impl",
@@ -105,13 +104,9 @@ sapling-crypto = { workspace = true }
 zcash_address = { workspace = true }
 zcash_keys = { workspace = true, features = ["orchard", "sapling"] }
 zcash_primitives = { workspace = true, features = ["transparent-inputs", "non-standard-fees"] }
-zcash_proofs = { workspace = true }
 zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
-
-# Test-only feature proptest-impl
-proptest = { workspace = true, optional = true }
 
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = [
     "json-conversion",

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -39,14 +39,12 @@ header-fuzz = []
 proptest-impl = [
     "proptest",
     "proptest-derive",
-    "zakura-test",
     "zakura-chain/proptest-impl"
 ]
 
 [dependencies]
 bincode = { workspace = true }
 chrono = { workspace = true, features = ["clock", "std"] }
-dirs = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
@@ -83,7 +81,6 @@ zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "2.1.0", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -106,7 +103,6 @@ proptest-derive = { workspace = true }
 rand = { workspace = true }
 
 halo2 = { workspace = true }
-jubjub = { workspace = true }
 orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }

--- a/crates/zakura-state/src/config.rs
+++ b/crates/zakura-state/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
     /// Storage mode is controlled separately by [`storage_mode`](Config::storage_mode).
     ///
     /// The default directory is platform dependent, based on
-    /// [`dirs::cache_dir()`](https://docs.rs/dirs/3.0.1/dirs/fn.cache_dir.html):
+    /// [the platform cache directory](https://docs.rs/dirs/3.0.1/dirs/fn.cache_dir.html):
     ///
     /// |Platform | Value                                           | Example                              |
     /// | ------- | ----------------------------------------------- | ------------------------------------ |

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -31,9 +31,15 @@ default = []
 # Each binary has a feature that activates the extra dependencies it needs
 
 zakura-checkpoints = [
-    "clap",
-    "itertools",
-    "tokio",
+    "dep:clap",
+    "dep:color-eyre",
+    "dep:hex",
+    "dep:itertools",
+    "dep:serde_json",
+    "dep:thiserror",
+    "dep:tokio",
+    "dep:zakura-chain",
+    "dep:zakura-node-services",
     "zakura-chain/json-conversion",
     "zakura-node-services/rpc-client"
 ]
@@ -49,23 +55,23 @@ zakura-checkpoints-offline = [
 search-issue-refs = [
     "regex",
     "reqwest",
-    "tokio"
+    "dep:tokio"
 ]
 regex = []
 reqwest = []
 
 [dependencies]
-color-eyre = { workspace = true }
+color-eyre = { workspace = true, optional = true }
 
 clap = { workspace = true, features = ["derive"], optional = true }
-hex = { workspace = true }
-serde_json = { workspace = true }
+hex = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
-thiserror = { workspace = true }
+thiserror = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
@@ -74,10 +80,7 @@ itertools = { workspace = true, optional = true }
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
-tokio = { workspace = true, features = ["full"], optional = true }
-
-zcash_primitives = { workspace = true, optional = true }
-zcash_protocol.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -31,13 +31,13 @@ default = []
 # Each binary has a feature that activates the extra dependencies it needs
 
 zakura-checkpoints = [
-    "dep:clap",
+    "clap",
     "dep:color-eyre",
     "dep:hex",
-    "dep:itertools",
+    "itertools",
     "dep:serde_json",
     "dep:thiserror",
-    "dep:tokio",
+    "tokio",
     "dep:zakura-chain",
     "dep:zakura-node-services",
     "zakura-chain/json-conversion",
@@ -52,13 +52,17 @@ zakura-checkpoints-offline = [
 ]
 
 # Preserve published feature names after removing the obsolete developer tools.
+clap = ["dep:clap"]
+itertools = ["dep:itertools"]
 search-issue-refs = [
     "regex",
     "reqwest",
-    "dep:tokio"
+    "tokio"
 ]
 regex = []
 reqwest = []
+tokio = ["dep:tokio"]
+zcash_primitives = ["dep:zcash_primitives"]
 
 [dependencies]
 color-eyre = { workspace = true, optional = true }
@@ -81,6 +85,8 @@ zakura-state = { path = "../zakura-state", version = "7.0.0-rc0", optional = tru
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
+
+zcash_primitives = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -185,7 +185,7 @@ zcash_script = { workspace = true }
 # Required for crates.io publishing, but it's only used in tests
 zakura-utils = { path = "../zakura-utils", version = "2.2.1-rc0", optional = true }
 
-abscissa_core = { workspace = true }
+abscissa_core = { workspace = true, default-features = false, features = ["application"] }
 clap = { workspace = true, features = ["cargo"] }
 chrono = { workspace = true, features = ["clock", "std"] }
 humantime-serde = { workspace = true }
@@ -239,7 +239,7 @@ nix = { workspace = true, features = ["fs"] }
 thread-priority = { workspace = true, optional = true }
 
 # prod feature sentry
-sentry = { workspace = true, features = ["backtrace", "contexts", "logs", "rustls", "tracing", "ureq"], optional = true }
+sentry = { workspace = true, features = ["backtrace", "logs", "rustls", "tracing", "ureq"], optional = true }
 
 # prod feature flamegraph
 tracing-flame = { workspace = true, optional = true }
@@ -287,30 +287,19 @@ vergen-gitcl = { workspace = true, features = ["cargo", "rustc"] }
 tonic-prost-build = { workspace = true, optional = true }
 
 [dev-dependencies]
-abscissa_core = { workspace = true, features = ["testing"] }
-anyhow = { workspace = true }
+abscissa_core = { workspace = true, default-features = false, features = ["testing"] }
 hex-literal = { workspace = true }
 jsonrpsee-types = { workspace = true }
-once_cell = { workspace = true }
 regex = { workspace = true }
 insta = { workspace = true, features = ["json"] }
-bytes = { workspace = true }
-http-body-util = { workspace = true }
-hyper-util = { workspace = true }
-strum = { workspace = true }
-strum_macros = { workspace = true }
 
 # zakura-rpc needs the preserve_order feature, it also makes test results more stable
 serde_json = { workspace = true, features = ["preserve_order"] }
-tempfile = { workspace = true }
-
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-stream = { workspace = true }
-
-zcash_keys = { workspace = true }
 
 # test feature lightwalletd-grpc-tests
 prost = { workspace = true }
@@ -319,9 +308,6 @@ tonic-prost = { workspace = true }
 
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-
-# enable span traces and track caller in tests
-color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0-rc0", features = ["proptest-impl"] }

--- a/docs/changelog/unreleased/762.md
+++ b/docs/changelog/unreleased/762.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only narrows internal dependency declarations and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

Workspace manifests retain unused declarations and enable test, utility, telemetry, and runtime features more broadly than their consumers require.

## Solution

Remove stale dependencies and scope optional features to the binaries, tests, and telemetry paths that use them.

## Testing

- `cargo check --workspace --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`
- `markdownlint docs/changelog/unreleased/762.md --config .github/.markdownlint.yaml`

## Changelog

`docs/changelog/unreleased/762.md` marks this internal-only change as excluded.