### PR TITLE
build: reduce dependency surface

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Check locked all-feature build
         if: ${{ !cancelled() }}
         run: cargo check --locked --all-features --all-targets
+      - name: Check generated RPC artifacts
+        if: ${{ !cancelled() }}
+        run: cargo xtask check-rpc-artifacts
 
   # NOTE: per-crate default / no-default-features checks moved to
   # `test-crates.yml`, which runs `cargo hack check --workspace` (and again with

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Run Codex
         id: codex
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 #v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 #v1.11
         with:
           openai-api-key: ${{ secrets.CODEX_API_KEY }}
           prompt-file: .github/upstream-sync/prompts/adapt-pr.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,15 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
-
-[[package]]
 name = "bounded-integer"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,43 +621,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "canonical-path"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "cast"
@@ -1307,36 +1265,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1354,22 +1288,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -1442,37 +1365,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -1566,16 +1458,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "objc2",
 ]
 
 [[package]]
@@ -2437,17 +2319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,12 +2379,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "human_bytes"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
 
 [[package]]
 name = "humantime"
@@ -3640,12 +3505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mset"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c4d16a3d2b0e89ec6e7d509cf791545fcb48cbc8fc2fb2e96a492defda9140"
-
-[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,178 +3860,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-ui-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
-dependencies = [
- "bitflags",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
 
 [[package]]
 name = "object"
@@ -4243,7 +3934,6 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -4320,22 +4010,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_info"
-version = "3.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
-dependencies = [
- "android_system_properties",
- "log",
- "nix",
- "objc2",
- "objc2-foundation",
- "objc2-ui-kit",
- "serde",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "owo-colors"
@@ -5769,7 +5443,6 @@ dependencies = [
  "reqwest 0.13.4",
  "rustls",
  "sentry-backtrace",
- "sentry-contexts",
  "sentry-core",
  "sentry-log",
  "sentry-tracing",
@@ -5785,20 +5458,6 @@ dependencies = [
  "backtrace",
  "regex",
  "sentry-core",
-]
-
-[[package]]
-name = "sentry-contexts"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
-dependencies = [
- "hostname",
- "libc",
- "os_info",
- "rustc_version",
- "sentry-core",
- "uname",
 ]
 
 [[package]]
@@ -5976,7 +5635,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -6525,9 +6184,7 @@ checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -7131,15 +6788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7282,46 +6930,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
- "rustc_version",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
 
 [[package]]
 name = "version_check"
@@ -7546,15 +7154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -8006,10 +7605,12 @@ dependencies = [
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "openrpsee",
  "serde",
  "sha2 0.10.9",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -8046,7 +7647,6 @@ name = "zakura"
 version = "1.3.0-rc0"
 dependencies = [
  "abscissa_core",
- "anyhow",
  "bytes",
  "chrono",
  "clap",
@@ -8075,8 +7675,6 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "nix",
- "num-integer",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -8093,8 +7691,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "strum",
- "strum_macros",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -8111,17 +7707,14 @@ dependencies = [
  "tracing-appender",
  "tracing-error",
  "tracing-flame",
- "tracing-futures",
  "tracing-journald",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
- "vergen-gitcl",
  "zakura-chain",
  "zakura-consensus",
  "zakura-header-chain",
  "zakura-jsonl-trace",
- "zakura-keys",
  "zakura-network",
  "zakura-node-services",
  "zakura-rpc",
@@ -8194,14 +7787,12 @@ dependencies = [
  "incrementalmerkletree",
  "itertools 0.14.0",
  "lazy_static",
- "num-integer",
  "primitive-types",
  "proptest",
  "proptest-derive",
  "rand 0.10.2",
  "rand 0.8.6",
  "rand_chacha 0.10.0",
- "rand_chacha 0.3.1",
  "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rayon",
@@ -8214,7 +7805,6 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "spandoc",
- "static_assertions",
  "strum",
  "tempfile",
  "thiserror 2.0.18",
@@ -8232,7 +7822,6 @@ dependencies = [
  "zakura-sinsemilla",
  "zakura-test",
  "zcash_address",
- "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
  "zcash_protocol",
@@ -8256,8 +7845,6 @@ dependencies = [
  "lazy_static",
  "libzcash_script",
  "metrics",
- "mset",
- "num-integer",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -8271,15 +7858,11 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tower 0.4.13",
  "tracing",
- "tracing-error",
- "tracing-futures",
- "tracing-subscriber",
  "zakura-bellman",
  "zakura-bls12-381",
  "zakura-chain",
  "zakura-halo2-proofs",
  "zakura-header-chain",
- "zakura-jubjub",
  "zakura-node-services",
  "zakura-orchard",
  "zakura-primitives",
@@ -8424,7 +8007,6 @@ dependencies = [
 name = "zakura-network"
 version = "7.0.0-rc0"
 dependencies = [
- "anyhow",
  "bitflags",
  "blake2b_simd",
  "byteorder",
@@ -8441,7 +8023,6 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "metrics",
- "num-integer",
  "pin-project",
  "proptest",
  "proptest-derive",
@@ -8451,7 +8032,6 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "static_assertions",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -8461,7 +8041,6 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "tracing-error",
- "tracing-futures",
  "tracing-subscriber",
  "zakura-chain",
  "zakura-header-chain",
@@ -8474,7 +8053,6 @@ dependencies = [
 name = "zakura-node-services"
 version = "3.2.1-rc0"
 dependencies = [
- "color-eyre",
  "jsonrpsee-types",
  "reqwest 0.12.28",
  "serde",
@@ -8682,11 +8260,9 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "tonic-reflection",
  "tower 0.4.13",
  "tracing",
- "which",
  "zakura-chain",
  "zakura-consensus",
  "zakura-keys",
@@ -8694,7 +8270,6 @@ dependencies = [
  "zakura-node-services",
  "zakura-orchard",
  "zakura-primitives",
- "zakura-proofs",
  "zakura-sapling-crypto",
  "zakura-script",
  "zakura-state",
@@ -8779,19 +8354,16 @@ dependencies = [
  "crossbeam-channel",
  "derive-getters",
  "derive-new",
- "dirs",
  "futures",
  "hex",
  "hex-literal",
  "howudoin",
- "human_bytes",
  "humantime-serde",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
  "lazy_static",
  "metrics",
- "mset",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -8815,7 +8387,6 @@ dependencies = [
  "zakura-chain",
  "zakura-halo2-proofs",
  "zakura-header-chain",
- "zakura-jubjub",
  "zakura-node-services",
  "zakura-orchard",
  "zakura-sapling-crypto",
@@ -8901,20 +8472,20 @@ dependencies = [
  "zakura-node-services",
  "zakura-primitives",
  "zakura-state",
- "zcash_protocol",
 ]
 
 [[package]]
 name = "zakura-watchdog"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "clap",
- "reqwest 0.12.28",
  "sentry",
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,13 @@ incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = { version = "1.0.0-rc.2", package = "zakura-orchard" }
 sapling-crypto = { version = "1.0.0-rc.2", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
-zcash_encoding = "0.4"
 zcash_history = "0.5.0"
 zcash_keys = { version = "1.0.0-rc.2", package = "zakura-keys" }
 zcash_primitives = { version = "1.0.0-rc.2", package = "zakura-primitives" }
 zcash_proofs = { version = "1.0.0-rc.2", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
-abscissa_core = "0.7"
+abscissa_core = { version = "0.7", default-features = false }
 base64 = "0.22.1"
 bech32 = "0.11.0"
 bellman = { version = "1.0.0-rc.2", package = "zakura-bellman" }
@@ -77,7 +76,6 @@ hex-literal = "0.4"
 howudoin = "0.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
-human_bytes = { version = "0.4", default-features = false }
 humantime = "2.2"
 humantime-serde = "1.1"
 hyper = "1.6"
@@ -97,9 +95,7 @@ libzcash_script = "0.1"
 log = "0.4.27"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
-mset = "0.1"
 nix = "0.31"
-num-integer = "0.1.46"
 once_cell = "1.21"
 openrpsee = "0.1.0"
 owo-colors = "4.2.0"
@@ -134,7 +130,6 @@ sha2 = "0.10"
 schemars = "1"
 sinsemilla = { version = "1.0.0-rc.2", package = "zakura-sinsemilla" }
 spandoc = "0.2"
-static_assertions = "1.1"
 anyhow = "1.0"
 strum = "0.27"
 strum_macros = "0.27"
@@ -147,7 +142,7 @@ tokio-stream = "0.1.17"
 tokio-test = "0.4"
 tokio-util = "0.7.14"
 toml = "1.0"
-tonic = { version = "0.14", features = ["tls-aws-lc"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
 tonic-reflection = "0.14"
@@ -162,16 +157,14 @@ tracing-journald = "0.3"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.4"
 tracing-opentelemetry = "0.33"
-opentelemetry = "0.32"
-opentelemetry_sdk = "0.32.1"
-opentelemetry-otlp = "0.32"
+opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", default-features = false }
 uint = "0.10"
-vergen-gitcl = { version = "9", default-features = false }
 x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"
 zcash_script = "0.4.5"
 config = { version = "0.15.14", default-features = false, features = ["toml"] }
-which = "8.0.0"
 
 # All cargo-release configuration lives in this table. Do not add a root
 # release.toml: it would silently shadow every setting here (cargo-release

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -15,9 +15,9 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
+openrpsee.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
-toml.workspace = true
-
-[dev-dependencies]
 tempfile.workspace = true
+toml.workspace = true
+tonic-prost-build.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 
 mod header_conformance;
 mod header_fuzz;
+mod rpc_artifacts;
 
 const DEFAULT_FEATURES: &str = "default-release-binaries";
 const DEFAULT_UBUNTU_IMAGE: &str = "ubuntu:22.04";
@@ -61,6 +62,24 @@ fn try_main() -> Result<(), BoxError> {
                 )));
             }
             header_fuzz::minimize(&repo_root()?, Path::new(&artifact))
+        }
+        Some("generate-rpc-artifacts") => {
+            if args.next().is_some() {
+                return Err(Box::new(UsageError(
+                    "`cargo xtask generate-rpc-artifacts` does not accept arguments",
+                )));
+            }
+
+            rpc_artifacts::update(&repo_root()?)
+        }
+        Some("check-rpc-artifacts") => {
+            if args.next().is_some() {
+                return Err(Box::new(UsageError(
+                    "`cargo xtask check-rpc-artifacts` does not accept arguments",
+                )));
+            }
+
+            rpc_artifacts::check(&repo_root()?)
         }
         Some("-h" | "--help") | None => {
             if args.next().is_some() {
@@ -263,6 +282,8 @@ fn print_usage(output: &mut impl fmt::Write) -> fmt::Result {
     writeln!(output, "  cargo xtask package ubuntu")?;
     writeln!(output, "  cargo xtask header-conformance [LC-…]")?;
     writeln!(output, "  cargo xtask minimize-header-fuzz <artifact>")?;
+    writeln!(output, "  cargo xtask generate-rpc-artifacts")?;
+    writeln!(output, "  cargo xtask check-rpc-artifacts")?;
     writeln!(output)?;
     writeln!(
         output,
@@ -286,5 +307,11 @@ fn print_usage(output: &mut impl fmt::Write) -> fmt::Result {
     writeln!(
         output,
         "its SHA-256, decoded bounded operations, and a deterministic Rust regression."
-    )
+    )?;
+    writeln!(output)?;
+    writeln!(
+        output,
+        "Regenerates deterministic protobuf and OpenRPC source artifacts, or checks that"
+    )?;
+    writeln!(output, "the checked-in artifacts are current.")
 }

--- a/crates/xtask/src/rpc_artifacts.rs
+++ b/crates/xtask/src/rpc_artifacts.rs
@@ -1,0 +1,94 @@
+use std::{fs, path::Path};
+
+use crate::BoxError;
+
+const INDEXER_PROTO: &str = "crates/zakura-rpc/proto/indexer.proto";
+const RPC_CRATE: &str = "crates/zakura-rpc";
+const METHODS_SOURCE: &str = "crates/zakura-rpc/src/methods.rs";
+const OPENRPC_ARTIFACT: &str = "crates/zakura-rpc/src/methods/rpc_openrpc.rs";
+
+const GENERATED_FILES: [(&str, &str); 3] = [
+    (
+        "indexer_descriptor.bin",
+        "crates/zakura-rpc/proto/__generated__/indexer_descriptor.bin",
+    ),
+    (
+        "zebra.indexer.rpc.rs",
+        "crates/zakura-rpc/proto/__generated__/zebra.indexer.rpc.rs",
+    ),
+    ("rpc_openrpc.rs", OPENRPC_ARTIFACT),
+];
+
+pub fn update(repo_root: &Path) -> Result<(), BoxError> {
+    compare_generated_artifacts(repo_root, true)
+}
+
+pub fn check(repo_root: &Path) -> Result<(), BoxError> {
+    compare_generated_artifacts(repo_root, false)
+}
+
+fn compare_generated_artifacts(repo_root: &Path, update: bool) -> Result<(), BoxError> {
+    let first_dir = tempfile::tempdir()?;
+    let second_dir = tempfile::tempdir()?;
+
+    generate(repo_root, first_dir.path())?;
+    generate(repo_root, second_dir.path())?;
+
+    for (file_name, checked_in_path) in GENERATED_FILES {
+        let first = fs::read(first_dir.path().join(file_name))?;
+        let second = fs::read(second_dir.path().join(file_name))?;
+
+        if first != second {
+            return Err(
+                format!("RPC artifact generation is not deterministic: {file_name}").into(),
+            );
+        }
+
+        let checked_in_path = repo_root.join(checked_in_path);
+        if fs::read(&checked_in_path).ok().as_deref() == Some(first.as_slice()) {
+            println!("unchanged {}", checked_in_path.display());
+        } else if !update {
+            return Err(format!(
+                "checked-in RPC artifact is stale: {}; run `cargo xtask generate-rpc-artifacts`",
+                checked_in_path.display()
+            )
+            .into());
+        } else {
+            fs::write(&checked_in_path, first)?;
+            println!("updated {}", checked_in_path.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn generate(repo_root: &Path, output_dir: &Path) -> Result<(), BoxError> {
+    let proto_file = repo_root.join(INDEXER_PROTO);
+    let rpc_crate = repo_root.join(RPC_CRATE);
+
+    tonic_prost_build::configure()
+        .emit_rerun_if_changed(false)
+        .out_dir(output_dir)
+        .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
+        .file_descriptor_set_path(output_dir.join("indexer_descriptor.bin"))
+        .compile_protos(&[proto_file], &[rpc_crate])?;
+
+    let methods_source = repo_root.join(METHODS_SOURCE);
+    let methods_source = methods_source
+        .to_str()
+        .ok_or("RPC methods source path should be valid UTF-8")?;
+    openrpsee::generate_openrpc(methods_source, &["Rpc"], false, output_dir)?;
+
+    verify_generated_files(output_dir)
+}
+
+fn verify_generated_files(output_dir: &Path) -> Result<(), BoxError> {
+    for (file_name, _) in GENERATED_FILES {
+        let path = output_dir.join(file_name);
+        if !path.is_file() {
+            return Err(format!("generator did not produce {}", path.display()).into());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -27,7 +27,7 @@ json-conversion = [
 
 # Async error handling convenience traits
 async-error = [
-    "tokio",
+    "tokio/rt",
 ]
 
 # Experimental internal miner support
@@ -38,8 +38,8 @@ internal-miner = ["equihash/solver"]
 proptest-impl = [
     "proptest",
     "proptest-derive",
-    "rand",
-    "rand_chacha",
+    "rand_chacha_10",
+    "rand_core_10",
     "tokio/tracing",
     "zakura-test",
 ]
@@ -65,12 +65,10 @@ group = { workspace = true }
 incrementalmerkletree.workspace = true
 jubjub = { workspace = true }
 dirs = { workspace = true }
-num-integer = { workspace = true }
 primitive-types = { workspace = true }
 rand_core = { workspace = true }
-rand_10 = { workspace = true }
-rand_chacha_10 = { workspace = true }
-rand_core_10 = { workspace = true }
+rand_chacha_10 = { workspace = true, optional = true }
+rand_core_10 = { workspace = true, optional = true }
 ripemd = { workspace = true }
 # Matches version used by hdwallet
 secp256k1 = { workspace = true, features = ["serde"] }
@@ -84,7 +82,6 @@ zcash_script.workspace = true
 # ECC deps
 halo2 = { workspace = true }
 orchard.workspace = true
-zcash_encoding.workspace = true
 zcash_history.workspace = true
 zcash_note_encryption = { workspace = true }
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
@@ -99,7 +96,6 @@ chrono = { workspace = true, features = ["clock", "std", "serde"] }
 humantime = { workspace = true }
 
 # Error Handling & Formatting
-static_assertions = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
@@ -113,7 +109,7 @@ serde-big-array = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 rayon = { workspace = true }
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
 
 # ZF deps
 ed25519-zebra = { workspace = true }
@@ -130,9 +126,6 @@ tokio = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-rand = { workspace = true, optional = true }
-rand_chacha = { workspace = true, optional = true }
-
 zakura-test = { path = "../zakura-test/", version = "2.1.0", optional = true }
 bounded-vec = { version = "0.9.0", features = ["serde"] }
 
@@ -143,14 +136,15 @@ criterion = { workspace = true, features = ["html_reports"] }
 # Error Handling & Formatting
 color-eyre = { workspace = true }
 spandoc = { workspace = true }
-tracing = { workspace = true }
 
 # Make the optional testing dependencies required
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
 rand = { workspace = true }
-rand_chacha = { workspace = true }
+rand_10 = { workspace = true }
+rand_chacha_10 = { workspace = true }
+rand_core_10 = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 

--- a/crates/zakura-chain/src/orchard/shielded_data.rs
+++ b/crates/zakura-chain/src/orchard/shielded_data.rs
@@ -232,7 +232,9 @@ impl TrustedPreallocate for Action {
         // This acts as nActionsOrchard and is therefore subject to the rule.
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
-        static_assertions::const_assert!(MAX < (1 << 16));
+        const {
+            assert!(MAX < (1 << 16));
+        }
         MAX
     }
 }

--- a/crates/zakura-chain/src/parameters/checkpoint/list/tests.rs
+++ b/crates/zakura-chain/src/parameters/checkpoint/list/tests.rs
@@ -4,8 +4,6 @@
 
 use std::sync::Arc;
 
-use num_integer::div_ceil;
-
 use crate::{
     block::{Block, HeightDiff, MAX_BLOCK_BYTES},
     parameters::{
@@ -336,7 +334,7 @@ fn checkpoint_list_hard_coded_max_gap(network: Network) -> Result<(), BoxError> 
     let max_checkpoint_height_gap =
         HeightDiff::try_from(MAX_CHECKPOINT_HEIGHT_GAP).expect("constant fits in HeightDiff");
     let min_checkpoint_height_gap =
-        HeightDiff::try_from(div_ceil(MAX_CHECKPOINT_BYTE_COUNT, MAX_BLOCK_BYTES))
+        HeightDiff::try_from(MAX_CHECKPOINT_BYTE_COUNT.div_ceil(MAX_BLOCK_BYTES))
             .expect("constant fits in HeightDiff");
 
     let list = network.checkpoint_list();

--- a/crates/zakura-chain/src/sapling/output.rs
+++ b/crates/zakura-chain/src/sapling/output.rs
@@ -276,7 +276,9 @@ impl TrustedPreallocate for OutputInTransactionV4 {
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
         // (The check is not required pre-NU5, but it doesn't cause problems.)
-        static_assertions::const_assert!(MAX < (1 << 16));
+        const {
+            assert!(MAX < (1 << 16));
+        }
         MAX
     }
 }

--- a/crates/zakura-chain/src/sapling/spend.rs
+++ b/crates/zakura-chain/src/sapling/spend.rs
@@ -318,7 +318,9 @@ impl TrustedPreallocate for Spend<PerSpendAnchor> {
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
         // (The check is not required pre-NU5, but it doesn't cause problems.)
-        static_assertions::const_assert!(MAX < (1 << 16));
+        const {
+            assert!(MAX < (1 << 16));
+        }
         MAX
     }
 }
@@ -344,7 +346,9 @@ impl TrustedPreallocate for SpendPrefixInTransactionV5 {
         // The maximum value is actually smaller due to the block size limit,
         // but we ensure the 2^16 limit with a static assertion.
         // (The check is not required pre-NU5, but it doesn't cause problems.)
-        static_assertions::const_assert!(MAX < (1 << 16));
+        const {
+            assert!(MAX < (1 << 16));
+        }
         MAX
     }
 }

--- a/crates/zakura-chain/src/transaction/unmined/zip317.rs
+++ b/crates/zakura-chain/src/transaction/unmined/zip317.rs
@@ -4,7 +4,6 @@
 
 use std::cmp::max;
 
-use num_integer::div_ceil;
 use thiserror::Error;
 
 use crate::{
@@ -156,8 +155,8 @@ pub fn conventional_actions(transaction: &Transaction) -> u32 {
     let n_actions_orchard = transaction.orchard_actions().count();
     let n_actions_ironwood = transaction.ironwood_actions().count();
 
-    let tx_in_logical_actions = div_ceil(tx_in_total_size, P2PKH_STANDARD_INPUT_SIZE);
-    let tx_out_logical_actions = div_ceil(tx_out_total_size, P2PKH_STANDARD_OUTPUT_SIZE);
+    let tx_in_logical_actions = tx_in_total_size.div_ceil(P2PKH_STANDARD_INPUT_SIZE);
+    let tx_out_logical_actions = tx_out_total_size.div_ceil(P2PKH_STANDARD_OUTPUT_SIZE);
 
     let logical_actions = max(tx_in_logical_actions, tx_out_logical_actions)
         + 2 * n_join_split

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -37,11 +37,9 @@ blake2b_simd = { workspace = true }
 bellman = { workspace = true }
 bls12_381 = { workspace = true }
 halo2 = { workspace = true }
-jubjub = { workspace = true }
 rand = { workspace = true }
 rand_10 = { workspace = true }
 rayon = { workspace = true }
-mset.workspace = true
 
 chrono = { workspace = true, features = ["clock", "std"] }
 lazy_static = { workspace = true }
@@ -54,7 +52,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "tracing", "rt-multi-thread"] }
 tower = { workspace = true, features = ["timeout", "util", "buffer"] }
 tracing = { workspace = true }
-tracing-futures = { workspace = true }
 derive-getters = { workspace = true, features = ["auto_copy_getters"] }
 
 sapling-crypto = { workspace = true, features = ["multicore"]}
@@ -88,15 +85,12 @@ proptest-derive = { workspace = true, optional = true }
 color-eyre = { workspace = true }
 
 hex = { workspace = true }
-num-integer = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 spandoc = { workspace = true }
 toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
-tracing-error = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0", features = ["proptest-impl"] }
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = ["proptest-impl"] }

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -4,7 +4,6 @@ use std::{collections::HashSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
-use mset::MultiSet;
 use zakura_chain::{
     amount::{
         Amount, DeferredPoolBalanceChange, Error as AmountError, NegativeAllowed, NonNegative,
@@ -24,6 +23,32 @@ use zakura_chain::{
 use zakura_header_chain::{CompactTargetError, PowPolicy};
 
 use crate::{error::*, funding_stream_address};
+
+/// Coinbase outputs that have not yet matched a required subsidy payment.
+///
+/// The source transaction bounds this vector through its serialized size limit.
+struct UnmatchedCoinbaseOutputs {
+    outputs: Vec<Output>,
+}
+
+impl UnmatchedCoinbaseOutputs {
+    /// Copies the bounded outputs from a coinbase transaction.
+    fn new(outputs: &[Output]) -> Self {
+        Self {
+            outputs: outputs.to_vec(),
+        }
+    }
+
+    /// Removes one matching output, preserving duplicate output multiplicity.
+    fn remove(&mut self, expected: &Output) -> bool {
+        let Some(index) = self.outputs.iter().position(|output| output == expected) else {
+            return false;
+        };
+
+        self.outputs.remove(index);
+        true
+    }
+}
 
 /// Checks if there is exactly one coinbase transaction in `Block`,
 /// and if that coinbase transaction is the first transaction in the block.
@@ -155,14 +180,13 @@ pub fn subsidy_is_valid(
 
     let height = block.coinbase_height().ok_or(SubsidyError::NoCoinbase)?;
 
-    let mut coinbase_outputs: MultiSet<Output> = block
-        .transactions
-        .first()
-        .ok_or(SubsidyError::NoCoinbase)?
-        .outputs()
-        .iter()
-        .cloned()
-        .collect();
+    let mut coinbase_outputs = UnmatchedCoinbaseOutputs::new(
+        block
+            .transactions
+            .first()
+            .ok_or(SubsidyError::NoCoinbase)?
+            .outputs(),
+    );
 
     let mut has_amount = |addr: &Address, amount| {
         assert!(addr.is_script_hash(), "address must be P2SH");
@@ -439,4 +463,35 @@ pub fn merkle_root_validity(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use zakura_chain::{
+        amount::{Amount, NonNegative},
+        transparent::{Output, Script},
+    };
+
+    use super::UnmatchedCoinbaseOutputs;
+
+    fn output(value: u64) -> Output {
+        let value = Amount::<NonNegative>::try_from(value).expect("test value is a valid amount");
+        Output::new(value, Script::new(&[]))
+    }
+
+    #[test]
+    fn unmatched_coinbase_outputs_remove_one_duplicate_at_a_time() {
+        let repeated_output = output(1);
+        let distinct_output = output(2);
+        let mut outputs = UnmatchedCoinbaseOutputs::new(&[
+            repeated_output.clone(),
+            repeated_output.clone(),
+            distinct_output.clone(),
+        ]);
+
+        assert!(outputs.remove(&repeated_output));
+        assert!(outputs.remove(&repeated_output));
+        assert!(!outputs.remove(&repeated_output));
+        assert!(outputs.remove(&distinct_output));
+    }
 }

--- a/crates/zakura-consensus/src/checkpoint/tests.rs
+++ b/crates/zakura-consensus/src/checkpoint/tests.rs
@@ -7,7 +7,7 @@ use std::{cmp::min, time::Duration};
 use color_eyre::eyre::{eyre, Report};
 use futures::stream::{FuturesUnordered, StreamExt};
 use tokio::time::timeout;
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     local_genesis::{generate_local_testnet_with_funded_keys, LocalTestnetGenesisOptions},

--- a/crates/zakura-consensus/src/primitives/groth16.rs
+++ b/crates/zakura-consensus/src/primitives/groth16.rs
@@ -137,7 +137,7 @@ impl Item {
     /// Encodes the primary input for the JoinSplit proof statement as Bls12_381 base
     /// field elements, to match [`bellman::groth16::verify_proof()`].
     ///
-    /// NB: [`jubjub::Fq`] is a type alias for [`bls12_381::Scalar`].
+    /// NB: Jubjub's base field is a type alias for [`bls12_381::Scalar`].
     ///
     /// `joinsplit_pub_key`: the JoinSplit public validation key for this JoinSplit, from
     /// the transaction. (All JoinSplits in a transaction share the same validation key.)

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -56,7 +56,6 @@ indexmap = { workspace = true, features = ["serde"] }
 iroh = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
-num-integer = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -64,7 +63,6 @@ regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 
 futures = { workspace = true }
@@ -74,7 +72,6 @@ tokio-util = { workspace = true, features = ["codec"] }
 tower = { workspace = true, features = ["retry", "discover", "load", "load-shed", "timeout", "util", "buffer"] }
 
 metrics = { workspace = true }
-tracing-futures = { workspace = true }
 tracing-error = { workspace = true, features = ["traced-error"] }
 tracing = { workspace = true }
 
@@ -91,12 +88,11 @@ zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0-rc0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 criterion = { workspace = true }
 
-static_assertions = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/zakura-network/src/config/tests/vectors.rs
+++ b/crates/zakura-network/src/config/tests/vectors.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::HashSet, fs, net::SocketAddr, time::Duration};
 
-use static_assertions::const_assert;
 use zakura_chain::{
     block::Height,
     parameters::{
@@ -79,10 +78,12 @@ fn ensure_peer_connection_limits_consistent() {
 
     // Zakura accepts more inbound connections than it opens outbound connections,
     // so peers which can not accept inbound connections can still reach these nodes.
-    const_assert!(
-        INBOUND_PEER_LIMIT_MULTIPLIER * OUTBOUND_PEER_LIMIT_DIVISOR
-            >= OUTBOUND_PEER_LIMIT_MULTIPLIER
-    );
+    const {
+        assert!(
+            INBOUND_PEER_LIMIT_MULTIPLIER * OUTBOUND_PEER_LIMIT_DIVISOR
+                >= OUTBOUND_PEER_LIMIT_MULTIPLIER
+        );
+    }
 
     let config = Config::default();
 

--- a/crates/zakura-network/src/peer/connection.rs
+++ b/crates/zakura-network/src/peer/connection.rs
@@ -13,7 +13,7 @@ use futures::{future::Either, prelude::*};
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use tokio::time::{sleep, Sleep};
 use tower::{Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     block::{self, Block},

--- a/crates/zakura-network/src/peer/connector.rs
+++ b/crates/zakura-network/src/peer/connector.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::prelude::*;
 use tokio::net::TcpStream;
 use tower::{Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::chain_tip::{ChainTip, NoChainTip};
 

--- a/crates/zakura-network/src/peer/handshake.rs
+++ b/crates/zakura-network/src/peer/handshake.rs
@@ -26,8 +26,8 @@ use tokio::{
 use tokio_stream::wrappers::IntervalStream;
 use tokio_util::codec::Framed;
 use tower::Service;
+use tracing::Instrument;
 use tracing::{span, Level, Span};
-use tracing_futures::Instrument;
 
 use zakura_chain::{
     block,

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -33,7 +33,7 @@ use tokio_util::task::AbortOnDropHandle;
 use tower::{
     buffer::Buffer, discover::Change, layer::Layer, util::BoxService, Service, ServiceExt,
 };
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     chain_tip::ChainTip,

--- a/crates/zakura-network/src/peer_set/set.rs
+++ b/crates/zakura-network/src/peer_set/set.rs
@@ -112,7 +112,6 @@ use futures::{
     task::noop_waker,
 };
 use itertools::Itertools;
-use num_integer::div_ceil;
 use tokio::{
     sync::{broadcast, mpsc as tokio_mpsc, watch},
     task::JoinHandle,
@@ -1524,7 +1523,9 @@ where
             const PEER_FRACTION_TO_BROADCAST: usize = 3;
 
             // Round up, so that if we have one ready peer, it gets the request.
-            div_ceil(self.ready_services.len(), PEER_FRACTION_TO_BROADCAST)
+            self.ready_services
+                .len()
+                .div_ceil(PEER_FRACTION_TO_BROADCAST)
         }
     }
 

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -22,6 +22,9 @@ default = []
 
 # Tool and test features
 
+# Retain the published feature name after removing its unused dependency.
+color-eyre = []
+
 rpc-client = [
     "color-eyre",
     "jsonrpsee-types",
@@ -38,7 +41,6 @@ tower = { workspace = true }
 # Optional dependencies
 
 # Tool and test feature rpc-client
-color-eyre = { workspace = true, optional = true }
 jsonrpsee-types = { workspace = true, optional = true }
 # Security: avoid default dependency on openssl
 reqwest = { workspace = true, features = ["rustls-tls"], optional = true }
@@ -48,7 +50,6 @@ tokio = { workspace = true, features = ["time", "sync"] }
 
 [dev-dependencies]
 
-color-eyre = { workspace = true }
 reqwest = { workspace = true, features = ["rustls-tls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -35,7 +35,6 @@ internal-miner = []
 
 # Test-only features
 proptest-impl = [
-    "proptest",
     "zakura-consensus/proptest-impl",
     "zakura-state/proptest-impl",
     "zakura-network/proptest-impl",
@@ -105,13 +104,9 @@ sapling-crypto = { workspace = true }
 zcash_address = { workspace = true }
 zcash_keys = { workspace = true, features = ["orchard", "sapling"] }
 zcash_primitives = { workspace = true, features = ["transparent-inputs", "non-standard-fees"] }
-zcash_proofs = { workspace = true }
 zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
-
-# Test-only feature proptest-impl
-proptest = { workspace = true, optional = true }
 
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = [
     "json-conversion",
@@ -123,15 +118,10 @@ zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0"
 ] }
 zakura-script = { path = "../zakura-script", version = "3.2.1-rc0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0" }
-rustls = "0.23.40"
-tokio-rustls = "0.26.4"
+rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
 der = "0.7.10"
-
-[build-dependencies]
-openrpsee = { workspace = true }
-tonic-prost-build = { workspace = true }
-which = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }

--- a/crates/zakura-rpc/build.rs
+++ b/crates/zakura-rpc/build.rs
@@ -1,59 +1,17 @@
-//! Compile proto files
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+//! Copy checked-in protobuf artifacts into Cargo's output directory.
+use std::{env, fs, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    build_or_copy_proto()?;
-    build_rpc_schema()?;
-
-    Ok(())
-}
-
-fn build_or_copy_proto() -> Result<(), Box<dyn std::error::Error>> {
-    const PROTO_FILE_PATH: &str = "proto/indexer.proto";
-
     let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
     let file_names = ["indexer_descriptor.bin", "zebra.indexer.rpc.rs"];
 
-    let is_proto_file_available = Path::new(PROTO_FILE_PATH).exists();
-    let is_protoc_available = env::var_os("PROTOC")
-        .map(PathBuf::from)
-        .or_else(|| which::which("protoc").ok())
-        .is_some();
-
-    if is_proto_file_available && is_protoc_available {
-        tonic_prost_build::configure()
-            .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
-            .file_descriptor_set_path(out_dir.join("indexer_descriptor.bin"))
-            .compile_protos(&[PROTO_FILE_PATH], &[""])?;
-
-        for file_name in file_names {
-            let out_path = out_dir.join(file_name);
-            let generated_path = format!("proto/__generated__/{file_name}");
-            if fs::read(&out_path).ok() != fs::read(&generated_path).ok() {
-                fs::copy(out_path, generated_path)?;
-            }
-        }
-    } else {
-        for file_name in file_names {
-            let out_path = out_dir.join(file_name);
-            let generated_path = format!("proto/__generated__/{file_name}");
-            if fs::read(&out_path).ok() != Some(fs::read(&generated_path)?) {
-                fs::copy(generated_path, out_path)?;
-            }
+    for file_name in file_names {
+        let out_path = out_dir.join(file_name);
+        let generated_path = PathBuf::from("proto/__generated__").join(file_name);
+        if fs::read(&out_path).ok() != Some(fs::read(&generated_path)?) {
+            fs::copy(generated_path, out_path)?;
         }
     }
-
-    Ok(())
-}
-
-fn build_rpc_schema() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
-    let json_rpc_methods_rs = "src/methods.rs";
-    let trait_names = ["Rpc"];
-    openrpsee::generate_openrpc(json_rpc_methods_rs, &trait_names, false, &out_dir)?;
 
     Ok(())
 }

--- a/crates/zakura-rpc/src/indexer/server.rs
+++ b/crates/zakura-rpc/src/indexer/server.rs
@@ -212,7 +212,7 @@ fn load_mtls_config(tls: IndexerTlsConfig) -> Result<ServerTlsConfig, BoxError> 
 
 /// Ensures tonic TLS connections have a rustls crypto provider.
 pub(crate) fn install_tls_crypto_provider() {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 /// Reads an indexer TLS file with its role included in any error.

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -148,7 +148,7 @@ where
     service.oneshot(request).await.map_misc_error()
 }
 
-include!(concat!(env!("OUT_DIR"), "/rpc_openrpc.rs"));
+include!("methods/rpc_openrpc.rs");
 
 // TODO: Review the parameter descriptions below, and update them as needed:
 // https://github.com/ZcashFoundation/zebra/issues/10320

--- a/crates/zakura-rpc/src/methods/rpc_openrpc.rs
+++ b/crates/zakura-rpc/src/methods/rpc_openrpc.rs
@@ -1,0 +1,307 @@
+/// Lookup table for JSON-RPC methods.
+#[allow(unused_qualifications)]
+pub static METHODS: ::phf::Map<&str, openrpsee::openrpc::RpcMethod> = ::phf::phf_map! {
+"getinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns software information from the RPC server, as a\n[`GetInfoResponse`] JSON struct.\n\nzcashd reference: [`getinfo`](https://zcash.github.io/rpc/getinfo.html)\nmethod: post\ntags: control\n\n# Notes\n\n[The zcashd reference](https://zcash.github.io/rpc/getinfo.html) might not show some fields\nin Zebra\'s [`GetInfoResponse`]. Zebra uses the field names and formats\nfrom the [zcashd\ncode](https://github.com/zcash/zcash/blob/v4.6.0-1/src/rpc/misc.cpp#L86-L87).\n\nSome fields from the zcashd reference are missing from Zebra\'s\n[`GetInfoResponse`]. It only contains the fields\n[required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L91-L95)\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getinfo_result"),
+    deprecated: false,
+},
+"getdeprecationinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns end-of-support information for this node release, as a\n[`GetDeprecationInfoResponse`] JSON struct.\n\nzcashd reference:\n[`getdeprecationinfo`](https://zcash.github.io/rpc/getdeprecationinfo.html)\nmethod: post\ntags: network\n\n# Notes\n\nAs in zcashd, the `end_of_service` object is only present on Mainnet,\nwhere end of support is enforced. Zakura reports the estimated last\nheight this release supports in `end_of_service.block_height`; the node\nhalts when the tip goes past it.\n\nSome fields from the zcashd response are missing from Zakura\'s response:\n`version` and `subversion` are available from `getinfo`,\n`deprecationheight` is deprecated in zcashd, and Zakura does not have\nzcashd\'s feature deprecation framework.\n\nThe estimate assumes the node is synced to the network tip; during\ninitial sync it is significantly overestimated.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getdeprecationinfo_result"),
+    deprecated: false,
+},
+"getblockchaininfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns blockchain state information, as a [`GetBlockchainInfoResponse`] JSON struct.\n\nzcashd reference: [`getblockchaininfo`](https://zcash.github.io/rpc/getblockchaininfo.html)\nmethod: post\ntags: blockchain\n\n# Notes\n\nSome fields from the zcashd reference are missing from Zebra\'s [`GetBlockchainInfoResponse`]. It only contains the fields\n[required for lightwalletd support.](https://github.com/zcash/lightwalletd/blob/v0.4.9/common/common.go#L72-L89)\n\nZebra includes an `ironwood` value pool entry. Like other value pool\nentries, it can be present with a zero balance.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockchaininfo_result"),
+    deprecated: false,
+},
+"getaddressbalance" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the total balance of provided `addresses` in a\n[`GetAddressBalanceResponse`] instance.\n\nzcashd reference: [`getaddressbalance`](https://zcash.github.io/rpc/getaddressbalance.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `address_strings`: (object, example={\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"]}) A JSON map with a single entry\n    - `addresses`: (array of strings) A list of base-58 encoded addresses.\n\n# Notes\n\nzcashd also accepts a single string parameter instead of an array of strings, but Zebra\ndoesn\'t because lightwalletd always calls this RPC with an array of addresses.\n\nzcashd also returns the total amount of Zatoshis received by the addresses, but Zebra\ndoesn\'t because lightwalletd doesn\'t use that information.\n\nThe RPC documentation says that the returned object has a string `balance` field, but\nzcashd actually [returns an\ninteger](https://github.com/zcash/lightwalletd/blob/bdaac63f3ee0dbef62bde04f6817a9f90d483b00/common/common.go#L128-L130).\n",
+    params: |_g| vec![
+        _g.param::<GetAddressBalanceRequest>("address_strings", crate::methods::PARAM_ADDRESS_STRINGS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddressbalance_result"),
+    deprecated: false,
+},
+"sendrawtransaction" => openrpsee::openrpc::RpcMethod {
+    description: "Sends the raw bytes of a signed transaction to the local node\'s mempool, if the transaction is valid.\nReturns the [`SendRawTransactionResponse`] for the transaction, as a\nJSON string.\n\nzcashd reference: [`sendrawtransaction`](https://zcash.github.io/rpc/sendrawtransaction.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `raw_transaction_hex`: (string, required, example=\"signedhex\") The hex-encoded raw transaction bytes.\n- `allow_high_fees`: (bool, optional) A legacy parameter accepted by zcashd but ignored by Zebra.\n\n# Notes\n\nzcashd accepts an optional `allowhighfees` parameter. Zebra doesn\'t support this parameter,\nbecause lightwalletd doesn\'t use it.\n",
+    params: |_g| vec![
+        _g.param::<String>("raw_transaction_hex", crate::methods::PARAM_RAW_TRANSACTION_HEX_DESC, true),
+        _g.param::<bool>("_allow_high_fees", crate::methods::PARAM__ALLOW_HIGH_FEES_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("sendrawtransaction_result"),
+    deprecated: false,
+},
+"getblock" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the requested block by hash or height, as a\n[`GetBlockResponse`] JSON string.\nIf the block is not in Zebra\'s state, returns\n[error code `-8`.](https://github.com/zcash/zcash/issues/5758) if a height was\npassed or -5 if a hash was passed.\n\nzcashd reference: [`getblock`](https://zcash.github.io/rpc/getblock.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash_or_height`: (string, required, example=\"1\") The hash or height for the block to be returned.\n- `verbosity`: (number, optional, default=1, example=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.\n\n# Notes\n\nThe `size` field is only returned with verbosity=2.\n\nThe undocumented `chainwork` field is not returned.\n\nWith verbosity=2, transaction objects include `ironwood` only when the\ntransaction contains Ironwood shielded data. Block `trees` can include an\nIronwood tree entry when the state has one for the requested block.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+        _g.param::<u8>("verbosity", crate::methods::PARAM_VERBOSITY_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblock_result"),
+    deprecated: false,
+},
+"getblockheader" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the requested block header by hash or height, as a\n[`GetBlockHeaderResponse`] JSON string.\nIf the block is not in Zebra\'s state,\nreturns [error code `-8`.](https://github.com/zcash/zcash/issues/5758)\nif a height was passed or -5 if a hash was passed.\n\nzcashd reference: [`getblockheader`](https://zcash.github.io/rpc/getblockheader.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash_or_height`: (string, required, example=\"1\") The hash or height for the block to be returned.\n- `verbose`: (bool, optional, default=false, example=true) false for hex encoded data, true for a json object\n\n# Notes\n\nThe undocumented `chainwork` field is not returned.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+        _g.param::<bool>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockheader_result"),
+    deprecated: false,
+},
+"getbestblockhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the hash of the current best blockchain tip block, as a\n[`GetBlockHashResponse`] JSON string.\n\nzcashd reference: [`getbestblockhash`](https://zcash.github.io/rpc/getbestblockhash.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getbestblockhash_result"),
+    deprecated: false,
+},
+"getbestblockheightandhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the height and hash of the current best blockchain tip block, as a [`GetBlockHeightAndHashResponse`] JSON struct.\n\nzcashd reference: none\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getbestblockheightandhash_result"),
+    deprecated: false,
+},
+"getmempoolinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns details on the active state of the TX memory pool.\n\nzcash reference: [`getmempoolinfo`](https://zcash.github.io/rpc/getmempoolinfo.html)\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getmempoolinfo_result"),
+    deprecated: false,
+},
+"getrawmempool" => openrpsee::openrpc::RpcMethod {
+    description: "Returns all transaction ids in the memory pool, as a JSON array.\n\n# Parameters\n\n- `verbose`: (boolean, optional, default=false) true for a json object, false for array of transaction ids.\n\nzcashd reference: [`getrawmempool`](https://zcash.github.io/rpc/getrawmempool.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+        _g.param::<bool>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getrawmempool_result"),
+    deprecated: false,
+},
+"z_gettreestate" => openrpsee::openrpc::RpcMethod {
+    description: "Returns information about the given block\'s Sapling, Orchard, and when\navailable Ironwood tree state.\n\nzcashd reference: [`z_gettreestate`](https://zcash.github.io/rpc/z_gettreestate.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `hash | height`: (string, required, example=\"00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5\") The block hash or height.\n\n# Notes\n\nThe zcashd doc reference above says that the parameter \"`height` can be\nnegative where -1 is the last known valid block\". On the other hand,\n`lightwalletd` only uses positive heights, so Zebra does not support\nnegative heights.\n\nThe `ironwood` field contains empty commitments unless Ironwood tree\nstate is available for the requested block.\n",
+    params: |_g| vec![
+        _g.param::<String>("hash_or_height", crate::methods::PARAM_HASH_OR_HEIGHT_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_gettreestate_result"),
+    deprecated: false,
+},
+"z_getsubtreesbyindex" => openrpsee::openrpc::RpcMethod {
+    description: "Returns information about a range of shielded subtrees.\n\nzcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `pool`: (string, required) The pool from which subtrees should be returned.\n  Either \"sapling\", \"orchard\", or \"ironwood\".\n- `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.\n- `limit`: (number, optional) The maximum number of subtree values to return.\n\n# Notes\n\nWhile Zebra is doing its initial subtree index rebuild, subtrees will become available\nstarting at the chain tip. This RPC will return an empty list if the `start_index` subtree\nexists, but has not been rebuilt yet. This matches `zcashd`\'s behaviour when subtrees aren\'t\navailable yet. (But `zcashd` does its rebuild before syncing any blocks.)\n",
+    params: |_g| vec![
+        _g.param::<String>("pool", crate::methods::PARAM_POOL_DESC, true),
+        _g.param::<NoteCommitmentSubtreeIndex>("start_index", crate::methods::PARAM_START_INDEX_DESC, true),
+        _g.param::<NoteCommitmentSubtreeIndex>("limit", crate::methods::PARAM_LIMIT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_getsubtreesbyindex_result"),
+    deprecated: false,
+},
+"getrawtransaction" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the raw transaction data, as a [`GetRawTransactionResponse`]\nJSON string or structure.\n\nzcashd reference: [`getrawtransaction`](https://zcash.github.io/rpc/getrawtransaction.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `txid`: (string, required, example=\"mytxid\") The transaction ID of the transaction to be returned.\n- `verbose`: (number, optional, default=0, example=1) If 0, return a string of hex-encoded data, otherwise return a JSON object.\n- `blockhash` (string, optional) The block in which to look for the transaction\n\n# Notes\n\nVerbose transaction output includes `ironwood` only when the transaction\ncontains Ironwood shielded data.\n",
+    params: |_g| vec![
+        _g.param::<String>("txid", crate::methods::PARAM_TXID_DESC, true),
+        _g.param::<u8>("verbose", crate::methods::PARAM_VERBOSE_DESC, false),
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getrawtransaction_result"),
+    deprecated: false,
+},
+"getaddresstxids" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the transaction ids made by the provided transparent addresses.\n\nzcashd reference: [`getaddresstxids`](https://zcash.github.io/rpc/getaddresstxids.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `request`: (required) Either:\n    - A single address string (e.g., `\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"`), or\n    - An object with the following named fields:\n        - `addresses`: (array of strings, required) The addresses to get transactions from.\n        - `start`: (numeric, optional) The lower height to start looking for transactions (inclusive).\n        - `end`: (numeric, optional) The upper height to stop looking for transactions (inclusive).\n\nExample of the object form:\n```json\n{\n  \"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"],\n  \"start\": 1000,\n  \"end\": 2000\n}\n```\n\n# Notes\n\n- Only the multi-argument format is used by lightwalletd and this is what we currently support:\n<https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L97-L102>\n- It is recommended that users call the method with start/end heights such that the response can\'t be too large.\n",
+    params: |_g| vec![
+        _g.param::<GetAddressTxIdsRequest>("request", crate::methods::PARAM_REQUEST_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddresstxids_result"),
+    deprecated: false,
+},
+"getaddressutxos" => openrpsee::openrpc::RpcMethod {
+    description: "Returns all unspent outputs for a list of addresses.\n\nzcashd reference: [`getaddressutxos`](https://zcash.github.io/rpc/getaddressutxos.html)\nmethod: post\ntags: address\n\n# Parameters\n\n- `request`: (required) Either:\n    - A single address string (e.g., `\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"`), or\n    - An object with the following named fields:\n        - `addresses`: (array, required, example=[\\\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\\\"]) The addresses to get outputs from.\n        - `chaininfo`: (boolean, optional, default=false) Include chain info with results\n\n# Notes\n\nlightwalletd always uses the multi-address request, without chaininfo:\n<https://github.com/zcash/lightwalletd/blob/master/frontend/service.go#L402>\n",
+    params: |_g| vec![
+        _g.param::<GetAddressUtxosRequest>("request", crate::methods::PARAM_REQUEST_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getaddressutxos_result"),
+    deprecated: false,
+},
+"stop" => openrpsee::openrpc::RpcMethod {
+    description: "Stop the running zakurad process.\n\n# Notes\n\n- Works for non windows targets only.\n- Works only if the network of the running zakurad process is `Regtest`.\n\nzcashd reference: [`stop`](https://zcash.github.io/rpc/stop.html)\nmethod: post\ntags: control\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("stop_result"),
+    deprecated: false,
+},
+"getblockcount" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the height of the most recent block in the best valid block chain (equivalently,\nthe number of blocks in this chain excluding the genesis block).\n\nzcashd reference: [`getblockcount`](https://zcash.github.io/rpc/getblockcount.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockcount_result"),
+    deprecated: false,
+},
+"getblockhash" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the hash of the block of a given height iff the index argument correspond\nto a block in the best chain.\n\nzcashd reference: [`getblockhash`](https://zcash-rpc.github.io/getblockhash.html)\nmethod: post\ntags: blockchain\n\n# Parameters\n\n- `index`: (numeric, required, example=1) The block index.\n\n# Notes\n\n- If `index` is positive then index = block height.\n- If `index` is negative then -1 is the last known valid block.\n",
+    params: |_g| vec![
+        _g.param::<i32>("index", crate::methods::PARAM_INDEX_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblockhash_result"),
+    deprecated: false,
+},
+"getblocktemplate" => openrpsee::openrpc::RpcMethod {
+    description: "Returns a block template for mining new Zcash blocks.\n\n# Parameters\n\n- `jsonrequestobject`: (string, optional) A JSON object containing arguments.\n\nzcashd reference: [`getblocktemplate`](https://zcash-rpc.github.io/getblocktemplate.html)\nmethod: post\ntags: mining\n\n# Notes\n\nArguments to this RPC are currently ignored.\nLong polling, block proposals, server lists, and work IDs are not supported.\n\nMiners can make arbitrary changes to blocks, as long as:\n- the data sent to `submitblock` is a valid Zcash block, and\n- the parent block is a valid block that Zebra already has, or will receive soon.\n\nZebra verifies blocks in parallel, and keeps recent chains in parallel,\nso moving between chains and forking chains is very cheap.\n",
+    params: |_g| vec![
+        _g.param::<GetBlockTemplateParameters>("parameters", crate::methods::PARAM_PARAMETERS_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblocktemplate_result"),
+    deprecated: false,
+},
+"submitblock" => openrpsee::openrpc::RpcMethod {
+    description: "Submits block to the node to be validated and committed.\nReturns the [`SubmitBlockResponse`] for the operation, as a JSON string.\n\nzcashd reference: [`submitblock`](https://zcash.github.io/rpc/submitblock.html)\nmethod: post\ntags: mining\n\n# Parameters\n\n- `hexdata`: (string, required)\n- `jsonparametersobject`: (string, optional) - currently ignored\n\n# Notes\n\n - `jsonparametersobject` holds a single field, workid, that must be included in submissions if provided by the server.\n",
+    params: |_g| vec![
+        _g.param::<HexData>("hex_data", crate::methods::PARAM_HEX_DATA_DESC, true),
+        _g.param::<SubmitBlockParameters>("_parameters", crate::methods::PARAM__PARAMETERS_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("submitblock_result"),
+    deprecated: false,
+},
+"getmininginfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns mining-related information.\n\nzcashd reference: [`getmininginfo`](https://zcash.github.io/rpc/getmininginfo.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getmininginfo_result"),
+    deprecated: false,
+},
+"getnetworksolps" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the estimated network solutions per second based on the last `num_blocks` before\n`height`.\n\nIf `num_blocks` is not supplied, uses 120 blocks. If it is 0 or -1, uses the difficulty\naveraging window.\nIf `height` is not supplied or is -1, uses the tip height.\n\nzcashd reference: [`getnetworksolps`](https://zcash.github.io/rpc/getnetworksolps.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+        _g.param::<i32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, false),
+        _g.param::<i32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworksolps_result"),
+    deprecated: false,
+},
+"getnetworkhashps" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the estimated network solutions per second based on the last `num_blocks` before\n`height`.\n\nThis method name is deprecated, use [`getnetworksolps`](Self::get_network_sol_ps) instead.\nSee that method for details.\n\nzcashd reference: [`getnetworkhashps`](https://zcash.github.io/rpc/getnetworkhashps.html)\nmethod: post\ntags: mining\n",
+    params: |_g| vec![
+        _g.param::<i32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, false),
+        _g.param::<i32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworkhashps_result"),
+    deprecated: false,
+},
+"getnetworkinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns an object containing various state info regarding P2P networking.\n\nzcashd reference: [`getnetworkinfo`](https://zcash.github.io/rpc/getnetworkinfo.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getnetworkinfo_result"),
+    deprecated: false,
+},
+"getpeerinfo" => openrpsee::openrpc::RpcMethod {
+    description: "Returns data about each connected network node.\n\nzcashd reference: [`getpeerinfo`](https://zcash.github.io/rpc/getpeerinfo.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getpeerinfo_result"),
+    deprecated: false,
+},
+"ping" => openrpsee::openrpc::RpcMethod {
+    description: "Requests that a ping be sent to all other nodes, to measure ping time.\n\nResults provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.\nPing command is handled in queue with all other commands, so it measures processing backlog, not just network ping.\n\nzcashd reference: [`ping`](https://zcash.github.io/rpc/ping.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("ping_result"),
+    deprecated: false,
+},
+"validateaddress" => openrpsee::openrpc::RpcMethod {
+    description: "Checks if a zcash transparent address of type P2PKH, P2SH or TEX is valid.\nReturns information about the given address if valid.\n\nzcashd reference: [`validateaddress`](https://zcash.github.io/rpc/validateaddress.html)\nmethod: post\ntags: util\n\n# Parameters\n\n- `address`: (string, required) The zcash address to validate.\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("validateaddress_result"),
+    deprecated: false,
+},
+"z_validateaddress" => openrpsee::openrpc::RpcMethod {
+    description: "Checks if a zcash address of type P2PKH, P2SH, TEX, SAPLING or UNIFIED is valid.\nReturns information about the given address if valid.\n\nzcashd reference: [`z_validateaddress`](https://zcash.github.io/rpc/z_validateaddress.html)\nmethod: post\ntags: util\n\n# Parameters\n\n- `address`: (string, required) The zcash address to validate.\n\n# Notes\n\n- No notes\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_validateaddress_result"),
+    deprecated: false,
+},
+"getblocksubsidy" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.\nReturns an error if `height` is less than the height of the first halving for the current network.\n\nzcashd reference: [`getblocksubsidy`](https://zcash.github.io/rpc/getblocksubsidy.html)\nmethod: post\ntags: mining\n\n# Parameters\n\n- `height`: (numeric, optional, example=1) Can be any valid current or future height.\n\n# Notes\n\nIf `height` is not supplied, uses the tip height.\n",
+    params: |_g| vec![
+        _g.param::<u32>("height", crate::methods::PARAM_HEIGHT_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getblocksubsidy_result"),
+    deprecated: false,
+},
+"getdifficulty" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the proof-of-work difficulty as a multiple of the minimum difficulty.\n\nzcashd reference: [`getdifficulty`](https://zcash.github.io/rpc/getdifficulty.html)\nmethod: post\ntags: blockchain\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("getdifficulty_result"),
+    deprecated: false,
+},
+"z_listunifiedreceivers" => openrpsee::openrpc::RpcMethod {
+    description: "Returns the list of individual payment addresses given a unified address.\n\nzcashd reference: [`z_listunifiedreceivers`](https://zcash.github.io/rpc/z_listunifiedreceivers.html)\nmethod: post\ntags: wallet\n\n# Parameters\n\n- `address`: (string, required) The zcash unified address to get the list from.\n\n# Notes\n\n- No notes\n",
+    params: |_g| vec![
+        _g.param::<String>("address", crate::methods::PARAM_ADDRESS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("z_listunifiedreceivers_result"),
+    deprecated: false,
+},
+"invalidateblock" => openrpsee::openrpc::RpcMethod {
+    description: "Invalidates a block if it is not yet finalized, removing it from the non-finalized\nstate if it is present and rejecting it during contextual validation if it is submitted.\n\n# Parameters\n\n- `block_hash`: (hex-encoded block hash, required) The block hash to invalidate.\n",
+    params: |_g| vec![
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("invalidateblock_result"),
+    deprecated: false,
+},
+"reconsiderblock" => openrpsee::openrpc::RpcMethod {
+    description: "Reconsiders a previously invalidated block if it exists in the cache of previously invalidated blocks.\n\n# Parameters\n\n- `block_hash`: (hex-encoded block hash, required) The block hash to reconsider.\n",
+    params: |_g| vec![
+        _g.param::<String>("block_hash", crate::methods::PARAM_BLOCK_HASH_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("reconsiderblock_result"),
+    deprecated: false,
+},
+"generate" => openrpsee::openrpc::RpcMethod {
+    description: "Mine blocks immediately. Returns the block hashes of the generated blocks.\n\n# Parameters\n\n- `num_blocks`: (numeric, required, example=1) Number of blocks to be generated.\n\n# Notes\n\nOnly works if the network of the running zakurad process is `Regtest`.\n\nzcashd reference: [`generate`](https://zcash.github.io/rpc/generate.html)\nmethod: post\ntags: generating\n",
+    params: |_g| vec![
+        _g.param::<u32>("num_blocks", crate::methods::PARAM_NUM_BLOCKS_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("generate_result"),
+    deprecated: false,
+},
+"addnode" => openrpsee::openrpc::RpcMethod {
+    description: "Add or remove a node from the address book.\n\n# Parameters\n\n- `addr`: (string, required) The address of the node to add or remove.\n- `command`: (string, required) The command to execute, either \"add\", \"onetry\", or \"remove\".\n\n# Notes\n\nOnly the \"add\" command is currently supported.\n\nzcashd reference: [`addnode`](https://zcash.github.io/rpc/addnode.html)\nmethod: post\ntags: network\n",
+    params: |_g| vec![
+        _g.param::<PeerSocketAddr>("addr", crate::methods::PARAM_ADDR_DESC, true),
+        _g.param::<AddNodeCommand>("command", crate::methods::PARAM_COMMAND_DESC, true),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("addnode_result"),
+    deprecated: false,
+},
+"rpc.discover" => openrpsee::openrpc::RpcMethod {
+    description: "Returns an OpenRPC schema as a description of this service.\n",
+    params: |_g| vec![
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("rpc.discover_result"),
+    deprecated: false,
+},
+"gettxout" => openrpsee::openrpc::RpcMethod {
+    description: "Returns details about an unspent transaction output.\n\nzcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)\nmethod: post\ntags: transaction\n\n# Parameters\n\n- `txid`: (string, required, example=\"mytxid\") The transaction ID that contains the output.\n- `n`: (number, required) The output index number.\n- `include_mempool` (bool, optional, default=true) Whether to include the mempool in the search.\n",
+    params: |_g| vec![
+        _g.param::<String>("txid", crate::methods::PARAM_TXID_DESC, true),
+        _g.param::<u32>("n", crate::methods::PARAM_N_DESC, true),
+        _g.param::<bool>("include_mempool", crate::methods::PARAM_INCLUDE_MEMPOOL_DESC, false),
+    ],
+    result: |g| g.result::<openrpsee::openrpc::ResultType>("gettxout_result"),
+    deprecated: false,
+},
+};

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -330,7 +330,7 @@ fn load_tls_config(
         )
     })?;
 
-    let crypto_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let crypto_provider = Arc::new(rustls::crypto::ring::default_provider());
     let config = RustlsServerConfig::builder_with_provider(crypto_provider)
         .with_safe_default_protocol_versions()
         .map_err(|error| format!("could not configure RPC TLS protocol versions: {error}"))?

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -39,24 +39,20 @@ header-fuzz = []
 proptest-impl = [
     "proptest",
     "proptest-derive",
-    "zakura-test",
     "zakura-chain/proptest-impl"
 ]
 
 [dependencies]
 bincode = { workspace = true }
 chrono = { workspace = true, features = ["clock", "std"] }
-dirs = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 humantime-serde = { workspace = true }
-human_bytes = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 metrics = { workspace = true }
-mset = { workspace = true }
 regex = { workspace = true }
 rlimit = { workspace = true }
 rocksdb = { workspace = true, features = ["lz4"] }
@@ -83,7 +79,6 @@ zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0-rc0" }
 howudoin = { workspace = true, optional = true }
 
 # test feature proptest-impl
-zakura-test = { path = "../zakura-test/", version = "2.1.0", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
@@ -106,7 +101,6 @@ proptest-derive = { workspace = true }
 rand = { workspace = true }
 
 halo2 = { workspace = true }
-jubjub = { workspace = true }
 orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }

--- a/crates/zakura-state/src/config.rs
+++ b/crates/zakura-state/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
     /// Storage mode is controlled separately by [`storage_mode`](Config::storage_mode).
     ///
     /// The default directory is platform dependent, based on
-    /// [`dirs::cache_dir()`](https://docs.rs/dirs/3.0.1/dirs/fn.cache_dir.html):
+    /// [the platform cache directory](https://docs.rs/dirs/3.0.1/dirs/fn.cache_dir.html):
     ///
     /// |Platform | Value                                           | Example                              |
     /// | ------- | ----------------------------------------------- | ------------------------------------ |

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -47,6 +47,33 @@ use super::{TypedColumnFamily, WriteTypedBatch};
 #[cfg(test)]
 mod tests;
 
+/// Decimal byte units used by database size logs.
+const DECIMAL_BYTE_UNITS: [&str; 7] = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
+
+/// Formats an integer byte count with one optional decimal digit.
+fn format_bytes(bytes: u64) -> String {
+    const UNIT_SCALE: u64 = 1_000;
+
+    let mut unit_index = 0;
+    let mut unit_size = 1;
+    while unit_index + 1 < DECIMAL_BYTE_UNITS.len() && bytes >= unit_size * UNIT_SCALE {
+        unit_index += 1;
+        unit_size *= UNIT_SCALE;
+    }
+
+    let rounded_tenths =
+        (u128::from(bytes) * 10 + u128::from(unit_size) / 2) / u128::from(unit_size);
+    let whole_units = rounded_tenths / 10;
+    let fractional_tenth = rounded_tenths % 10;
+    let unit = DECIMAL_BYTE_UNITS[unit_index];
+
+    if fractional_tenth == 0 {
+        format!("{whole_units} {unit}")
+    } else {
+        format!("{whole_units}.{fractional_tenth} {unit}")
+    }
+}
+
 /// The [`rocksdb::ThreadMode`] used by the database.
 pub type DBThreadMode = rocksdb::SingleThreaded;
 
@@ -645,8 +672,8 @@ impl DiskDb {
                 column_families_log_string,
                 "{} (Disk: {}, Memory: {})",
                 cf_name,
-                human_bytes::human_bytes(cf_disk_size as f64),
-                human_bytes::human_bytes(mem_table_size.unwrap_or(0) as f64)
+                format_bytes(cf_disk_size),
+                format_bytes(mem_table_size.unwrap_or(0))
             )
             .unwrap();
         }
@@ -654,15 +681,15 @@ impl DiskDb {
         debug!("{}", column_families_log_string);
         info!(
             "Total Database Disk Size: {}",
-            human_bytes::human_bytes(total_size_on_disk as f64)
+            format_bytes(total_size_on_disk)
         );
         info!(
             "Total Live Data Disk Size: {}",
-            human_bytes::human_bytes(total_live_size_on_disk as f64)
+            format_bytes(total_live_size_on_disk)
         );
         info!(
             "Total Database Memory Size: {}",
-            human_bytes::human_bytes(total_size_in_mem as f64)
+            format_bytes(total_size_in_mem)
         );
     }
 

--- a/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
@@ -5,7 +5,7 @@
 
 use std::ops::Deref;
 
-use crate::service::finalized_state::disk_db::{DiskDb, DB};
+use crate::service::finalized_state::disk_db::{format_bytes, DiskDb, DB};
 
 // Enable older test code to automatically access the inner database via Deref coercion.
 impl Deref for DiskDb {
@@ -24,6 +24,19 @@ impl DiskDb {
 
         rocksdb::DB::list_cf(&opts, path)
     }
+}
+
+#[test]
+fn format_bytes_preserves_decimal_unit_boundaries() {
+    assert_eq!(format_bytes(0), "0 B");
+    assert_eq!(format_bytes(999), "999 B");
+    assert_eq!(format_bytes(1_000), "1 KB");
+    assert_eq!(format_bytes(1_049), "1 KB");
+    assert_eq!(format_bytes(1_050), "1.1 KB");
+    assert_eq!(format_bytes(999_949), "999.9 KB");
+    assert_eq!(format_bytes(999_950), "1000 KB");
+    assert_eq!(format_bytes(1_000_000), "1 MB");
+    assert_eq!(format_bytes(u64::MAX), "18.4 EB");
 }
 
 /// Check that zs_iter_opts returns an upper bound one greater than provided inclusive end bounds.

--- a/crates/zakura-state/src/service/non_finalized_state/chain.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
-use mset::MultiSet;
 use tracing::instrument;
 
 use zakura_chain::{
@@ -43,8 +42,9 @@ use crate::{
 #[cfg(feature = "indexer")]
 use crate::request::Spend;
 
-use self::index::TransparentTransfers;
+use self::{counted_set::CountedSet, index::TransparentTransfers};
 
+mod counted_set;
 pub mod index;
 
 /// A single non-finalized partial chain, from the child of the finalized tip,
@@ -166,7 +166,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) sprout_anchors: MultiSet<sprout::tree::Root>,
+    pub(crate) sprout_anchors: CountedSet<sprout::tree::Root>,
     /// The Sprout anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -177,7 +177,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) sapling_anchors: MultiSet<sapling::tree::Root>,
+    pub(crate) sapling_anchors: CountedSet<sapling::tree::Root>,
     /// The Sapling anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -191,7 +191,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) orchard_anchors: MultiSet<orchard::tree::Root>,
+    pub(crate) orchard_anchors: CountedSet<orchard::tree::Root>,
     /// The Orchard anchors created by each block in `blocks`.
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
@@ -209,7 +209,7 @@ pub struct ChainInner {
     ///
     /// When a chain is forked from the finalized tip, also contains the finalized tip root.
     /// This extra root is removed when the first non-finalized block is committed.
-    pub(crate) ironwood_anchors: MultiSet<ironwood::tree::Root>,
+    pub(crate) ironwood_anchors: CountedSet<ironwood::tree::Root>,
 
     /// The Ironwood anchors created by each block in `blocks`.
     ///
@@ -278,19 +278,19 @@ impl Chain {
             tx_loc_by_hash: Default::default(),
             created_utxos: Default::default(),
             spent_utxos: Default::default(),
-            sprout_anchors: MultiSet::new(),
+            sprout_anchors: CountedSet::new(),
             sprout_anchors_by_height: Default::default(),
             sprout_trees_by_anchor: Default::default(),
             sprout_trees_by_height: Default::default(),
-            sapling_anchors: MultiSet::new(),
+            sapling_anchors: CountedSet::new(),
             sapling_anchors_by_height: Default::default(),
             sapling_trees_by_height: Default::default(),
             sapling_subtrees: Default::default(),
-            orchard_anchors: MultiSet::new(),
+            orchard_anchors: CountedSet::new(),
             orchard_anchors_by_height: Default::default(),
             orchard_trees_by_height: Default::default(),
             orchard_subtrees: Default::default(),
-            ironwood_anchors: MultiSet::new(),
+            ironwood_anchors: CountedSet::new(),
             ironwood_anchors_by_height: Default::default(),
             ironwood_trees_by_height: Default::default(),
             ironwood_subtrees: Default::default(),

--- a/crates/zakura-state/src/service/non_finalized_state/chain/counted_set.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain/counted_set.rs
@@ -1,0 +1,101 @@
+//! A set that tracks the multiplicity of each distinct value.
+
+use std::{collections::HashMap, hash::Hash};
+
+/// Stores one count for each distinct value.
+///
+/// Removing a value decrements its count and only removes the distinct value
+/// after its final occurrence is removed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CountedSet<T: Eq + Hash> {
+    counts: HashMap<T, usize>,
+}
+
+impl<T> CountedSet<T>
+where
+    T: Eq + Hash,
+{
+    /// Creates an empty counted set.
+    pub(crate) fn new() -> Self {
+        Self {
+            counts: HashMap::new(),
+        }
+    }
+
+    /// Adds one occurrence of `value`.
+    pub(crate) fn insert(&mut self, value: T) {
+        let count = self.counts.entry(value).or_default();
+        *count = count
+            .checked_add(1)
+            .expect("a counted set cannot contain more values than usize::MAX");
+    }
+
+    /// Removes one occurrence of `value`, returning whether it was present.
+    pub(crate) fn remove(&mut self, value: &T) -> bool {
+        let Some(count) = self.counts.get_mut(value) else {
+            return false;
+        };
+
+        if *count > 1 {
+            *count -= 1;
+            return true;
+        }
+
+        self.counts.remove(value);
+        true
+    }
+
+    /// Returns whether at least one occurrence of `value` is present.
+    pub(crate) fn contains(&self, value: &T) -> bool {
+        self.counts.contains_key(value)
+    }
+
+    /// Returns whether the set contains no values.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.counts.is_empty()
+    }
+
+    /// Iterates over each distinct value once.
+    pub(crate) fn distinct_values(&self) -> impl Iterator<Item = &T> {
+        self.counts.keys()
+    }
+}
+
+impl<T> Default for CountedSet<T>
+where
+    T: Eq + Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::CountedSet;
+
+    #[test]
+    fn removal_preserves_multiplicity() {
+        let mut values = CountedSet::new();
+
+        values.insert("repeated");
+        values.insert("repeated");
+        values.insert("distinct");
+
+        assert!(values.remove(&"repeated"));
+        assert!(values.contains(&"repeated"));
+        assert!(values.remove(&"repeated"));
+        assert!(!values.contains(&"repeated"));
+        assert!(!values.remove(&"repeated"));
+
+        assert_eq!(
+            values.distinct_values().copied().collect::<HashSet<_>>(),
+            HashSet::from(["distinct"])
+        );
+        assert!(!values.is_empty());
+        assert!(values.remove(&"distinct"));
+        assert!(values.is_empty());
+    }
+}

--- a/crates/zakura-state/src/service/non_finalized_state/chain/index.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/chain/index.rs
@@ -5,8 +5,6 @@ use std::{
     ops::RangeInclusive,
 };
 
-use mset::MultiSet;
-
 use zakura_chain::{
     amount::{Amount, NegativeAllowed},
     block::Height,
@@ -15,7 +13,7 @@ use zakura_chain::{
 
 use crate::{OutputLocation, TransactionLocation, ValidateContextError};
 
-use super::{RevertPosition, UpdateWith};
+use super::{counted_set::CountedSet, RevertPosition, UpdateWith};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TransparentTransfers {
@@ -30,7 +28,7 @@ pub struct TransparentTransfers {
     /// inconsistencies.
     ///
     /// The `getaddresstxids` RPC needs these transaction IDs to be sorted in chain order.
-    tx_ids: MultiSet<transaction::Hash>,
+    tx_ids: CountedSet<transaction::Hash>,
 
     /// The partial list of UTXOs received by a transparent address.
     ///
@@ -257,7 +255,7 @@ impl TransparentTransfers {
         query_height_range: RangeInclusive<Height>,
     ) -> BTreeMap<TransactionLocation, transaction::Hash> {
         self.tx_ids
-            .distinct_elements()
+            .distinct_values()
             .filter_map(|tx_hash| {
                 let tx_loc = *chain_tx_loc_by_hash
                     .get(tx_hash)

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -32,8 +32,14 @@ default = []
 
 zakura-checkpoints = [
     "clap",
+    "dep:color-eyre",
+    "dep:hex",
     "itertools",
+    "dep:serde_json",
+    "dep:thiserror",
     "tokio",
+    "dep:zakura-chain",
+    "dep:zakura-node-services",
     "zakura-chain/json-conversion",
     "zakura-node-services/rpc-client"
 ]
@@ -46,6 +52,8 @@ zakura-checkpoints-offline = [
 ]
 
 # Preserve published feature names after removing the obsolete developer tools.
+clap = ["dep:clap"]
+itertools = ["dep:itertools"]
 search-issue-refs = [
     "regex",
     "reqwest",
@@ -53,19 +61,21 @@ search-issue-refs = [
 ]
 regex = []
 reqwest = []
+tokio = ["dep:tokio"]
+zcash_primitives = ["dep:zcash_primitives"]
 
 [dependencies]
-color-eyre = { workspace = true }
+color-eyre = { workspace = true, optional = true }
 
 clap = { workspace = true, features = ["derive"], optional = true }
-hex = { workspace = true }
-serde_json = { workspace = true }
+hex = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
-thiserror = { workspace = true }
+thiserror = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.1-rc0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
@@ -74,10 +84,9 @@ itertools = { workspace = true, optional = true }
 zakura-state = { path = "../zakura-state", version = "7.0.0-rc0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
-tokio = { workspace = true, features = ["full"], optional = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }
 
 zcash_primitives = { workspace = true, optional = true }
-zcash_protocol.workspace = true
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -185,7 +185,7 @@ zcash_script = { workspace = true }
 # Required for crates.io publishing, but it's only used in tests
 zakura-utils = { path = "../zakura-utils", version = "2.2.1-rc0", optional = true }
 
-abscissa_core = { workspace = true }
+abscissa_core = { workspace = true, default-features = false, features = ["application"] }
 clap = { workspace = true, features = ["cargo"] }
 chrono = { workspace = true, features = ["clock", "std"] }
 humantime-serde = { workspace = true }
@@ -211,7 +211,6 @@ thiserror = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = { workspace = true }
 tracing-error = { workspace = true }
-tracing-futures = { workspace = true }
 tracing = { workspace = true }
 
 metrics = { workspace = true }
@@ -231,7 +230,6 @@ hyper-util = { workspace = true, features = ["service", "server", "tokio"] }
 # Configuration management
 config = { workspace = true }
 
-num-integer = { workspace = true }
 rand = { workspace = true }
 nix = { workspace = true, features = ["fs"] }
 
@@ -239,7 +237,7 @@ nix = { workspace = true, features = ["fs"] }
 thread-priority = { workspace = true, optional = true }
 
 # prod feature sentry
-sentry = { workspace = true, features = ["backtrace", "contexts", "logs", "rustls", "tracing", "ureq"], optional = true }
+sentry = { workspace = true, features = ["backtrace", "logs", "rustls", "tracing", "ureq"], optional = true }
 
 # prod feature flamegraph
 tracing-flame = { workspace = true, optional = true }
@@ -281,36 +279,23 @@ derive-new.workspace = true
 hex.workspace = true
 
 [build-dependencies]
-vergen-gitcl = { workspace = true, features = ["cargo", "rustc"] }
-
 # test feature lightwalletd-grpc-tests
 tonic-prost-build = { workspace = true, optional = true }
 
 [dev-dependencies]
-abscissa_core = { workspace = true, features = ["testing"] }
-anyhow = { workspace = true }
+abscissa_core = { workspace = true, default-features = false, features = ["testing"] }
 hex-literal = { workspace = true }
 jsonrpsee-types = { workspace = true }
-once_cell = { workspace = true }
 regex = { workspace = true }
 insta = { workspace = true, features = ["json"] }
-bytes = { workspace = true }
-http-body-util = { workspace = true }
-hyper-util = { workspace = true }
-strum = { workspace = true }
-strum_macros = { workspace = true }
 
 # zakura-rpc needs the preserve_order feature, it also makes test results more stable
 serde_json = { workspace = true, features = ["preserve_order"] }
-tempfile = { workspace = true }
-
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-stream = { workspace = true }
-
-zcash_keys = { workspace = true }
 
 # test feature lightwalletd-grpc-tests
 prost = { workspace = true }
@@ -319,9 +304,6 @@ tonic-prost = { workspace = true }
 
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-
-# enable span traces and track caller in tests
-color-eyre = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "6.0.0-rc0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0-rc0", features = ["proptest-impl"] }

--- a/crates/zakurad/build.rs
+++ b/crates/zakurad/build.rs
@@ -6,74 +6,20 @@
 //! When compiling the `lightwalletd` gRPC tests, also builds a gRPC client
 //! Rust API for `lightwalletd`.
 
-use vergen_gitcl::{CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
+#[path = "build/metadata.rs"]
+mod metadata;
 
-/// Process entry point for `zakurad`'s build script
-#[allow(clippy::print_stderr)]
+#[cfg(feature = "lightwalletd-grpc-tests")]
+#[path = "build/lightwalletd.rs"]
+mod lightwalletd;
+
+/// Process entry point for `zakurad`'s build script.
 fn main() {
-    let mut emitter = Emitter::default();
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build");
 
-    // Configures an [`Emitter`] for everything except for `git` env vars.
-    // This builder fails the build on error.
-    //
-    // The cargo instructions are listed explicitly instead of using
-    // `all_cargo()`: its `dependencies` instruction (whose output nothing
-    // consumes) runs `cargo metadata` at compile time, which resolves the
-    // dependency graph against the registry index — that fails in the
-    // `cargo package`/`cargo publish` verify build of the packaged crate
-    // (before the zakura-* dependencies are published) and in offline builds.
-    let cargo_instructions = CargoBuilder::default()
-        .debug(true)
-        .features(true)
-        .opt_level(true)
-        .target_triple(true)
-        .build()
-        .expect("cargo instruction builder should build successfully");
-
-    emitter
-        .fail_on_error()
-        .add_instructions(&cargo_instructions)
-        .expect("adding cargo instructions should succeed")
-        .add_instructions(
-            &RustcBuilder::all_rustc().expect("all_rustc() should build successfully"),
-        )
-        .expect("adding all_rustc() instructions should succeed");
-
-    // Get git information. This is used by e.g. ZakuradApp::register_components()
-    // to log the commit hash
-    let all_git = GitclBuilder::default()
-        .branch(true)
-        .commit_author_email(true)
-        .commit_author_name(true)
-        .commit_count(true)
-        .commit_date(true)
-        .commit_message(true)
-        .commit_timestamp(true)
-        .describe(false, false, None)
-        .sha(true)
-        .dirty(false)
-        .describe(true, true, Some("v*.*.*"))
-        .build()
-        .expect("all_git + describe + sha should build successfully");
-
-    if let Err(e) = emitter.add_instructions(&all_git) {
-        // The most common failure here is due to a missing `.git` directory,
-        // e.g., when building from `cargo install zakurad`. We simply
-        // proceed with the build.
-        // Note that this won't be printed unless in cargo very verbose mode (-vv).
-        // We could emit a build warning, but that might scare users.
-        eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);
-    }
-
-    emitter.emit().expect("base emit should succeed");
+    metadata::emit();
 
     #[cfg(feature = "lightwalletd-grpc-tests")]
-    tonic_prost_build::configure()
-        .build_client(true)
-        .build_server(false)
-        .compile_protos(
-            &["tests/common/lightwalletd/proto/service.proto"],
-            &["tests/common/lightwalletd/proto"],
-        )
-        .expect("Failed to generate lightwalletd gRPC files");
+    lightwalletd::generate_client();
 }

--- a/crates/zakurad/build/lightwalletd.rs
+++ b/crates/zakurad/build/lightwalletd.rs
@@ -1,0 +1,12 @@
+//! Generates the lightwalletd gRPC test client.
+
+pub fn generate_client() {
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(false)
+        .compile_protos(
+            &["tests/common/lightwalletd/proto/service.proto"],
+            &["tests/common/lightwalletd/proto"],
+        )
+        .expect("lightwalletd test protobufs should compile");
+}

--- a/crates/zakurad/build/metadata.rs
+++ b/crates/zakurad/build/metadata.rs
@@ -1,0 +1,158 @@
+//! Emits Cargo, Rust compiler, and Git metadata for `zakurad`.
+
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Emits all metadata consumed by `zakurad` diagnostics.
+#[allow(clippy::print_stderr)]
+pub fn emit() {
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
+    emit_cargo_metadata();
+    emit_rustc_metadata();
+
+    if let Err(error) = emit_git_metadata() {
+        // Source archives and `cargo install` builds do not have a `.git`
+        // directory, so Git metadata is intentionally optional.
+        eprintln!("git metadata unavailable: skipping git env vars: {error}");
+    }
+}
+
+fn emit_cargo_metadata() {
+    let mut features: Vec<_> = env::vars()
+        .filter_map(|(name, _)| {
+            name.strip_prefix("CARGO_FEATURE_")
+                .map(|feature| feature.to_lowercase())
+        })
+        .collect();
+    features.sort_unstable();
+
+    emit_env("VERGEN_CARGO_FEATURES", features.join(","));
+    emit_env("VERGEN_CARGO_TARGET_TRIPLE", required_env("TARGET"));
+    emit_env("VERGEN_CARGO_OPT_LEVEL", required_env("OPT_LEVEL"));
+    emit_env("VERGEN_CARGO_DEBUG", required_env("DEBUG"));
+}
+
+fn emit_rustc_metadata() {
+    let rustc = env::var_os("RUSTC").expect("Cargo always sets RUSTC for build scripts");
+    let output = Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .expect("rustc must be executable to compile zakurad");
+    assert!(output.status.success(), "rustc -vV must succeed");
+
+    let version = String::from_utf8(output.stdout).expect("rustc -vV output must be UTF-8");
+    emit_env("VERGEN_RUSTC_SEMVER", rustc_field(&version, "release"));
+    emit_env(
+        "VERGEN_RUSTC_COMMIT_DATE",
+        rustc_field(&version, "commit-date"),
+    );
+}
+
+fn emit_git_metadata() -> Result<(), String> {
+    if git(&["rev-parse", "--is-inside-work-tree"])? != "true" {
+        return Err("not inside a Git worktree".to_string());
+    }
+
+    emit_git_rerun_triggers()?;
+
+    let branch = git(&["rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD"])?;
+    let sha = git(&["rev-parse", "HEAD"])?;
+    let timestamp = match env::var("SOURCE_DATE_EPOCH") {
+        Ok(epoch) => format_source_date_epoch(&epoch)?,
+        Err(env::VarError::NotPresent) => git(&["log", "-1", "--pretty=format:%cI"])?,
+        Err(error) => return Err(format!("invalid SOURCE_DATE_EPOCH: {error}")),
+    };
+
+    let mut describe = git(&["describe", "--always", "--tags", "--match", "v*.*.*"])?;
+    if !git(&["status", "--porcelain", "--untracked-files=no"])?.is_empty() {
+        describe.push_str("-dirty");
+    }
+
+    emit_env("VERGEN_GIT_BRANCH", branch);
+    emit_env("VERGEN_GIT_COMMIT_TIMESTAMP", timestamp);
+    emit_env("VERGEN_GIT_DESCRIBE", describe);
+    emit_env("VERGEN_GIT_SHA", sha);
+
+    Ok(())
+}
+
+fn emit_git_rerun_triggers() -> Result<(), String> {
+    let git_dir = PathBuf::from(git(&["rev-parse", "--git-dir"])?);
+    emit_rerun_if_exists(&git_dir.join("HEAD"));
+
+    if let Ok(reference) = git(&["symbolic-ref", "HEAD"]) {
+        emit_rerun_if_exists(&git_dir.join(reference));
+    }
+
+    Ok(())
+}
+
+fn emit_rerun_if_exists(path: &Path) {
+    if path.exists() {
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+}
+
+fn git(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .output()
+        .map_err(|error| format!("could not run git: {error}"))?;
+
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn format_source_date_epoch(epoch: &str) -> Result<String, String> {
+    let seconds: i64 = epoch
+        .parse()
+        .map_err(|error| format!("SOURCE_DATE_EPOCH must be an integer: {error}"))?;
+    let days = seconds.div_euclid(86_400);
+    let seconds_of_day = seconds.rem_euclid(86_400);
+    let (year, month, day) = civil_date(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = seconds_of_day % 3_600 / 60;
+    let second = seconds_of_day % 60;
+
+    Ok(format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.000000000Z"
+    ))
+}
+
+fn civil_date(days_since_unix_epoch: i64) -> (i64, i64, i64) {
+    let days = days_since_unix_epoch + 719_468;
+    let era = days.div_euclid(146_097);
+    let day_of_era = days - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}
+
+fn rustc_field<'a>(version: &'a str, field: &str) -> &'a str {
+    version
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{field}: ")))
+        .unwrap_or_else(|| panic!("rustc -vV output must contain {field}"))
+}
+
+fn required_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("Cargo always sets {name} for build scripts"))
+}
+
+fn emit_env(name: &str, value: impl AsRef<str>) {
+    println!("cargo:rustc-env={name}={}", value.as_ref());
+}

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -91,7 +91,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::block::{self, genesis::regtest_genesis_block};
 use zakura_consensus::router::BackgroundTaskHandles;

--- a/crates/zakurad/src/components/inbound/downloads.rs
+++ b/crates/zakurad/src/components/inbound/downloads.rs
@@ -19,7 +19,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tower::{Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     block::{self, HeightDiff},

--- a/crates/zakurad/src/components/mempool/crawler.rs
+++ b/crates/zakurad/src/components/mempool/crawler.rs
@@ -56,7 +56,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 use tower::{timeout::Timeout, BoxError, Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{block::Height, transaction::UnminedTxId};
 use zakura_network as zn;

--- a/crates/zakurad/src/components/mempool/downloads.rs
+++ b/crates/zakurad/src/components/mempool/downloads.rs
@@ -42,7 +42,7 @@ use pin_project::{pin_project, pinned_drop};
 use thiserror::Error;
 use tokio::{sync::oneshot, task::JoinHandle};
 use tower::{Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     block::Height,

--- a/crates/zakurad/src/components/mempool/queue_checker.rs
+++ b/crates/zakurad/src/components/mempool/queue_checker.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use tokio::{task::JoinHandle, time::sleep};
 use tower::{BoxError, Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use crate::components::mempool;
 

--- a/crates/zakurad/src/components/sync/downloads.rs
+++ b/crates/zakurad/src/components/sync/downloads.rs
@@ -22,7 +22,7 @@ use tokio::{
     time::timeout,
 };
 use tower::{hedge, Service, ServiceExt};
-use tracing_futures::Instrument;
+use tracing::Instrument;
 
 use zakura_chain::{
     block::{self, Height, HeightDiff},

--- a/crates/zakurad/src/components/sync/progress.rs
+++ b/crates/zakurad/src/components/sync/progress.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use chrono::Utc;
-use num_integer::div_ceil;
 
 use tokio::sync::watch;
 use zakura_chain::{
@@ -260,10 +259,9 @@ pub async fn show_block_chain_progress(
             } else if is_syncer_stopped && current_height <= after_checkpoint_height {
                 // We've stopped syncing blocks,
                 // but we're below the minimum height estimated from our checkpoints.
-                let min_minutes_after_checkpoint_update = div_ceil(
-                    MIN_BLOCKS_MINED_AFTER_CHECKPOINT_UPDATE * POST_BLOSSOM_POW_TARGET_SPACING,
-                    60,
-                );
+                let min_minutes_after_checkpoint_update = (MIN_BLOCKS_MINED_AFTER_CHECKPOINT_UPDATE
+                    * POST_BLOSSOM_POW_TARGET_SPACING)
+                    .div_ceil(60);
 
                 warn!(
                     %sync_percent,

--- a/deploy/zakura-watchdog/Cargo.toml
+++ b/deploy/zakura-watchdog/Cargo.toml
@@ -12,13 +12,14 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls", "json"] }
-sentry = { workspace = true, features = ["backtrace", "contexts", "logs", "rustls", "tracing", "ureq"] }
+sentry = { workspace = true, features = ["backtrace", "logs", "rustls", "tracing", "ureq"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+ureq = { version = "3.0.11", default-features = false }
 
 [lints]
 workspace = true

--- a/deploy/zakura-watchdog/src/checks/zcashd_compat.rs
+++ b/deploy/zakura-watchdog/src/checks/zcashd_compat.rs
@@ -11,6 +11,7 @@
 
 use std::{collections::BTreeMap, fs, path::Path, process::Command, time::Duration};
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde_json::{json, Value};
 
 use crate::config::Config;
@@ -38,7 +39,11 @@ pub enum RpcError {
 
     /// The HTTP request failed or returned a non-success status.
     #[error("RPC request failed: {0}")]
-    Http(#[from] reqwest::Error),
+    Http(#[from] ureq::Error),
+
+    /// The HTTP response body was not valid JSON.
+    #[error("RPC response was not valid JSON: {0}")]
+    Json(#[from] serde_json::Error),
 
     /// The JSON-RPC response reported an error.
     #[error("RPC error response: {0}")]
@@ -52,16 +57,16 @@ pub enum RpcError {
 /// The zcashd-compat sync check. See the module docs for the predicates.
 pub struct ZcashdCompatSyncCheck {
     config: Config,
-    client: reqwest::blocking::Client,
+    client: ureq::Agent,
 }
 
 impl ZcashdCompatSyncCheck {
     /// Creates the check from watchdog configuration.
     pub fn new(config: &Config) -> Self {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(config.rpc_timeout))
+        let client = ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(config.rpc_timeout)))
             .build()
-            .expect("static client configuration with a timeout is always valid");
+            .new_agent();
 
         Self {
             config: config.clone(),
@@ -84,19 +89,21 @@ impl ZcashdCompatSyncCheck {
                     path: cookie_file.display().to_string(),
                 })?;
 
-        let body: Value = self
+        let authorization = format!("Basic {}", STANDARD.encode(format!("{user}:{password}")));
+        let request = json!({
+            "jsonrpc": "1.0",
+            "id": "zakura-watchdog",
+            "method": method,
+            "params": [],
+        })
+        .to_string();
+        let mut response = self
             .client
             .post(url)
-            .basic_auth(user, Some(password))
-            .json(&json!({
-                "jsonrpc": "1.0",
-                "id": "zakura-watchdog",
-                "method": method,
-                "params": [],
-            }))
-            .send()?
-            .error_for_status()?
-            .json()?;
+            .header("Authorization", authorization)
+            .content_type("application/json")
+            .send(&request)?;
+        let body = serde_json::from_str(&response.body_mut().read_to_string()?)?;
 
         extract_result(body)
     }

--- a/docs/changelog/unreleased/764.md
+++ b/docs/changelog/unreleased/764.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only reduces internal dependency and build surface without changing operator-visible behavior.


### PR DESCRIPTION
## Motivation

Zakura's production and workspace builds compile several unused, duplicate, single-purpose, and build-only dependency subgraphs. This increases clean-build time and the amount of third-party code participating in the supply chain.

## Solution

- Pre-generate protobuf and OpenRPC artifacts and verify drift in CI.
- Replace `vergen-gitcl` with focused build metadata helpers.
- Standardize RPC TLS on Ring and reuse Ureq in the watchdog.
- Replace `mset`, `human_bytes`, `num-integer`, `static_assertions`, and direct `tracing-futures` uses where small local or standard APIs suffice.
- Remove stale declarations and narrow test, utility, telemetry, and runtime features while preserving published Cargo feature compatibility.

The same work remains available as independently reviewable drafts: [#755](https://github.com/zakura-core/zakura/pull/755), [#756](https://github.com/zakura-core/zakura/pull/756), [#757](https://github.com/zakura-core/zakura/pull/757), [#758](https://github.com/zakura-core/zakura/pull/758), [#759](https://github.com/zakura-core/zakura/pull/759), [#760](https://github.com/zakura-core/zakura/pull/760), [#761](https://github.com/zakura-core/zakura/pull/761), and [#762](https://github.com/zakura-core/zakura/pull/762).

## Testing

- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- RPC library tests: 113 passed, 1 ignored
- Watchdog tests: 18 passed
- Focused consensus, counted-set, and byte-format tests
- `cargo test --locked -p zakura-utils --all-features`
- Semver checks for `zakura-node-services` and `zakura-utils`
- `cargo xtask check-rpc-artifacts`
- Zizmor 1.29.0 workflow audit
- Changelog and Markdown validation

## Changelog

`docs/changelog/unreleased/764.md` marks this internal-only change as excluded.