### PR TITLE
fix(consensus): restore multiset subsidy output tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,7 +1457,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,7 +1653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1999,7 +1999,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -2993,7 +2993,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3505,6 +3505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4d16a3d2b0e89ec6e7d509cf791545fcb48cbc8fc2fb2e96a492defda9140"
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,7 +3786,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4666,7 +4672,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4705,7 +4711,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6101,7 +6107,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7184,7 +7190,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7845,6 +7851,7 @@ dependencies = [
  "lazy_static",
  "libzcash_script",
  "metrics",
+ "mset",
  "once_cell",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ libzcash_script = "0.1"
 log = "0.4.27"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
+mset = "0.1"
 nix = "0.31"
 once_cell = "1.21"
 openrpsee = "0.1.0"

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -40,6 +40,7 @@ halo2 = { workspace = true }
 rand = { workspace = true }
 rand_10 = { workspace = true }
 rayon = { workspace = true }
+mset.workspace = true
 
 chrono = { workspace = true, features = ["clock", "std"] }
 lazy_static = { workspace = true }

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -4,6 +4,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
+use mset::MultiSet;
 use zakura_chain::{
     amount::{
         Amount, DeferredPoolBalanceChange, Error as AmountError, NegativeAllowed, NonNegative,
@@ -23,32 +24,6 @@ use zakura_chain::{
 use zakura_header_chain::{CompactTargetError, PowPolicy};
 
 use crate::{error::*, funding_stream_address};
-
-/// Coinbase outputs that have not yet matched a required subsidy payment.
-///
-/// The source transaction bounds this vector through its serialized size limit.
-struct UnmatchedCoinbaseOutputs {
-    outputs: Vec<Output>,
-}
-
-impl UnmatchedCoinbaseOutputs {
-    /// Copies the bounded outputs from a coinbase transaction.
-    fn new(outputs: &[Output]) -> Self {
-        Self {
-            outputs: outputs.to_vec(),
-        }
-    }
-
-    /// Removes one matching output, preserving duplicate output multiplicity.
-    fn remove(&mut self, expected: &Output) -> bool {
-        let Some(index) = self.outputs.iter().position(|output| output == expected) else {
-            return false;
-        };
-
-        self.outputs.remove(index);
-        true
-    }
-}
 
 /// Checks if there is exactly one coinbase transaction in `Block`,
 /// and if that coinbase transaction is the first transaction in the block.
@@ -180,13 +155,14 @@ pub fn subsidy_is_valid(
 
     let height = block.coinbase_height().ok_or(SubsidyError::NoCoinbase)?;
 
-    let mut coinbase_outputs = UnmatchedCoinbaseOutputs::new(
-        block
-            .transactions
-            .first()
-            .ok_or(SubsidyError::NoCoinbase)?
-            .outputs(),
-    );
+    let mut coinbase_outputs: MultiSet<Output> = block
+        .transactions
+        .first()
+        .ok_or(SubsidyError::NoCoinbase)?
+        .outputs()
+        .iter()
+        .cloned()
+        .collect();
 
     let mut has_amount = |addr: &Address, amount| {
         assert!(addr.is_script_hash(), "address must be P2SH");
@@ -463,35 +439,4 @@ pub fn merkle_root_validity(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use zakura_chain::{
-        amount::{Amount, NonNegative},
-        transparent::{Output, Script},
-    };
-
-    use super::UnmatchedCoinbaseOutputs;
-
-    fn output(value: u64) -> Output {
-        let value = Amount::<NonNegative>::try_from(value).expect("test value is a valid amount");
-        Output::new(value, Script::new(&[]))
-    }
-
-    #[test]
-    fn unmatched_coinbase_outputs_remove_one_duplicate_at_a_time() {
-        let repeated_output = output(1);
-        let distinct_output = output(2);
-        let mut outputs = UnmatchedCoinbaseOutputs::new(&[
-            repeated_output.clone(),
-            repeated_output.clone(),
-            distinct_output.clone(),
-        ]);
-
-        assert!(outputs.remove(&repeated_output));
-        assert!(outputs.remove(&repeated_output));
-        assert!(!outputs.remove(&repeated_output));
-        assert!(outputs.remove(&distinct_output));
-    }
 }


### PR DESCRIPTION
## Motivation

The vector replacement for `mset::MultiSet` preserves consensus behavior, but each match performs a linear search and shifts the remaining outputs. Repeated subsidy checks can therefore become quadratic in the number of coinbase outputs.

## Solution

Restore the original `MultiSet<Output>` implementation and its workspace dependency. This retains duplicate-output multiplicity while using the purpose-built hash-based collection.

## Testing

- `cargo fmt --all`
- `cargo check -p zakura-consensus --locked`
- `cargo test -p zakura-consensus --lib --locked`
- IDE diagnostics: no errors

## Changelog

Intentionally omitted because a release is in flight. The `C-exclude-from-changelog` label is applied.

### Specifications & References

- Addresses review feedback from https://github.com/zakura-core/zakura/pull/764#discussion_r3827852597