### PR TITLE
feat(state): derive historical treestates from frontier grids

### DIFF
--- a/crates/zakura-state/src/config.rs
+++ b/crates/zakura-state/src/config.rs
@@ -146,6 +146,18 @@ pub struct Config {
     #[serde(skip)]
     pub vct_fast_sync: bool,
 
+    /// Optional path to a frontier artifact used to anchor historical tree derivation.
+    ///
+    /// When unset, historical tree derivation remains idle and the absent band is reported as
+    /// unavailable. The artifact holds note commitment frontiers at a sparse height grid, so a
+    /// cold request replays from the nearest grid entry rather than from genesis. Every entry is
+    /// checked against the authenticated root this node already stores before it is used, so a
+    /// corrupt or hostile artifact is rejected rather than absorbed.
+    ///
+    /// Completed subtree roots need no equivalent setting: they ship embedded in the binary and
+    /// are loaded without operator configuration.
+    pub historical_frontier_artifact: Option<PathBuf>,
+
     /// Whether to delete the old database directories when present.
     ///
     /// Set to `true` by default. If this is set to `false`,
@@ -296,6 +308,25 @@ impl Config {
 
         Ok(())
     }
+
+    /// Whether this node rebuilds historical note commitment trees on demand for RPC queries.
+    ///
+    /// True when an archive node either currently uses the verified-commitment-trees fast path or
+    /// has a durable marker showing that its database previously completed a VCT fast sync. The
+    /// marker keeps an existing absent tree band serviceable after sync settings change. A legacy
+    /// database has no marker, so disabling either setting keeps derivation off.
+    ///
+    /// This is derived rather than configured because it grants no capability an operator needs to
+    /// weigh: a derived frontier is served only when it reproduces the authenticated root this node
+    /// already stores, so the answer is verified rather than trusted, and a node that can answer a
+    /// treestate query correctly has no reason to refuse it. What an operator does choose is the
+    /// cost bound: derivation anchors on [`Self::historical_frontier_artifact`], and
+    /// [`crate::MAX_HISTORICAL_TREE_REPLAY_BLOCKS`] bounds it from both ends, refusing a grid whose
+    /// gaps are too wide at startup and a request that would replay too far at serving time.
+    pub fn derive_historical_trees(&self, database_was_vct_fast_synced: bool) -> bool {
+        self.pruning_config().is_none()
+            && ((self.checkpoint_sync && self.vct_fast_sync) || database_was_vct_fast_synced)
+    }
 }
 
 /// Selects whether Zebra keeps all historical block data, or stores only the data
@@ -431,6 +462,7 @@ impl Default for Config {
             enable_zakura_header_seed_from_committed_blocks: false,
             checkpoint_sync: true,
             vct_fast_sync: true,
+            historical_frontier_artifact: None,
             delete_old_database: true,
             storage_mode: StorageMode::default(),
             debug_stop_at_height: None,
@@ -510,6 +542,69 @@ mod tests {
             !serialized.contains("vct_fast_sync"),
             "vct_fast_sync is configured under [consensus], not [state]"
         );
+    }
+
+    #[test]
+    fn historical_tree_derivation_follows_storage_mode_and_vct() {
+        assert!(
+            Config::default().derive_historical_trees(false),
+            "an archive node on the VCT fast path can rebuild the trees it skipped storing"
+        );
+
+        let legacy_recompute = Config {
+            vct_fast_sync: false,
+            ..Config::default()
+        };
+        assert!(
+            !legacy_recompute.derive_historical_trees(false),
+            "a node that recomputes every per-height tree has no absent band to derive"
+        );
+        assert!(
+            legacy_recompute.derive_historical_trees(true),
+            "a durable VCT marker preserves derivation after the fast path is disabled"
+        );
+
+        let full_verification = Config {
+            checkpoint_sync: false,
+            ..Config::default()
+        };
+        assert!(
+            !full_verification.derive_historical_trees(false),
+            "without checkpoint sync the VCT mirror is inert, so no band is skipped"
+        );
+        assert!(
+            full_verification.derive_historical_trees(true),
+            "a durable VCT marker preserves derivation after checkpoint sync is disabled"
+        );
+
+        let pruned = Config {
+            storage_mode: StorageMode::Pruned(PruningConfig::default()),
+            ..Config::default()
+        };
+        assert!(
+            !pruned.derive_historical_trees(false),
+            "replay reads block bodies that pruned mode deletes"
+        );
+        assert!(
+            !pruned.derive_historical_trees(true),
+            "a durable VCT marker cannot make pruned block bodies available"
+        );
+    }
+
+    #[test]
+    fn retired_historical_tree_settings_are_rejected() {
+        // Both keys were only ever available in pre-release builds, so a config carrying one is a
+        // preview config that must be updated. Silently ignoring it would leave an operator
+        // believing they had turned derivation off, or capped its replay.
+        for retired in [
+            "derive_historical_trees = true",
+            "max_historical_tree_replay_blocks = 100",
+        ] {
+            assert!(
+                toml::from_str::<Config>(retired).is_err(),
+                "{retired} is no longer a state setting and must not parse"
+            );
+        }
     }
 }
 

--- a/crates/zakura-state/src/constants.rs
+++ b/crates/zakura-state/src/constants.rs
@@ -39,14 +39,24 @@ pub const STATE_DATABASE_KIND: &str = "state";
 /// get the network-specific floor.
 pub const MIN_PRUNING_RETENTION: u32 = 10_000;
 
-/// The default bound on how many blocks one historical note commitment tree derivation may
-/// replay. Used as the `audit-historical-treestates` CLI default until the config knob lands.
+/// The most blocks one historical note commitment tree derivation may replay to serve a request.
 ///
-/// Sized to cover a cold request anywhere in a from-genesis fast-synced node's absent band on
-/// Mainnet, so the first request of a wallet sweep succeeds rather than failing at a limit. Later
-/// requests in the sweep replay only from the previous memoized frontier, so the bound applies to
-/// the cold case alone.
-pub const DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS: u64 = 4_000_000;
+/// One number bounds the cost two ways, because they are the same cost. Startup refuses a
+/// configured frontier grid whose largest cold-request gap, measured from genesis, exceeds this,
+/// and serving refuses a request that would still replay more than this. Checking only the grid
+/// would leave the request path open when entries load but fail their root checks, and checking
+/// only the request path would let a node start on a grid it can never serve from.
+///
+/// Sized to sit far above a real grid's gaps and far below the absent band it must never replay.
+/// The published Mainnet grid's largest cold request is 1,333 blocks, so this leaves roughly 75x
+/// headroom, while the band itself is ~3.4M blocks. Generation is deliberately not bounded by it:
+/// `export-historical-treestates` replays between grid targets, and the grid-free
+/// `audit-historical-treestates` walk measures the whole band on purpose.
+///
+/// Deliberately a constant rather than a setting. It bounds nothing an operator picks: the grid an
+/// operator does pick is what decides replay cost, and no value of this backstop makes a node with
+/// a gappy grid serve faster or a node with a dense one serve more.
+pub const MAX_HISTORICAL_TREE_REPLAY_BLOCKS: u64 = 100_000;
 
 /// The minimum retention window allowed in pruned storage mode on `network`.
 ///

--- a/crates/zakura-state/src/constants.rs
+++ b/crates/zakura-state/src/constants.rs
@@ -47,11 +47,9 @@ pub const MIN_PRUNING_RETENTION: u32 = 10_000;
 /// would leave the request path open when entries load but fail their root checks, and checking
 /// only the request path would let a node start on a grid it can never serve from.
 ///
-/// Sized to sit far above a real grid's gaps and far below the absent band it must never replay.
-/// The published Mainnet grid's largest cold request is 1,333 blocks, so this leaves roughly 75x
-/// headroom, while the band itself is ~3.4M blocks. Generation is deliberately not bounded by it:
-/// `export-historical-treestates` replays between grid targets, and the grid-free
-/// `audit-historical-treestates` walk measures the whole band on purpose.
+/// Sized to sit far above expected grid gaps and far below the absent band it must never replay.
+/// Generation is deliberately not bounded by it, and the grid-free `audit-historical-treestates`
+/// walk measures the whole band on purpose.
 ///
 /// Deliberately a constant rather than a setting. It bounds nothing an operator picks: the grid an
 /// operator does pick is what decides replay cost, and no value of this backstop makes a node with

--- a/crates/zakura-state/src/error.rs
+++ b/crates/zakura-state/src/error.rs
@@ -132,6 +132,35 @@ pub enum HistoricalSubtreeUnavailableReason {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum StateInitError {
+    /// The configured historical frontier artifact could not be read or decoded.
+    ///
+    /// Only nodes that derive historical trees reach this. A node that does not derive ignores an
+    /// unusable artifact, because nothing would have read it.
+    #[error(
+        "the historical frontier artifact configured at {path:?} could not be loaded: {source}. \
+         Hint: remove state.historical_frontier_artifact to serve without it"
+    )]
+    HistoricalFrontierArtifact {
+        /// Artifact path that failed to load.
+        path: PathBuf,
+        /// Underlying I/O or artifact decoding error.
+        source: BoxError,
+    },
+
+    /// The configured historical frontier artifact has gaps larger than one request may replay.
+    #[error(
+        "historical frontier artifact at {path:?} has a {blocks}-block gap, more than \
+         MAX_HISTORICAL_TREE_REPLAY_BLOCKS = {limit}; a cold request would replay that range"
+    )]
+    HistoricalFrontierArtifactTooSparse {
+        /// Artifact path whose grid does not tile genesis through `last_checkpoint`.
+        path: PathBuf,
+        /// Largest cold-request replay the file would require.
+        blocks: u64,
+        /// Configured per-request replay limit.
+        limit: u64,
+    },
+
     /// State could not read or parse the on-disk semantic format version.
     #[error(
         "cannot read state database format version at {path:?}. Hint: check the cache directory permissions and version file contents"

--- a/crates/zakura-state/src/lib.rs
+++ b/crates/zakura-state/src/lib.rs
@@ -45,8 +45,8 @@ pub use config::{
     StorageMode,
 };
 pub use constants::{
-    state_database_format_version_in_code, DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
-    MAX_BLOCK_REORG_HEIGHT,
+    state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT,
+    MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
 };
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitCheckpointVerifiedError,
@@ -114,7 +114,7 @@ pub use service::finalized_state::{
     validate_final_frontiers_bytes, FinalFrontiersGenerationError, FinalFrontiersValidationError,
 };
 pub use service::read::{
-    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_CACHED_FRONTIERS,
 };
 pub use service::{
     finalized_state::{DiskWriteBatch, FallibleDiskValue, FromDisk, IntoDisk, WriteDisk, ZakuraDb},

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -18,8 +18,9 @@ use std::{
     collections::{BTreeMap, HashMap},
     future::Future,
     ops::Bound,
+    path::PathBuf,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -44,7 +45,7 @@ use zakura_chain::{
 use crate::{
     constants::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS,
-        MAX_HEADER_SYNC_HEIGHT_RANGE, MAX_LEGACY_CHAIN_BLOCKS,
+        MAX_HEADER_SYNC_HEIGHT_RANGE, MAX_HISTORICAL_TREE_REPLAY_BLOCKS, MAX_LEGACY_CHAIN_BLOCKS,
     },
     error::{CommitBlockError, CommitCheckpointVerifiedError, InvalidateError, ReconsiderError},
     request::TimedSpan,
@@ -62,8 +63,9 @@ use crate::{
         read::find,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, KnownBlock,
-    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock, StateInitError,
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, HashOrHeight,
+    HistoricalTreeUnavailable, KnownBlock, ReadRequest, ReadResponse, Request, Response,
+    SemanticallyVerifiedBlock, StateInitError,
 };
 
 pub mod block_iter;
@@ -260,6 +262,14 @@ pub struct ReadStateService {
     /// Shared fail-closed attachment result, visible to every clone without joining the worker.
     block_write_failure: Arc<OnceLock<write::BlockWriteTaskFailure>>,
 
+    /// Note commitment frontiers this service has derived and root-checked for heights in a
+    /// verified-commitment-trees fast-synced database's absent band.
+    ///
+    /// Shared across clones so a wallet's sequential scan anchors each request on the previous
+    /// one. Empty, and never written, on a node that does not derive
+    /// ([`Config::derive_historical_trees`]) or has no frontier grid configured.
+    historical_trees: Arc<Mutex<read::HistoricalTreeCache>>,
+
     /// Published completed subtree roots for heights below the last checkpoint.
     ///
     /// `None` on networks without an embedded artifact, in which case `z_getsubtreesbyindex`
@@ -377,13 +387,18 @@ impl StateService {
     ///
     /// Returns the read-write and read-only state services,
     /// and read-only watch channels for its best chain tip.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`StateInitError`] if historical tree derivation is misconfigured or its
+    /// frontier artifact cannot be loaded.
     pub async fn new(
         config: Config,
         network: &Network,
         max_checkpoint_height: block::Height,
         checkpoint_verify_concurrency_limit: usize,
-    ) -> (Self, ReadStateService, LatestChainTip, ChainTipChange) {
-        let (finalized_state, finalized_tip, timer) = {
+    ) -> Result<(Self, ReadStateService, LatestChainTip, ChainTipChange), StateInitError> {
+        let (finalized_state, finalized_tip, historical_trees, timer) = {
             let config = config.clone();
             let network = network.clone();
             tokio::task::spawn_blocking(move || {
@@ -408,11 +423,18 @@ impl StateService {
 
                 let timer = CodeTimer::start();
                 let finalized_tip = finalized_chain_tip(&finalized_state.db);
+                let historical_trees = load_historical_frontier_artifact(
+                    &network,
+                    &config,
+                    finalized_state.db.vct_synced_below().is_some(),
+                )?;
+                let historical_trees =
+                    historical_trees.discard_if_before_vct_handoff(&config, &finalized_state.db);
 
-                (finalized_state, finalized_tip, timer)
+                Ok::<_, StateInitError>((finalized_state, finalized_tip, historical_trees, timer))
             })
             .await
-            .expect("failed to join blocking task")
+            .expect("failed to join blocking task")?
         };
 
         // # Correctness
@@ -514,6 +536,7 @@ impl StateService {
                 runtime_status: header_runtime_status_receiver,
                 reader: header_chain_reader_receiver,
             },
+            historical_trees,
         );
 
         let full_verifier_utxo_lookahead = max_checkpoint_height
@@ -594,7 +617,7 @@ impl StateService {
             }
         });
 
-        (state, read_service, latest_chain_tip, chain_tip_change)
+        Ok((state, read_service, latest_chain_tip, chain_tip_change))
     }
 
     /// Call read only state service to log rocksdb database metrics.
@@ -1225,6 +1248,7 @@ impl ReadStateService {
         non_finalized_state_receiver: WatchReceiver<NonFinalizedState>,
         vct_root_repair_receiver: tokio::sync::watch::Receiver<VctRootRepairStatus>,
         header_chain: HeaderChainSubscriptions,
+        historical_trees: Arc<Mutex<read::HistoricalTreeCache>>,
     ) -> Self {
         let historical_subtrees =
             finalized_state::embedded_historical_subtrees(&finalized_state.network()).map(Arc::new);
@@ -1235,6 +1259,7 @@ impl ReadStateService {
             non_finalized_state_receiver,
             block_write_task,
             block_write_failure,
+            historical_trees,
             historical_subtrees,
             vct_root_repair_receiver,
             header_chain_snapshot_receiver: header_chain.snapshots,
@@ -1273,6 +1298,34 @@ impl ReadStateService {
         let vct_applied_below = self.db.vct_synced_below()?;
 
         (artifact.last_checkpoint >= vct_applied_below).then_some((artifact, vct_applied_below))
+    }
+
+    /// Whether a published frontier grid is loaded and covers the durable VCT handoff.
+    ///
+    /// A marker written after construction can make the loaded grid too old. The first request
+    /// that observes that transition reports it and discards the grid, so later requests see the
+    /// absent band as unavailable without repeatedly checking the stale artifact.
+    fn has_usable_historical_frontier_grid(&self) -> bool {
+        let mut historical_trees = self
+            .historical_trees
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let artifact_checkpoint = historical_trees.last_checkpoint();
+        if let Some((artifact_checkpoint, vct_handoff)) =
+            frontier_grid_ends_before_vct_handoff(artifact_checkpoint, self.db.vct_synced_below())
+        {
+            tracing::warn!(
+                ?artifact_checkpoint,
+                ?vct_handoff,
+                "discarding historical frontier artifact that does not cover the database's VCT \
+                 handoff"
+            );
+            metrics::counter!("state.historical_tree.artifact_before_vct_handoff").increment(1);
+            *historical_trees = read::HistoricalTreeCache::default();
+            return false;
+        }
+
+        artifact_checkpoint.is_some()
     }
 
     /// Subscribe to VCT supplied-root repair needs discovered by the finalized writer.
@@ -1941,6 +1994,212 @@ fn subtrees_with_published_fallback<Node, Error>(
     }
 }
 
+/// A decoded frontier artifact waiting for the database-dependent coverage check.
+struct LoadedHistoricalFrontierArtifact {
+    cache: Arc<Mutex<read::HistoricalTreeCache>>,
+    last_checkpoint: Option<block::Height>,
+    source_path: Option<PathBuf>,
+}
+
+impl LoadedHistoricalFrontierArtifact {
+    /// Discards a frontier grid that ends below this database's durable VCT handoff, leaving
+    /// historical trees in the absent band unavailable instead of preventing startup.
+    ///
+    /// When the handoff marker has not been written yet, the grid is retained because its coverage
+    /// cannot be checked. Serving checks again after ordinary fast-sync commits write the marker
+    /// and reports the affected historical trees as unavailable if the grid is too old.
+    fn discard_if_before_vct_handoff(
+        self,
+        config: &Config,
+        db: &ZakuraDb,
+    ) -> Arc<Mutex<read::HistoricalTreeCache>> {
+        if config.derive_historical_trees(db.vct_synced_below().is_some()) {
+            if let Some((artifact_checkpoint, vct_handoff)) =
+                frontier_grid_ends_before_vct_handoff(self.last_checkpoint, db.vct_synced_below())
+            {
+                let source_path = self
+                    .source_path
+                    .expect("a loaded artifact has a source description");
+                tracing::warn!(
+                    path = ?source_path,
+                    ?artifact_checkpoint,
+                    ?vct_handoff,
+                    "ignoring historical frontier artifact that does not cover the database's VCT \
+                     handoff"
+                );
+                return Arc::new(Mutex::new(read::HistoricalTreeCache::default()));
+            }
+        }
+
+        self.cache
+    }
+}
+
+/// Returns the artifact checkpoint and database handoff when the published grid ends below this
+/// database's skip band.
+///
+/// `None` means the comparison cannot be made yet — the grid is unloaded, or the durable last
+/// checkpoint marker has not been written — or the grid already covers the band.
+fn frontier_grid_ends_before_vct_handoff(
+    artifact_checkpoint: Option<block::Height>,
+    vct_handoff: Option<block::Height>,
+) -> Option<(block::Height, block::Height)> {
+    artifact_checkpoint
+        .zip(vct_handoff)
+        .filter(|(artifact_checkpoint, vct_handoff)| artifact_checkpoint < vct_handoff)
+}
+
+/// Returns the cold-request replay length when it exceeds `limit`.
+///
+/// Gaps are measured from genesis: a published grid is a chain-shaped artifact, so a file that
+/// starts at a mid-chain `U` cannot serve a from-scratch node below `U`. `limit` is the same
+/// bound serving applies per request, so a grid that passes here cannot produce a cold request
+/// the read path would then refuse.
+fn frontier_grid_gap_exceeds_replay_limit(
+    artifact: &finalized_state::FrontierArtifact,
+    limit: u64,
+) -> Option<u64> {
+    let blocks = artifact.max_cold_replay_blocks();
+    (blocks > limit).then_some(blocks)
+}
+
+/// Loads the configured frontier grid into a fresh cache.
+///
+/// An unreadable or invalid configured artifact is fatal for a node that derives
+/// ([`Config::derive_historical_trees`]) and a warning for one that does not. Without a configured
+/// grid, the node keeps reporting the absent band as unavailable. A well-framed artifact is still
+/// refused unless its entries tile genesis through
+/// `last_checkpoint` at gaps of at most [`MAX_HISTORICAL_TREE_REPLAY_BLOCKS`].
+fn load_historical_frontier_artifact(
+    network: &Network,
+    config: &Config,
+    database_was_vct_fast_synced: bool,
+) -> Result<LoadedHistoricalFrontierArtifact, StateInitError> {
+    load_historical_frontier_artifact_if_enabled(
+        network,
+        config,
+        config.derive_historical_trees(database_was_vct_fast_synced),
+    )
+}
+
+fn load_historical_frontier_artifact_if_enabled(
+    network: &Network,
+    config: &Config,
+    derivation_enabled: bool,
+) -> Result<LoadedHistoricalFrontierArtifact, StateInitError> {
+    let (artifact, source_path) = if let Some(path) = config.historical_frontier_artifact.as_ref() {
+        (
+            std::fs::read(path)
+                .map_err(|error| Box::new(error) as BoxError)
+                .and_then(|bytes| {
+                    finalized_state::FrontierArtifact::decode(&bytes, network)
+                        .map(Arc::new)
+                        .map_err(|error| Box::new(error) as BoxError)
+                }),
+            path.clone(),
+        )
+    } else {
+        if derivation_enabled {
+            tracing::info!(
+                "historical tree derivation is idle: no historical frontier artifact is configured"
+            );
+        }
+        return Ok(LoadedHistoricalFrontierArtifact {
+            cache: Arc::new(Mutex::new(read::HistoricalTreeCache::default())),
+            last_checkpoint: None,
+            source_path: None,
+        });
+    };
+
+    match artifact {
+        Ok(artifact) => {
+            if derivation_enabled {
+                if let Some(blocks) = frontier_grid_gap_exceeds_replay_limit(
+                    &artifact,
+                    MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                ) {
+                    return Err(StateInitError::HistoricalFrontierArtifactTooSparse {
+                        path: source_path,
+                        blocks,
+                        limit: MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                    });
+                }
+            }
+
+            tracing::info!(
+                ?source_path,
+                entries = artifact.entries.len(),
+                spacing = artifact.spacing,
+                "loaded historical frontier artifact"
+            );
+            Ok(LoadedHistoricalFrontierArtifact {
+                last_checkpoint: Some(artifact.last_checkpoint),
+                cache: Arc::new(Mutex::new(read::HistoricalTreeCache::with_artifact(
+                    artifact,
+                ))),
+                source_path: Some(source_path),
+            })
+        }
+        Err(source) if derivation_enabled => Err(StateInitError::HistoricalFrontierArtifact {
+            path: source_path,
+            source,
+        }),
+        Err(error) => {
+            tracing::warn!(?source_path, %error, "ignoring historical frontier artifact");
+            Ok(LoadedHistoricalFrontierArtifact {
+                cache: Arc::new(Mutex::new(read::HistoricalTreeCache::default())),
+                last_checkpoint: None,
+                source_path: None,
+            })
+        }
+    }
+}
+
+/// Derives the note commitment frontiers for `hash_or_height`, whose stored per-height trees are
+/// absent because this is a verified-commitment-trees fast-synced database.
+///
+/// Callers reach this only once a tree read has already reported the absent band, so `unavailable`
+/// is the error that stands if derivation is switched off or this node is pruned. Inside the band
+/// the request either derives a root-checked frontier or fails: an absent tree there must never
+/// reach a client as an empty treestate (see [`crate::HistoricalTreeUnavailable`]).
+fn historical_frontiers(
+    state: &ReadStateService,
+    hash_or_height: HashOrHeight,
+    unavailable: HistoricalTreeUnavailable,
+) -> Result<Arc<read::DerivedFrontiers>, BoxError> {
+    // Archive mode is part of this: replay needs every block body from the selected anchor through
+    // the requested height, and pruned mode does not guarantee that range.
+    if !state
+        .db
+        .config()
+        .derive_historical_trees(state.db.vct_synced_below().is_some())
+    {
+        return Err(unavailable.into());
+    }
+
+    // Derivation anchors on the published grid. Without one the nearest anchor is the stored
+    // frontier below the absent band, so a cold request would replay the band end to end — the
+    // cost this design exists to avoid. Report the band as unavailable instead.
+    if !state.has_usable_historical_frontier_grid() {
+        return Err(unavailable.into());
+    }
+
+    let Some(height) = hash_or_height.height_or_else(|hash| state.db.height(hash)) else {
+        // The absent-band check resolved this block to a height, so failing to resolve it again
+        // means the database changed underneath the read. Report the original error rather than
+        // an empty tree.
+        return Err(unavailable.into());
+    };
+
+    read::derive_historical_frontiers(
+        &state.db,
+        &state.historical_trees,
+        height,
+        MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+    )
+    .map_err(BoxError::from)
+}
+
 fn block_roots_by_height_range<C>(
     chain: Option<C>,
     db: &ZakuraDb,
@@ -2468,20 +2727,48 @@ impl Service<ReadRequest> for ReadStateService {
             }
 
             ReadRequest::SaplingTree(hash_or_height) => {
-                let tree =
-                    read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
+                let tree = match read::sapling_tree(
+                    state.latest_best_chain(),
+                    &state.db,
+                    hash_or_height,
+                ) {
+                    Ok(tree) => tree,
+                    Err(unavailable) => Some(
+                        historical_frontiers(&state, hash_or_height, unavailable)?
+                            .sapling
+                            .clone(),
+                    ),
+                };
                 Ok(ReadResponse::SaplingTree(tree))
             }
 
             ReadRequest::OrchardTree(hash_or_height) => {
-                let tree =
-                    read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
+                let tree = match read::orchard_tree(
+                    state.latest_best_chain(),
+                    &state.db,
+                    hash_or_height,
+                ) {
+                    Ok(tree) => tree,
+                    Err(unavailable) => Some(
+                        historical_frontiers(&state, hash_or_height, unavailable)?
+                            .orchard
+                            .clone(),
+                    ),
+                };
                 Ok(ReadResponse::OrchardTree(tree))
             }
 
             ReadRequest::IronwoodTree(hash_or_height) => {
                 let tree =
-                    read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height)?;
+                    match read::ironwood_tree(state.latest_best_chain(), &state.db, hash_or_height)
+                    {
+                        Ok(tree) => tree,
+                        Err(unavailable) => Some(
+                            historical_frontiers(&state, hash_or_height, unavailable)?
+                                .ironwood
+                                .clone(),
+                        ),
+                    };
                 Ok(ReadResponse::IronwoodTree(tree))
             }
 
@@ -2827,17 +3114,25 @@ impl Service<ReadRequest> for ReadStateService {
 /// It's possible to construct multiple state services in the same application (as
 /// long as they, e.g., use different storage locations), but doing so is
 /// probably not what you want.
+///
+/// # Errors
+///
+/// Returns a [`StateInitError`] if historical tree derivation is misconfigured or its frontier
+/// artifact cannot be loaded.
 pub async fn init(
     config: Config,
     network: &Network,
     max_checkpoint_height: block::Height,
     checkpoint_verify_concurrency_limit: usize,
-) -> (
-    BoxService<Request, Response, BoxError>,
-    ReadStateService,
-    LatestChainTip,
-    ChainTipChange,
-) {
+) -> Result<
+    (
+        BoxService<Request, Response, BoxError>,
+        ReadStateService,
+        LatestChainTip,
+        ChainTipChange,
+    ),
+    StateInitError,
+> {
     let (state_service, read_only_state_service, latest_chain_tip, chain_tip_change) =
         StateService::new(
             config,
@@ -2845,44 +3140,52 @@ pub async fn init(
             max_checkpoint_height,
             checkpoint_verify_concurrency_limit,
         )
-        .await;
+        .await?;
 
-    (
+    Ok((
         BoxService::new(state_service),
         read_only_state_service,
         latest_chain_tip,
         chain_tip_change,
-    )
+    ))
 }
 
 /// Initialize state and return the separate capability used to seal completion-gated body
 /// evidence before it enters the general-purpose state request service.
+///
+/// # Errors
+///
+/// Returns a [`StateInitError`] if historical tree derivation is misconfigured or its frontier
+/// artifact cannot be loaded.
 pub async fn init_with_header_chain_body_evidence(
     config: Config,
     network: &Network,
     max_checkpoint_height: block::Height,
     checkpoint_verify_concurrency_limit: usize,
-) -> (
-    BoxService<Request, Response, BoxError>,
-    ReadStateService,
-    LatestChainTip,
-    ChainTipChange,
-    crate::HeaderChainBodyEvidenceAuthority,
-) {
+) -> Result<
+    (
+        BoxService<Request, Response, BoxError>,
+        ReadStateService,
+        LatestChainTip,
+        ChainTipChange,
+        crate::HeaderChainBodyEvidenceAuthority,
+    ),
+    StateInitError,
+> {
     let (state, read_state, latest_chain_tip, chain_tip_change) = init(
         config,
         network,
         max_checkpoint_height,
         checkpoint_verify_concurrency_limit,
     )
-    .await;
-    (
+    .await?;
+    Ok((
         state,
         read_state,
         latest_chain_tip,
         chain_tip_change,
         crate::HeaderChainBodyEvidenceAuthority::new(),
-    )
+    ))
 }
 
 /// Initialize a read state service from the provided [`Config`].
@@ -2903,6 +3206,13 @@ pub fn init_read_only(
     StateInitError,
 > {
     let finalized_state = FinalizedState::new_with_debug(&config, network, true, true)?;
+    let historical_trees = load_historical_frontier_artifact(
+        network,
+        &config,
+        finalized_state.db.vct_synced_below().is_some(),
+    )?;
+    let historical_trees =
+        historical_trees.discard_if_before_vct_handoff(&config, &finalized_state.db);
     let (non_finalized_state_sender, non_finalized_state_receiver) =
         tokio::sync::watch::channel(NonFinalizedState::new(network));
     let (_vct_root_repair_sender, vct_root_repair_receiver) =
@@ -2933,6 +3243,7 @@ pub fn init_read_only(
                 runtime_status: header_runtime_status_receiver,
                 reader: header_chain_reader_receiver,
             },
+            historical_trees,
         ),
         finalized_state.db.clone(),
         non_finalized_state_sender,
@@ -2972,7 +3283,9 @@ pub async fn init_test(
     // TODO: pass max_checkpoint_height and checkpoint_verify_concurrency limit
     //       if we ever need to test final checkpoint sent UTXO queries
     let (state_service, _, _, _) =
-        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0).await;
+        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
 
     Buffer::new(BoxService::new(state_service), 1)
 }
@@ -2993,7 +3306,9 @@ pub async fn init_test_services(
     // TODO: pass max_checkpoint_height and checkpoint_verify_concurrency limit
     //       if we ever need to test final checkpoint sent UTXO queries
     let (state_service, read_state_service, latest_chain_tip, chain_tip_change) =
-        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0).await;
+        StateService::new(Config::ephemeral(), network, block::Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
 
     let state_service = Buffer::new(BoxService::new(state_service), 1);
 

--- a/crates/zakura-state/src/service/arbitrary.rs
+++ b/crates/zakura-state/src/service/arbitrary.rs
@@ -219,7 +219,9 @@ pub async fn populated_state(
     // TODO: write a test that checks the finalized to non-finalized transition with UTXOs,
     //       and set max_checkpoint_height and checkpoint_verify_concurrency_limit correctly.
     let (state, read_state, latest_chain_tip, mut chain_tip_change) =
-        StateService::new(Config::ephemeral(), network, Height::MAX, 0).await;
+        StateService::new(Config::ephemeral(), network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
     let mut state = Buffer::new(BoxService::new(state), 1);
 
     let mut responses = FuturesUnordered::new();

--- a/crates/zakura-state/src/service/finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/prop.rs
@@ -5,7 +5,7 @@ use std::{
     env,
     error::Error,
     fs,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use tempfile::TempDir;
@@ -28,7 +28,7 @@ use zakura_chain::{
 use zakura_test::prelude::*;
 
 use crate::{
-    config::Config,
+    config::{Config, PruningConfig, StorageMode},
     error::HistoricalTreeUnavailable,
     service::{
         arbitrary::PreparedChain,
@@ -41,14 +41,14 @@ use crate::{
         },
     },
     tests::FakeChainHelper,
-    HashOrHeight,
+    HashOrHeight, ReadRequest, ReadResponse,
 };
 
 use super::super::{
     commitment_aux, export_frontier_grid_to, serve_block_roots,
     vct::validate_final_frontiers_bytes, verify_subtrees_against_stored, CheckpointVerifiedBlock,
-    DiskWriteBatch, FinalizedState, FrontierGridExportError, GridSpacing, VctAuxiliaryWindow,
-    VctSuccessorWitness,
+    DiskWriteBatch, FinalizedState, FrontierArtifact, FrontierEntry, FrontierGridExportError,
+    GridSpacing, VctAuxiliaryWindow, VctSuccessorWitness,
 };
 
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -3137,6 +3137,248 @@ fn vct_untrusted_fixture_drives_byte_identical_state() -> Result<()> {
 
             prop_assert_eq!(fast.db.vct_anchor_digest(), golden_anchors, "fast anchors from fixture roots match legacy");
             prop_assert_eq!(fast.db.history_tree().hash(), golden_history, "fast history from fixture roots match legacy");
+    });
+
+    Ok(())
+}
+
+/// Builds a [`crate::ReadStateService`] over `finalized_state`, so tests can exercise the real
+/// read handlers rather than the helpers underneath them.
+///
+/// The config gate, the artifact load, and the typed-error fallback all live in the handler, so
+/// testing only the helpers would leave the seam that actually serves `z_gettreestate` unproven.
+fn read_service_over(finalized_state: &FinalizedState) -> crate::ReadStateService {
+    use zakura_node_services::sync_lifecycle::{
+        HeaderRuntimeDetachedReason, HeaderRuntimeStatus, LifecycleEpoch,
+    };
+
+    use crate::service::{
+        non_finalized_state::NonFinalizedState, watch_receiver::WatchReceiver,
+        HeaderChainSubscriptions, ReadStateService, VctRootRepairStatus,
+    };
+
+    let (_non_finalized_sender, non_finalized_receiver) =
+        tokio::sync::watch::channel(NonFinalizedState::new(&finalized_state.network()));
+    let (_repair_sender, repair_receiver) =
+        tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let (_header_chain_snapshot_sender, header_chain_snapshot_receiver) =
+        tokio::sync::watch::channel(None);
+    let (_header_chain_view_sender, header_chain_view_receiver) = tokio::sync::watch::channel(None);
+    let (_header_runtime_status_sender, header_runtime_status_receiver) =
+        tokio::sync::watch::channel(HeaderRuntimeStatus::Detached {
+            epoch: LifecycleEpoch::INITIAL,
+            reason: HeaderRuntimeDetachedReason::AwaitingSemanticHandoff,
+        });
+    let (_header_chain_reader_sender, header_chain_reader_receiver) =
+        tokio::sync::watch::channel(None);
+
+    ReadStateService::new(
+        finalized_state,
+        None,
+        Arc::new(OnceLock::new()),
+        WatchReceiver::new(non_finalized_receiver),
+        repair_receiver,
+        HeaderChainSubscriptions {
+            snapshots: header_chain_snapshot_receiver,
+            views: header_chain_view_receiver,
+            runtime_status: header_runtime_status_receiver,
+            reader: header_chain_reader_receiver,
+        },
+        crate::service::load_historical_frontier_artifact(
+            &finalized_state.network(),
+            finalized_state.db.config(),
+            finalized_state.db.vct_synced_below().is_some(),
+        )
+        .expect("the test historical frontier artifact loads")
+        .discard_if_before_vct_handoff(finalized_state.db.config(), &finalized_state.db),
+    )
+}
+
+/// Writes a genesis-empty frontier grid, the anchor a deriving node needs before it will serve
+/// the absent band at all.
+///
+/// Height 0 is empty on this synthetic chain, so the entry root-checks and a below-handoff
+/// request still has to replay. The file must outlive the [`FinalizedState`] that points at it.
+fn write_genesis_frontier_artifact(
+    network: &zakura_chain::parameters::Network,
+    last_checkpoint: Height,
+) -> tempfile::NamedTempFile {
+    let artifact = FrontierArtifact {
+        spacing: 1,
+        last_checkpoint,
+        entries: vec![FrontierEntry {
+            height: Height(0),
+            sapling: Arc::new(Default::default()),
+            orchard: Arc::new(Default::default()),
+            ironwood: Arc::new(Default::default()),
+        }],
+    };
+    let file = tempfile::NamedTempFile::new().expect("a temporary artifact file is created");
+    fs::write(file.path(), artifact.encode(network)).expect("the genesis frontier artifact writes");
+    file
+}
+
+/// The read service must serve absent-band treestates when derivation is enabled, and report the
+/// typed archive-mode error when it is not, including when the node is pruned.
+///
+/// This exercises the handler itself — config gating, derivation, the pruned-mode short-circuit,
+/// and the fallback to [`HistoricalTreeUnavailable`] — rather than the helpers underneath it,
+/// because that handler is what a wallet's `z_gettreestate` actually reaches.
+#[test]
+#[allow(clippy::needless_range_loop)] // the loops index blocks[i + 1] for the successor witness
+fn vct_read_service_serves_or_refuses_absent_band_treestates() -> Result<()> {
+    use tower::ServiceExt;
+
+    let _init_guard = zakura_test::init();
+
+    let network = ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(10),
+            sapling: Some(15),
+            blossom: Some(20),
+            heartwood: Some(25),
+            canopy: Some(30),
+            nu5: Some(35),
+            nu6: Some(40),
+            nu6_1: Some(45),
+            nu6_2: Some(47),
+            nu6_3: Some(48),
+            nu7: Some(50),
+        })
+        .expect("failed to set activation heights")
+        .extend_funding_streams()
+        .to_network()
+        .expect("failed to build configured network");
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 activation height is configured");
+    let tested_block_count =
+        usize::try_from(nu5_height.0 + 4).expect("test activation height fits in usize");
+    let ledger_strategy =
+        LedgerState::genesis_strategy(Some(network), None::<NetworkUpgrade>, None, false);
+
+    proptest!(ProptestConfig::with_cases(1),
+        |((blocks, network) in super::valid_commitment_chain(ledger_strategy.clone(), tested_block_count).no_shrink())| {
+
+        let nu5 = NetworkUpgrade::Nu5.activation_height(&network).unwrap().0;
+        let heartwood = NetworkUpgrade::Heartwood.activation_height(&network).unwrap().0;
+        let last = (nu5 + 3) as usize;
+        prop_assert!(blocks.len() > last, "generated chain unexpectedly short");
+        let handoff = Height(last as u32);
+        let seed = (heartwood - 1) as usize;
+
+        // Legacy pass: the per-block fixture, and the golden trees to compare against.
+        let mut legacy = FinalizedState::new(&Config::ephemeral(), &network)
+            .expect("opening an ephemeral database should succeed");
+        let mut fixture = TestRootMap::new();
+        let mut handoff_trees = None;
+        for i in 0..=last {
+            let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+            let (_h, trees) = legacy
+                .commit_finalized_direct(cv.into(), None, None, "vct legacy")
+                .unwrap();
+            if i > seed {
+                fixture.insert(
+                    i as u32,
+                    (trees.sapling.root(), trees.orchard.root(), trees.ironwood.root()),
+                );
+            }
+            if i == last {
+                handoff_trees = Some(trees);
+            }
+        }
+        let handoff_trees = handoff_trees.expect("the handoff produced trees");
+
+        let commit_fast = |config: Config| {
+            let mut fast = FinalizedState::new(&config, &network)
+                .expect("opening an ephemeral database should succeed");
+            enable_vct_test_fixture_source_with_handoff(
+                &mut fast,
+                fixture.clone(),
+                handoff,
+                handoff_trees.sapling.clone(),
+                handoff_trees.orchard.clone(),
+                handoff_trees.sprout.clone(),
+                handoff_trees.ironwood.clone(),
+            );
+            for i in 0..=last {
+                let cv = CheckpointVerifiedBlock::from(blocks[i].block.clone());
+                let next = (i < last).then(|| vct_successor_witness(blocks[i + 1].block.clone()));
+                fast.commit_finalized_direct(cv.into(), None, next, "vct fast")
+                    .expect("verified fast commit succeeds");
+            }
+            fast
+        };
+
+        let probe = Height(last as u32 - 1);
+        let runtime = tokio::runtime::Runtime::new().expect("a test runtime starts");
+
+        // An archive node on the VCT fast path derives: the handler serves trees matching the
+        // legacy node's. A genesis-empty grid is enough to anchor on, and still leaves the probe
+        // as a replay rather than a zero-cost hit.
+        let artifact_file = write_genesis_frontier_artifact(&network, handoff);
+        let deriving = Config {
+            historical_frontier_artifact: Some(artifact_file.path().to_path_buf()),
+            ..Config::ephemeral()
+        };
+        let fast = commit_fast(deriving);
+        prop_assert!(fast.db.vct_tree_absent(probe), "the probe height is in the absent band");
+
+        let read_state = read_service_over(&fast);
+        let sapling = runtime
+            .block_on(read_state.clone().oneshot(ReadRequest::SaplingTree(probe.into())))
+            .expect("the read service answers");
+        let ReadResponse::SaplingTree(Some(tree)) = sapling else {
+            panic!("derivation is enabled, so the absent band must be served, got {sapling:?}")
+        };
+        prop_assert_eq!(
+            tree.root(),
+            legacy.db.sapling_tree_by_height(&probe).expect("legacy stores every tree").root(),
+            "the served Sapling treestate matches the legacy node"
+        );
+
+        let orchard = runtime
+            .block_on(read_state.oneshot(ReadRequest::OrchardTree(probe.into())))
+            .expect("the read service answers");
+        let ReadResponse::OrchardTree(Some(tree)) = orchard else {
+            panic!("derivation is enabled, so the absent band must be served, got {orchard:?}")
+        };
+        prop_assert_eq!(
+            tree.root(),
+            legacy.db.orchard_tree_by_height(&probe).expect("legacy stores every tree").root(),
+            "the served Orchard treestate matches the legacy node"
+        );
+
+        // Pruned mode, grid and all: bodies in the retention window may still be present on this
+        // short chain, but a pruned node cannot serve historical treestates. Fail with the typed
+        // archive-mode error rather than walking the replay until a missing body.
+        let pruned = Config {
+            historical_frontier_artifact: Some(artifact_file.path().to_path_buf()),
+            storage_mode: StorageMode::Pruned(PruningConfig::default()),
+            ..Config::ephemeral()
+        };
+        let fast = commit_fast(pruned);
+        let read_state = read_service_over(&fast);
+        let sapling_error = runtime
+            .block_on(read_state.clone().oneshot(ReadRequest::SaplingTree(probe.into())))
+            .expect_err("pruned mode must not derive historical treestates");
+        prop_assert!(
+            sapling_error.to_string().contains("fast-synced"),
+            "pruned mode reports the typed archive-mode error, got: {sapling_error}"
+        );
+        prop_assert!(
+            !sapling_error.to_string().contains("not retained"),
+            "pruned mode must not surface a per-height missing-body replay failure, got: {sapling_error}"
+        );
+        let orchard_error = runtime
+            .block_on(read_state.oneshot(ReadRequest::OrchardTree(probe.into())))
+            .expect_err("pruned mode must not derive historical treestates");
+        prop_assert!(
+            orchard_error.to_string().contains("fast-synced"),
+            "pruned mode reports the typed archive-mode error, got: {orchard_error}"
+        );
+
     });
 
     Ok(())

--- a/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
+++ b/crates/zakura-state/src/service/finalized_state/vct_treestate_audit.rs
@@ -187,7 +187,7 @@ pub struct DerivationSample {
 
     /// How many blocks the derivation replayed.
     ///
-    /// Zero means the height was already memoized, so nothing was replayed.
+    /// Zero means the height was already in the cache, so nothing was replayed.
     pub replayed_blocks: u64,
 
     /// How long the derivation took, including the root check.
@@ -208,7 +208,7 @@ impl DerivationSample {
 /// height *is* a root match at that height, and the first mismatch stops the walk. That makes this
 /// both the invariant check and the cost measurement.
 ///
-/// `cache` carries memoized frontiers between heights. Pass a fresh cache to measure cold cost from
+/// `cache` carries derived frontiers between heights. Pass a fresh cache to measure cold cost from
 /// the bottom of the band; reuse one across ascending heights to measure the sequential cost a
 /// wallet actually pays.
 pub fn measure_derivations(
@@ -220,7 +220,7 @@ pub fn measure_derivations(
 ) -> Result<(), (Height, HistoricalTreeDerivationError)> {
     for height in heights {
         let start = Instant::now();
-        // The derivation reports its own replay length: it may have anchored on the memo, on a
+        // The derivation reports its own replay length: it may have anchored on the cache, on a
         // published grid entry, or on genesis, and only it knows which.
         let derivation = derive_historical_frontiers_measured(db, cache, height, max_replay_blocks)
             .map_err(|error| (height, error))?;

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1513,6 +1513,13 @@ async fn raw_block_range_read_stops_at_pruned_gap_before_retained_bodies() {
             runtime_status: header_runtime_status_receiver,
             reader: header_chain_reader_receiver,
         },
+        crate::service::load_historical_frontier_artifact(
+            &state.network(),
+            state.db.config(),
+            state.db.vct_synced_below().is_some(),
+        )
+        .expect("the default historical frontier configuration loads")
+        .discard_if_before_vct_handoff(state.db.config(), &state.db),
     );
 
     let response = read_state

--- a/crates/zakura-state/src/service/read.rs
+++ b/crates/zakura-state/src/service/read.rs
@@ -44,7 +44,7 @@ pub use find::{
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use historical_tree::{
-    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_MEMOIZED_FRONTIERS,
+    derive_historical_frontiers, DerivedFrontiers, HistoricalTreeCache, MAX_CACHED_FRONTIERS,
 };
 pub(crate) use tree::{
     check_historical_ironwood_subtrees_available, check_historical_orchard_subtrees_available,

--- a/crates/zakura-state/src/service/read/historical_tree.rs
+++ b/crates/zakura-state/src/service/read/historical_tree.rs
@@ -30,14 +30,16 @@ use zakura_chain::{
 
 use zakura_chain::subtree::NoteCommitmentSubtreeIndex;
 
-use crate::service::finalized_state::{serve_block_roots, TransactionLocation, ZakuraDb};
+use crate::service::finalized_state::{
+    serve_block_roots, FrontierArtifact, TransactionLocation, ZakuraDb,
+};
 
-/// The most derived frontiers to keep memoized per node.
+/// The most derived frontiers to keep in the per-node cache.
 ///
 /// Wallet access is sequential, so a single entry already collapses a scan's steady-state cost to
 /// one batch of replay. The rest of the budget covers concurrent clients scanning different parts
 /// of the band. Each entry is a few kilobytes, so this is a negligible amount of memory.
-pub const MAX_MEMOIZED_FRONTIERS: usize = 64;
+pub const MAX_CACHED_FRONTIERS: usize = 64;
 
 /// Which shielded pool a replay event belongs to.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -181,39 +183,77 @@ pub enum HistoricalTreeDerivationError {
     },
 }
 
-/// A bounded memo of frontiers this node has already derived and root-checked.
+/// A bounded in-memory cache of frontiers this node has already derived and root-checked.
 ///
-/// Entries double as anchors: a derivation for height `h` starts from the highest memoized height
-/// at or below `h`, so a wallet scanning forward replays only from the end of its previous batch.
+/// Entries double as anchors. A derivation for height `h` starts from the highest verified
+/// frontier at or below `h` across this cache and the published grid, so a wallet scanning forward
+/// replays only from the end of its previous batch, and a cold request still takes the nearest
+/// grid entry rather than a distant cache hit.
 #[derive(Debug, Default)]
 pub struct HistoricalTreeCache {
     /// Verified frontiers, keyed by the height they are the state at the end of.
     frontiers: BTreeMap<Height, Arc<DerivedFrontiers>>,
+
+    /// A published frontier grid to fall back on when the cache has nothing nearby.
+    ///
+    /// Entries here are *not* trusted: one is root-checked before it anchors anything, exactly
+    /// like a locally derived frontier, which is what lets the grid be coarse and distributed
+    /// outside the binary.
+    artifact: Option<Arc<FrontierArtifact>>,
 }
 
 impl HistoricalTreeCache {
-    /// Returns the highest memoized frontier at or below `height`, if any.
-    fn anchor_at_or_below(&self, height: Height) -> Option<(Height, Arc<DerivedFrontiers>)> {
+    /// Returns a cache that can also anchor on `artifact`'s published grid.
+    pub fn with_artifact(artifact: Arc<FrontierArtifact>) -> Self {
+        Self {
+            frontiers: BTreeMap::new(),
+            artifact: Some(artifact),
+        }
+    }
+
+    /// The last checkpoint encoded in the published grid, if one is loaded.
+    pub(crate) fn last_checkpoint(&self) -> Option<Height> {
+        self.artifact
+            .as_ref()
+            .map(|artifact| artifact.last_checkpoint)
+    }
+
+    /// Returns the highest published grid entry at or below `height`, if any.
+    fn artifact_anchor_at_or_below(&self, height: Height) -> Option<(Height, DerivedFrontiers)> {
+        let entry = self.artifact.as_ref()?.anchor_at_or_below(height)?;
+
+        Some((
+            entry.height,
+            DerivedFrontiers {
+                sapling: entry.sapling.clone(),
+                orchard: entry.orchard.clone(),
+                ironwood: entry.ironwood.clone(),
+            },
+        ))
+    }
+
+    /// Returns the highest cached frontier at or below `height`, if any.
+    fn cached_anchor_at_or_below(&self, height: Height) -> Option<(Height, Arc<DerivedFrontiers>)> {
         self.frontiers
             .range(..=height)
             .next_back()
             .map(|(anchor, frontiers)| (*anchor, frontiers.clone()))
     }
 
-    /// Memoizes `frontiers` as the verified state at the end of `height`.
+    /// Caches `frontiers` as the verified state at the end of `height`.
     ///
     /// Evicts the lowest height when full. Clients sweep forward, so the lowest entry is the one
     /// least likely to anchor the next request.
     fn insert(&mut self, height: Height, frontiers: Arc<DerivedFrontiers>) {
         self.frontiers.insert(height, frontiers);
 
-        while self.frontiers.len() > MAX_MEMOIZED_FRONTIERS {
+        while self.frontiers.len() > MAX_CACHED_FRONTIERS {
             self.frontiers.pop_first();
         }
     }
 }
 
-/// Locks the memo, recovering from poisoning.
+/// Locks the cache, recovering from poisoning.
 ///
 /// The cache holds only root-checked frontiers keyed by height, so a panic elsewhere cannot leave
 /// it in a state that would make a later derivation wrong. Refusing to serve because an unrelated
@@ -224,13 +264,24 @@ fn lock(cache: &Mutex<HistoricalTreeCache>) -> std::sync::MutexGuard<'_, Histori
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Returns whether a published grid entry is strictly closer to the target than a cached one.
+///
+/// Equal heights prefer the cache: it is already root-checked and already resident. A cache hit at
+/// any lower height is not closer; that is the case that used to skip the grid entirely.
+fn published_is_nearer(cached: Option<Height>, published: Option<Height>) -> bool {
+    published.is_some_and(|published_height| {
+        cached.is_none_or(|cached_height| published_height > cached_height)
+    })
+}
+
 /// Derives the note commitment frontiers as of the end of block `height`, verified against the
 /// authenticated root stored for that height.
 ///
-/// Replays block bodies forward from the nearest anchor: the highest memoized frontier at or below
-/// `height`, else the last frontier stored below the absent band, else empty frontiers at genesis.
-/// The result is memoized in `cache` only after it reproduces the authenticated root, so a
-/// derivation can never be anchored on an unverified frontier.
+/// Replays block bodies forward from the nearest anchor: the higher of the highest cached
+/// frontier and the highest published grid entry at or below `height`, else the last frontier
+/// stored below the absent band, else empty frontiers at genesis. The result is stored in
+/// `cache` only after it reproduces the authenticated root, so a derivation can never be anchored
+/// on an unverified frontier.
 ///
 /// `max_replay_blocks` bounds the work one request can cost. It is a serving limit, not a
 /// correctness one.
@@ -254,7 +305,7 @@ pub struct Derivation {
     ///
     /// Zero when the requested height was already available as an anchor. Callers measuring cost
     /// must read this rather than infer it from the height, because the anchor may have come from
-    /// the memo or from a published grid rather than from genesis.
+    /// the cache or from a published grid rather than from genesis.
     pub replayed_blocks: u64,
 }
 
@@ -272,7 +323,7 @@ pub fn derive_historical_frontiers_measured(
     if let Some((anchor_height, frontiers)) = &anchor {
         match anchor_height.cmp(&height) {
             std::cmp::Ordering::Equal => {
-                // Memoized entries have already passed this check, but a database fallback has
+                // Cached entries have already passed this check, but a database fallback has
                 // not. Keep the check here so a zero-replay result follows the same acceptance
                 // rule as every replayed result.
                 verify_against_index(db, height, frontiers)?;
@@ -330,51 +381,81 @@ pub fn derive_historical_frontiers_measured(
 ///
 /// `None` means start from empty frontiers at genesis, which is correct when this binary committed
 /// every block from genesis (`U == 0`) and so stored no per-height trees to anchor on.
+///
+/// Published grid entries at or above the VCT upgrade height are tried nearest-first. Entries
+/// below the upgrade cannot be checked against the VCT roots index and are also lower than the
+/// stored `U - 1` frontier, so they are never useful anchors. A failed root check skips that cell
+/// and tries the next-lower eligible one while it stays nearer than the cache. The grid is the
+/// bound on cold replay; ignoring it and restarting at genesis is the expensive path it exists to
+/// avoid.
 fn anchor_for(
     db: &ZakuraDb,
     cache: &Mutex<HistoricalTreeCache>,
     height: Height,
 ) -> Result<Option<(Height, Arc<DerivedFrontiers>)>, HistoricalTreeDerivationError> {
-    let memoized = lock(cache).anchor_at_or_below(height);
+    let cached = lock(cache).cached_anchor_at_or_below(height);
+    let cached_height = cached.as_ref().map(|(anchor_height, _)| *anchor_height);
+    let published_floor = db.vct_upgrade_height().unwrap_or(Height(0));
 
-    if memoized.is_some() {
-        return Ok(memoized);
+    let mut skip_at_or_above: Option<Height> = None;
+    loop {
+        let search_height = match skip_at_or_above {
+            None => Some(height),
+            Some(Height(0)) => None,
+            Some(skipped) => Some(Height(skipped.0 - 1)),
+        };
+        let Some(search_height) = search_height else {
+            break;
+        };
+
+        let published = lock(cache).artifact_anchor_at_or_below(search_height);
+        let Some((anchor_height, frontiers)) = published else {
+            break;
+        };
+
+        // The roots index starts at U, and the durable U - 1 frontier is nearer than every
+        // published entry below U. Since artifact entries are sorted, all remaining entries are
+        // also below the floor.
+        if anchor_height < published_floor {
+            break;
+        }
+
+        if !published_is_nearer(cached_height, Some(anchor_height)) {
+            break;
+        }
+
+        // The entry is checked against this node's own authenticated root before it anchors
+        // anything, so a wrong or hostile artifact cannot steer a derivation.
+        //
+        // A failed check is deliberately *not* fatal: the artifact is an optimization with no
+        // trust weight, so a bad entry is ignored and the derivation tries the next-lower cell.
+        // Making it fatal would hand anyone who can supply a corrupt artifact a denial of service
+        // over a node that is perfectly capable of answering without one.
+        match verify_against_index(db, anchor_height, &frontiers) {
+            Ok(()) => {
+                let frontiers = Arc::new(frontiers);
+                lock(cache).insert(anchor_height, frontiers.clone());
+
+                return Ok(Some((anchor_height, frontiers)));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    ?anchor_height,
+                    %error,
+                    "ignoring a published frontier entry that does not match the authenticated root",
+                );
+                metrics::counter!("state.historical_tree.artifact_entry_rejected").increment(1);
+                skip_at_or_above = Some(anchor_height);
+            }
+        }
     }
 
-    // Below the upgrade height `U` this binary did not run, so per-height trees are present. The
-    // tree at `U - 1` is therefore the last stored frontier before the absent band starts.
-    let Some(upgrade) = db.vct_upgrade_height().filter(|upgrade| upgrade.0 > 0) else {
-        return Ok(None);
-    };
-
-    let anchor = Height(upgrade.0 - 1);
-    // Rollback can move the tip below the write-once upgrade marker. In that case a backwards tree
-    // lookup would return a retained row below the rollback target and mislabel it as `anchor`.
-    if db
-        .finalized_tip_height()
-        .is_none_or(|tip_height| anchor > tip_height)
-    {
-        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
+    if cached.is_some() {
+        return Ok(cached);
     }
 
-    // These reads intentionally search backwards because unchanged trees are deduplicated. The tip
-    // check above establishes that the chain still reaches `anchor`, so such a row is its state.
-    let (Some(sapling), Some(orchard), Some(ironwood)) = (
-        db.latest_stored_sapling_tree(&anchor),
-        db.latest_stored_orchard_tree(&anchor),
-        db.latest_stored_ironwood_tree(&anchor),
-    ) else {
-        return Err(HistoricalTreeDerivationError::MissingAnchor { height, anchor });
-    };
-
-    Ok(Some((
-        anchor,
-        Arc::new(DerivedFrontiers {
-            sapling,
-            orchard,
-            ironwood,
-        }),
-    )))
+    stored_frontier_before_absent_band(db, height)
+        .map(|anchor| anchor.map(|(height, frontiers)| (height, Arc::new(frontiers))))
 }
 
 /// Returns the stored frontier immediately before the absent band, if the band starts above
@@ -645,15 +726,33 @@ fn authenticated_roots(
 
 #[cfg(test)]
 mod tests {
-    use zakura_chain::{block::Height, parameters::Network};
+    use std::sync::{Arc, Mutex};
+
+    use zakura_chain::{
+        block::{merkle::AuthDataRoot, Height},
+        orchard,
+        parameters::Network,
+    };
 
     use crate::{
         config::Config,
-        constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
-        service::finalized_state::{DiskWriteBatch, STATE_COLUMN_FAMILIES_IN_CODE},
+        constants::{
+            state_database_format_version_in_code, MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+            STATE_DATABASE_KIND,
+        },
+        service::finalized_state::{
+            DiskWriteBatch, FrontierArtifact, FrontierEntry, STATE_COLUMN_FAMILIES_IN_CODE,
+        },
     };
 
     use super::*;
+
+    /// A low cache fill, matching the "request U+1000 first" case.
+    const LOW: Height = Height(1_000);
+    /// A grid cell between LOW and HIGH.
+    const MID: Height = Height(2_000_000);
+    /// A later high request, matching the "then ask for 3,000,000" case.
+    const HIGH: Height = Height(3_000_000);
 
     fn ephemeral_db() -> ZakuraDb {
         ZakuraDb::new(
@@ -668,6 +767,78 @@ mod tests {
             false,
         )
         .expect("opening an ephemeral database should succeed")
+    }
+
+    fn mismatched_frontiers() -> DerivedFrontiers {
+        let mut orchard = orchard::tree::NoteCommitmentTree::default();
+        orchard
+            .append(halo2::pasta::pallas::Base::from(1u64))
+            .expect("test tree is not full");
+        DerivedFrontiers {
+            sapling: Arc::new(Default::default()),
+            orchard: Arc::new(orchard),
+            ironwood: Arc::new(Default::default()),
+        }
+    }
+
+    fn seed_roots(db: &ZakuraDb, height: Height, frontiers: &DerivedFrontiers) {
+        let mut batch = DiskWriteBatch::new();
+        batch.insert_commitment_roots_by_height(
+            db,
+            height,
+            &frontiers.sapling.root(),
+            &frontiers.orchard.root(),
+            &frontiers.ironwood.root(),
+            0,
+            0,
+            0,
+            &AuthDataRoot::from([0; 32]),
+        );
+        db.write_batch(batch)
+            .expect("seeding authenticated roots succeeds");
+    }
+
+    fn artifact_at(height: Height, frontiers: &DerivedFrontiers) -> Arc<FrontierArtifact> {
+        artifact_entries(Height(height.0 + 1), &[(height, frontiers)])
+    }
+
+    fn artifact_entries(
+        last_checkpoint: Height,
+        entries: &[(Height, &DerivedFrontiers)],
+    ) -> Arc<FrontierArtifact> {
+        Arc::new(FrontierArtifact {
+            spacing: 1,
+            last_checkpoint,
+            entries: entries
+                .iter()
+                .map(|(height, frontiers)| FrontierEntry {
+                    height: *height,
+                    sapling: frontiers.sapling.clone(),
+                    orchard: frontiers.orchard.clone(),
+                    ironwood: frontiers.ironwood.clone(),
+                })
+                .collect(),
+        })
+    }
+
+    fn cache_with(
+        artifact: Arc<FrontierArtifact>,
+        cached_height: Height,
+        cached: DerivedFrontiers,
+    ) -> Mutex<HistoricalTreeCache> {
+        let mut cache = HistoricalTreeCache::with_artifact(artifact);
+        cache.insert(cached_height, Arc::new(cached));
+        Mutex::new(cache)
+    }
+
+    #[test]
+    fn published_is_nearer_takes_the_higher_height() {
+        assert!(published_is_nearer(None, Some(HIGH)));
+        assert!(published_is_nearer(Some(LOW), Some(HIGH)));
+        assert!(!published_is_nearer(Some(HIGH), Some(LOW)));
+        assert!(!published_is_nearer(Some(HIGH), Some(HIGH)));
+        assert!(!published_is_nearer(Some(LOW), None));
+        assert!(!published_is_nearer(None, None));
     }
 
     #[test]
@@ -687,5 +858,160 @@ mod tests {
         assert!(stored_frontier_before_absent_band(&db, Height(0))
             .expect("a genesis upgrade starts replay at genesis")
             .is_none());
+    }
+
+    /// The bug: a cache hit at or below the target used to win unconditionally, so a later high
+    /// request replayed from the low fill instead of the nearby grid entry.
+    #[test]
+    fn nearer_grid_entry_wins_over_a_lower_cache_entry() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let frontiers = DerivedFrontiers::empty();
+        seed_roots(&db, HIGH, &frontiers);
+
+        let cache = cache_with(artifact_at(HIGH, &frontiers), LOW, frontiers);
+        let derivation = derive_historical_frontiers_measured(&db, &cache, HIGH, 0)
+            .expect("a grid entry at the target is a zero-replay hit");
+
+        assert_eq!(derivation.replayed_blocks, 0);
+    }
+
+    /// Published entries below U have no VCT roots-index rows and are farther away than the
+    /// durable U - 1 frontier. They must not be considered even if an unexpected stale index row
+    /// would make one pass verification.
+    #[test]
+    fn grid_entries_below_the_vct_upgrade_height_are_not_anchors() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let cached_height = Height(500);
+        let published_height = Height(1_500);
+        let upgrade = Height(2_000);
+        let frontiers = DerivedFrontiers::empty();
+
+        let mut batch = DiskWriteBatch::new();
+        batch.update_vct_upgrade_marker(&db, upgrade);
+        db.write_batch(batch)
+            .expect("seeding the VCT upgrade marker succeeds");
+
+        // This row is deliberately inconsistent with the production layout. It makes accepting
+        // the below-U grid entry observable instead of merely producing the same final fallback.
+        seed_roots(&db, published_height, &frontiers);
+
+        let cache = cache_with(
+            artifact_at(published_height, &frontiers),
+            cached_height,
+            frontiers,
+        );
+        let (anchor_height, _) = anchor_for(&db, &cache, upgrade)
+            .expect("the cached anchor is available")
+            .unwrap();
+
+        assert_eq!(
+            anchor_height, cached_height,
+            "a published entry below U must not displace an eligible fallback"
+        );
+    }
+
+    /// Sequential scans still prefer a higher cache entry over a coarser grid point behind it.
+    #[test]
+    fn nearer_cache_entry_wins_over_a_lower_grid_entry() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let frontiers = DerivedFrontiers::empty();
+        seed_roots(&db, LOW, &frontiers);
+        seed_roots(&db, HIGH, &frontiers);
+
+        let cache = cache_with(artifact_at(LOW, &frontiers), HIGH, frontiers);
+        let derivation = derive_historical_frontiers_measured(&db, &cache, HIGH, 0)
+            .expect("a cached target is a zero-replay hit");
+
+        assert_eq!(derivation.replayed_blocks, 0);
+    }
+
+    /// A rejected nearer grid entry must not discard a usable cache entry. Genesis replay from
+    /// height 0 would be one block longer than replay from the low cache entry.
+    #[test]
+    fn rejected_nearer_grid_entry_falls_back_to_the_cache() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let frontiers = DerivedFrontiers::empty();
+        seed_roots(&db, HIGH, &frontiers);
+
+        let cache = cache_with(artifact_at(HIGH, &mismatched_frontiers()), LOW, frontiers);
+        let error = derive_historical_frontiers_measured(&db, &cache, HIGH, 0)
+            .expect_err("replay from the low cache entry exceeds a zero-block bound");
+
+        assert_eq!(
+            error,
+            HistoricalTreeDerivationError::ReplayTooLong {
+                height: HIGH,
+                blocks: u64::from(HIGH.0 - LOW.0),
+                limit: 0,
+            }
+        );
+    }
+
+    /// A rejected nearer grid entry must try the next-lower cell rather than restart at genesis.
+    #[test]
+    fn rejected_nearer_grid_entry_falls_back_to_the_previous_grid_entry() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let frontiers = DerivedFrontiers::empty();
+        let mismatched = mismatched_frontiers();
+        seed_roots(&db, MID, &frontiers);
+        seed_roots(&db, HIGH, &frontiers);
+
+        let cache = Mutex::new(HistoricalTreeCache::with_artifact(artifact_entries(
+            Height(HIGH.0 + 1),
+            &[(MID, &frontiers), (HIGH, &mismatched)],
+        )));
+        let error = derive_historical_frontiers_measured(&db, &cache, HIGH, 0)
+            .expect_err("replay from the previous grid entry exceeds a zero-block bound");
+
+        assert_eq!(
+            error,
+            HistoricalTreeDerivationError::ReplayTooLong {
+                height: HIGH,
+                blocks: u64::from(HIGH.0 - MID.0),
+                limit: 0,
+            }
+        );
+    }
+
+    /// A grid whose every entry fails its root check falls through to a genesis replay, and the
+    /// serving bound must refuse that rather than replaying the whole absent band.
+    ///
+    /// This is what ties the load-time grid-gap check to the request path: a stale or wrong-chain
+    /// grid can pass the gap check at startup and still verify against nothing here, so the same
+    /// constant has to hold on both sides.
+    #[test]
+    fn a_wholly_unverifiable_grid_cannot_replay_past_the_serving_bound() {
+        let _init_guard = zakura_test::init();
+        let db = ephemeral_db();
+        let mismatched = mismatched_frontiers();
+        seed_roots(&db, HIGH, &DerivedFrontiers::empty());
+
+        // Gaps of one block, so this grid passes the load-time check, yet no entry anchors.
+        let cache = Mutex::new(HistoricalTreeCache::with_artifact(artifact_entries(
+            Height(HIGH.0 + 1),
+            &[(MID, &mismatched), (HIGH, &mismatched)],
+        )));
+        let error = derive_historical_frontiers_measured(
+            &db,
+            &cache,
+            HIGH,
+            MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+        )
+        .expect_err("a genesis fall-through must not be served");
+
+        assert_eq!(
+            error,
+            HistoricalTreeDerivationError::ReplayTooLong {
+                height: HIGH,
+                blocks: u64::from(HIGH.0) + 1,
+                limit: MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+            },
+            "the serving bound is what stops a fall-through to genesis"
+        );
     }
 }

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -24,13 +24,393 @@ use zakura_test::{prelude::*, transcript::Transcript};
 use crate::{
     arbitrary::Prepare,
     init_test,
-    service::{arbitrary::populated_state, chain_tip::TipAction, StateService},
+    service::{
+        arbitrary::populated_state,
+        chain_tip::TipAction,
+        finalized_state::{DiskWriteBatch, FinalizedState, FrontierArtifact, FrontierEntry},
+        StateService,
+    },
     tests::setup::{partial_nu5_chain_strategy, transaction_v4_from_coinbase},
-    BoxError, CheckpointVerifiedBlock, Config, Request, Response, SemanticallyVerifiedBlock,
-    CHAIN_TIP_UPDATE_WAIT_LIMIT,
+    BoxError, CheckpointVerifiedBlock, Config, HistoricalTreeUnavailable, PruningConfig, Request,
+    Response, SemanticallyVerifiedBlock, StateInitError, StorageMode, CHAIN_TIP_UPDATE_WAIT_LIMIT,
+    MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
 };
 
 const LAST_BLOCK_HEIGHT: u32 = 10;
+
+#[tokio::test]
+async fn historical_frontier_load_errors_are_returned_from_state_init() {
+    let network = Network::Mainnet;
+    let temp_dir = tempfile::tempdir().expect("temporary directory is created");
+    let missing_path = temp_dir.path().join("missing.bin");
+    let missing_config = Config {
+        historical_frontier_artifact: Some(missing_path.clone()),
+        ..Config::ephemeral()
+    };
+
+    assert!(matches!(
+        super::init(missing_config, &network, Height::MAX, 0).await,
+        Err(StateInitError::HistoricalFrontierArtifact { path, .. }) if path == missing_path
+    ));
+
+    let corrupt_path = temp_dir.path().join("corrupt.bin");
+    std::fs::write(&corrupt_path, b"not a frontier artifact")
+        .expect("corrupt test artifact is written");
+    let corrupt_config = Config {
+        historical_frontier_artifact: Some(corrupt_path.clone()),
+        ..Config::ephemeral()
+    };
+
+    assert!(matches!(
+        super::init(corrupt_config.clone(), &network, Height::MAX, 0).await,
+        Err(StateInitError::HistoricalFrontierArtifact { path, .. }) if path == corrupt_path
+    ));
+
+    // A node that does not derive never reads the file, so the same broken path is a warning
+    // rather than a refusal to start.
+    let legacy_recompute = Config {
+        vct_fast_sync: false,
+        ..corrupt_config
+    };
+    assert!(
+        super::load_historical_frontier_artifact(&network, &legacy_recompute, false).is_ok(),
+        "an unusable grid must not stop a node that would never have read it"
+    );
+}
+
+#[test]
+fn durable_vct_marker_keeps_historical_derivation_enabled_after_config_change() {
+    let network = Network::Mainnet;
+    let initial_config = Config::ephemeral();
+    let finalized_state =
+        FinalizedState::new(&initial_config, &network).expect("ephemeral finalized state opens");
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&finalized_state.db, Height(10));
+    finalized_state
+        .db
+        .write_batch(batch)
+        .expect("VCT handoff marker is written");
+
+    let reopened_config = Config {
+        checkpoint_sync: false,
+        vct_fast_sync: false,
+        ..initial_config
+    };
+    assert!(
+        !reopened_config.derive_historical_trees(false),
+        "the current configuration does not start a VCT fast sync"
+    );
+
+    let loaded = super::load_historical_frontier_artifact(
+        &network,
+        &reopened_config,
+        finalized_state.db.vct_synced_below().is_some(),
+    )
+    .expect("the durable marker loads the embedded grid after sync settings change");
+    assert_eq!(
+        loaded.last_checkpoint,
+        Some(network.checkpoint_list().max_height()),
+        "the reopened archive keeps the grid needed to serve its absent band"
+    );
+}
+
+#[test]
+fn historical_frontier_artifact_older_than_database_vct_handoff_is_ignored() {
+    let network = Network::Mainnet;
+    let temp_dir = tempfile::tempdir().expect("temporary directory is created");
+    let state_config = Config::ephemeral();
+    let finalized_state =
+        FinalizedState::new(&state_config, &network).expect("ephemeral finalized state opens");
+    let vct_handoff = Height(10);
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&finalized_state.db, vct_handoff);
+    finalized_state
+        .db
+        .write_batch(batch)
+        .expect("VCT handoff marker is written");
+
+    let artifact_path = |checkpoint: Height| {
+        let path = temp_dir
+            .path()
+            .join(format!("frontiers-{}.bin", checkpoint.0));
+        let artifact = FrontierArtifact {
+            spacing: 1,
+            last_checkpoint: checkpoint,
+            entries: vec![FrontierEntry {
+                height: checkpoint,
+                sapling: Arc::new(Default::default()),
+                orchard: Arc::new(Default::default()),
+                ironwood: Arc::new(Default::default()),
+            }],
+        };
+        std::fs::write(&path, artifact.encode(&network))
+            .expect("historical frontier artifact is written");
+        path
+    };
+
+    let stale_path = artifact_path(Height(9));
+    let stale_config = Config {
+        historical_frontier_artifact: Some(stale_path.clone()),
+        ..state_config.clone()
+    };
+    let stale_cache = super::load_historical_frontier_artifact(&network, &stale_config, false)
+        .expect("the stale artifact decodes")
+        .discard_if_before_vct_handoff(&stale_config, &finalized_state.db);
+    assert_eq!(
+        stale_cache
+            .lock()
+            .expect("historical tree cache lock is available")
+            .last_checkpoint(),
+        None,
+        "a stale artifact is unavailable rather than preventing startup"
+    );
+
+    for checkpoint in [vct_handoff, Height(11)] {
+        let config = Config {
+            historical_frontier_artifact: Some(artifact_path(checkpoint)),
+            ..state_config.clone()
+        };
+        let cache = super::load_historical_frontier_artifact(&network, &config, false)
+            .expect("the covering artifact decodes")
+            .discard_if_before_vct_handoff(&config, &finalized_state.db);
+        assert_eq!(
+            cache
+                .lock()
+                .expect("historical tree cache lock is available")
+                .last_checkpoint(),
+            Some(checkpoint),
+            "an artifact at or above the VCT handoff must cover the absent band"
+        );
+    }
+}
+
+#[test]
+fn historical_frontier_artifact_must_tile_the_band_within_the_replay_limit() {
+    let network = Network::Mainnet;
+    let temp_dir = tempfile::tempdir().expect("temporary directory is created");
+
+    let write = |name: &str, last_checkpoint: Height, entries: Vec<Height>| {
+        let path = temp_dir.path().join(name);
+        let artifact = FrontierArtifact {
+            spacing: 1,
+            last_checkpoint,
+            entries: entries
+                .into_iter()
+                .map(|height| FrontierEntry {
+                    height,
+                    sapling: Arc::new(Default::default()),
+                    orchard: Arc::new(Default::default()),
+                    ironwood: Arc::new(Default::default()),
+                })
+                .collect(),
+        };
+        std::fs::write(&path, artifact.encode(&network)).expect("artifact writes");
+        path
+    };
+
+    let sparse_path = write("sparse.bin", Height(200_000), vec![Height(0)]);
+    let sparse = Config {
+        historical_frontier_artifact: Some(sparse_path.clone()),
+        ..Config::ephemeral()
+    };
+    assert!(matches!(
+        super::load_historical_frontier_artifact(&network, &sparse, false),
+        Err(StateInitError::HistoricalFrontierArtifactTooSparse {
+            path,
+            blocks: 199_999,
+            limit: MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+        }) if path == sparse_path
+    ));
+
+    let empty_path = write("empty.bin", Height(200_000), vec![]);
+    let empty = Config {
+        historical_frontier_artifact: Some(empty_path.clone()),
+        ..Config::ephemeral()
+    };
+    assert!(matches!(
+        super::load_historical_frontier_artifact(&network, &empty, false),
+        Err(StateInitError::HistoricalFrontierArtifactTooSparse {
+            path,
+            blocks: 200_000,
+            limit: MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+        }) if path == empty_path
+    ));
+
+    let covering = Config {
+        historical_frontier_artifact: Some(write(
+            "covering.bin",
+            Height(10),
+            vec![Height(0), Height(10)],
+        )),
+        ..Config::ephemeral()
+    };
+    assert!(
+        super::load_historical_frontier_artifact(&network, &covering, false).is_ok(),
+        "a grid whose gaps fit the serving replay limit must load"
+    );
+
+    let mid_chain_path = write("mid-chain.bin", Height(2_000_100), vec![Height(2_000_000)]);
+    let mid_chain = Config {
+        historical_frontier_artifact: Some(mid_chain_path.clone()),
+        ..Config::ephemeral()
+    };
+    assert!(matches!(
+        super::load_historical_frontier_artifact(&network, &mid_chain, false),
+        Err(StateInitError::HistoricalFrontierArtifactTooSparse {
+            path,
+            blocks: 2_000_000,
+            limit: MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+        }) if path == mid_chain_path
+    ));
+
+    let unused_sparse = Config {
+        historical_frontier_artifact: Some(sparse_path),
+        storage_mode: StorageMode::Pruned(PruningConfig::default()),
+        ..Config::ephemeral()
+    };
+    assert!(
+        super::load_historical_frontier_artifact(&network, &unused_sparse, false).is_ok(),
+        "a sparse grid is ignored when derivation is off"
+    );
+}
+
+#[test]
+fn frontier_grid_coverage_is_incomparable_until_both_sides_exist() {
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(None, None),
+        None,
+        "neither side is comparable"
+    );
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(Some(Height(9)), None),
+        None,
+        "an unmarked database cannot fail coverage"
+    );
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(None, Some(Height(10))),
+        None,
+        "an unloaded grid cannot fail coverage"
+    );
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(Some(Height(9)), Some(Height(10))),
+        Some((Height(9), Height(10))),
+        "a grid that ends below the handoff is uncovered"
+    );
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(Some(Height(10)), Some(Height(10))),
+        None,
+        "a grid that ends on the handoff covers the band"
+    );
+    assert_eq!(
+        super::frontier_grid_ends_before_vct_handoff(Some(Height(11)), Some(Height(10))),
+        None,
+        "a newer grid may cover an older handoff"
+    );
+}
+
+#[test]
+fn historical_frontier_coverage_is_rechecked_once_the_vct_marker_exists() {
+    use std::sync::OnceLock;
+
+    use zakura_node_services::sync_lifecycle::{
+        HeaderRuntimeDetachedReason, HeaderRuntimeStatus, LifecycleEpoch,
+    };
+
+    use crate::service::{
+        non_finalized_state::NonFinalizedState, watch_receiver::WatchReceiver,
+        HeaderChainSubscriptions, ReadStateService, VctRootRepairStatus,
+    };
+
+    let network = Network::Mainnet;
+    let temp_dir = tempfile::tempdir().expect("temporary directory is created");
+    let artifact_path = temp_dir.path().join("frontiers.bin");
+    let artifact = FrontierArtifact {
+        spacing: 1,
+        last_checkpoint: Height(9),
+        entries: vec![FrontierEntry {
+            height: Height(9),
+            sapling: Arc::new(Default::default()),
+            orchard: Arc::new(Default::default()),
+            ironwood: Arc::new(Default::default()),
+        }],
+    };
+    std::fs::write(&artifact_path, artifact.encode(&network))
+        .expect("historical frontier artifact is written");
+
+    let config = Config {
+        historical_frontier_artifact: Some(artifact_path),
+        ..Config::ephemeral()
+    };
+    let finalized_state =
+        FinalizedState::new(&config, &network).expect("ephemeral finalized state opens");
+    let historical_trees = super::load_historical_frontier_artifact(&network, &config, false)
+        .expect("the historical frontier artifact loads")
+        .discard_if_before_vct_handoff(&config, &finalized_state.db);
+
+    let (_non_finalized_sender, non_finalized_receiver) =
+        tokio::sync::watch::channel(NonFinalizedState::new(&network));
+    let (_repair_sender, repair_receiver) =
+        tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let (_header_chain_snapshot_sender, header_chain_snapshot_receiver) =
+        tokio::sync::watch::channel(None);
+    let (_header_chain_view_sender, header_chain_view_receiver) = tokio::sync::watch::channel(None);
+    let (_header_runtime_status_sender, header_runtime_status_receiver) =
+        tokio::sync::watch::channel(HeaderRuntimeStatus::Detached {
+            epoch: LifecycleEpoch::INITIAL,
+            reason: HeaderRuntimeDetachedReason::AwaitingSemanticHandoff,
+        });
+    let (_header_chain_reader_sender, header_chain_reader_receiver) =
+        tokio::sync::watch::channel(None);
+
+    let read_state = ReadStateService::new(
+        &finalized_state,
+        None,
+        Arc::new(OnceLock::new()),
+        WatchReceiver::new(non_finalized_receiver),
+        repair_receiver,
+        HeaderChainSubscriptions {
+            snapshots: header_chain_snapshot_receiver,
+            views: header_chain_view_receiver,
+            runtime_status: header_runtime_status_receiver,
+            reader: header_chain_reader_receiver,
+        },
+        historical_trees,
+    );
+
+    assert!(
+        read_state.has_usable_historical_frontier_grid(),
+        "the grid is usable before the durable marker exists"
+    );
+
+    let mut batch = DiskWriteBatch::new();
+    batch.update_vct_sync_marker(&finalized_state.db, Height(10));
+    finalized_state
+        .db
+        .write_batch(batch)
+        .expect("a newer VCT handoff marker is written");
+    let unavailable = HistoricalTreeUnavailable {
+        hash_or_height: Height(9).into(),
+        last_checkpoint: Height(10),
+    };
+    let error = super::historical_frontiers(&read_state, Height(9).into(), unavailable.clone())
+        .expect_err("a stale grid must not serve the uncovered band");
+    assert_eq!(
+        error.downcast_ref::<HistoricalTreeUnavailable>(),
+        Some(&unavailable),
+        "a stale grid makes historical trees unavailable without surfacing an artifact error"
+    );
+    assert_eq!(
+        read_state
+            .historical_trees
+            .lock()
+            .expect("historical tree cache lock is available")
+            .last_checkpoint(),
+        None,
+        "the stale artifact is discarded after the first serving-time check"
+    );
+    assert!(!read_state.has_usable_historical_frontier_grid());
+}
 
 #[test]
 fn block_sync_body_anchor_rolls_back_to_the_selected_fork_intersection() {
@@ -333,7 +713,9 @@ async fn poll_ready_hands_off_at_max_checkpoint_height() -> Result<()> {
     // The fixture has no network-supplied auxiliary root.
     config.vct_fast_sync = false;
     let (mut state_service, read, _tip, _tip_change) =
-        StateService::new(config, &network, max_checkpoint_height, 0).await;
+        StateService::new(config, &network, max_checkpoint_height, 0)
+            .await
+            .expect("test state initialization succeeds");
 
     // Commit blocks 0 and 1 to the finalized state and wait for each write to land on disk, so the
     // finalized tip catches up to the maximum checkpoint height and the last block hash we sent.
@@ -446,7 +828,9 @@ async fn legacy_mode_handoff_keeps_header_runtime_detached() -> Result<()> {
         .zcash_deserialize_into::<Arc<Block>>()?;
 
     let (mut state, read, _tip, _tip_change) =
-        StateService::new(Config::ephemeral(), &network, Height(0), 0).await;
+        StateService::new(Config::ephemeral(), &network, Height(0), 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
     let result = state
         .queue_and_commit_to_finalized_state(CheckpointVerifiedBlock::from(genesis))
         .await;
@@ -514,7 +898,9 @@ async fn handoff_trigger_microbench() -> Result<()> {
     // Use `Height::MAX` so the height condition is never met: the helper runs its full guard but
     // never transitions, which is exactly the non-transitioning path we want to measure.
     let (mut state_service, _read, _tip, _tip_change) =
-        StateService::new(Config::ephemeral(), &network, Height::MAX, 0).await;
+        StateService::new(Config::ephemeral(), &network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
 
     for block in &blocks[0..=1] {
         let checkpoint = CheckpointVerifiedBlock::from(block.clone());
@@ -706,7 +1092,7 @@ proptest! {
         let (mut state_service, _, _, _) = Runtime::new().unwrap().block_on(async {
             // We're waiting to verify each block here, so we don't need the maximum checkpoint height.
             StateService::new(Config::ephemeral(), &network, Height::MAX, 0).await
-        });
+        }).expect("ephemeral state initialization succeeds");
 
         prop_assert_eq!(state_service.read_service.db.finalized_value_pool(), ValueBalance::zero());
         prop_assert_eq!(
@@ -801,7 +1187,7 @@ proptest! {
         let (mut state_service, _read_only_state_service, latest_chain_tip, mut chain_tip_change) = runtime.block_on(async {
             // We're waiting to verify each block here, so we don't need the maximum checkpoint height.
             StateService::new(Config::ephemeral(), &network, Height::MAX, 0).await
-        });
+        }).expect("ephemeral state initialization succeeds");
 
         prop_assert_eq!(latest_chain_tip.best_tip_height(), None);
         prop_assert_eq!(chain_tip_change.last_tip_change(), None);

--- a/crates/zakura-state/src/service/tests.rs
+++ b/crates/zakura-state/src/service/tests.rs
@@ -84,6 +84,21 @@ fn durable_vct_marker_keeps_historical_derivation_enabled_after_config_change() 
     let initial_config = Config::ephemeral();
     let finalized_state =
         FinalizedState::new(&initial_config, &network).expect("ephemeral finalized state opens");
+    let artifact_checkpoint = Height(11);
+    let artifact_file =
+        tempfile::NamedTempFile::new().expect("temporary frontier artifact is created");
+    let artifact = FrontierArtifact {
+        spacing: 1,
+        last_checkpoint: artifact_checkpoint,
+        entries: vec![FrontierEntry {
+            height: Height(0),
+            sapling: Arc::new(Default::default()),
+            orchard: Arc::new(Default::default()),
+            ironwood: Arc::new(Default::default()),
+        }],
+    };
+    std::fs::write(artifact_file.path(), artifact.encode(&network))
+        .expect("historical frontier artifact is written");
 
     let mut batch = DiskWriteBatch::new();
     batch.update_vct_sync_marker(&finalized_state.db, Height(10));
@@ -95,6 +110,7 @@ fn durable_vct_marker_keeps_historical_derivation_enabled_after_config_change() 
     let reopened_config = Config {
         checkpoint_sync: false,
         vct_fast_sync: false,
+        historical_frontier_artifact: Some(artifact_file.path().to_path_buf()),
         ..initial_config
     };
     assert!(
@@ -107,10 +123,10 @@ fn durable_vct_marker_keeps_historical_derivation_enabled_after_config_change() 
         &reopened_config,
         finalized_state.db.vct_synced_below().is_some(),
     )
-    .expect("the durable marker loads the embedded grid after sync settings change");
+    .expect("the durable marker loads the configured grid after sync settings change");
     assert_eq!(
         loaded.last_checkpoint,
-        Some(network.checkpoint_list().max_height()),
+        Some(artifact_checkpoint),
         "the reopened archive keeps the grid needed to serve its absent band"
     );
 }

--- a/crates/zakura-state/tests/basic.rs
+++ b/crates/zakura-state/tests/basic.rs
@@ -84,7 +84,7 @@ async fn check_transcripts(network: Network) -> Result<(), Report> {
     for transcript_data in net_data {
         // We're not verifying UTXOs here.
         let (service, _, _, _) =
-            zakura_state::init(Config::ephemeral(), &network, Height::MAX, 0).await;
+            zakura_state::init(Config::ephemeral(), &network, Height::MAX, 0).await?;
         let transcript = Transcript::from(transcript_data.iter().cloned());
         /// SPANDOC: check the on disk service against the transcript
         transcript.check(service).await?;

--- a/crates/zakurad/src/commands/audit_historical_treestates.rs
+++ b/crates/zakurad/src/commands/audit_historical_treestates.rs
@@ -17,13 +17,22 @@ use color_eyre::eyre::{eyre, Result};
 use zakura_chain::{block::Height, parameters::Network};
 use zakura_state::{
     DerivationSample, HistoricalTreeCache, PruningConfig, StorageMode, SubtreeVerification,
-    VctTreestateInventory, DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+    VctTreestateInventory,
 };
 
 use crate::prelude::APPLICATION;
 
 /// Bounds audit bookkeeping and catches accidentally enormous CLI ranges before any allocation.
 const MAX_AUDIT_SAMPLES: u64 = 5_000_000;
+
+/// The replay bound for an audit walk: none.
+///
+/// This walk runs with no frontier grid, deliberately, because measuring what a grid-free cold
+/// replay costs is the whole point of the command. Serving's
+/// [`zakura_state::MAX_HISTORICAL_TREE_REPLAY_BLOCKS`] would stop that walk at the first height
+/// past its bound, so the audit opts out rather than reusing it. `--to` and [`MAX_AUDIT_SAMPLES`]
+/// are what bound an audit run.
+const AUDIT_REPLAY_BLOCKS: u64 = u64::MAX;
 
 /// Audit historical note commitment treestate serving in an existing state database
 #[derive(Command, Debug, Default, Parser)]
@@ -69,11 +78,11 @@ pub struct AuditHistoricalTreestatesCmd {
     #[clap(long, help = "last height to derive")]
     to: Option<u32>,
 
-    /// Start each derivation from a fresh memo, measuring cold replay rather than sequential.
+    /// Start each derivation from a fresh cache, measuring cold replay rather than sequential.
     ///
     /// This is what sizes the published frontier grid: it reports what a client pays when no
-    /// nearby frontier is memoized.
-    #[clap(long, help = "clear the memo before each derivation")]
+    /// nearby frontier is cached.
+    #[clap(long, help = "clear the cache before each derivation")]
     cold: bool,
 
     /// Print one line per derivation with its measured cost and its replay inputs.
@@ -284,7 +293,7 @@ impl AuditHistoricalTreestatesCmd {
                     db,
                     &cache,
                     [height],
-                    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                    AUDIT_REPLAY_BLOCKS,
                 )
                 .map_err(|(height, error)| {
                     eyre!("derivation failed at height {}: {error}", height.0)
@@ -336,7 +345,7 @@ impl AuditHistoricalTreestatesCmd {
         let new_cache = HistoricalTreeCache::default;
 
         let result = if self.cold {
-            // A fresh memo per height forces every derivation to replay from the bottom of the
+            // A fresh cache per height forces every derivation to replay from the bottom of the
             // band, which is the cost a client pays with no nearby frontier.
             let mut result = Ok(());
             for height in heights {
@@ -345,7 +354,7 @@ impl AuditHistoricalTreestatesCmd {
                     db,
                     &cache,
                     [height],
-                    DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
+                    AUDIT_REPLAY_BLOCKS,
                     &mut report,
                 ) {
                     Ok(_) => {}
@@ -358,13 +367,7 @@ impl AuditHistoricalTreestatesCmd {
             result
         } else {
             let cache = Mutex::new(new_cache());
-            zakura_state::measure_derivations(
-                db,
-                &cache,
-                heights,
-                DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS,
-                &mut report,
-            )
+            zakura_state::measure_derivations(db, &cache, heights, AUDIT_REPLAY_BLOCKS, &mut report)
         };
 
         print_walk_summary(&samples);

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -401,7 +401,8 @@ impl StartCmd {
             config.sync.checkpoint_verify_concurrency_limit
                 * (VERIFICATION_PIPELINE_SCALING_MULTIPLIER + 1),
         )
-        .await;
+        .await
+        .map_err(|error| eyre!("state initialization failed: {error}"))?;
 
         state_service
             .ready()
@@ -1803,7 +1804,8 @@ mod zakura_header_sync_driver_tests {
                     block::Height(0),
                     2,
                 )
-                .await;
+                .await
+                .expect("persistent test state initialization succeeds");
             let committed = state_service
                 .ready()
                 .await
@@ -1894,7 +1896,8 @@ mod zakura_header_sync_driver_tests {
                     block::Height(0),
                     2,
                 )
-                .await;
+                .await
+                .expect("persistent test state reopens");
             state_service
                 .ready()
                 .await

--- a/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
+++ b/crates/zakurad/src/components/inbound/tests/fake_peer_set.rs
@@ -1154,7 +1154,9 @@ async fn caches_getaddr_response() {
 
         // UTXO verification doesn't matter for these tests.
         let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
-            zakura_state::init(state_config.clone(), &network, Height::MAX, 0).await;
+            zakura_state::init(state_config.clone(), &network, Height::MAX, 0)
+                .await
+                .expect("ephemeral state initialization succeeds");
 
         let state_service = ServiceBuilder::new().buffer(1).service(state);
 
@@ -1331,7 +1333,9 @@ async fn setup_with_misbehavior_receiver(
 
     // UTXO verification doesn't matter for these tests.
     let (state, _read_only_state_service, latest_chain_tip, mut chain_tip_change) =
-        zakura_state::init(state_config.clone(), &network, Height::MAX, 0).await;
+        zakura_state::init(state_config.clone(), &network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
 
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);
 

--- a/crates/zakurad/src/components/inbound/tests/real_peer_set.rs
+++ b/crates/zakurad/src/components/inbound/tests/real_peer_set.rs
@@ -963,7 +963,9 @@ async fn setup(
     // State
     // UTXO verification doesn't matter for these tests.
     let (state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
-        zakura_state::init(state_config, &network, Height::MAX, 0).await;
+        zakura_state::init(state_config, &network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
     let state_service = ServiceBuilder::new().buffer(10).service(state_service);
 
     // Network
@@ -1156,7 +1158,9 @@ mod submitblock_test {
         // State
         let state_config = StateConfig::ephemeral();
         let (_state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
-            zakura_state::init(state_config, &Network::Mainnet, Height::MAX, 0).await;
+            zakura_state::init(state_config, &Network::Mainnet, Height::MAX, 0)
+                .await
+                .expect("ephemeral state initialization succeeds");
 
         let config_listen_addr = "127.0.0.1:0".parse().unwrap();
 

--- a/crates/zakurad/src/components/mempool/tests/vector.rs
+++ b/crates/zakurad/src/components/mempool/tests/vector.rs
@@ -2705,7 +2705,9 @@ async fn setup_with_mempool_config_and_misbehavior_sender(
     // UTXO verification doesn't matter here.
     let state_config = StateConfig::ephemeral();
     let (state, _read_only_state_service, latest_chain_tip, mut chain_tip_change) =
-        zakura_state::init(state_config, network, Height::MAX, 0).await;
+        zakura_state::init(state_config, network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
     let mut state_service = ServiceBuilder::new().buffer(10).service(state);
 
     let tx_verifier = MockService::build().for_unit_tests();

--- a/crates/zakurad/src/components/sync/tests/gossip.rs
+++ b/crates/zakurad/src/components/sync/tests/gossip.rs
@@ -38,7 +38,9 @@ async fn setup_gossip_test() -> GossipTestSetup {
     let network = Mainnet;
     let state_config = StateConfig::ephemeral();
     let (state, _read_only_state, _latest_chain_tip, mut chain_tip_change) =
-        zakura_state::init(state_config, &network, Height::MAX, 0).await;
+        zakura_state::init(state_config, &network, Height::MAX, 0)
+            .await
+            .expect("ephemeral state initialization succeeds");
 
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);
 

--- a/crates/zakurad/tests/acceptance.rs
+++ b/crates/zakurad/tests/acceptance.rs
@@ -411,7 +411,7 @@ async fn db_init_outside_future_executor() -> Result<()> {
         "futures executor was blocked longer than expected ({block_duration:?})",
     );
 
-    db_init_handle.await.map_err(|e| eyre!(e))?;
+    db_init_handle.await.map_err(|e| eyre!(e))??;
 
     Ok(())
 }

--- a/crates/zakurad/tests/common/cached_state.rs
+++ b/crates/zakurad/tests/common/cached_state.rs
@@ -146,7 +146,7 @@ pub async fn start_state_service_with_cache_dir(
     };
 
     // These tests don't need UTXOs to be verified efficiently, because they use cached states.
-    Ok(zakura_state::init(config, network, Height::MAX, 0).await)
+    Ok(zakura_state::init(config, network, Height::MAX, 0).await?)
 }
 
 /// Loads the finalized tip height from the state stored in a specified directory.

--- a/docs/changelog/params.md
+++ b/docs/changelog/params.md
@@ -28,6 +28,7 @@ Keep entries **newest-first**. Each row records:
 
 | Parameter | Location | Old → New | PR | Why |
 | --- | --- | --- | --- | --- |
+| `MAX_HISTORICAL_TREE_REPLAY_BLOCKS` | `crates/zakura-state/src/constants.rs` | `DEFAULT_MAX_HISTORICAL_TREE_REPLAY_BLOCKS = 4_000_000` → `100_000` | [#775](https://github.com/zakura-core/zakura/pull/775) | Use one bound for startup grid-gap validation and per-request replay, preventing a grid whose anchors fail verification from falling back to replaying the entire absent band. |
 | `TLS_HANDSHAKE_TIMEOUT` | `crates/zakura-rpc/src/indexer/server.rs` | new → `10 s` | [#596](https://github.com/zakura-core/zakura/pull/596) | Drop indexer connections that do not complete the unauthenticated TLS handshake promptly, so stalled handshakes cannot retain a bounded connection slot indefinitely. |
 | `MAX_CONCURRENT_STREAMS_PER_CONNECTION` | `crates/zakura-rpc/src/indexer/server.rs` | new → `64` streams | [#596](https://github.com/zakura-core/zakura/pull/596) | Let trusted indexers multiplex long-lived subscriptions, parallel block-range backfills, and unary queries on one HTTP/2 connection while retaining a finite per-connection task and response-buffer bound. |
 | `MAX_CONNECTIONS` | `crates/zakura-rpc/src/indexer/server.rs` | new → `64` connections | [#596](https://github.com/zakura-core/zakura/pull/596) | Leave ample capacity for trusted indexer clients and operational probes while bounding accepted sockets, TLS handshakes, and HTTP/2 connection tasks server-wide. |

--- a/docs/changelog/unreleased/775.md
+++ b/docs/changelog/unreleased/775.md
@@ -1,0 +1,8 @@
+## Added
+
+- Added opt-in historical treestate serving for verified-commitment-tree fast-synced archive nodes.
+  When `state.historical_frontier_artifact` names a sparse frontier grid, the node replays retained
+  block bodies from the nearest root-verified anchor and serves the result only after reproducing
+  its authenticated root. Missing or unusable grids and pruned nodes continue to report the typed
+  historical-tree-unavailable error
+  ([#775](https://github.com/zakura-core/zakura/pull/775)).


### PR DESCRIPTION
## Motivation

Verified-commitment-tree fast sync leaves an absent band of per-height note commitment trees. The replay engine and typed unavailable error already exist, but the read service does not connect them, so historical tree reads cannot serve data the node can safely reconstruct.

This is the core Rust serving slice extracted from #703. Mainnet artifact distribution, release-state automation, and RPC integration fixtures remain outside this PR.

## Solution

- Load an explicitly configured historical frontier grid and reject malformed or overly sparse grids before serving.
- Select the nearest root-verified cache or grid anchor, replay retained block bodies within `MAX_HISTORICAL_TREE_REPLAY_BLOCKS`, and cache only verified results.
- Derive only for archive databases with a current or durable VCT fast-sync marker.
- Preserve the typed `HistoricalTreeUnavailable` response for pruned nodes, missing grids, stale grids, and other paths that cannot safely derive.
- Route Sapling, Orchard, and Ironwood tree reads through this seam after the ordinary stored-tree read reports the absent band.

A configured path is required in this slice. Mainnet remains unavailable by default until a follow-up distribution PR supplies and activates the reviewed grid.

## Testing

- `cargo test -p zakura-state --lib` — 512 passed, 0 failed, 3 ignored.
- `cargo clippy -p zakura-state --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — passed.
- `./scripts/changelog.py check` — passed.

## Changelog

- `docs/changelog/unreleased/775.md`
- `docs/changelog/params.md`

### Specifications & References

- Extracted from #703.
- Builds on #750 (artifact format) and #751 (grid generation).
- `docs/design/historical-treestate-serving.md`.

### Follow-up Work

- Distribute and activate the reviewed Mainnet frontier grid.
- Add reusable fast-sync fixtures and RPC end-to-end coverage.
- Integrate frontier grids into release-state automation.