### PR TITLE
perf(state): avoid contextual UTXO copies

### DIFF
--- a/crates/zakura-chain/src/block.rs
+++ b/crates/zakura-chain/src/block.rs
@@ -296,6 +296,15 @@ impl Block {
     }
 
     /// Returns the overall chain value pool change using borrowed ordered UTXOs.
+    ///
+    /// The given `utxos` must contain the [`transparent::OrderedUtxo`]s of every
+    /// input in this block. This includes UTXOs created by earlier transactions
+    /// in the same block. The map can also contain unrelated UTXOs, which this
+    /// method ignores.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `utxos` omits a transparent input's UTXO.
     pub fn chain_value_pool_change_from_ordered_utxos(
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,

--- a/crates/zakura-chain/src/block.rs
+++ b/crates/zakura-chain/src/block.rs
@@ -290,6 +290,30 @@ impl Block {
         utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
         deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
     ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
+        self.chain_value_pool_change_from_utxos(deferred_pool_balance_change, |transaction| {
+            transaction.value_balance(utxos)
+        })
+    }
+
+    /// Returns the overall chain value pool change using borrowed ordered UTXOs.
+    pub fn chain_value_pool_change_from_ordered_utxos(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+        deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
+        self.chain_value_pool_change_from_utxos(deferred_pool_balance_change, |transaction| {
+            transaction.value_balance_from_ordered_utxos(utxos)
+        })
+    }
+
+    fn chain_value_pool_change_from_utxos<F>(
+        &self,
+        deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
+        mut transaction_value_balance: F,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError>
+    where
+        F: FnMut(&Transaction) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError>,
+    {
         // `Result<T, E>` implements `IntoIterator`, so a `flat_map(|t| t.value_balance(utxos))`
         // would silently drop transactions whose value balance returns `Err`. Use `try_fold`
         // to propagate the first error instead.
@@ -297,7 +321,7 @@ impl Block {
             .transactions
             .iter()
             .try_fold(ValueBalance::<NegativeAllowed>::zero(), |acc, tx| {
-                acc + tx.value_balance(utxos)?
+                acc + transaction_value_balance(tx)?
             })?;
 
         Ok(*tx_pool_sum.neg().set_deferred_amount(

--- a/crates/zakura-chain/src/block/tests/vectors.rs
+++ b/crates/zakura-chain/src/block/tests/vectors.rs
@@ -115,6 +115,55 @@ fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
     );
 }
 
+#[test]
+fn ordered_utxo_value_balances_match_plain_utxo_value_balances() {
+    let _init_guard = zakura_test::init();
+
+    let outpoint = transparent::OutPoint {
+        hash: crate::transaction::Hash([1; 32]),
+        index: 0,
+    };
+    let input_value = 5.try_into().expect("five zatoshi is a valid amount");
+    let output_value = 3.try_into().expect("three zatoshi is a valid amount");
+    let spent_utxo = transparent::Utxo::new(
+        transparent::Output::new(input_value, transparent::Script::new(&[])),
+        Height(1),
+        false,
+    );
+    let transaction = Arc::new(Transaction::V1 {
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint,
+            unlock_script: transparent::Script::new(&[]),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![transparent::Output::new(
+            output_value,
+            transparent::Script::new(&[]),
+        )],
+        lock_time: LockTime::unlocked(),
+    });
+    let plain_utxos = HashMap::from([(outpoint, spent_utxo.clone())]);
+    let ordered_utxos =
+        HashMap::from([(outpoint, transparent::OrderedUtxo::from_utxo(spent_utxo, 0))]);
+
+    assert_eq!(
+        transaction.value_balance(&plain_utxos),
+        transaction.value_balance_from_ordered_utxos(&ordered_utxos),
+    );
+
+    let header = zakura_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![transaction],
+    };
+    assert_eq!(
+        block.chain_value_pool_change(&plain_utxos, None),
+        block.chain_value_pool_change_from_ordered_utxos(&ordered_utxos, None),
+    );
+}
+
 /// The block-level Orchard and Ironwood accessors must read from their own
 /// pool's shielded data and preserve transaction order.
 ///

--- a/crates/zakura-chain/src/block/tests/vectors.rs
+++ b/crates/zakura-chain/src/block/tests/vectors.rs
@@ -143,8 +143,20 @@ fn ordered_utxo_value_balances_match_plain_utxo_value_balances() {
         lock_time: LockTime::unlocked(),
     });
     let plain_utxos = HashMap::from([(outpoint, spent_utxo.clone())]);
-    let ordered_utxos =
-        HashMap::from([(outpoint, transparent::OrderedUtxo::from_utxo(spent_utxo, 0))]);
+    let unrelated_outpoint = transparent::OutPoint {
+        hash: crate::transaction::Hash([2; 32]),
+        index: 1,
+    };
+    let ordered_utxos = HashMap::from([
+        (
+            outpoint,
+            transparent::OrderedUtxo::from_utxo(spent_utxo.clone(), 0),
+        ),
+        (
+            unrelated_outpoint,
+            transparent::OrderedUtxo::from_utxo(spent_utxo, 1),
+        ),
+    ]);
 
     assert_eq!(
         transaction.value_balance(&plain_utxos),

--- a/crates/zakura-chain/src/transaction.rs
+++ b/crates/zakura-chain/src/transaction.rs
@@ -1346,6 +1346,7 @@ impl Transaction {
     /// using the outputs spent by this transaction.
     ///
     /// See `transparent_value_balance` for details.
+    #[cfg(any(test, feature = "proptest-impl"))]
     #[allow(clippy::unwrap_in_result)]
     fn transparent_value_balance_from_outputs(
         &self,
@@ -1713,6 +1714,7 @@ impl Transaction {
     }
 
     /// Returns the value balances for this transaction using the provided transparent outputs.
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub(crate) fn value_balance_from_outputs(
         &self,
         outputs: &HashMap<transparent::OutPoint, transparent::Output>,

--- a/crates/zakura-chain/src/transaction.rs
+++ b/crates/zakura-chain/src/transaction.rs
@@ -1752,6 +1752,15 @@ impl Transaction {
     }
 
     /// Returns the value balances for this transaction using borrowed ordered UTXOs.
+    ///
+    /// `utxos` must contain the [`transparent::OrderedUtxo`] of every input in
+    /// the transaction. This includes UTXOs created by earlier transactions in
+    /// the same block. The map can also contain unrelated UTXOs, which this
+    /// method ignores.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if `utxos` omits a transparent input's UTXO.
     pub fn value_balance_from_ordered_utxos(
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,

--- a/crates/zakura-chain/src/transaction.rs
+++ b/crates/zakura-chain/src/transaction.rs
@@ -1374,6 +1374,38 @@ impl Transaction {
             .map_err(ValueBalanceError::Transparent)
     }
 
+    /// Return the transparent value balance using borrowed UTXOs.
+    #[allow(clippy::unwrap_in_result)]
+    fn transparent_value_balance_from_utxos<U>(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, U>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError>
+    where
+        U: AsRef<transparent::Utxo>,
+    {
+        let input_value = self
+            .inputs()
+            .iter()
+            .map(|input| input.value_from_utxos(utxos))
+            .sum::<Result<Amount<NonNegative>, AmountError>>()
+            .map_err(ValueBalanceError::Transparent)?
+            .constrain()
+            .expect("conversion from NonNegative to NegativeAllowed is always valid");
+
+        let output_value = self
+            .outputs()
+            .iter()
+            .map(|output| output.value())
+            .sum::<Result<Amount<NonNegative>, AmountError>>()
+            .map_err(ValueBalanceError::Transparent)?
+            .constrain()
+            .expect("conversion from NonNegative to NegativeAllowed is always valid");
+
+        (input_value - output_value)
+            .map(ValueBalance::from_transparent_amount)
+            .map_err(ValueBalanceError::Transparent)
+    }
+
     /// Returns the `vpub_old` fields from `JoinSplit`s in this transaction,
     /// regardless of version, in the order they appear in the transaction.
     ///
@@ -1716,16 +1748,29 @@ impl Transaction {
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
     ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
-        let outputs = self
-            .spent_outpoints()
-            .filter_map(|outpoint| {
-                utxos
-                    .get(&outpoint)
-                    .map(|utxo| (outpoint, utxo.output.clone()))
-            })
-            .collect();
+        self.value_balance_from_utxos(utxos)
+    }
 
-        self.value_balance_from_outputs(&outputs)
+    /// Returns the value balances for this transaction using borrowed ordered UTXOs.
+    pub fn value_balance_from_ordered_utxos(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
+        self.value_balance_from_utxos(utxos)
+    }
+
+    fn value_balance_from_utxos<U>(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, U>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError>
+    where
+        U: AsRef<transparent::Utxo>,
+    {
+        self.transparent_value_balance_from_utxos(utxos)?
+            + self.sprout_value_balance()?
+            + self.sapling_value_balance()
+            + self.orchard_value_balance()
+            + self.ironwood_value_balance()
     }
 
     /// Converts [`Transaction`] to [`zcash_primitives::transaction::Transaction`].

--- a/crates/zakura-chain/src/transparent.rs
+++ b/crates/zakura-chain/src/transparent.rs
@@ -241,6 +241,7 @@ impl Input {
     /// # Panics
     ///
     /// If the provided [`Output`]s don't have this input's [`OutPoint`].
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub(crate) fn value_from_outputs(
         &self,
         outputs: &HashMap<OutPoint, Output>,

--- a/crates/zakura-chain/src/transparent.rs
+++ b/crates/zakura-chain/src/transparent.rs
@@ -283,7 +283,12 @@ impl Input {
         if let Some(outpoint) = self.outpoint() {
             utxos
                 .get(&outpoint)
-                .expect("provided Utxos don't have spent OutPoint")
+                .unwrap_or_else(|| {
+                    panic!(
+                        "spent outpoint {outpoint:?} is missing from the {} provided UTXOs; the caller must supply every spent UTXO",
+                        utxos.len()
+                    )
+                })
                 .as_ref()
                 .output
                 .value

--- a/crates/zakura-chain/src/transparent.rs
+++ b/crates/zakura-chain/src/transparent.rs
@@ -7,7 +7,7 @@ mod script;
 mod serialize;
 mod utxo;
 
-use std::{collections::HashMap, fmt, iter, ops::AddAssign};
+use std::{collections::HashMap, fmt, ops::AddAssign};
 
 use zcash_script::{opcode::Evaluable as _, pattern::push_num};
 use zcash_transparent::{address::TransparentAddress, bundle::TxOut};
@@ -271,17 +271,24 @@ impl Input {
     ///
     /// If the provided [`Utxo`]s don't have this input's [`OutPoint`].
     pub fn value(&self, utxos: &HashMap<OutPoint, utxo::Utxo>) -> Amount<NonNegative> {
+        self.value_from_utxos(utxos)
+    }
+
+    /// Get the value spent by this input from any UTXO index whose values
+    /// reference [`Utxo`](utxo::Utxo).
+    pub(crate) fn value_from_utxos<U>(&self, utxos: &HashMap<OutPoint, U>) -> Amount<NonNegative>
+    where
+        U: AsRef<utxo::Utxo>,
+    {
         if let Some(outpoint) = self.outpoint() {
-            // look up the specific Output and convert it to the expected format
-            let output = utxos
+            utxos
                 .get(&outpoint)
                 .expect("provided Utxos don't have spent OutPoint")
+                .as_ref()
                 .output
-                .clone();
-            self.value_from_outputs(&iter::once((outpoint, output)).collect())
+                .value
         } else {
-            // coinbase inputs don't need any UTXOs
-            self.value_from_outputs(&HashMap::new())
+            Amount::zero()
         }
     }
 }

--- a/crates/zakura-chain/src/transparent/utxo.rs
+++ b/crates/zakura-chain/src/transparent/utxo.rs
@@ -54,6 +54,12 @@ pub struct OrderedUtxo {
     pub tx_index_in_block: usize,
 }
 
+impl AsRef<Utxo> for Utxo {
+    fn as_ref(&self) -> &Utxo {
+        self
+    }
+}
+
 impl AsRef<Utxo> for OrderedUtxo {
     fn as_ref(&self) -> &Utxo {
         &self.utxo

--- a/crates/zakura-state/benches/transparent_spend_worst_case.rs
+++ b/crates/zakura-state/benches/transparent_spend_worst_case.rs
@@ -23,7 +23,9 @@ use zakura_chain::{
     transaction::{self, LockTime, Transaction},
     transparent,
 };
-use zakura_state::{check::remaining_transaction_value, SemanticallyVerifiedBlock};
+use zakura_state::{
+    check::remaining_transaction_value, ContextuallyVerifiedBlock, SemanticallyVerifiedBlock,
+};
 use zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES;
 
 const MAX_SPEND_TRANSACTIONS: usize = 26_645;
@@ -46,14 +48,32 @@ fn main() {
         let block_bytes = block.zcash_serialized_size();
 
         let start = Instant::now();
+        black_box((prepared.clone(), spent_utxos.clone()));
+        let contextual_input_clone_elapsed = start.elapsed();
+
+        let start = Instant::now();
         black_box(remaining_transaction_value(
             black_box(&prepared),
             black_box(&spent_utxos),
         ))
         .expect("equal input and output values have nonnegative remaining value");
-        let elapsed = start.elapsed();
+        let remaining_value_elapsed = start.elapsed();
 
-        print_result(transaction_count, block_bytes, elapsed);
+        let start = Instant::now();
+        black_box(ContextuallyVerifiedBlock::with_block_and_spent_utxos(
+            black_box(prepared),
+            black_box(spent_utxos),
+        ))
+        .expect("equal input and output values have a valid chain value pool change");
+        let contextual_preparation_elapsed = start.elapsed();
+
+        print_result(
+            transaction_count,
+            block_bytes,
+            contextual_input_clone_elapsed,
+            remaining_value_elapsed,
+            contextual_preparation_elapsed,
+        );
     }
 }
 
@@ -81,6 +101,7 @@ fn benchmark_fixture(
     let coinbase = Arc::new(minimal_v5_coinbase());
     let mut transactions = Vec::with_capacity(transaction_count + 1);
     let mut spent_utxos = HashMap::with_capacity(transaction_count);
+    let mut new_outputs = HashMap::with_capacity(transaction_count);
 
     transactions.push(coinbase);
 
@@ -99,6 +120,13 @@ fn benchmark_fixture(
             transparent::OrderedUtxo::from_utxo(
                 transparent::Utxo::new(spendable_output(), Height(1), false),
                 0,
+            ),
+        );
+        new_outputs.insert(
+            synthetic_new_outpoint(index),
+            transparent::OrderedUtxo::from_utxo(
+                transparent::Utxo::new(unspendable_output(), BENCHMARK_HEIGHT, false),
+                index + 1,
             ),
         );
         transactions.push(Arc::new(transaction));
@@ -133,7 +161,7 @@ fn benchmark_fixture(
         block: block.clone(),
         hash: block.hash(),
         height: BENCHMARK_HEIGHT,
-        new_outputs: HashMap::new(),
+        new_outputs,
         transaction_hashes: vec![transaction::Hash([0; 32]); transaction_count + 1].into(),
         deferred_pool_balance_change: None,
         auth_data_root: None,
@@ -188,6 +216,12 @@ fn synthetic_outpoint(index: usize) -> transparent::OutPoint {
     }
 }
 
+fn synthetic_new_outpoint(index: usize) -> transparent::OutPoint {
+    let mut outpoint = synthetic_outpoint(index);
+    outpoint.hash.0[31] = 1;
+    outpoint
+}
+
 fn spendable_output() -> transparent::Output {
     transparent::Output::new(one_zatoshi(), transparent::Script::new(&[OP_TRUE]))
 }
@@ -201,16 +235,40 @@ fn one_zatoshi() -> Amount<NonNegative> {
 }
 
 #[allow(clippy::print_stdout)]
-fn print_result(transaction_count: usize, block_bytes: usize, elapsed: Duration) {
+fn print_result(
+    transaction_count: usize,
+    block_bytes: usize,
+    contextual_input_clone_elapsed: Duration,
+    remaining_value_elapsed: Duration,
+    contextual_preparation_elapsed: Duration,
+) {
     let transaction_count: u32 = transaction_count
         .try_into()
         .expect("benchmark transaction count fits in u32");
-    let transactions_per_second = f64::from(transaction_count) / elapsed.as_secs_f64();
+    let contextual_input_clone_tps =
+        f64::from(transaction_count) / contextual_input_clone_elapsed.as_secs_f64();
+    let remaining_value_tps = f64::from(transaction_count) / remaining_value_elapsed.as_secs_f64();
+    let contextual_preparation_tps =
+        f64::from(transaction_count) / contextual_preparation_elapsed.as_secs_f64();
 
     println!(
-        "transactions={transaction_count} block_bytes={block_bytes} \
+        "operation=contextual_input_clone transactions={transaction_count} \
+         block_bytes={block_bytes} input_lookups={transaction_count} elapsed_seconds={:.3} \
+         transactions_per_second={:.1}",
+        contextual_input_clone_elapsed.as_secs_f64(),
+        contextual_input_clone_tps,
+    );
+    println!(
+        "operation=remaining_value transactions={transaction_count} block_bytes={block_bytes} \
          input_lookups={transaction_count} elapsed_seconds={:.3} transactions_per_second={:.1}",
-        elapsed.as_secs_f64(),
-        transactions_per_second,
+        remaining_value_elapsed.as_secs_f64(),
+        remaining_value_tps,
+    );
+    println!(
+        "operation=contextual_preparation transactions={transaction_count} \
+         block_bytes={block_bytes} input_lookups={transaction_count} elapsed_seconds={:.3} \
+         transactions_per_second={:.1}",
+        contextual_preparation_elapsed.as_secs_f64(),
+        contextual_preparation_tps,
     );
 }

--- a/crates/zakura-state/src/arbitrary.rs
+++ b/crates/zakura-state/src/arbitrary.rs
@@ -60,6 +60,7 @@ impl SemanticallyVerifiedBlock {
 impl ContextuallyVerifiedBlock {
     /// Create a block that's ready for non-finalized `Chain` contextual
     /// validation, using a [`SemanticallyVerifiedBlock`] and fake zero-valued spent UTXOs.
+    /// The helper assigns zero value to intra-block spends as well as chain spends.
     ///
     /// Only for use in tests.
     pub fn test_with_zero_spent_utxos(block: impl Into<SemanticallyVerifiedBlock>) -> Self {

--- a/crates/zakura-state/src/request.rs
+++ b/crates/zakura-state/src/request.rs
@@ -505,12 +505,16 @@ impl ContextuallyVerifiedBlock {
     /// Create a block that's ready for non-finalized `Chain` contextual validation,
     /// using a [`SemanticallyVerifiedBlock`] and the UTXOs it spends.
     ///
-    /// When combined, `semantically_verified.new_outputs` and `spent_utxos` must contain
-    /// the [`Utxo`](transparent::Utxo)s spent by every transparent input in this block,
-    /// including UTXOs created by earlier transactions in this block.
+    /// `spent_outputs` must contain the [`Utxo`](transparent::Utxo) spent by
+    /// every transparent input in this block. This includes UTXOs created by
+    /// earlier transactions in the same block.
     ///
     /// Note: a [`ContextuallyVerifiedBlock`] isn't actually contextually valid until
     /// [`Chain::push()`](crate::service::non_finalized_state::Chain::push) returns success.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `spent_outputs` omits a transparent input's UTXO.
     pub fn with_block_and_spent_utxos(
         semantically_verified: SemanticallyVerifiedBlock,
         spent_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,

--- a/crates/zakura-state/src/request.rs
+++ b/crates/zakura-state/src/request.rs
@@ -27,7 +27,7 @@ use zakura_chain::{
     sprout,
     subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeIndex},
     transaction::{self, UnminedTx},
-    transparent::{self, utxos_from_ordered_utxos},
+    transparent,
     value_balance::{ValueBalance, ValueBalanceError},
 };
 
@@ -513,7 +513,7 @@ impl ContextuallyVerifiedBlock {
     /// [`Chain::push()`](crate::service::non_finalized_state::Chain::push) returns success.
     pub fn with_block_and_spent_utxos(
         semantically_verified: SemanticallyVerifiedBlock,
-        mut spent_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+        spent_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
     ) -> Result<Self, ValueBalanceError> {
         let SemanticallyVerifiedBlock {
             block,
@@ -525,23 +525,19 @@ impl ContextuallyVerifiedBlock {
             auth_data_root: _,
         } = semantically_verified;
 
-        // This is redundant for the non-finalized state,
-        // but useful to make some tests pass more easily.
-        //
-        // TODO: fix the tests, and stop adding unrelated outputs.
-        spent_outputs.extend(new_outputs.clone());
+        let chain_value_pool_change = block.chain_value_pool_change_from_ordered_utxos(
+            &spent_outputs,
+            deferred_pool_balance_change,
+        )?;
 
         Ok(Self {
-            block: block.clone(),
+            block,
             hash,
             height,
             new_outputs,
-            spent_outputs: spent_outputs.clone(),
+            spent_outputs,
             transaction_hashes,
-            chain_value_pool_change: block.chain_value_pool_change(
-                &utxos_from_ordered_utxos(spent_outputs),
-                deferred_pool_balance_change,
-            )?,
+            chain_value_pool_change,
         })
     }
 }

--- a/crates/zakura-state/src/service/check/tests/utxo.rs
+++ b/crates/zakura-state/src/service/check/tests/utxo.rs
@@ -222,6 +222,12 @@ proptest! {
             prop_assert!(!chain.unspent_utxos().contains_key(&expected_outpoint));
             prop_assert!(chain.created_utxos.contains_key(&expected_outpoint));
             prop_assert!(chain.spent_utxos.contains_key(&expected_outpoint));
+            prop_assert!(chain
+                .blocks
+                .get(&Height(1))
+                .expect("the committed block is stored at height 1")
+                .spent_outputs
+                .contains_key(&expected_outpoint));
 
             // the finalized state does not have the UTXO
             prop_assert!(finalized_state.utxo(&expected_outpoint).is_none());

--- a/crates/zakura-state/src/service/check/utxo.rs
+++ b/crates/zakura-state/src/service/check/utxo.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use zakura_chain::{
     amount,
-    transparent::{self, utxos_from_ordered_utxos, CoinbaseSpendRestriction::*},
+    transparent::{self, CoinbaseSpendRestriction::*},
 };
 
 use crate::{
@@ -232,8 +232,6 @@ pub fn remaining_transaction_value(
     semantically_verified: &SemanticallyVerifiedBlock,
     utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) -> Result<(), ValidateContextError> {
-    let utxos = utxos_from_ordered_utxos(utxos.clone());
-
     for (tx_index_in_block, transaction) in
         semantically_verified.block.transactions.iter().enumerate()
     {
@@ -242,7 +240,7 @@ pub fn remaining_transaction_value(
         }
 
         // Check the remaining transparent value pool for this transaction
-        let value_balance = transaction.value_balance(&utxos);
+        let value_balance = transaction.value_balance_from_ordered_utxos(utxos);
         match value_balance {
             Ok(vb) => match vb.remaining_transaction_value() {
                 Ok(_) => Ok(()),

--- a/crates/zakura-state/src/service/non_finalized_state.rs
+++ b/crates/zakura-state/src/service/non_finalized_state.rs
@@ -601,19 +601,20 @@ impl NonFinalizedState {
         );
 
         // Quick check that doesn't read from disk
-        let contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
-            prepared.clone(),
-            spent_utxos.clone(),
-        )
-        .map_err(|value_balance_error| {
-            ValidateContextError::CalculateBlockChainValueChange {
-                value_balance_error,
-                height: prepared.height,
-                block_hash: prepared.hash,
-                transaction_count: prepared.block.transactions.len(),
-                spent_utxo_count: spent_utxos.len(),
-            }
-        })?;
+        let height = prepared.height;
+        let block_hash = prepared.hash;
+        let transaction_count = prepared.block.transactions.len();
+        let spent_utxo_count = spent_utxos.len();
+        let contextual =
+            ContextuallyVerifiedBlock::with_block_and_spent_utxos(prepared, spent_utxos).map_err(
+                |value_balance_error| ValidateContextError::CalculateBlockChainValueChange {
+                    value_balance_error,
+                    height,
+                    block_hash,
+                    transaction_count,
+                    spent_utxo_count,
+                },
+            )?;
 
         Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates)
     }

--- a/crates/zakura-state/src/service/non_finalized_state/tests/prop.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/tests/prop.rs
@@ -1,6 +1,10 @@
 //! Randomised property tests for the non-finalized state.
 
-use std::{collections::BTreeMap, env, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+    sync::Arc,
+};
 
 use zakura_test::prelude::*;
 
@@ -10,6 +14,7 @@ use zakura_chain::{
     history_tree::{HistoryTree, NonEmptyHistoryTree},
     parameters::NetworkUpgrade::*,
     parameters::*,
+    transparent,
     value_balance::ValueBalance,
     LedgerState,
 };
@@ -18,7 +23,32 @@ use crate::{
     arbitrary::Prepare,
     request::ContextuallyVerifiedBlock,
     service::{arbitrary::PreparedChain, non_finalized_state::Chain},
+    SemanticallyVerifiedBlock,
 };
+
+fn spent_utxos(
+    block: &SemanticallyVerifiedBlock,
+    chain: &Chain,
+) -> HashMap<transparent::OutPoint, transparent::OrderedUtxo> {
+    let chain_utxos = chain.unspent_utxos();
+
+    block
+        .block
+        .transactions
+        .iter()
+        .flat_map(|transaction| transaction.inputs())
+        .filter_map(transparent::Input::outpoint)
+        .map(|outpoint| {
+            let utxo = block
+                .new_outputs
+                .get(&outpoint)
+                .or_else(|| chain_utxos.get(&outpoint))
+                .expect("prepared test chains provide every spent UTXO")
+                .clone();
+            (outpoint, utxo)
+        })
+        .collect()
+}
 
 /// The default number of proptest cases for long partial chain tests.
 const DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES: u32 = 1;
@@ -48,10 +78,11 @@ fn push_genesis_chain() -> Result<()> {
         chain_values.insert(None, (None, only_chain.chain_value_pools.into()));
 
         for block in chain.iter().take(count).skip(1).cloned() {
+            let spent_utxos = spent_utxos(&block, &only_chain);
             let block =
             ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                     block,
-                    only_chain.unspent_utxos(),
+                    spent_utxos,
                 )
                 .map_err(|e| (e, chain_values.clone()))
                 .expect("invalid block value pool change");
@@ -146,9 +177,10 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             ValueBalance::zero(),
         );
         for block in chain.iter().take(fork_at_count).skip(1).cloned() {
+            let spent_utxos = spent_utxos(&block, &partial_chain);
             let block = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                 block,
-                partial_chain.unspent_utxos(),
+                spent_utxos,
             )?;
             partial_chain = partial_chain
                 .push(block)
@@ -168,8 +200,8 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         );
 
         for block in chain.iter().cloned() {
-            let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos())?;
+            let spent_utxos = spent_utxos(&block, &full_chain);
+            let block = ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, spent_utxos)?;
 
             // Check some properties of the genesis block and don't push it to the chain.
             if block.height == block::Height(0) {
@@ -211,8 +243,8 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         // Re-add blocks to the fork and check if we arrive at the
         // same original full chain.
         for block in chain.iter().skip(fork_at_count).cloned() {
-            let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, forked.unspent_utxos())?;
+            let spent_utxos = spent_utxos(&block, &forked);
+            let block = ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, spent_utxos)?;
             forked = forked.push(block).expect("forked chain push is valid");
         }
 

--- a/docs/changelog/unreleased/779.md
+++ b/docs/changelog/unreleased/779.md
@@ -1,0 +1,4 @@
+## Changed
+
+- Reduced contextual block verification latency by removing redundant UTXO
+  copies ([#779](https://github.com/zakura-core/zakura/pull/779)).


### PR DESCRIPTION
## Motivation

The contextual path copied large UTXO maps several times before it validated
a block.

The worst-case transparent benchmark models a 1,999,944-byte block with 26,645
spends and 26,645 new outputs. The old contextual constructor copied every
spent UTXO and then duplicated every new output into the same map.

## Solution

- Move prepared blocks and spent UTXOs into contextual validation.
- Keep new outputs separate from spent outputs.
- Read `OrderedUtxo` values directly during transaction and block value-balance
  checks.
- Document and test the invariant that the spent-output map contains every
  transparent input, including intra-block spends.
- Preserve the offending outpoint and map size in invariant failures.
- Extend the worst-case transparent benchmark to measure each affected step.
- Add an equivalence test for ordered and plain UTXO value-balance paths.

The change preserves contextual validation order. It changes ownership and
lookup representation only.

## Results

| Benchmark | Baseline | Result | Reduction |
| --- | ---: | ---: | ---: |
| Contextual preparation | 13.663 ms | 4.840 ms | 64.58% |
| Remaining-value check | 6.495 ms | 3.486 ms | 46.33% |

Moving the contextual inputs also removes a 2.850 ms median clone from the
worst-case transparent path. These measurements isolate local preparation.
They do not predict the full production contextual interval.

## Testing

- `cargo bench -p zakura-state --bench transparent_spend_worst_case --features internal-bench`
- `cargo test -p zakura-chain -p zakura-state --lib --locked` on the #780 stack tip
  - the state suite passed 515 tests and ignored 3 tests
- `cargo check -p zakura-chain -p zakura-state --all-targets --locked`
- `cargo clippy -p zakura-chain -p zakura-state --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

## Changelog

This PR adds `docs/changelog/unreleased/779.md`.

## Stack

- Base: `main`.
- Parent: none.
- Child: #780.
- This PR is independent of #748, #754, #776, and #773.

### Follow-up Work

- Use the new-fleet A/B to rank the remaining contextual components.
- Measure nullifier, anchor, UTXO lookup, tree, header transition, and writer
  scheduling work separately.
- Evaluate authenticated contextual preparation during semantic verification.