### PR TITLE
perf(state): measure contextual verification phases

### DIFF
--- a/crates/zakura-state/src/service/non_finalized_state.rs
+++ b/crates/zakura-state/src/service/non_finalized_state.rs
@@ -39,14 +39,38 @@ mod tests;
 pub(crate) use backup::write_semantically_verified_backup_block;
 pub(crate) use chain::{Chain, SpendingTransactionId};
 
-macro_rules! record_contextual_duration {
-    ($metric_name:literal, $mined_metric_name:literal, $duration:expr, $is_mined:expr $(,)?) => {{
-        let duration = $duration.as_secs_f64();
-        metrics::histogram!($metric_name).record(duration);
-        if $is_mined {
-            metrics::histogram!($mined_metric_name).record(duration);
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ContextualMetrics {
+    Disabled,
+    AllBlocks,
+    Mined,
+}
+
+impl ContextualMetrics {
+    pub(crate) fn for_commit(is_mined: bool) -> Self {
+        if is_mined {
+            Self::Mined
+        } else {
+            Self::AllBlocks
         }
-    }};
+    }
+
+    pub(crate) fn record_duration(
+        self,
+        metric_name: &'static str,
+        mined_metric_name: &'static str,
+        duration: std::time::Duration,
+    ) {
+        if self == Self::Disabled {
+            return;
+        }
+
+        let duration = duration.as_secs_f64();
+        metrics::histogram!(metric_name).record(duration);
+        if self == Self::Mined {
+            metrics::histogram!(mined_metric_name).record(duration);
+        }
+    }
 }
 
 /// The state of the chains in memory, including queued blocks.
@@ -366,7 +390,7 @@ impl NonFinalizedState {
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
     ) -> Result<(), ValidateContextError> {
-        self.commit_block_with_metrics(prepared, finalized_state, false)
+        self.commit_block_with_metrics(prepared, finalized_state, ContextualMetrics::Disabled)
     }
 
     #[tracing::instrument(
@@ -378,25 +402,24 @@ impl NonFinalizedState {
         &mut self,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
-        is_mined: bool,
+        contextual_metrics: ContextualMetrics,
     ) -> Result<(), ValidateContextError> {
         let parent_hash = prepared.block.header.previous_block_hash;
         let (height, hash) = (prepared.height, prepared.hash);
 
         let parent_chain_start = Instant::now();
         let parent_chain = self.parent_chain(parent_hash);
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parent_chain.duration_seconds",
             "state.contextual.mined.parent_chain.duration_seconds",
             parent_chain_start.elapsed(),
-            is_mined,
         );
         let parent_chain = parent_chain?;
 
         // If the block is invalid, return the error,
         // and drop the cloned parent Arc, or newly created chain fork.
         let modified_chain =
-            self.validate_and_commit(parent_chain, prepared, finalized_state, is_mined)?;
+            self.validate_and_commit(parent_chain, prepared, finalized_state, contextual_metrics)?;
 
         // If the block is valid:
         // - add the new chain fork or updated chain to the set of recent chains
@@ -555,7 +578,7 @@ impl NonFinalizedState {
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
     ) -> Result<(), ValidateContextError> {
-        self.commit_new_chain_with_metrics(prepared, finalized_state, false)
+        self.commit_new_chain_with_metrics(prepared, finalized_state, ContextualMetrics::Disabled)
     }
 
     #[tracing::instrument(
@@ -568,7 +591,7 @@ impl NonFinalizedState {
         &mut self,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
-        is_mined: bool,
+        contextual_metrics: ContextualMetrics,
     ) -> Result<(), ValidateContextError> {
         let chain_new_start = Instant::now();
         let chain: Result<Chain, ValidateContextError> = (|| {
@@ -593,19 +616,22 @@ impl NonFinalizedState {
                 finalized_state.finalized_value_pool(),
             ))
         })();
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.chain_new.duration_seconds",
             "state.contextual.mined.chain_new.duration_seconds",
             chain_new_start.elapsed(),
-            is_mined,
         );
         let chain = chain?;
 
         let (height, hash) = (prepared.height, prepared.hash);
 
         // If the block is invalid, return the error, and drop the newly created chain fork
-        let chain =
-            self.validate_and_commit(Arc::new(chain), prepared, finalized_state, is_mined)?;
+        let chain = self.validate_and_commit(
+            Arc::new(chain),
+            prepared,
+            finalized_state,
+            contextual_metrics,
+        )?;
 
         // If the block is valid, add the new chain fork to the set of recent chains.
         self.insert(chain);
@@ -625,7 +651,7 @@ impl NonFinalizedState {
         new_chain: Arc<Chain>,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
-        is_mined: bool,
+        contextual_metrics: ContextualMetrics,
     ) -> Result<Arc<Chain>, ValidateContextError> {
         if self
             .invalidated_blocks
@@ -642,11 +668,10 @@ impl NonFinalizedState {
         // TODO: if these disk reads show up in profiles, run them in parallel, using std::thread::spawn()
         let unspent_utxo_snapshot_start = Instant::now();
         let unspent_utxos = new_chain.unspent_utxos();
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.unspent_utxo_snapshot.duration_seconds",
             "state.contextual.mined.unspent_utxo_snapshot.duration_seconds",
             unspent_utxo_snapshot_start.elapsed(),
-            is_mined,
         );
 
         let transparent_spend_start = Instant::now();
@@ -656,11 +681,10 @@ impl NonFinalizedState {
             &new_chain.spent_utxos,
             finalized_state,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.transparent_spend.duration_seconds",
             "state.contextual.mined.transparent_spend.duration_seconds",
             transparent_spend_start.elapsed(),
-            is_mined,
         );
         let spent_utxos = spent_utxos?;
 
@@ -672,11 +696,10 @@ impl NonFinalizedState {
                 &new_chain,
                 &prepared,
             );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.shielded_anchors.duration_seconds",
             "state.contextual.mined.shielded_anchors.duration_seconds",
             shielded_anchor_start.elapsed(),
-            is_mined,
         );
         shielded_anchors?;
 
@@ -687,11 +710,10 @@ impl NonFinalizedState {
             &new_chain,
             &prepared,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.sprout_anchor_fetch.duration_seconds",
             "state.contextual.mined.sprout_anchor_fetch.duration_seconds",
             sprout_anchor_fetch_start.elapsed(),
-            is_mined,
         );
 
         // Quick check that doesn't read from disk
@@ -710,11 +732,10 @@ impl NonFinalizedState {
                     spent_utxo_count,
                 },
             );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.block_construction.duration_seconds",
             "state.contextual.mined.block_construction.duration_seconds",
             contextual_block_start.elapsed(),
-            is_mined,
         );
         let contextual = contextual?;
 
@@ -723,13 +744,12 @@ impl NonFinalizedState {
             new_chain,
             contextual,
             sprout_final_treestates,
-            is_mined,
+            contextual_metrics,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parallel_update.duration_seconds",
             "state.contextual.mined.parallel_update.duration_seconds",
             parallel_update_start.elapsed(),
-            is_mined,
         );
         result
     }
@@ -741,7 +761,7 @@ impl NonFinalizedState {
         new_chain: Arc<Chain>,
         contextual: ContextuallyVerifiedBlock,
         sprout_final_treestates: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
-        is_mined: bool,
+        contextual_metrics: ContextualMetrics,
     ) -> Result<Arc<Chain>, ValidateContextError> {
         let mut block_commitment_result = None;
         let mut sprout_anchor_result = None;
@@ -806,29 +826,25 @@ impl NonFinalizedState {
 
         // These task durations overlap. Only `parallel_update` measures their
         // combined critical-path wall time.
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parallel_task.block_commitment.duration_seconds",
             "state.contextual.mined.parallel_task.block_commitment.duration_seconds",
             block_commitment_duration,
-            is_mined,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parallel_task.sprout_anchor_check.duration_seconds",
             "state.contextual.mined.parallel_task.sprout_anchor_check.duration_seconds",
             sprout_anchor_duration,
-            is_mined,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parallel_task.chain_clone.duration_seconds",
             "state.contextual.mined.parallel_task.chain_clone.duration_seconds",
             chain_clone_duration,
-            is_mined,
         );
-        record_contextual_duration!(
+        contextual_metrics.record_duration(
             "state.contextual.parallel_task.chain_push.duration_seconds",
             "state.contextual.mined.parallel_task.chain_push.duration_seconds",
             chain_push_duration,
-            is_mined,
         );
 
         block_commitment_result?;

--- a/crates/zakura-state/src/service/non_finalized_state.rs
+++ b/crates/zakura-state/src/service/non_finalized_state.rs
@@ -7,6 +7,7 @@ use std::{
     mem,
     path::{Path, PathBuf},
     sync::Arc,
+    time::Instant,
 };
 
 use indexmap::IndexMap;
@@ -579,28 +580,41 @@ impl NonFinalizedState {
         // Reads from disk
         //
         // TODO: if these disk reads show up in profiles, run them in parallel, using std::thread::spawn()
+        let transparent_spend_start = Instant::now();
         let spent_utxos = check::utxo::transparent_spend(
             &prepared,
             &new_chain.unspent_utxos(),
             &new_chain.spent_utxos,
             finalized_state,
-        )?;
+        );
+        metrics::histogram!("state.contextual.transparent_spend.duration_seconds")
+            .record(transparent_spend_start.elapsed().as_secs_f64());
+        let spent_utxos = spent_utxos?;
 
         // Reads from disk
-        check::anchors::block_sapling_orchard_ironwood_anchors_refer_to_final_treestates(
-            finalized_state,
-            &new_chain,
-            &prepared,
-        )?;
+        let shielded_anchor_start = Instant::now();
+        let shielded_anchors =
+            check::anchors::block_sapling_orchard_ironwood_anchors_refer_to_final_treestates(
+                finalized_state,
+                &new_chain,
+                &prepared,
+            );
+        metrics::histogram!("state.contextual.shielded_anchors.duration_seconds")
+            .record(shielded_anchor_start.elapsed().as_secs_f64());
+        shielded_anchors?;
 
         // Reads from disk
+        let sprout_anchor_fetch_start = Instant::now();
         let sprout_final_treestates = check::anchors::block_fetch_sprout_final_treestates(
             finalized_state,
             &new_chain,
             &prepared,
         );
+        metrics::histogram!("state.contextual.sprout_anchor_fetch.duration_seconds")
+            .record(sprout_anchor_fetch_start.elapsed().as_secs_f64());
 
         // Quick check that doesn't read from disk
+        let contextual_block_start = Instant::now();
         let height = prepared.height;
         let block_hash = prepared.hash;
         let transaction_count = prepared.block.transactions.len();
@@ -614,9 +628,17 @@ impl NonFinalizedState {
                     transaction_count,
                     spent_utxo_count,
                 },
-            )?;
+            );
+        metrics::histogram!("state.contextual.block_construction.duration_seconds")
+            .record(contextual_block_start.elapsed().as_secs_f64());
+        let contextual = contextual?;
 
-        Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates)
+        let parallel_update_start = Instant::now();
+        let result =
+            Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates);
+        metrics::histogram!("state.contextual.parallel_update.duration_seconds")
+            .record(parallel_update_start.elapsed().as_secs_f64());
+        result
     }
 
     /// Validate `contextual` and update `new_chain`, doing CPU-intensive work in parallel batches.
@@ -642,22 +664,25 @@ impl NonFinalizedState {
 
         rayon::in_place_scope_fifo(|scope| {
             scope.spawn_fifo(|_scope| {
-                block_commitment_result = Some(check::block_commitment_is_valid_for_chain_history(
+                let start = Instant::now();
+                let result = check::block_commitment_is_valid_for_chain_history(
                     block,
                     &network,
                     &history_tree,
                     None,
-                ));
+                );
+                block_commitment_result = Some((result, start.elapsed()));
             });
 
             scope.spawn_fifo(|_scope| {
-                sprout_anchor_result =
-                    Some(check::anchors::block_sprout_anchors_refer_to_treestates(
-                        sprout_final_treestates,
-                        block2,
-                        transaction_hashes,
-                        height,
-                    ));
+                let start = Instant::now();
+                let result = check::anchors::block_sprout_anchors_refer_to_treestates(
+                    sprout_final_treestates,
+                    block2,
+                    transaction_hashes,
+                    height,
+                );
+                sprout_anchor_result = Some((result, start.elapsed()));
             });
 
             // We're pretty sure the new block is valid,
@@ -666,19 +691,35 @@ impl NonFinalizedState {
             // Pushing a block onto a Chain can launch additional parallel batches.
             // TODO: should we pass _scope into Chain::push()?
             scope.spawn_fifo(|_scope| {
+                let start = Instant::now();
                 // TODO: Replace with Arc::unwrap_or_clone() when it stabilises:
                 // https://github.com/rust-lang/rust/issues/93610
                 let new_chain = Arc::try_unwrap(new_chain)
                     .unwrap_or_else(|shared_chain| (*shared_chain).clone());
-                chain_push_result = Some(new_chain.push(contextual).map(Arc::new));
+                let result = new_chain.push(contextual).map(Arc::new);
+                chain_push_result = Some((result, start.elapsed()));
             });
         });
 
         // Don't return the updated Chain unless all the parallel results were Ok
-        block_commitment_result.expect("scope has finished")?;
-        sprout_anchor_result.expect("scope has finished")?;
+        let (block_commitment_result, block_commitment_duration) =
+            block_commitment_result.expect("scope has finished");
+        let (sprout_anchor_result, sprout_anchor_duration) =
+            sprout_anchor_result.expect("scope has finished");
+        let (chain_push_result, chain_push_duration) =
+            chain_push_result.expect("scope has finished");
 
-        chain_push_result.expect("scope has finished")
+        metrics::histogram!("state.contextual.block_commitment.duration_seconds")
+            .record(block_commitment_duration.as_secs_f64());
+        metrics::histogram!("state.contextual.sprout_anchor_check.duration_seconds")
+            .record(sprout_anchor_duration.as_secs_f64());
+        metrics::histogram!("state.contextual.chain_push.duration_seconds")
+            .record(chain_push_duration.as_secs_f64());
+
+        block_commitment_result?;
+        sprout_anchor_result?;
+
+        chain_push_result
     }
 
     /// Returns the length of the non-finalized portion of the current best chain

--- a/crates/zakura-state/src/service/non_finalized_state.rs
+++ b/crates/zakura-state/src/service/non_finalized_state.rs
@@ -39,6 +39,16 @@ mod tests;
 pub(crate) use backup::write_semantically_verified_backup_block;
 pub(crate) use chain::{Chain, SpendingTransactionId};
 
+macro_rules! record_contextual_duration {
+    ($metric_name:literal, $mined_metric_name:literal, $duration:expr, $is_mined:expr $(,)?) => {{
+        let duration = $duration.as_secs_f64();
+        metrics::histogram!($metric_name).record(duration);
+        if $is_mined {
+            metrics::histogram!($mined_metric_name).record(duration);
+        }
+    }};
+}
+
 /// The state of the chains in memory, including queued blocks.
 ///
 /// Clones of the non-finalized state contain independent copies of the chains.
@@ -351,20 +361,42 @@ impl NonFinalizedState {
     /// Commit block to the non-finalized state, on top of:
     /// - an existing chain's tip, or
     /// - a newly forked chain.
-    #[tracing::instrument(level = "debug", skip(self, finalized_state, prepared))]
     pub fn commit_block(
         &mut self,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
     ) -> Result<(), ValidateContextError> {
+        self.commit_block_with_metrics(prepared, finalized_state, false)
+    }
+
+    #[tracing::instrument(
+        name = "commit_block",
+        level = "debug",
+        skip(self, finalized_state, prepared)
+    )]
+    pub(crate) fn commit_block_with_metrics(
+        &mut self,
+        prepared: SemanticallyVerifiedBlock,
+        finalized_state: &ZakuraDb,
+        is_mined: bool,
+    ) -> Result<(), ValidateContextError> {
         let parent_hash = prepared.block.header.previous_block_hash;
         let (height, hash) = (prepared.height, prepared.hash);
 
-        let parent_chain = self.parent_chain(parent_hash)?;
+        let parent_chain_start = Instant::now();
+        let parent_chain = self.parent_chain(parent_hash);
+        record_contextual_duration!(
+            "state.contextual.parent_chain.duration_seconds",
+            "state.contextual.mined.parent_chain.duration_seconds",
+            parent_chain_start.elapsed(),
+            is_mined,
+        );
+        let parent_chain = parent_chain?;
 
         // If the block is invalid, return the error,
         // and drop the cloned parent Arc, or newly created chain fork.
-        let modified_chain = self.validate_and_commit(parent_chain, prepared, finalized_state)?;
+        let modified_chain =
+            self.validate_and_commit(parent_chain, prepared, finalized_state, is_mined)?;
 
         // If the block is valid:
         // - add the new chain fork or updated chain to the set of recent chains
@@ -517,36 +549,63 @@ impl NonFinalizedState {
 
     /// Commit block to the non-finalized state as a new chain where its parent
     /// is the finalized tip.
-    #[tracing::instrument(level = "debug", skip(self, finalized_state, prepared))]
     #[allow(clippy::unwrap_in_result)]
     pub fn commit_new_chain(
         &mut self,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
     ) -> Result<(), ValidateContextError> {
-        let finalized_tip_height = finalized_state.finalized_tip_height();
+        self.commit_new_chain_with_metrics(prepared, finalized_state, false)
+    }
 
-        // TODO: fix tests that don't initialize the finalized state
-        #[cfg(not(test))]
-        let finalized_tip_height = finalized_tip_height.expect("finalized state contains blocks");
-        #[cfg(test)]
-        let finalized_tip_height = finalized_tip_height.unwrap_or(zakura_chain::block::Height(0));
+    #[tracing::instrument(
+        name = "commit_new_chain",
+        level = "debug",
+        skip(self, finalized_state, prepared)
+    )]
+    #[allow(clippy::unwrap_in_result)]
+    pub(crate) fn commit_new_chain_with_metrics(
+        &mut self,
+        prepared: SemanticallyVerifiedBlock,
+        finalized_state: &ZakuraDb,
+        is_mined: bool,
+    ) -> Result<(), ValidateContextError> {
+        let chain_new_start = Instant::now();
+        let chain: Result<Chain, ValidateContextError> = (|| {
+            let finalized_tip_height = finalized_state.finalized_tip_height();
 
-        let chain = Chain::new(
-            &self.network,
-            finalized_tip_height,
-            finalized_state.sprout_tree_for_tip()?,
-            finalized_state.sapling_tree_for_tip(),
-            finalized_state.orchard_tree_for_tip(),
-            finalized_state.ironwood_tree_for_tip(),
-            finalized_state.history_tree(),
-            finalized_state.finalized_value_pool(),
+            // TODO: fix tests that don't initialize the finalized state
+            #[cfg(not(test))]
+            let finalized_tip_height =
+                finalized_tip_height.expect("finalized state contains blocks");
+            #[cfg(test)]
+            let finalized_tip_height =
+                finalized_tip_height.unwrap_or(zakura_chain::block::Height(0));
+
+            Ok(Chain::new(
+                &self.network,
+                finalized_tip_height,
+                finalized_state.sprout_tree_for_tip()?,
+                finalized_state.sapling_tree_for_tip(),
+                finalized_state.orchard_tree_for_tip(),
+                finalized_state.ironwood_tree_for_tip(),
+                finalized_state.history_tree(),
+                finalized_state.finalized_value_pool(),
+            ))
+        })();
+        record_contextual_duration!(
+            "state.contextual.chain_new.duration_seconds",
+            "state.contextual.mined.chain_new.duration_seconds",
+            chain_new_start.elapsed(),
+            is_mined,
         );
+        let chain = chain?;
 
         let (height, hash) = (prepared.height, prepared.hash);
 
         // If the block is invalid, return the error, and drop the newly created chain fork
-        let chain = self.validate_and_commit(Arc::new(chain), prepared, finalized_state)?;
+        let chain =
+            self.validate_and_commit(Arc::new(chain), prepared, finalized_state, is_mined)?;
 
         // If the block is valid, add the new chain fork to the set of recent chains.
         self.insert(chain);
@@ -566,6 +625,7 @@ impl NonFinalizedState {
         new_chain: Arc<Chain>,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZakuraDb,
+        is_mined: bool,
     ) -> Result<Arc<Chain>, ValidateContextError> {
         if self
             .invalidated_blocks
@@ -580,15 +640,28 @@ impl NonFinalizedState {
         // Reads from disk
         //
         // TODO: if these disk reads show up in profiles, run them in parallel, using std::thread::spawn()
+        let unspent_utxo_snapshot_start = Instant::now();
+        let unspent_utxos = new_chain.unspent_utxos();
+        record_contextual_duration!(
+            "state.contextual.unspent_utxo_snapshot.duration_seconds",
+            "state.contextual.mined.unspent_utxo_snapshot.duration_seconds",
+            unspent_utxo_snapshot_start.elapsed(),
+            is_mined,
+        );
+
         let transparent_spend_start = Instant::now();
         let spent_utxos = check::utxo::transparent_spend(
             &prepared,
-            &new_chain.unspent_utxos(),
+            &unspent_utxos,
             &new_chain.spent_utxos,
             finalized_state,
         );
-        metrics::histogram!("state.contextual.transparent_spend.duration_seconds")
-            .record(transparent_spend_start.elapsed().as_secs_f64());
+        record_contextual_duration!(
+            "state.contextual.transparent_spend.duration_seconds",
+            "state.contextual.mined.transparent_spend.duration_seconds",
+            transparent_spend_start.elapsed(),
+            is_mined,
+        );
         let spent_utxos = spent_utxos?;
 
         // Reads from disk
@@ -599,8 +672,12 @@ impl NonFinalizedState {
                 &new_chain,
                 &prepared,
             );
-        metrics::histogram!("state.contextual.shielded_anchors.duration_seconds")
-            .record(shielded_anchor_start.elapsed().as_secs_f64());
+        record_contextual_duration!(
+            "state.contextual.shielded_anchors.duration_seconds",
+            "state.contextual.mined.shielded_anchors.duration_seconds",
+            shielded_anchor_start.elapsed(),
+            is_mined,
+        );
         shielded_anchors?;
 
         // Reads from disk
@@ -610,8 +687,12 @@ impl NonFinalizedState {
             &new_chain,
             &prepared,
         );
-        metrics::histogram!("state.contextual.sprout_anchor_fetch.duration_seconds")
-            .record(sprout_anchor_fetch_start.elapsed().as_secs_f64());
+        record_contextual_duration!(
+            "state.contextual.sprout_anchor_fetch.duration_seconds",
+            "state.contextual.mined.sprout_anchor_fetch.duration_seconds",
+            sprout_anchor_fetch_start.elapsed(),
+            is_mined,
+        );
 
         // Quick check that doesn't read from disk
         let contextual_block_start = Instant::now();
@@ -629,15 +710,27 @@ impl NonFinalizedState {
                     spent_utxo_count,
                 },
             );
-        metrics::histogram!("state.contextual.block_construction.duration_seconds")
-            .record(contextual_block_start.elapsed().as_secs_f64());
+        record_contextual_duration!(
+            "state.contextual.block_construction.duration_seconds",
+            "state.contextual.mined.block_construction.duration_seconds",
+            contextual_block_start.elapsed(),
+            is_mined,
+        );
         let contextual = contextual?;
 
         let parallel_update_start = Instant::now();
-        let result =
-            Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates);
-        metrics::histogram!("state.contextual.parallel_update.duration_seconds")
-            .record(parallel_update_start.elapsed().as_secs_f64());
+        let result = Self::validate_and_update_parallel(
+            new_chain,
+            contextual,
+            sprout_final_treestates,
+            is_mined,
+        );
+        record_contextual_duration!(
+            "state.contextual.parallel_update.duration_seconds",
+            "state.contextual.mined.parallel_update.duration_seconds",
+            parallel_update_start.elapsed(),
+            is_mined,
+        );
         result
     }
 
@@ -648,6 +741,7 @@ impl NonFinalizedState {
         new_chain: Arc<Chain>,
         contextual: ContextuallyVerifiedBlock,
         sprout_final_treestates: HashMap<sprout::tree::Root, Arc<sprout::tree::NoteCommitmentTree>>,
+        is_mined: bool,
     ) -> Result<Arc<Chain>, ValidateContextError> {
         let mut block_commitment_result = None;
         let mut sprout_anchor_result = None;
@@ -691,13 +785,14 @@ impl NonFinalizedState {
             // Pushing a block onto a Chain can launch additional parallel batches.
             // TODO: should we pass _scope into Chain::push()?
             scope.spawn_fifo(|_scope| {
-                let start = Instant::now();
-                // TODO: Replace with Arc::unwrap_or_clone() when it stabilises:
-                // https://github.com/rust-lang/rust/issues/93610
-                let new_chain = Arc::try_unwrap(new_chain)
-                    .unwrap_or_else(|shared_chain| (*shared_chain).clone());
+                let chain_clone_start = Instant::now();
+                let new_chain = Arc::unwrap_or_clone(new_chain);
+                let chain_clone_duration = chain_clone_start.elapsed();
+
+                let chain_push_start = Instant::now();
                 let result = new_chain.push(contextual).map(Arc::new);
-                chain_push_result = Some((result, start.elapsed()));
+                chain_push_result =
+                    Some((result, chain_clone_duration, chain_push_start.elapsed()));
             });
         });
 
@@ -706,15 +801,35 @@ impl NonFinalizedState {
             block_commitment_result.expect("scope has finished");
         let (sprout_anchor_result, sprout_anchor_duration) =
             sprout_anchor_result.expect("scope has finished");
-        let (chain_push_result, chain_push_duration) =
+        let (chain_push_result, chain_clone_duration, chain_push_duration) =
             chain_push_result.expect("scope has finished");
 
-        metrics::histogram!("state.contextual.block_commitment.duration_seconds")
-            .record(block_commitment_duration.as_secs_f64());
-        metrics::histogram!("state.contextual.sprout_anchor_check.duration_seconds")
-            .record(sprout_anchor_duration.as_secs_f64());
-        metrics::histogram!("state.contextual.chain_push.duration_seconds")
-            .record(chain_push_duration.as_secs_f64());
+        // These task durations overlap. Only `parallel_update` measures their
+        // combined critical-path wall time.
+        record_contextual_duration!(
+            "state.contextual.parallel_task.block_commitment.duration_seconds",
+            "state.contextual.mined.parallel_task.block_commitment.duration_seconds",
+            block_commitment_duration,
+            is_mined,
+        );
+        record_contextual_duration!(
+            "state.contextual.parallel_task.sprout_anchor_check.duration_seconds",
+            "state.contextual.mined.parallel_task.sprout_anchor_check.duration_seconds",
+            sprout_anchor_duration,
+            is_mined,
+        );
+        record_contextual_duration!(
+            "state.contextual.parallel_task.chain_clone.duration_seconds",
+            "state.contextual.mined.parallel_task.chain_clone.duration_seconds",
+            chain_clone_duration,
+            is_mined,
+        );
+        record_contextual_duration!(
+            "state.contextual.parallel_task.chain_push.duration_seconds",
+            "state.contextual.mined.parallel_task.chain_push.duration_seconds",
+            chain_push_duration,
+            is_mined,
+        );
 
         block_commitment_result?;
         sprout_anchor_result?;

--- a/crates/zakura-state/src/service/non_finalized_state/tests.rs
+++ b/crates/zakura-state/src/service/non_finalized_state/tests.rs
@@ -2,3 +2,82 @@
 
 mod prop;
 mod vectors;
+
+use std::sync::Mutex;
+
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
+
+use super::ContextualMetrics;
+
+#[derive(Default)]
+struct MetricNameRecorder {
+    histogram_names: Mutex<Vec<String>>,
+}
+
+impl Recorder for MetricNameRecorder {
+    fn describe_counter(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn describe_gauge(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn describe_histogram(&self, _key: KeyName, _unit: Option<Unit>, _description: SharedString) {}
+
+    fn register_counter(&self, _key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        Counter::noop()
+    }
+
+    fn register_gauge(&self, _key: &Key, _metadata: &Metadata<'_>) -> Gauge {
+        Gauge::noop()
+    }
+
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
+        self.histogram_names
+            .lock()
+            .expect("the metric test does not poison its recorder")
+            .push(key.name().to_owned());
+        Histogram::noop()
+    }
+}
+
+#[test]
+fn contextual_metrics_record_only_selected_series() {
+    let recorder = MetricNameRecorder::default();
+
+    assert_eq!(
+        ContextualMetrics::for_commit(false),
+        ContextualMetrics::AllBlocks
+    );
+    assert_eq!(
+        ContextualMetrics::for_commit(true),
+        ContextualMetrics::Mined
+    );
+
+    metrics::with_local_recorder(&recorder, || {
+        ContextualMetrics::Disabled.record_duration(
+            "test.contextual.disabled.all",
+            "test.contextual.disabled.mined",
+            std::time::Duration::ZERO,
+        );
+        ContextualMetrics::AllBlocks.record_duration(
+            "test.contextual.all.all",
+            "test.contextual.all.mined",
+            std::time::Duration::ZERO,
+        );
+        ContextualMetrics::Mined.record_duration(
+            "test.contextual.mined.all",
+            "test.contextual.mined.mined",
+            std::time::Duration::ZERO,
+        );
+    });
+
+    assert_eq!(
+        *recorder
+            .histogram_names
+            .lock()
+            .expect("the metric test does not poison its recorder"),
+        [
+            "test.contextual.all.all",
+            "test.contextual.mined.all",
+            "test.contextual.mined.mined",
+        ]
+    );
+}

--- a/crates/zakura-state/src/service/write.rs
+++ b/crates/zakura-state/src/service/write.rs
@@ -1332,7 +1332,12 @@ pub(crate) fn validate_and_commit_non_finalized(
     non_finalized_state: &mut NonFinalizedState,
     prepared: SemanticallyVerifiedBlock,
 ) -> Result<(), ValidateContextError> {
-    check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)?;
+    let initial_checks_start = Instant::now();
+    let initial_checks =
+        check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared);
+    metrics::histogram!("state.contextual.initial_checks.duration_seconds")
+        .record(initial_checks_start.elapsed().as_secs_f64());
+    initial_checks?;
     let parent_hash = prepared.block.header.previous_block_hash;
 
     if finalized_state.finalized_tip_hash() == parent_hash {
@@ -2782,7 +2787,10 @@ impl WriteBlockWorkerTask {
                 } else {
                     tracing::trace!(?child_hash, "validating queued child");
                     if let Some(writer) = header_chain.as_ref() {
+                        let snapshot_clone_start = Instant::now();
                         let mut staged = non_finalized_state.clone();
+                        metrics::histogram!("state.contextual.snapshot_clone.duration_seconds")
+                            .record(snapshot_clone_start.elapsed().as_secs_f64());
                         validate_and_commit_non_finalized(
                             &finalized_state.db,
                             &mut staged,
@@ -2791,12 +2799,13 @@ impl WriteBlockWorkerTask {
                         .map_err(|error| CommitBlockError::from(Box::new(error)))
                         .and_then(|()| {
                             let accepted = Frontier::new(child_height, child_hash);
+                            let transition_prepare_start = Instant::now();
                             let (evidence, event_path, request) =
                                 verified_request(writer, non_finalized_state, &staged, accepted)
                                     .map_err(|error| CommitBlockError::HeaderChainError {
                                         error: error.to_string(),
                                     })?;
-                            PreparedFullStateTransition::new(
+                            let transition = PreparedFullStateTransition::new(
                                 evidence,
                                 writer
                                     .runtime
@@ -2809,16 +2818,21 @@ impl WriteBlockWorkerTask {
                                 None,
                                 request,
                             )
-                            .map_err(|error| CommitBlockError::HeaderChainError {
-                                error: error.to_string(),
-                            })?
-                            .commit(&writer.runtime, non_finalized_state, &writer.context())
-                            .map(|_| ())
                             .map_err(|error| {
                                 CommitBlockError::HeaderChainError {
                                     error: error.to_string(),
                                 }
-                            })
+                            })?;
+                            metrics::histogram!(
+                                "state.contextual.header_transition_prepare.duration_seconds"
+                            )
+                            .record(transition_prepare_start.elapsed().as_secs_f64());
+                            transition
+                                .commit(&writer.runtime, non_finalized_state, &writer.context())
+                                .map(|_| ())
+                                .map_err(|error| CommitBlockError::HeaderChainError {
+                                    error: error.to_string(),
+                                })
                         })
                     } else {
                         validate_and_commit_non_finalized(

--- a/crates/zakura-state/src/service/write.rs
+++ b/crates/zakura-state/src/service/write.rs
@@ -45,7 +45,7 @@ use crate::{
             DiskWriteBatch, FinalizedState, VctAuthenticationProof, VctAuxiliaryFailureAttribution,
             VctAuxiliaryWindow, VctSuccessorWitness, ZakuraDb,
         },
-        non_finalized_state::NonFinalizedState,
+        non_finalized_state::{ContextualMetrics, NonFinalizedState},
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
         ChainTipBlock, ChainTipSender, InvalidateError, ReconsiderError,
     },
@@ -1316,16 +1316,6 @@ fn commit_operator_change(
 /// We allow enough space for multiple concurrent chain forks with errors.
 const REJECTED_ANCESTOR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
 
-macro_rules! record_contextual_duration {
-    ($metric_name:literal, $mined_metric_name:literal, $duration:expr, $is_mined:expr $(,)?) => {{
-        let duration = $duration.as_secs_f64();
-        metrics::histogram!($metric_name).record(duration);
-        if $is_mined {
-            metrics::histogram!($mined_metric_name).record(duration);
-        }
-    }};
-}
-
 /// Run contextual validation on the prepared block and add it to the
 /// non-finalized state if it is contextually valid.
 pub(crate) fn validate_and_commit_non_finalized(
@@ -1337,7 +1327,7 @@ pub(crate) fn validate_and_commit_non_finalized(
         finalized_state,
         non_finalized_state,
         prepared,
-        false,
+        ContextualMetrics::Disabled,
     )
 }
 
@@ -1355,32 +1345,38 @@ fn validate_and_commit_non_finalized_with_metrics(
     finalized_state: &ZakuraDb,
     non_finalized_state: &mut NonFinalizedState,
     prepared: SemanticallyVerifiedBlock,
-    is_mined: bool,
+    contextual_metrics: ContextualMetrics,
 ) -> Result<(), ValidateContextError> {
     let total_start = Instant::now();
     let initial_checks_start = Instant::now();
     let initial_checks =
         check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared);
-    record_contextual_duration!(
+    contextual_metrics.record_duration(
         "state.contextual.initial_checks.duration_seconds",
         "state.contextual.mined.initial_checks.duration_seconds",
         initial_checks_start.elapsed(),
-        is_mined,
     );
     let result = initial_checks.and_then(|()| {
         let parent_hash = prepared.block.header.previous_block_hash;
 
         if finalized_state.finalized_tip_hash() == parent_hash {
-            non_finalized_state.commit_new_chain_with_metrics(prepared, finalized_state, is_mined)
+            non_finalized_state.commit_new_chain_with_metrics(
+                prepared,
+                finalized_state,
+                contextual_metrics,
+            )
         } else {
-            non_finalized_state.commit_block_with_metrics(prepared, finalized_state, is_mined)
+            non_finalized_state.commit_block_with_metrics(
+                prepared,
+                finalized_state,
+                contextual_metrics,
+            )
         }
     });
-    record_contextual_duration!(
+    contextual_metrics.record_duration(
         "state.contextual.total.duration_seconds",
         "state.contextual.mined.total.duration_seconds",
         total_start.elapsed(),
-        is_mined,
     );
 
     result
@@ -2805,6 +2801,7 @@ impl WriteBlockWorkerTask {
             metrics::histogram!("state.block_writer.queue.duration_seconds")
                 .record(writer_queue_duration);
             let is_mined = admission.is_some();
+            let contextual_metrics = ContextualMetrics::for_commit(is_mined);
             if is_mined {
                 metrics::histogram!("state.block_writer.queue.mined.duration_seconds")
                     .record(writer_queue_duration);
@@ -2827,17 +2824,16 @@ impl WriteBlockWorkerTask {
                     if let Some(writer) = header_chain.as_ref() {
                         let snapshot_clone_start = Instant::now();
                         let mut staged = non_finalized_state.clone();
-                        record_contextual_duration!(
+                        contextual_metrics.record_duration(
                             "state.contextual.snapshot_clone.duration_seconds",
                             "state.contextual.mined.snapshot_clone.duration_seconds",
                             snapshot_clone_start.elapsed(),
-                            is_mined,
                         );
                         validate_and_commit_non_finalized_with_metrics(
                             &finalized_state.db,
                             &mut staged,
                             queued_child,
-                            is_mined,
+                            contextual_metrics,
                         )
                         .map_err(|error| CommitBlockError::from(Box::new(error)))
                         .and_then(|()| {
@@ -2868,11 +2864,10 @@ impl WriteBlockWorkerTask {
                                             }
                                         })
                                     });
-                            record_contextual_duration!(
+                            contextual_metrics.record_duration(
                                 "state.contextual.header_transition_prepare.duration_seconds",
                                 "state.contextual.mined.header_transition_prepare.duration_seconds",
                                 transition_prepare_start.elapsed(),
-                                is_mined,
                             );
                             let transition = transition?;
 
@@ -2883,11 +2878,10 @@ impl WriteBlockWorkerTask {
                                 .map_err(|error| CommitBlockError::HeaderChainError {
                                     error: error.to_string(),
                                 });
-                            record_contextual_duration!(
+                            contextual_metrics.record_duration(
                                 "state.contextual.header_transition_commit.duration_seconds",
                                 "state.contextual.mined.header_transition_commit.duration_seconds",
                                 transition_commit_start.elapsed(),
-                                is_mined,
                             );
                             result
                         })
@@ -2896,7 +2890,7 @@ impl WriteBlockWorkerTask {
                             &finalized_state.db,
                             non_finalized_state,
                             queued_child,
-                            is_mined,
+                            contextual_metrics,
                         )
                         .map_err(|error| CommitBlockError::from(Box::new(error)))
                     }

--- a/crates/zakura-state/src/service/write.rs
+++ b/crates/zakura-state/src/service/write.rs
@@ -1316,9 +1316,33 @@ fn commit_operator_change(
 /// We allow enough space for multiple concurrent chain forks with errors.
 const REJECTED_ANCESTOR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
 
+macro_rules! record_contextual_duration {
+    ($metric_name:literal, $mined_metric_name:literal, $duration:expr, $is_mined:expr $(,)?) => {{
+        let duration = $duration.as_secs_f64();
+        metrics::histogram!($metric_name).record(duration);
+        if $is_mined {
+            metrics::histogram!($mined_metric_name).record(duration);
+        }
+    }};
+}
+
 /// Run contextual validation on the prepared block and add it to the
 /// non-finalized state if it is contextually valid.
+pub(crate) fn validate_and_commit_non_finalized(
+    finalized_state: &ZakuraDb,
+    non_finalized_state: &mut NonFinalizedState,
+    prepared: SemanticallyVerifiedBlock,
+) -> Result<(), ValidateContextError> {
+    validate_and_commit_non_finalized_with_metrics(
+        finalized_state,
+        non_finalized_state,
+        prepared,
+        false,
+    )
+}
+
 #[tracing::instrument(
+    name = "validate_and_commit_non_finalized",
     level = "debug",
     skip(finalized_state, non_finalized_state, prepared),
     fields(
@@ -1327,26 +1351,39 @@ const REJECTED_ANCESTOR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
         chains = non_finalized_state.chain_count()
     )
 )]
-pub(crate) fn validate_and_commit_non_finalized(
+fn validate_and_commit_non_finalized_with_metrics(
     finalized_state: &ZakuraDb,
     non_finalized_state: &mut NonFinalizedState,
     prepared: SemanticallyVerifiedBlock,
+    is_mined: bool,
 ) -> Result<(), ValidateContextError> {
+    let total_start = Instant::now();
     let initial_checks_start = Instant::now();
     let initial_checks =
         check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared);
-    metrics::histogram!("state.contextual.initial_checks.duration_seconds")
-        .record(initial_checks_start.elapsed().as_secs_f64());
-    initial_checks?;
-    let parent_hash = prepared.block.header.previous_block_hash;
+    record_contextual_duration!(
+        "state.contextual.initial_checks.duration_seconds",
+        "state.contextual.mined.initial_checks.duration_seconds",
+        initial_checks_start.elapsed(),
+        is_mined,
+    );
+    let result = initial_checks.and_then(|()| {
+        let parent_hash = prepared.block.header.previous_block_hash;
 
-    if finalized_state.finalized_tip_hash() == parent_hash {
-        non_finalized_state.commit_new_chain(prepared, finalized_state)?;
-    } else {
-        non_finalized_state.commit_block(prepared, finalized_state)?;
-    }
+        if finalized_state.finalized_tip_hash() == parent_hash {
+            non_finalized_state.commit_new_chain_with_metrics(prepared, finalized_state, is_mined)
+        } else {
+            non_finalized_state.commit_block_with_metrics(prepared, finalized_state, is_mined)
+        }
+    });
+    record_contextual_duration!(
+        "state.contextual.total.duration_seconds",
+        "state.contextual.mined.total.duration_seconds",
+        total_start.elapsed(),
+        is_mined,
+    );
 
-    Ok(())
+    result
 }
 
 /// Update the [`LatestChainTip`], [`ChainTipChange`], and `non_finalized_state_sender`
@@ -2767,7 +2804,8 @@ impl WriteBlockWorkerTask {
             let writer_queue_duration = queued_at.elapsed().as_secs_f64();
             metrics::histogram!("state.block_writer.queue.duration_seconds")
                 .record(writer_queue_duration);
-            if admission.is_some() {
+            let is_mined = admission.is_some();
+            if is_mined {
                 metrics::histogram!("state.block_writer.queue.mined.duration_seconds")
                     .record(writer_queue_duration);
             }
@@ -2789,56 +2827,76 @@ impl WriteBlockWorkerTask {
                     if let Some(writer) = header_chain.as_ref() {
                         let snapshot_clone_start = Instant::now();
                         let mut staged = non_finalized_state.clone();
-                        metrics::histogram!("state.contextual.snapshot_clone.duration_seconds")
-                            .record(snapshot_clone_start.elapsed().as_secs_f64());
-                        validate_and_commit_non_finalized(
+                        record_contextual_duration!(
+                            "state.contextual.snapshot_clone.duration_seconds",
+                            "state.contextual.mined.snapshot_clone.duration_seconds",
+                            snapshot_clone_start.elapsed(),
+                            is_mined,
+                        );
+                        validate_and_commit_non_finalized_with_metrics(
                             &finalized_state.db,
                             &mut staged,
                             queued_child,
+                            is_mined,
                         )
                         .map_err(|error| CommitBlockError::from(Box::new(error)))
                         .and_then(|()| {
                             let accepted = Frontier::new(child_height, child_hash);
                             let transition_prepare_start = Instant::now();
-                            let (evidence, event_path, request) =
+                            let transition =
                                 verified_request(writer, non_finalized_state, &staged, accepted)
                                     .map_err(|error| CommitBlockError::HeaderChainError {
                                         error: error.to_string(),
-                                    })?;
-                            let transition = PreparedFullStateTransition::new(
-                                evidence,
-                                writer
-                                    .runtime
-                                    .publisher()
-                                    .snapshot()
-                                    .frontiers
-                                    .verified_best,
-                                event_path,
-                                staged,
-                                None,
-                                request,
-                            )
-                            .map_err(|error| {
-                                CommitBlockError::HeaderChainError {
-                                    error: error.to_string(),
-                                }
-                            })?;
-                            metrics::histogram!(
-                                "state.contextual.header_transition_prepare.duration_seconds"
-                            )
-                            .record(transition_prepare_start.elapsed().as_secs_f64());
-                            transition
+                                    })
+                                    .and_then(|(evidence, event_path, request)| {
+                                        PreparedFullStateTransition::new(
+                                            evidence,
+                                            writer
+                                                .runtime
+                                                .publisher()
+                                                .snapshot()
+                                                .frontiers
+                                                .verified_best,
+                                            event_path,
+                                            staged,
+                                            None,
+                                            request,
+                                        )
+                                        .map_err(|error| {
+                                            CommitBlockError::HeaderChainError {
+                                                error: error.to_string(),
+                                            }
+                                        })
+                                    });
+                            record_contextual_duration!(
+                                "state.contextual.header_transition_prepare.duration_seconds",
+                                "state.contextual.mined.header_transition_prepare.duration_seconds",
+                                transition_prepare_start.elapsed(),
+                                is_mined,
+                            );
+                            let transition = transition?;
+
+                            let transition_commit_start = Instant::now();
+                            let result = transition
                                 .commit(&writer.runtime, non_finalized_state, &writer.context())
                                 .map(|_| ())
                                 .map_err(|error| CommitBlockError::HeaderChainError {
                                     error: error.to_string(),
-                                })
+                                });
+                            record_contextual_duration!(
+                                "state.contextual.header_transition_commit.duration_seconds",
+                                "state.contextual.mined.header_transition_commit.duration_seconds",
+                                transition_commit_start.elapsed(),
+                                is_mined,
+                            );
+                            result
                         })
                     } else {
-                        validate_and_commit_non_finalized(
+                        validate_and_commit_non_finalized_with_metrics(
                             &finalized_state.db,
                             non_finalized_state,
                             queued_child,
+                            is_mined,
                         )
                         .map_err(|error| CommitBlockError::from(Box::new(error)))
                     }

--- a/docs/changelog/unreleased/782.md
+++ b/docs/changelog/unreleased/782.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR adds internal contextual-verification metrics and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Summary

- measure the full contextual interval, initial checks, parent-chain work, new
  chain construction, and state-writer snapshot cloning;
- separate the cumulative UTXO snapshot from transparent spend checks;
- measure shielded anchors, contextual block construction, and the parallel
  state update;
- separate the parallel chain clone from `Chain::push`;
- measure header-transition preparation and commit on success and error paths;
- emit matching mined-only series for every phase on the mined-block path.

## Motivation

The preserved memo-enabled field run reduced the median transaction phase to
1.795 ms. Its median state commit remained 34.338 ms. PR #781 separates writer
queue delay from writer execution. This PR splits writer execution so the fleet
can identify the next material optimization without inferring phase costs from
aggregate quantiles.

## Safety

The change adds elapsed-time capture and histograms only. It does not move a
check, change state ownership, or alter chain selection.

The outer `parallel_update` duration includes task scheduling and completion.
The `parallel_task.*` durations overlap because block commitment, Sprout anchor
validation, and chain update run concurrently. Only `parallel_update` measures
their critical-path wall time.

## Benchmark scope

This PR adds observability. It does not claim a runtime speedup. A synthetic
microbenchmark would not show whether these histograms partition the production
contextual interval. The state tests exercise every instrumented success and
error path. The next fleet run must compare each mined-only phase count with
the outer contextual count, then rank phase means from matching campaign
deltas. Concurrent `parallel_task.*` means must not be added together.

## Verification

- `cargo test -p zakura-consensus -p zakura-state --lib --locked`
  - 234 consensus tests passed and 1 test remained ignored
  - 567 state tests passed and 4 tests remained ignored
- `cargo clippy -p zakura-state -p zakura-consensus --all-targets -- -D warnings`
- `cargo check -p zakura-state -p zakura-consensus --all-targets --locked`
- `cargo fmt --all -- --check`
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/782.md --config .github/.markdownlint.yaml`
- `git diff --check`
- `./scripts/changelog.py check`

This PR adds `docs/changelog/unreleased/782.md` with an internal-only marker.

## Stack

- Base: `main`.
- Parents #748 and #781 are merged.
- Children: none.
