### PR TITLE
fix(deploy): skip the release-state export while a snapshot is running

### DIFF
--- a/deploy/release-state/SNAPSHOT_HOST.md
+++ b/deploy/release-state/SNAPSHOT_HOST.md
@@ -23,6 +23,11 @@ changes made that possible, and one made it necessary:
   only for convenience.
 - It therefore takes no snapshot lock and cannot delay a snapshot. Its own
   `/run/zakura-release-state-publish.lock` still rejects overlapping timer or manual runs.
+- It does skip a run while `zakura-snapshot.service` is active, because that job stops the
+  archive container to tar its state. Skipping costs a slightly older bundle; failing would cost
+  an alert. It reads that unit's state rather than taking the snapshot lock on purpose:
+  `check-and-publish.sh` also decides from the unit, so a held lock would not defer a snapshot —
+  it would start one that then died on the lock.
 - The frontier grid covers the heights below the checkpoint, which the pruned database no
   longer holds. That is why the source moved from `zakura-pruned` to `zakura`.
 

--- a/deploy/release-state/publish-from-archive-host.sh
+++ b/deploy/release-state/publish-from-archive-host.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 EXPECTED_HOST=zakura-snapshot
 CONTAINER=zakura
+SNAPSHOT_UNIT=zakura-snapshot.service
 INSTALL_ROOT=/opt/zakura-release-state
 R2_ENDPOINT=https://152e2a8834283136c2f0575782b1b7aa.r2.cloudflarestorage.com
 R2_BUCKET=zakura-release-state
@@ -17,6 +18,20 @@ PUBLIC_BASE=https://zakura-release.valargroup.dev/release-state
 die() {
     echo "release-state publisher: $*" >&2
     exit 1
+}
+
+note() {
+    echo "release-state publisher: $*" >&2
+}
+
+# Deliberately the same predicate check-and-publish.sh uses, so both sides agree on what "a
+# snapshot is running" means. Reading the unit rather than the lock matters: the snapshot side
+# decides from the unit too, so a lock this script held would not defer a snapshot, it would
+# start one that then died on the lock.
+snapshot_publish_active() {
+    local state
+    state=$(systemctl show -p ActiveState --value "$SNAPSHOT_UNIT" 2>/dev/null) || return 1
+    [ "$state" = active ] || [ "$state" = activating ]
 }
 
 main() {
@@ -34,10 +49,23 @@ main() {
     [ -d "$state_dir" ] \
         || die "cache directory does not exist: $state_dir"
 
+    # The archive snapshot job stops this container to tar a quarter-terabyte of state, and it
+    # triggers on snapshot age rather than a fixed hour, so its window drifts across this timer's
+    # every few days. Skip rather than fail: the import side is weekly, so a missed daily export
+    # costs nothing but a slightly older bundle, whereas a failed unit costs an alert.
+    if snapshot_publish_active; then
+        note "$SNAPSHOT_UNIT is running; skipping this export"
+        exit 0
+    fi
+
+    # A stopped container is not fatal. The exporter reads the cache as a read-only RocksDB
+    # secondary, which works just as well against a quiesced database — that is what the
+    # pre-secondary design did on purpose. This check exists to catch a cache path that belongs
+    # to no container at all, so it warns rather than refusing.
     running=$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null) \
         || die "cannot inspect container $CONTAINER"
     [ "$running" = true ] \
-        || die "container $CONTAINER must be running so its cache is a live archive node"
+        || note "warning: $CONTAINER is not running; exporting from its cache as a quiesced database"
 
     : "${R2_ACCESS_KEY_ID:?R2 access key was not injected}"
     : "${R2_SECRET_ACCESS_KEY:?R2 secret key was not injected}"


### PR DESCRIPTION
**Prototype / draft.** Stacked on #703 — base is `feat/vct-treestate-seam-rebased`, not `main`.

## The collision

#703 installs a release-state publisher onto the snapshot host, on its own daily timer at 05:40
UTC. That host also runs the archive snapshot job, which stops the `zakura` container to tar
about a quarter-terabyte of state. The release-state wrapper currently refuses to start unless
that container is up:

```bash
[ "$running" = true ] \
    || die "container $CONTAINER must be running so its cache is a live archive node"
```

The two jobs never see each other. `zakura-snapshot.service` is not on a fixed schedule — it is
triggered by `check-and-publish.sh` whenever snapshot age crosses 20h, checked hourly at `:07`
— so its window drifts across the export's every few days. When they land together, the export
unit fails.

## Why not just take the snapshot's lock

That was my first instinct, and it is worse. `check-and-publish.sh` decides whether a snapshot is
already running from the **unit's** state, not the lock:

```bash
publish_running() {  # true if the publish unit is active or mid-run (activating)
  local st; st="$(systemctl show -p ActiveState --value "$PUBLISH_UNIT" 2>/dev/null || true)"
  [[ "$st" == active || "$st" == activating ]]
}
```

So a lock held here would not defer a snapshot. It would let one start and then die on
`flock -n`, turning a benign overlap into a failed archive publish — the host's primary product.
Holding it for the length of a grid export makes that worse, since the first run on a fast-synced
archive is hours.

## What this does

Reads the same predicate the snapshot side uses, and skips the export when a snapshot is running.
The import side is weekly, so a missed daily export costs a slightly older bundle; a failed unit
costs an alert.

It also downgrades the stopped-container check to a warning. The exporter reads the cache as a
read-only RocksDB secondary, which works against a quiesced database just as well — that is what
the pre-secondary design did deliberately. The check is meant to catch a cache path that belongs
to no container, not to require a live node.

## Testing

`bash -n` and `shellcheck` clean. Not exercised on the host — the release-state publisher is not
deployed there yet, which is the point of the sequencing note below.

## Sequencing

Nothing here is urgent until the publisher is actually installed, which cannot happen until #703
merges (`deploy-snapshot-host.sh` refuses a revision that is not already an ancestor of
`origin/main`). It should land before the timer is enabled, though — otherwise the first drift
into a snapshot window is a failed unit and a page.

The matching host-side change is in `valargroup/zakura-snapshots`.
