### PR TITLE
feat(deploy): manage the legacy archive node in the mainnet fleet

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -174,7 +174,8 @@ jobs:
             161.35.156.226 \
             139.59.64.115 \
             168.144.173.250 \
-            159.203.113.196; do
+            159.203.113.196 \
+            104.131.174.28; do
             ssh-keyscan -T 30 -H "$host" >> ~/.ssh/known_hosts
           done
           chmod 600 ~/.ssh/known_hosts

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -274,6 +274,19 @@ jobs:
           log_file   = ""
           rpc_listen_addr = "127.0.0.1:8232"
           state_cache_dir = "/mnt/data/import-zebra"
+
+          # Legacy archive node: `vct_fast_sync = false`, so it holds per-height
+          # commitment trees everywhere and never fast-synced. That is what makes it
+          # the supported generator for the release-state historical frontier grid —
+          # entries come from reads instead of replaying an absent band. Binary-only
+          # like the rest of the fleet, so its `vct_fast_sync = false` config is not
+          # rewritten by a deploy; that setting is the whole point of the node.
+          [[nodes]]
+          name       = "archive-vct-off"
+          ssh_string = "root@104.131.174.28"
+          commit     = "${REF}"
+          rpc_listen_addr = "127.0.0.1:8232"
+          log_file   = "/var/log/zakura/zakura.log"
           EOF
 
       - name: Build deployer binary

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -288,6 +288,13 @@ jobs:
           commit     = "${REF}"
           rpc_listen_addr = "127.0.0.1:8232"
           log_file   = "/var/log/zakura/zakura.log"
+          # Metadata only under manage_config = false, but it records why this node
+          # differs. On `dual` its body tip wedged: the v2 coordinator logged
+          # `accepted block apply lost terminal observation; apply lifecycle is
+          # failed` and the header chain ran ~6,000 blocks ahead of the verified
+          # tip. Switching the node to `legacy` cleared it immediately. Do not flip
+          # this host to config-managed without carrying that setting across.
+          p2p_stack  = "legacy"
           EOF
 
       - name: Build deployer binary

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -215,6 +215,15 @@ frontier grid, whose entries then come from reads rather than from replaying a
 fast-synced node's absent band. It is not a public bootstrap peer and is
 deliberately absent from the node ids in `zakura-network`.
 
+One fleet entry buys three things, because the dashboard and the alerting both
+derive from the same config. `zakura-mainnet-deploy.yml` copies the generated
+`nodes.ci.toml` into `/opt/zakura-mainnet-dashboard/nodes.toml`, so a node added
+here appears on the status dashboard; `zakura-cluster-watchdog.py` then reads
+that dashboard's `/data` and alerts `#zakura-alerts` when a node stays unhealthy.
+Nothing separate has to be registered for monitoring. Note that the dashboard
+step runs `if: always()` and rewrites the whole node list, so it picks up a new
+node even on a deploy scoped to one host with `--node`.
+
 A node only becomes deployable once the deployer runner can reach it. The fleet's
 deploy key is `zakura-mainnet-deployer@us-east-0`; it must be in the node's
 `~/.ssh/authorized_keys`, and the node's address must be in the workflow's

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -204,10 +204,16 @@ and deploys it to:
 - `asia-south-0` — `root@139.59.64.115`
 - `asia-pacific-0` — `root@168.144.173.250`
 - `zakura-compat` — `root@159.203.113.196`
+- `archive-vct-off` — `root@104.131.174.28`
 
 The first nine run a hand-provisioned `zakurad` systemd service.
 `zakura-compat` runs `zakurad-compat` alongside a native `zcashd` sidecar on the
-same host. One-time runner bootstrap from an operator machine with SSH access
+same host. `archive-vct-off` is a legacy archive node — `vct_fast_sync = false`,
+so it never fast-synced and holds per-height commitment trees at every height.
+That is what makes it the supported generator for the release-state historical
+frontier grid, whose entries then come from reads rather than from replaying a
+fast-synced node's absent band. It is not a public bootstrap peer and is
+deliberately absent from the node ids in `zakura-network`. One-time runner bootstrap from an operator machine with SSH access
 and CI credentials in `~/agents-env`:
 
 ```bash

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -213,7 +213,13 @@ so it never fast-synced and holds per-height commitment trees at every height.
 That is what makes it the supported generator for the release-state historical
 frontier grid, whose entries then come from reads rather than from replaying a
 fast-synced node's absent band. It is not a public bootstrap peer and is
-deliberately absent from the node ids in `zakura-network`. One-time runner bootstrap from an operator machine with SSH access
+deliberately absent from the node ids in `zakura-network`.
+
+A node only becomes deployable once the deployer runner can reach it. The fleet's
+deploy key is `zakura-mainnet-deployer@us-east-0`; it must be in the node's
+`~/.ssh/authorized_keys`, and the node's address must be in the workflow's
+host-key pin list. A host that is missing the key fails the deploy with
+`Permission denied (publickey)` at the scp step, after a successful build. One-time runner bootstrap from an operator machine with SSH access
 and CI credentials in `~/agents-env`:
 
 ```bash

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -213,7 +213,13 @@ so it never fast-synced and holds per-height commitment trees at every height.
 That is what makes it the supported generator for the release-state historical
 frontier grid, whose entries then come from reads rather than from replaying a
 fast-synced node's absent band. It is not a public bootstrap peer and is
-deliberately absent from the node ids in `zakura-network`.
+deliberately absent from the node ids in `zakura-network`, and it runs
+`p2p_stack = "legacy"` rather than the fleet's `dual`: on `dual` its verified body
+tip wedged roughly 6,000 blocks behind its own header chain while the v2
+coordinator logged `accepted block apply lost terminal observation; apply
+lifecycle is failed`. The fleet is binary-only, so that setting lives in the
+node's own config; flipping this host to config-managed without carrying it
+across would silently reintroduce the stall.
 
 One fleet entry buys three things, because the dashboard and the alerting both
 derive from the same config. `zakura-mainnet-deploy.yml` copies the generated


### PR DESCRIPTION
Brings the legacy archive node into managed infrastructure, and unblocks repairing it.

## Why this node matters

`archive-vct-off` runs with `vct_fast_sync = false`. It never fast-synced, so it holds per-height
commitment trees at every height. That makes it the supported generator for the release-state
historical frontier grid: entries come from **reads** rather than from replaying a fast-synced
node's absent band.

The difference is not marginal. Appendix B of `docs/design/historical-treestate-serving.md`
measured a full grid generation on a legacy archive node at **4,873s**. The same run against a
fast-synced archive replays the whole band — hours. The snapshot host's `zakura` container takes
Zakura's defaults (`vct_fast_sync = true`), so generating there is the slow path.

## Why it needs to be managed

It was provisioned by hand and referenced nowhere in this repository — not in this workflow, not
in the deployer README, not in Terraform. Nothing deployed to it, and nothing noticed when it
stopped.

It is currently **crashlooping**:

```
Zakura refuses to run if the release date is older than 18 days.
Release name: 1.0.4, Estimated release height: 3432500
```

Restart counter is past **4,400**, exit 101 every ~40 seconds. The first end-of-support panic was
`Aug 19 12:08:41`, so it had been crashlooping for about 4.6 days. Its database is frozen at
**3,452,571**, roughly 6,000 blocks behind the tip — which matches 4.6 days of missed blocks at
Zcash's ~75s spacing.

That matters beyond the node itself: an export from a cache that stale would produce a checkpoint
list ending *below* the committed 3,453,771, so the importer would see no advance and nothing
would ever land.

## What this changes

One fleet entry and a README line. Two per-node overrides, following what `zakura-compat` already
does — it binds RPC on loopback and logs to `/var/log/zakura/zakura.log`. Both are dashboard
metadata, not deployed configuration.

The fleet is binary-only (`manage_config = false`), which matters more here than anywhere else: a
config-managed deploy would rewrite `vct_fast_sync = false`, and that setting is the entire reason
the node exists.

It is deliberately **not** added to the public bootstrap node ids in `zakura-network`. It is an
internal generator, not a peer.

## Deploying it

After merge, from `main`:

```
gh workflow run zakura-mainnet-deploy.yml \
  -f ref=v1.3.0-rc1 -f node=archive-vct-off -f validate_start=true
```

`node=` scopes the rollout to this host — without it the workflow deploys all eleven. Binary-only
plus a restart is exactly the fix for the end-of-support crashloop; the node then has ~24,000
blocks to catch up before it can generate a useful bundle.

## Dashboard and alerting

Both come from this same entry, which is worth knowing because it is not obvious from either
file alone. The workflow copies the generated `nodes.ci.toml` into
`/opt/zakura-mainnet-dashboard/nodes.toml`, so the node appears on the status dashboard; the
Slack watchdog then reads that dashboard's `/data` and pages `#zakura-alerts` when a node stays
unhealthy. No separate monitoring registration exists or is needed.

The dashboard step runs `if: always()` and rewrites the whole node list, so it picked this up
even though the deploy was scoped to one host.

Verified live after deploying:

- dashboard: 12 nodes, `archive-vct-off` present, `healthy: true`, height 3,452,571
- `zakura-fleet-watchdog.service`: active, mainnet fleet pointed at that dashboard

So the node is now deployed, observed, and alerting — the gap that let it crashloop unnoticed for
three weeks is closed.

## Deploy result

Run [32683941206](https://github.com/zakura-core/zakura/actions/runs/32683941206) succeeded with
`validate_start=true`:

| | Before | After |
| --- | --- | --- |
| Version | 1.0.4 (end-of-support) | 1.3.0-rc1 |
| `NRestarts` | 4,453 | 0 |
| Height | 3,452,571, frozen | 3,452,571, still not advancing |

**The binary is fixed; the node is not yet syncing.** Its header chain reaches 3,456,208 while the
verified body tip stays at 3,452,571, and after a 600s stall it logged

> Zakura body sync is not closing the gap to the network tip; resuming legacy ChainSync as the
> body-sync driver

with `apply_phase="fallback_draining"`. It has 147 peers, so this is not connectivity. Until the
body tip advances past the committed checkpoint 3,453,771, an export from this cache cannot
produce a bundle that advances, so the node is not yet usable as a grid generator.


