### PR TITLE
feat(deploy): give the release-state publisher host profiles

### DIFF
--- a/deploy/release-state/README.md
+++ b/deploy/release-state/README.md
@@ -8,6 +8,21 @@ Design: `docs/design/verified-commitment-trees.md`, section 16.
 Production host wiring, operations, and rollback:
 [`SNAPSHOT_HOST.md`](SNAPSHOT_HOST.md).
 
+## Where the publisher runs
+
+Selected by `RELEASE_STATE_HOST_PROFILE` when running `deploy-snapshot-host.sh`:
+`snapshot` (default, the containerised host) or `archive`
+(`roman-zakura-archive-vct-off`, the supported generator). The archive node runs
+`vct_fast_sync = false`, so the frontier grid comes from reads rather than replaying
+an absent band, and it shares its host with no snapshot job.
+
+Nothing in the publisher needs a container runtime. `publish-release-state.sh` has no
+docker in it at all: the exporter is a plain binary reading the cache as a read-only
+RocksDB secondary. Docker appears only as a liveness hint on the `snapshot` profile,
+because that host happens to run its node in a container; the `archive` profile checks
+`zakurad.service` instead, and the unit only `Wants=docker.service` so it starts on a
+host with none.
+
 ## What runs where
 
 - **This host (archive node):** `publish-release-state.sh <archive-cache-dir>`

--- a/deploy/release-state/SNAPSHOT_HOST.md
+++ b/deploy/release-state/SNAPSHOT_HOST.md
@@ -1,5 +1,37 @@
 # Production release-state publisher host
 
+## Host profiles
+
+The publisher runs on exactly one machine, but which machine is a deployment choice.
+`deploy-snapshot-host.sh` selects it with `RELEASE_STATE_HOST_PROFILE`:
+
+| Profile | Host | Node | Grid generation |
+| --- | --- | --- | --- |
+| `snapshot` (default) | `zakura-snapshot` | `zakura` container, docker | replays the absent band — hours |
+| `archive` | `roman-zakura-archive-vct-off` | `zakurad.service`, no docker | reads stored trees — ~81 min measured |
+
+The `archive` profile is the supported generator. That node runs
+`vct_fast_sync = false`, so it holds per-height commitment trees everywhere and the
+grid comes from reads rather than replay, and it shares its host with no snapshot
+job. The rest of this document describes the `snapshot` profile, which remains
+supported; the differences are that the archive host has no containers to check, no
+snapshot units to defer to, and supplies R2 credentials from its EnvironmentFile
+rather than through a secrets wrapper.
+
+The installer stamps the profile into `/opt/zakura-release-state/profile.env`, which
+the publisher reads, so the host identity and liveness checks describe the host they
+actually run on.
+
+### R2 credentials
+
+The unit no longer bakes a secrets wrapper into `ExecStart`. Either mechanism works,
+chosen in `/etc/zakura-release-state.env`:
+
+- set `RELEASE_STATE_SECRETS_WRAPPER=/usr/local/bin/with-secrets.sh` and the
+  publisher re-execs through it, as the snapshot host does today; or
+- set `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY` directly, for a host with no
+  secrets manager.
+
 ## Purpose and topology
 
 The production release-state publisher generates a trusted, coupled Mainnet checkpoint list, VCT

--- a/deploy/release-state/deploy-snapshot-host.sh
+++ b/deploy/release-state/deploy-snapshot-host.sh
@@ -4,9 +4,42 @@
 # or enable the timer.
 set -euo pipefail
 
-TARGET=${1:-root@45.55.96.29}
-EXPECTED_TARGET=root@45.55.96.29
-EXPECTED_HOST=zakura-snapshot
+# Which host this installs to. The publisher runs on exactly one machine, but which
+# machine is a deployment choice: the snapshot host has the node in docker beside a
+# snapshot job, while the archive host runs a legacy `vct_fast_sync = false` node
+# under systemd and generates the frontier grid from reads instead of replay.
+PROFILE=${RELEASE_STATE_HOST_PROFILE:-snapshot}
+case "$PROFILE" in
+    snapshot)
+        EXPECTED_TARGET=root@45.55.96.29
+        EXPECTED_HOST=zakura-snapshot
+        # Both caches live in containers here, and the pruned one must stay up too:
+        # it is the node the other snapshot job publishes from.
+        NODE_CONTAINER=zakura
+        REQUIRED_CONTAINERS="zakura zakura-pruned"
+        NODE_UNIT=""
+        SNAPSHOT_UNIT=zakura-snapshot.service
+        IDLE_UNITS="zakura-snapshot-pruned.service zakura-snapshot.service zakura-release-state.service"
+        VERIFY_UNITS="zakura-snapshot-pruned.service zakura-release-state.timer"
+        ;;
+    archive)
+        EXPECTED_TARGET=root@104.131.174.28
+        EXPECTED_HOST=roman-zakura-archive-vct-off
+        # No docker on this host at all; zakurad runs as a plain systemd service.
+        NODE_CONTAINER=""
+        REQUIRED_CONTAINERS=""
+        NODE_UNIT=zakurad.service
+        # No snapshot job to collide with, so nothing for the publisher to defer to.
+        SNAPSHOT_UNIT=""
+        IDLE_UNITS="zakura-release-state.service"
+        VERIFY_UNITS="zakura-release-state.timer"
+        ;;
+    *)
+        echo "release-state deployment: unknown RELEASE_STATE_HOST_PROFILE: $PROFILE" >&2
+        exit 1
+        ;;
+esac
+TARGET=${1:-$EXPECTED_TARGET}
 REPOSITORY=https://github.com/zakura-core/zakura.git
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SOURCE_ROOT=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)
@@ -30,11 +63,15 @@ done
 ssh -o BatchMode=yes "$TARGET" "
     set -e
     [ \"\$(hostname -s)\" = \"$EXPECTED_HOST\" ]
-    ! systemctl is-active --quiet zakura-snapshot-pruned.service
-    ! systemctl is-active --quiet zakura-snapshot.service
-    ! systemctl is-active --quiet zakura-release-state.service
-    [ \"\$(docker inspect --format '{{.State.Running}}' zakura-pruned)\" = true ]
-    [ \"\$(docker inspect --format '{{.State.Running}}' zakura)\" = true ]
+    for unit in $IDLE_UNITS; do
+        ! systemctl is-active --quiet \"\$unit\"
+    done
+    for container in $REQUIRED_CONTAINERS; do
+        [ \"\$(docker inspect --format '{{.State.Running}}' \"\$container\")\" = true ]
+    done
+    if [ -n \"$NODE_UNIT\" ]; then
+        systemctl is-active --quiet \"$NODE_UNIT\"
+    fi
 " || die "host identity or inactive-publisher preflight failed"
 
 echo "Building zakura-checkpoints at pinned main revision $EXPORTER_REVISION"
@@ -66,11 +103,12 @@ scp -q -r "$WORK/stage/." "$TARGET:$REMOTE_STAGE/"
 ssh -o BatchMode=yes "$TARGET" "
     set -euo pipefail
     [ \"\$(hostname -s)\" = \"$EXPECTED_HOST\" ]
-    ! systemctl is-active --quiet zakura-snapshot-pruned.service
-    ! systemctl is-active --quiet zakura-snapshot.service
-    ! systemctl is-active --quiet zakura-release-state.service
-    [ \"\$(docker inspect --format '{{.State.Running}}' zakura-pruned)\" = true ]
-    [ \"\$(docker inspect --format '{{.State.Running}}' zakura)\" = true ]
+    for unit in $IDLE_UNITS; do
+        ! systemctl is-active --quiet \"\$unit\"
+    done
+    for container in $REQUIRED_CONTAINERS; do
+        [ \"\$(docker inspect --format '{{.State.Running}}' \"\$container\")\" = true ]
+    done
 
     if ! command -v rclone >/dev/null 2>&1; then
         apt-get update -qq
@@ -96,9 +134,20 @@ ssh -o BatchMode=yes "$TARGET" "
         /etc/systemd/system/zakura-release-state.service
     install -m 0644 '$REMOTE_STAGE/systemd/zakura-release-state.timer' \
         /etc/systemd/system/zakura-release-state.timer
+    # The profile decides what exists to verify: the archive host has no snapshot
+    # units at all, and verifying an absent unit fails.
+    install -m 0644 /dev/stdin /opt/zakura-release-state/profile.env <<'PROFILE'
+# Written by deploy-snapshot-host.sh. Describes the host the publisher runs on, so
+# publish-from-archive-host.sh checks this host rather than a hardcoded one.
+RELEASE_STATE_EXPECTED_HOST=$EXPECTED_HOST
+RELEASE_STATE_NODE_CONTAINER=$NODE_CONTAINER
+RELEASE_STATE_NODE_UNIT=$NODE_UNIT
+RELEASE_STATE_SNAPSHOT_UNIT=$SNAPSHOT_UNIT
+PROFILE
     systemctl daemon-reload
-    systemd-analyze verify zakura-snapshot-pruned.service
-    systemd-analyze verify zakura-release-state.timer
+    for unit in $VERIFY_UNITS; do
+        systemd-analyze verify \"\$unit\"
+    done
 
     # The unit reads the archive cache path from here. Installing without it
     # leaves the timer inert rather than exporting from the wrong database.

--- a/deploy/release-state/publish-from-archive-host.sh
+++ b/deploy/release-state/publish-from-archive-host.sh
@@ -7,9 +7,19 @@
 # database no longer holds.
 set -euo pipefail
 
-EXPECTED_HOST=zakura-snapshot
-CONTAINER=zakura
 INSTALL_ROOT=/opt/zakura-release-state
+# Written by deploy-snapshot-host.sh from the profile it installed, so the identity
+# and liveness checks below describe this host rather than a hardcoded one. Absent
+# only on an installation predating profiles, where the defaults reproduce the
+# original snapshot-host behaviour.
+PROFILE_ENV="$INSTALL_ROOT/profile.env"
+# shellcheck source=/dev/null
+[ -r "$PROFILE_ENV" ] && . "$PROFILE_ENV"
+EXPECTED_HOST=${RELEASE_STATE_EXPECTED_HOST:-zakura-snapshot}
+# Unset and empty differ: empty means this profile has no container to check.
+CONTAINER=${RELEASE_STATE_NODE_CONTAINER-zakura}
+NODE_UNIT=${RELEASE_STATE_NODE_UNIT-}
+SNAPSHOT_UNIT=${RELEASE_STATE_SNAPSHOT_UNIT-zakura-snapshot.service}
 R2_ENDPOINT=https://152e2a8834283136c2f0575782b1b7aa.r2.cloudflarestorage.com
 R2_BUCKET=zakura-release-state
 PUBLIC_BASE=https://zakura-release.valargroup.dev/release-state
@@ -19,8 +29,53 @@ die() {
     exit 1
 }
 
+note() {
+    echo "release-state publisher: $*" >&2
+}
+
+# A host that keeps R2 credentials in a secrets manager sets
+# RELEASE_STATE_SECRETS_WRAPPER to a command that injects them and execs its
+# argument. A host that keeps them in the EnvironmentFile leaves it unset. The
+# guard variable stops the wrapper from re-entering this script forever.
+maybe_reexec_with_secrets() {
+    [ -n "${RELEASE_STATE_SECRETS_WRAPPER:-}" ] || return 0
+    [ -z "${RELEASE_STATE_SECRETS_REEXEC:-}" ] || return 0
+    [ -x "$RELEASE_STATE_SECRETS_WRAPPER" ] \
+        || die "RELEASE_STATE_SECRETS_WRAPPER is not executable: $RELEASE_STATE_SECRETS_WRAPPER"
+    export RELEASE_STATE_SECRETS_REEXEC=1
+    exec "$RELEASE_STATE_SECRETS_WRAPPER" "$0" "$@"
+}
+
+# Deliberately the same predicate check-and-publish.sh uses, so both sides agree on
+# what "a snapshot is running" means. Reading the unit rather than taking the lock
+# matters: the snapshot side decides from the unit too, so a lock held here would
+# not defer a snapshot, it would start one that then died on the lock. Reports
+# false on a host with no such unit, which is the archive profile.
+snapshot_publish_active() {
+    [ -n "$SNAPSHOT_UNIT" ] || return 1
+    local state
+    state=$(systemctl show -p ActiveState --value "$SNAPSHOT_UNIT" 2>/dev/null) || return 1
+    [ "$state" = active ] || [ "$state" = activating ]
+}
+
+# True when the node owning this cache looks alive: docker on the snapshot
+# profile, systemd on the archive profile, nothing to check when neither is
+# configured. Advisory either way — the exporter reads a read-only RocksDB
+# secondary, which works against a quiesced database too.
+node_looks_live() {
+    if [ -n "$CONTAINER" ] && command -v docker >/dev/null 2>&1; then
+        [ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null)" = true ]
+        return
+    fi
+    if [ -n "$NODE_UNIT" ]; then
+        systemctl is-active --quiet "$NODE_UNIT"
+        return
+    fi
+    return 0
+}
+
 main() {
-    local state_dir running
+    local state_dir
 
     # No default: the archive cache path is host configuration, and silently
     # falling back to the wrong directory would publish a bundle from a database
@@ -34,10 +89,21 @@ main() {
     [ -d "$state_dir" ] \
         || die "cache directory does not exist: $state_dir"
 
-    running=$(docker inspect --format '{{.State.Running}}' "$CONTAINER" 2>/dev/null) \
-        || die "cannot inspect container $CONTAINER"
-    [ "$running" = true ] \
-        || die "container $CONTAINER must be running so its cache is a live archive node"
+    # Only the snapshot profile shares a host with a job that stops the node to tar a
+    # quarter-terabyte of state, and that job triggers on snapshot age rather than a
+    # fixed hour, so its window drifts across this timer's. Skip rather than fail: the
+    # import side is weekly, so a missed daily export costs a slightly older bundle
+    # while a failed unit costs an alert.
+    if snapshot_publish_active; then
+        note "$SNAPSHOT_UNIT is running; skipping this export"
+        exit 0
+    fi
+
+    # A stopped node is not fatal: the exporter reads a read-only RocksDB secondary,
+    # which works against a quiesced database too — that is what the pre-secondary
+    # design did on purpose. So this warns rather than refusing.
+    node_looks_live \
+        || note "warning: the node owning this cache is not running; exporting from a quiesced database"
 
     : "${R2_ACCESS_KEY_ID:?R2 access key was not injected}"
     : "${R2_SECRET_ACCESS_KEY:?R2 secret key was not injected}"
@@ -61,5 +127,6 @@ main() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    maybe_reexec_with_secrets "$@"
     main "$@"
 fi

--- a/deploy/release-state/zakura-release-state.service
+++ b/deploy/release-state/zakura-release-state.service
@@ -5,15 +5,23 @@
 # /run/zakura-release-state-publish.lock rejects overlapping runs.
 [Unit]
 Description=Publish Mainnet release-state bundle
+# Wants rather than Requires: the archive profile's node runs under systemd
+# directly and the host has no docker at all, where Requires would fail the unit.
 After=docker.service
-Requires=docker.service
+Wants=docker.service
 
 [Service]
 Type=oneshot
 # Supplies RELEASE_STATE_ARCHIVE_CACHE, and optionally RELEASE_STATE_KEEP or
 # RELEASE_STATE_GRID_COST_MS. The publisher refuses to run without the cache path.
+#
+# R2 credentials reach the publisher one of two ways, chosen by this same file.
+# A host with a secrets manager sets RELEASE_STATE_SECRETS_WRAPPER to a command
+# that injects them and execs its argument; the publisher re-execs through it. A
+# host without one puts R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY here directly.
+# The wrapper is therefore no longer baked into ExecStart.
 EnvironmentFile=/etc/zakura-release-state.env
-ExecStart=/usr/local/bin/with-secrets.sh /opt/zakura-release-state/bin/publish-from-archive-host.sh
+ExecStart=/opt/zakura-release-state/bin/publish-from-archive-host.sh
 # A whole-band frontier grid replay takes hours on a fast-synced archive
 # database. A legacy archive database reads the grid instead and finishes in
 # minutes, but the ceiling has to cover both.


### PR DESCRIPTION
Lets the release-state publisher install on `archive-vct-off` instead of the snapshot host, and
removes the container runtime from its requirements.

## Why

`archive-vct-off` is the right generator: it runs `vct_fast_sync = false`, so it holds per-height
commitment trees everywhere and the frontier grid comes from **reads** rather than replaying an
absent band — the 4,873s measured in Appendix B against hours on a fast-synced node. It also
shares its host with no snapshot job.

But the publisher was written for one machine and hardcoded it seven ways: the ssh target, the
hostname assertion, two container names, the units it verifies, the units it requires idle, and a
secrets wrapper baked into `ExecStart`. Installing anywhere else failed at whichever check came
first.

## Docker is not required, and now isn't referenced by the archive path at all

Worth stating plainly, because it looked like a dependency and never was:
`publish-release-state.sh` — which does all the actual work — contains **zero** docker references.
The exporter is a plain binary reading the cache as a read-only RocksDB secondary.

Docker only ever appeared as a *liveness hint*, because the snapshot host happens to run its node
in a container. That is now:

- conditional on a configured container name, with a `systemctl is-active` check for hosts that
  run the node directly, and nothing when neither is set;
- `Wants=docker.service` rather than `Requires=`, so the unit starts on a host with no docker;
- gone from the installer's preflight for the archive profile, whose `REQUIRED_CONTAINERS` is
  empty.

On `archive-vct-off` the path is: timer → wrapper (checks `zakurad.service`) → `zakura-checkpoints`
binary → rclone → R2. No container runtime anywhere.

The liveness check also warns instead of refusing. A quiesced database reads fine through a
secondary — that is what the pre-secondary design relied on — so it exists to catch a cache
belonging to no node, not to demand a live one.

## Profiles

| Profile | Host | Node | Grid generation |
| --- | --- | --- | --- |
| `snapshot` (default) | `zakura-snapshot` | `zakura` container | replays the absent band — hours |
| `archive` | `roman-zakura-archive-vct-off` | `zakurad.service` | reads stored trees — ~81 min |

Selected with `RELEASE_STATE_HOST_PROFILE`. The installer stamps the choice into
`/opt/zakura-release-state/profile.env`, which the publisher reads, so its identity and liveness
checks describe the host they actually run on. Defaults reproduce the previous behaviour for an
installation predating profiles.

The snapshot profile is kept rather than deleted because that host publishes today's bundles and
has to keep working through the cutover. Once `archive-vct-off` has produced a four-file bundle,
retiring it is a clean follow-up that removes the word "docker" from `deploy/release-state/`
entirely.

## Secrets — the easy route

`ExecStart` no longer bakes in `with-secrets.sh`. Either mechanism works, chosen in
`/etc/zakura-release-state.env`:

- `RELEASE_STATE_SECRETS_WRAPPER=/usr/local/bin/with-secrets.sh` — the publisher re-execs through
  it, as the snapshot host does today; or
- `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` set directly, for a host with no secrets manager.

`archive-vct-off` has no Infisical identity, so it takes the second route. A re-exec guard stops
the wrapper re-entering the script.

## Supersedes #786

That PR added the snapshot-collision guard. It is folded in here, because both touch the same
function and the host decision changed its premise: on `archive-vct-off` there is no
`zakura-snapshot.service`, so the guard is inert. It remains correct for the snapshot profile and
is kept for it. I will close #786 in favour of this.

Note #786 would **not** have been enough on its own: it softened the `running != true` branch, but
`docker inspect` failing outright — which is what happens on a host with no docker — still hit
`die`.

## Testing

`bash -n` and `shellcheck` clean on both scripts. The new logic is exercised directly:

- archive profile (no container, systemd unit, no snapshot unit) → `snapshot_publish_active` false,
  `node_looks_live` resolves via systemctl
- snapshot profile defaults with no `profile.env` → `zakura-snapshot` / `zakura` /
  `zakura-snapshot.service`, i.e. today's behaviour
- unset secrets wrapper → re-exec is a clean no-op
- `profile.env` rendering verified for local-expansion vs remote-heredoc quoting

Not yet exercised on the host — that is the next step, and it needs R2 credentials provisioned on
`archive-vct-off` first.
