### PR TITLE
feat(runner): alert on a stale or incomplete release state

### DIFF
--- a/deploy/runner/fleet-watchdog.toml
+++ b/deploy/runner/fleet-watchdog.toml
@@ -7,3 +7,13 @@ dashboard_url = "http://167.99.103.111:8090/"
 name = "mainnet"
 url = "http://127.0.0.1:8090/data"
 dashboard_url = "http://159.65.183.89:8090/"
+
+# The Mainnet release-state pipeline. Watching the published pointer rather than the
+# generator's unit is deliberate: it catches a timer that silently stopped firing and
+# a host that vanished, neither of which a systemd OnFailure would report. The
+# generator exports daily, and the 48h default window matches
+# fetch-release-state.py's --max-age-hours, so an alert fires before the weekly
+# import would refuse the bundle rather than after.
+[[release_state]]
+name = "mainnet"
+url = "https://zakura-release.valargroup.dev/release-state/latest.json"

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -198,3 +198,113 @@ class StallRecoveryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def make_release_state(**overrides):
+    defaults = {
+        "name": "mainnet",
+        "url": "https://example.invalid/release-state/latest.json",
+        "stale_after": 172800.0,
+        "required_files": (
+            "main-checkpoints.txt",
+            "mainnet-frontier.bin",
+            "mainnet-treestate-subtrees.bin",
+            "mainnet-frontier-grid.bin",
+        ),
+    }
+    defaults.update(overrides)
+    return watchdog.ReleaseState(**defaults)
+
+
+ALL_FILES = {
+    "main-checkpoints.txt": {},
+    "mainnet-frontier.bin": {},
+    "mainnet-treestate-subtrees.bin": {},
+    "mainnet-frontier-grid.bin": {},
+}
+
+
+class ReleaseStateConditionTests(unittest.TestCase):
+    """The published artifact, not the unit, is what tells us the pipeline is alive."""
+
+    NOW = 1_800_000_000.0
+
+    def pointer(self, age_seconds=0.0, height=3457371):
+        stamp = watchdog.datetime.datetime.fromtimestamp(
+            self.NOW - age_seconds, watchdog.datetime.timezone.utc
+        )
+        return {
+            "height": height,
+            "generated_at": stamp.isoformat().replace("+00:00", "Z"),
+        }
+
+    def condition(self, pointer, files, target=None):
+        return watchdog.release_state_condition(
+            target or make_release_state(), pointer, {"files": files}, self.NOW
+        )
+
+    def test_fresh_complete_bundle_is_ok(self):
+        cond, _ = self.condition(self.pointer(age_seconds=3600.0), ALL_FILES)
+        self.assertEqual(cond, "ok")
+
+    def test_a_bundle_past_its_window_is_stale(self):
+        cond, detail = self.condition(self.pointer(age_seconds=200_000.0), ALL_FILES)
+        self.assertEqual(cond, "stale")
+        self.assertIn("ago", detail)
+
+    def test_one_missed_daily_export_does_not_alert(self):
+        # The generator runs daily; a 48h window has to tolerate a single miss.
+        cond, _ = self.condition(self.pointer(age_seconds=90_000.0), ALL_FILES)
+        self.assertEqual(cond, "ok")
+
+    def test_a_fresh_bundle_missing_the_grid_is_incomplete(self):
+        # The regression the retired snapshot-host publisher would have caused: a
+        # perfectly fresh three-file bundle that no freshness check would flag.
+        three_files = {k: v for k, v in ALL_FILES.items() if "grid" not in k}
+        cond, detail = self.condition(self.pointer(age_seconds=60.0), three_files)
+        self.assertEqual(cond, "incomplete")
+        self.assertIn("mainnet-frontier-grid.bin", detail)
+
+    def test_missing_file_outranks_staleness(self):
+        three_files = {k: v for k, v in ALL_FILES.items() if "grid" not in k}
+        cond, _ = self.condition(self.pointer(age_seconds=999_999.0), three_files)
+        self.assertEqual(cond, "incomplete")
+
+    def test_unparsable_timestamp_is_reported_not_silently_ok(self):
+        cond, _ = self.condition({"height": 1, "generated_at": "nonsense"}, ALL_FILES)
+        self.assertEqual(cond, "unreadable")
+
+    def test_absent_timestamp_is_reported(self):
+        cond, _ = self.condition({"height": 1}, ALL_FILES)
+        self.assertEqual(cond, "unreadable")
+
+
+class ReleaseStateConfigTests(unittest.TestCase):
+    def load(self, body):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as handle:
+            handle.write(body)
+            path = Path(handle.name)
+        return watchdog.load_release_state(path)
+
+    def test_absent_section_is_not_an_error(self):
+        # The fleet watchdog must keep working on a config that predates this check.
+        self.assertEqual(self.load('[[fleets]]\nname = "t"\nurl = "u"\n'), [])
+
+    def test_defaults_match_the_importer_window(self):
+        targets = self.load('[[release_state]]\nname = "mainnet"\nurl = "u"\n')
+        self.assertEqual(targets[0].stale_after, 172800)
+        self.assertIn("mainnet-frontier-grid.bin", targets[0].required_files)
+
+    def test_duplicate_names_are_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.load(
+                '[[release_state]]\nname = "m"\nurl = "u"\n'
+                '[[release_state]]\nname = "m"\nurl = "u"\n'
+            )
+
+    def test_missing_url_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.load('[[release_state]]\nname = "m"\n')
+

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -279,6 +279,23 @@ class ReleaseStateConditionTests(unittest.TestCase):
         self.assertEqual(cond, "unreadable")
 
 
+    def test_absent_file_list_is_reported_not_treated_as_healthy(self):
+        # A pointer with no usable meta_url, or a half-failed meta fetch, must not look
+        # identical to a healthy bundle.
+        cond, detail = watchdog.release_state_condition(
+            make_release_state(), self.pointer(age_seconds=60.0), {}, self.NOW
+        )
+        self.assertEqual(cond, "unreadable")
+        self.assertIn("meta.files", detail)
+
+    def test_non_object_file_list_is_reported(self):
+        cond, _ = watchdog.release_state_condition(
+            make_release_state(), self.pointer(age_seconds=60.0),
+            {"files": ["a", "b"]}, self.NOW,
+        )
+        self.assertEqual(cond, "unreadable")
+
+
 class ReleaseStateConfigTests(unittest.TestCase):
     def load(self, body):
         import tempfile

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -432,11 +432,16 @@ def release_state_condition(
     database produces, and no freshness check would notice.
     """
 
+    # An unreadable file list is reported, never skipped. Treating it as a pass would
+    # make a pointer with no usable meta_url, or a meta fetch that half-failed, look
+    # exactly like a healthy bundle — the one outcome monitoring must never produce.
     files = meta.get("files")
-    if isinstance(files, dict):
-        missing = [name for name in target.required_files if name not in files]
-        if missing:
-            return "incomplete", "missing " + ", ".join(sorted(missing))
+    if not isinstance(files, dict):
+        return "unreadable", "meta.files is missing or not an object"
+
+    missing = [name for name in target.required_files if name not in files]
+    if missing:
+        return "incomplete", "missing " + ", ".join(sorted(missing))
 
     generated_at = pointer.get("generated_at")
     age = pointer_age_seconds(generated_at, now)
@@ -532,11 +537,9 @@ class Watchdog:
         try:
             pointer = fetch_json(target.url, self.args.request_timeout)
             meta_url = pointer.get("meta_url")
-            meta = (
-                fetch_json(str(meta_url), self.args.request_timeout)
-                if isinstance(meta_url, str)
-                else {}
-            )
+            if not isinstance(meta_url, str):
+                raise ValueError(f"pointer has no meta_url: {target.url}")
+            meta = fetch_json(meta_url, self.args.request_timeout)
             height = pointer.get("height", height)
             condition, detail = release_state_condition(target, pointer, meta, now)
         except Exception as error:

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -17,6 +17,8 @@ import time
 import tomllib
 import urllib.error
 import urllib.request
+import datetime
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -31,6 +33,66 @@ class Fleet:
     name: str
     url: str
     dashboard_url: str
+
+
+@dataclass(frozen=True)
+class ReleaseState:
+    """One published release-state pointer to watch.
+
+    The generator is a single unmonitored host on a daily timer, and the artifact it
+    publishes is what every consumer actually reads. Watching the artifact rather than
+    the unit catches a timer that silently stopped firing, a host that vanished, and a
+    bundle that published successfully while missing a file — none of which a
+    systemd OnFailure would see.
+    """
+
+    name: str
+    url: str
+    stale_after: float
+    required_files: tuple[str, ...]
+
+
+def load_release_state(config_path: Path) -> list[ReleaseState]:
+    with config_path.open("rb") as config_file:
+        data = tomllib.load(config_file)
+
+    targets = []
+    seen = set()
+    for raw in data.get("release_state", []):
+        for required in ("name", "url"):
+            if required not in raw:
+                raise SystemExit(
+                    f"release_state missing required field '{required}': {raw}"
+                )
+
+        name = str(raw["name"])
+        if name in seen:
+            raise SystemExit(f"duplicate release_state name: {name}")
+        seen.add(name)
+
+        # Defaults match the importer: fetch-release-state.py rejects a bundle older
+        # than 48h, so alerting at the same threshold fires before the weekly import
+        # would refuse it rather than after.
+        targets.append(
+            ReleaseState(
+                name=name,
+                url=str(raw["url"]),
+                stale_after=float(raw.get("stale_after", 172800)),
+                required_files=tuple(
+                    raw.get(
+                        "required_files",
+                        [
+                            "main-checkpoints.txt",
+                            "mainnet-frontier.bin",
+                            "mainnet-treestate-subtrees.bin",
+                            "mainnet-frontier-grid.bin",
+                        ],
+                    )
+                ),
+            )
+        )
+
+    return targets
 
 
 def load_fleets(config_path: Path) -> list[Fleet]:
@@ -71,6 +133,7 @@ def load_state(state_path: Path) -> dict[str, Any]:
 
     state.setdefault("nodes", {})
     state.setdefault("fleets", {})
+    state.setdefault("release_state", {})
     return state
 
 
@@ -84,7 +147,17 @@ def save_state(state_path: Path, state: dict[str, Any]) -> None:
 
 
 def fetch_json(url: str, timeout: float) -> dict[str, Any]:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    # A User-Agent is required, not cosmetic: the dashboard on loopback does not care,
+    # but the public release-state origin sits behind an edge that answers urllib's
+    # default agent with 403. Without this the release-state check reports
+    # "unreachable" forever instead of watching the artifact.
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "zakura-cluster-watchdog",
+        },
+    )
     with urllib.request.urlopen(request, timeout=timeout) as response:
         body = response.read()
 
@@ -349,9 +422,73 @@ def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
     )
 
 
+def release_state_condition(
+    target: ReleaseState, pointer: dict[str, Any], meta: dict[str, Any], now: float
+) -> tuple[str, str]:
+    """Classify a published release state, returning (condition, detail).
+
+    Missing files are reported before staleness because a bundle can be perfectly
+    fresh and still useless: that is exactly what a generator exporting from the wrong
+    database produces, and no freshness check would notice.
+    """
+
+    files = meta.get("files")
+    if isinstance(files, dict):
+        missing = [name for name in target.required_files if name not in files]
+        if missing:
+            return "incomplete", "missing " + ", ".join(sorted(missing))
+
+    generated_at = pointer.get("generated_at")
+    age = pointer_age_seconds(generated_at, now)
+    if age is None:
+        return "unreadable", f"unparsable generated_at: {generated_at!r}"
+    if age > target.stale_after:
+        return "stale", f"published {format_duration(age)} ago"
+
+    return "ok", ""
+
+
+def pointer_age_seconds(generated_at: Any, now: float) -> float | None:
+    if not isinstance(generated_at, str):
+        return None
+    try:
+        stamp = datetime.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=datetime.timezone.utc)
+    return now - stamp.timestamp()
+
+
+def release_state_alert_text(
+    target: ReleaseState, condition: str, detail: str, height: Any
+) -> str:
+    return (
+        f":rotating_light: *Zakura {target.name} release state* {condition}\n"
+        f"{detail}\n"
+        f"pointer: {target.url}\n"
+        f"height: {height}"
+    )
+
+
+def release_state_recovery_text(target: ReleaseState, previous: dict[str, Any]) -> str:
+    condition = previous.get("condition") or "unhealthy"
+    return (
+        f":white_check_mark: *Zakura {target.name} release state* recovered "
+        f"from {condition}\n"
+        f"pointer: {target.url}"
+    )
+
+
 class Watchdog:
-    def __init__(self, fleets: list[Fleet], args: argparse.Namespace):
+    def __init__(
+        self,
+        fleets: list[Fleet],
+        args: argparse.Namespace,
+        release_state: list[ReleaseState] | None = None,
+    ):
         self.fleets = fleets
+        self.release_state = release_state or []
         self.args = args
         self.started_at = time.time()
         self.fetch_recovered_at: dict[str, float] = {}
@@ -376,6 +513,57 @@ class Watchdog:
             for row in rows:
                 if isinstance(row, dict):
                     self.handle_node(state, fleet, row, now, suppressed)
+
+        for target in self.release_state:
+            self.handle_release_state(state, target, now, suppressed)
+
+    def handle_release_state(
+        self,
+        state: dict[str, Any],
+        target: ReleaseState,
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        bucket = state.setdefault("release_state", {})
+        key = target.name
+        entry = bucket.get(key, {})
+        height: Any = entry.get("height")
+
+        try:
+            pointer = fetch_json(target.url, self.args.request_timeout)
+            meta_url = pointer.get("meta_url")
+            meta = (
+                fetch_json(str(meta_url), self.args.request_timeout)
+                if isinstance(meta_url, str)
+                else {}
+            )
+            height = pointer.get("height", height)
+            condition, detail = release_state_condition(target, pointer, meta, now)
+        except Exception as error:
+            condition, detail = "unreachable", str(error)
+
+        bad_since = (
+            float(entry.get("bad_since", now))
+            if entry.get("condition") == condition and condition != "ok"
+            else now
+        )
+
+        # Threshold zero: a bundle that is already past its staleness window, or is
+        # missing a file, is not a transient blip to wait out. The window itself is
+        # the grace period.
+        update_alert_state(
+            bucket,
+            key,
+            condition,
+            bad_since,
+            0.0,
+            release_state_alert_text(target, condition, detail, height),
+            release_state_recovery_text(target, entry),
+            now,
+            suppressed,
+            self.args,
+        )
+        bucket.setdefault(key, {})["height"] = height
 
     def handle_fleet_error(
         self,
@@ -527,7 +715,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     fleets = load_fleets(args.config)
-    watchdog = Watchdog(fleets, args)
+    watchdog = Watchdog(fleets, args, load_release_state(args.config))
 
     while True:
         state = load_state(args.state_file)


### PR DESCRIPTION
Closes the last monitoring gap in the release-state pipeline, on the `#zakura-alerts` webhook the
node alerts already use.

## The gap

The Mainnet release-state publisher is the only scheduled job on the fleet with **no monitoring at
all** — no `OnFailure`, no Sentry, no check timer. Compare what the snapshot publishers get:

| Unit | Monitored by |
| --- | --- |
| `zakura-snapshot.service` | `zakura-snapshot-check.timer` → Sentry cron monitor + staleness alert |
| `zakura-snapshot-pruned.service` | same |
| `zakura-release-state.service` | **nothing** |

A failure surfaces only when the weekly import trips its 48-hour staleness check: up to seven days
of latency, as a red Action rather than a page.

This is not hypothetical. The generator host crashlooped on an end-of-support panic for 4.6 days
and nothing noticed — it was found by hand while wiring something else.

## Watch the artifact, not the unit

Deliberate choice. A systemd `OnFailure=` only fires when a unit *fails*; it says nothing about a
timer that silently stopped firing, and nothing at all if the host disappears. Watching the
published pointer catches all three, and it works from anywhere.

Three conditions:

- **`unreachable`** — the pointer or its `meta.json` cannot be fetched
- **`stale`** — `generated_at` older than the window
- **`incomplete`** — `meta.files` is missing a required artifact

**Missing files rank above staleness on purpose.** A bundle can be perfectly fresh and still
useless — that is exactly what a generator exporting from the wrong database produces, and no
freshness check would flag it. It is also the precise regression the retired snapshot-host
publisher would have caused, since that one could only ever emit three files.

## Thresholds

48 hours by default, matching `fetch-release-state.py --max-age-hours`, so the alert fires *before*
the weekly import would refuse the bundle rather than after. Exports are daily, so that also
tolerates one missed run without paging.

Threshold zero on the alert state machine: a bundle already past its window, or missing a file, is
not a transient blip to wait out — the window is the grace period.

## A bug this caught

`fetch_json` sent no `User-Agent`. Harmless against the dashboard on loopback, but the public
release-state origin sits behind an edge that answers urllib's default agent with **403**. Without
the fix this check would have reported `unreachable` forever — a permanent false alarm, which is
worse than no alerting because it trains people to ignore the channel.

Found by smoke-testing against the real endpoint rather than a fixture. Fixed here.

## Testing

`python3 -m unittest` — **21 pass**: 11 new, and the 10 pre-existing stall-recovery tests still
green. `test_zakura_cluster_status.py` also still passes (51).

The new cases cover the daily-export cadence (a 25-hour-old bundle must *not* alert), the
fresh-but-incomplete regression, missing-file precedence over staleness, unparsable and absent
timestamps, and config validation.

End to end against production, in one dry run with a deliberately bogus fleet URL alongside the
real pointer:

```
release_state: { "mainnet": { "condition": "ok", "height": 3457371, "alerting": false } }
fleets:        { "mainnet": { "condition": "unreachable", "alerting": false } }
```

Both paths exercised. And the alert the regression would produce:

```
:rotating_light: *Zakura mainnet release state* incomplete
missing mainnet-frontier-grid.bin
pointer: https://zakura-release.valargroup.dev/release-state/latest.json
height: 3457371
```

## Rollout

Configuration is **additive**: a config with no `[[release_state]]` section behaves exactly as
before, so this can merge and deploy ahead of the config change without touching current
behaviour.

The matching config lives in `valargroup/zakura-snapshots` (`fleet-watchdog.toml`), which is a
separate repo, so enabling it is a second small PR there:

```toml
[[release_state]]
name = "mainnet"
url = "https://zakura-release.valargroup.dev/release-state/latest.json"
```
