### PR TITLE
feat(assets)!: retarget the release-state asset crate to zakura-assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,12 +6920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valargroup-zakura-assets"
-version = "0.3457371.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42207ed9d1df776c64849d93644b7c5c4625c2b66304c2d05b71938b5d8ac90d"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7732,6 +7726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zakura-assets"
+version = "0.3457371.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380d37960ac8b518a75c17fcf8554a1b81e7387267d6b42a56fbed298255b723"
+
+[[package]]
 name = "zakura-bellman"
 version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8390,7 +8390,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tower 0.4.13",
  "tracing",
- "valargroup-zakura-assets",
+ "zakura-assets",
  "zakura-chain",
  "zakura-halo2-proofs",
  "zakura-header-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,11 +44,10 @@ edition = "2021"
 # manifest without fetching anything. The requirement is exact because these are reviewed bytes,
 # not a compatible range; `Cargo.lock` carries the registry checksum that pins them.
 #
-# Renamed so that no Rust source or script mentions the published crate name. The package is
-# published from `crates/zakura-assets/` in this repository. TODO(#703 follow-up): retarget to
-# `zakura-assets` once its crates.io owner adds the Trusted Publisher entry, which is a one-line
-# change here.
-zakura-assets = { version = "=0.3457371.0", package = "valargroup-zakura-assets" }
+# Published from `crates/zakura-assets/` in this repository. The dependency name and the
+# published name now match, so no `package` rename is needed: every consumer, script, and
+# gate refers to `zakura-assets` and nothing else.
+zakura-assets = { version = "=0.3457371.0" }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
 orchard = { version = "1.0.0-rc.2", package = "zakura-orchard" }
 sapling-crypto = { version = "1.0.0-rc.2", package = "zakura-sapling-crypto" }

--- a/crates/zakura-assets/Cargo.toml
+++ b/crates/zakura-assets/Cargo.toml
@@ -6,12 +6,14 @@
 # published crate from crates.io like any other dependency.
 #
 # The package name is the one place the published name is written down.
-# `scripts/pack-assets-crate.py` reads it from here rather than hardcoding it.
+# `scripts/pack-assets-crate.py` reads it from here rather than hardcoding it, and
+# `scripts/check-release-state.sh` resolves it from the workspace pin, so renaming the
+# published crate is this line plus the pin.
 [package]
-name = "valargroup-zakura-assets"
+name = "zakura-assets"
 # Stamped by `scripts/pack-assets-crate.py` as `0.<last_checkpoint>.<revision>`,
 # so the version a consumer pins states which checkpoint the payload covers.
-version = "0.3453771.0"
+version = "0.3457371.0"
 authors = ["Zakura Contributors"]
 edition = "2021"
 rust-version = "1.91"

--- a/deploy/release-state/SNAPSHOT_HOST.md
+++ b/deploy/release-state/SNAPSHOT_HOST.md
@@ -36,9 +36,9 @@ construction rather than by coincidence:
 
 ```sh
 curl -sSL -o /tmp/pub.crate \
-  https://static.crates.io/crates/valargroup-zakura-assets/valargroup-zakura-assets-0.3453771.0.crate
+  https://static.crates.io/crates/zakura-assets/zakura-assets-0.3457371.0.crate
 tar xzOf /tmp/pub.crate \
-  valargroup-zakura-assets-0.3453771.0/src/mainnet-frontier-grid.bin \
+  zakura-assets-0.3457371.0/src/mainnet-frontier-grid.bin \
   > /opt/zakura-release-state/seed-frontier-grid.bin
 
 RELEASE_STATE_PREVIOUS_GRID=/opt/zakura-release-state/seed-frontier-grid.bin \

--- a/docs/changelog/unreleased/793.md
+++ b/docs/changelog/unreleased/793.md
@@ -2,7 +2,7 @@
 
 - The Mainnet release-state asset package is now published as `zakura-assets` rather than
   `valargroup-zakura-assets`. The prefixed name was a stand-in taken while `zakura-assets` was
-  reserved but unpublishable, and the workspace pin carried a `package = ` alias to translate
+  reserved but unpublishable, and the workspace pin carried a `package` alias to translate
   between the dependency name and the published one. Both now agree, so the pin, the packer, and
   the release-state coupling gate all refer to `zakura-assets` and nothing else. Consumers that
   build `zakura-state` from crates.io resolve the renamed package; the payload, the

--- a/docs/changelog/unreleased/793.md
+++ b/docs/changelog/unreleased/793.md
@@ -1,0 +1,11 @@
+## Changed
+
+- The Mainnet release-state asset package is now published as `zakura-assets` rather than
+  `valargroup-zakura-assets`. The prefixed name was a stand-in taken while `zakura-assets` was
+  reserved but unpublishable, and the workspace pin carried a `package = ` alias to translate
+  between the dependency name and the published one. Both now agree, so the pin, the packer, and
+  the release-state coupling gate all refer to `zakura-assets` and nothing else. Consumers that
+  build `zakura-state` from crates.io resolve the renamed package; the payload, the
+  `0.<last_checkpoint>.<revision>` version scheme, and the digest the provenance manifest binds it
+  to are unchanged
+  ([#793](https://github.com/zakura-core/zakura/pull/793)).

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -4330,6 +4330,12 @@ end = "2025-07-29"
 
 [[trusted.zakura-assets]]
 criteria = "safe-to-deploy"
+user-id = 1244 # Sean Bowe (ebfull)
+start = "2026-08-11"
+end = "2027-08-24"
+
+[[trusted.zakura-assets]]
+criteria = "safe-to-deploy"
 trusted-publisher = "github:zakura-core/zakura"
 start = "2026-08-24"
 end = "2027-08-24"

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -4328,7 +4328,7 @@ user-id = 6741
 start = "2020-12-25"
 end = "2025-07-29"
 
-[[trusted.valargroup-zakura-assets]]
+[[trusted.zakura-assets]]
 criteria = "safe-to-deploy"
 trusted-publisher = "github:zakura-core/zakura"
 start = "2026-08-24"

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -76,6 +76,13 @@ version = "0.57.1"
 when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
+[[publisher.zakura-assets]]
+version = "0.3457371.0"
+when = "2026-08-24"
+user-id = 1244
+user-login = "ebfull"
+user-name = "Sean Bowe"
+
 [[publisher.zcash_address]]
 version = "0.13.0"
 when = "2026-07-09"

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -64,11 +64,6 @@ user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
 
-[[publisher.valargroup-zakura-assets]]
-version = "0.3457371.0"
-when = "2026-08-24"
-trusted-publisher = "github:zakura-core/zakura"
-
 [[publisher.wasip2]]
 version = "1.0.4+wasi-0.2.12"
 when = "2026-06-12"


### PR DESCRIPTION
Retargets the release-state asset crate from `valargroup-zakura-assets` to `zakura-assets`,
resolving the `TODO(#703 follow-up)` the workspace pin has carried since the grid stopped being
committed.

> [!IMPORTANT]
> **This PR is red on every cargo job until @ebfull configures the crate and a version is
> published.** That is expected, not a defect — see *What @ebfull needs to do* below. Nothing here
> can turn green from this side.

## Why the crate had the wrong name

`zakura-assets` is reserved on crates.io by `ebfull`, the account that owns every published version
of `zakura`, `zakura-state`, `zakura-chain`, and `zakura-rpc`. It exists only as a placeholder:

```
zakura-assets            versions: ['0.0.0']   description: "Reserved"
valargroup-zakura-assets versions: ['0.3453771.0', '0.3457371.0']   owner: p0mvn
```

So the pipeline shipped under a prefixed name with a note to retarget later. This is that.

## What changed

Two meaningful lines, plus the bookkeeping that follows them:

```diff
-name = "valargroup-zakura-assets"
+name = "zakura-assets"

-zakura-assets = { version = "=0.3457371.0", package = "valargroup-zakura-assets" }
+zakura-assets = { version = "=0.3457371.0" }
```

The dependency name and the published name are now the same string, so nothing translates between
them any more.

**No supporting code needed changing**, which was the point of writing it the way it was:

- `pack-assets-crate.py` reads the name out of the crate manifest — verified: `crate_name()` now
  returns `zakura-assets`
- `check-release-state.sh` resolves the published name from the pin's `package = ` and **falls back
  to the dependency name** when no alias is present — verified against the new pin: resolves
  `zakura-assets`, exact requirement, parses as `0.<checkpoint>.<revision>`
- `update-release-state.yml` repins by matching `^zakura-assets = {`, the dependency name, which is
  unchanged

The cargo-vet trust record is keyed on the *published* name, so it moves with the rename. Its
publisher is unchanged — the same repository and workflow publish it either way.

## Next steps

Two things, and only the first strictly needs you.

### 1. Add a Trusted Publisher entry on `zakura-assets`

On crates.io → `zakura-assets` → **Settings → Trusted Publishing → Add**:

| Field | Value |
| --- | --- |
| Repository owner | `zakura-core` |
| Repository name | `zakura` |
| Workflow filename | `update-release-state.yml` |
| Environment | `crates-io-assets` |

All four must match exactly — the environment name is part of the binding. The equivalent entry
already exists on `valargroup-zakura-assets` (`id 17477`) and is working: yesterday's publish shows

```json
"published_by": null,
"trustpub_data": {"provider": "github", "repository": "zakura-core/zakura",
                  "run_id": "32689067452", "sha": "e6e92e767…"}
```

so no personal token is involved, and each publish is attributable to a specific workflow run and
commit.

Once that entry exists, **you are not in the loop again** — the weekly release-state refresh
publishes on its own.

### 2. One bootstrap publish

There is a chicken-and-egg step. The workflow publishes whatever name the manifest on `main` says,
but this PR cannot merge while the pin does not resolve. So the first version under the new name has
to be published before the merge, and that publish has to come from you:

```sh
git fetch origin feat/retarget-zakura-assets-crate
git checkout feat/retarget-zakura-assets-crate
curl -sSL -o /tmp/pub.crate \
  https://static.crates.io/crates/valargroup-zakura-assets/valargroup-zakura-assets-0.3457371.0.crate
tar xzOf /tmp/pub.crate \
  valargroup-zakura-assets-0.3457371.0/src/mainnet-frontier-grid.bin > /tmp/grid.bin
python3 scripts/pack-assets-crate.py --grid /tmp/grid.bin
cargo publish --manifest-path crates/zakura-assets/Cargo.toml --allow-dirty --no-verify
```

That republishes the **identical payload** already reviewed and pinned — sha256
`d4adb027032c4c865409d11ea1360f5eda321b2d3932fa95b93467f47c9f4392`, 2,282 entries, checkpoint
3,457,371 — under the new name at the same version. Nothing new is being trusted; the same bytes
change name. `--allow-dirty` is needed because the payload is gitignored and shipped via the
manifest's explicit `include`; `--no-verify` matches what the workflow does.

### After that

We finish it from here — regenerate `Cargo.lock`, regenerate the trust record, confirm
`check-release-state.sh` passes, and CI goes green. The old `valargroup-zakura-assets` versions can
be left published; once the pin moves nothing references them, so yanking is optional tidying.

## Note on scope

The reserved `0.0.0` is no obstacle: the version scheme is `0.<last_checkpoint>.<revision>`, and
`0.3457371.0` sorts far above it. And this is a rename, not a migration — cargo treats it as a new
crate, so no download history or audit carries across, which is why the vet record has to be
regenerated rather than edited.

