### PR TITLE
fix(state): preserve shared cached UTXOs

### DIFF
--- a/crates/zakura-state/src/service/queued_blocks.rs
+++ b/crates/zakura-state/src/service/queued_blocks.rs
@@ -62,6 +62,8 @@ impl QueuedBlocks {
     ///
     /// If a block with the same hash is already queued, this method keeps the
     /// existing block and ignores `new`.
+    /// The ignored request is dropped without sending a result, so its response
+    /// receiver observes a closed channel.
     #[instrument(skip(self), fields(height = ?new.0.height, hash = %new.0.hash))]
     pub fn queue(&mut self, new: QueuedSemanticallyVerified) {
         let new_hash = new.0.hash;

--- a/crates/zakura-state/src/service/queued_blocks.rs
+++ b/crates/zakura-state/src/service/queued_blocks.rs
@@ -16,8 +16,12 @@ use crate::{
     NonFinalizedState, SemanticallyVerifiedBlock,
 };
 
+mod utxo_provider_cache;
+
 #[cfg(test)]
 mod tests;
+
+use utxo_provider_cache::UtxoProviderCache;
 
 /// Bounds semantically verified blocks retained while their parents are unavailable.
 pub(crate) const MAX_QUEUED_BLOCKS: usize = crate::MAX_BLOCK_REORG_HEIGHT as usize;
@@ -44,8 +48,8 @@ pub struct QueuedBlocks {
     by_parent: HashMap<block::Hash, HashSet<block::Hash>>,
     /// Hashes from `queued_blocks`, indexed by block height.
     by_height: BTreeMap<block::Height, HashSet<block::Hash>>,
-    /// Known UTXOs.
-    known_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
+    /// Known UTXOs, indexed by outpoint and provider block.
+    known_utxos: UtxoProviderCache,
 }
 
 impl QueuedBlocks {
@@ -56,9 +60,8 @@ impl QueuedBlocks {
 
     /// Queue a block for eventual verification and commit.
     ///
-    /// # Panics
-    ///
-    /// - if a block with the same `block::Hash` has already been queued.
+    /// If a block with the same hash is already queued, this method keeps the
+    /// existing block and ignores `new`.
     #[instrument(skip(self), fields(height = ?new.0.height, hash = %new.0.hash))]
     pub fn queue(&mut self, new: QueuedSemanticallyVerified) {
         let new_hash = new.0.hash;
@@ -73,7 +76,7 @@ impl QueuedBlocks {
         // Track known UTXOs in queued blocks.
         for (outpoint, ordered_utxo) in new.0.new_outputs.iter() {
             self.known_utxos
-                .insert(*outpoint, ordered_utxo.utxo.clone());
+                .insert(new_hash, *outpoint, ordered_utxo.utxo.clone());
         }
 
         self.blocks.insert(new_hash, new);
@@ -124,10 +127,8 @@ impl QueuedBlocks {
                 }
             }
 
-            // TODO: only remove UTXOs if there are no queued blocks with that UTXO
-            //       (known_utxos is best-effort, so this is ok for now)
             for outpoint in queued.0.new_outputs.keys() {
-                self.known_utxos.remove(outpoint);
+                self.known_utxos.remove_provider(&queued.0.hash, outpoint);
             }
         }
 
@@ -205,10 +206,8 @@ impl QueuedBlocks {
             )
             .into()));
 
-            // TODO: only remove UTXOs if there are no queued blocks with that UTXO
-            //       (known_utxos is best-effort, so this is ok for now)
             for outpoint in expired_block.new_outputs.keys() {
-                self.known_utxos.remove(outpoint);
+                self.known_utxos.remove_provider(&hash, outpoint);
             }
 
             let parent_list = self
@@ -263,11 +262,11 @@ impl QueuedBlocks {
         );
 
         for outpoint in old.0.new_outputs.keys() {
-            self.known_utxos.remove(outpoint);
+            self.known_utxos.remove_provider(&hash, outpoint);
         }
         for (outpoint, ordered_utxo) in &replacement.0.new_outputs {
             self.known_utxos
-                .insert(*outpoint, ordered_utxo.utxo.clone());
+                .insert(hash, *outpoint, ordered_utxo.utxo.clone());
         }
         old
     }
@@ -324,8 +323,8 @@ pub(crate) struct SentHashes {
     /// may not be in the finalized state yet.
     pub sent: HashMap<block::Hash, Vec<transparent::OutPoint>>,
 
-    /// Known UTXOs.
-    known_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
+    /// Known UTXOs, indexed by outpoint and provider block.
+    known_utxos: UtxoProviderCache,
 
     /// Whether the hashes in this struct can be used check if the chain can be forked.
     /// This is set to false until all checkpoint-verified block hashes have been pruned.
@@ -336,11 +335,11 @@ impl SentHashes {
     /// Creates a new [`SentHashes`] with the block hashes and UTXOs in the provided non-finalized state.
     pub fn new(non_finalized_state: &NonFinalizedState) -> Self {
         let mut sent_hashes = Self::default();
-        for (_, block) in non_finalized_state
-            .chain_iter()
-            .flat_map(|c| c.blocks.clone())
-        {
-            sent_hashes.add(&block.into());
+        for chain in non_finalized_state.chain_iter() {
+            for (_, block) in chain.blocks.clone() {
+                sent_hashes.add(&block.into());
+            }
+            sent_hashes.finish_batch();
         }
 
         if !sent_hashes.sent.is_empty() {
@@ -353,25 +352,12 @@ impl SentHashes {
     /// Stores the `block`'s hash, height, and UTXOs, so they can be used to check if a block or UTXO
     /// is available in the state.
     ///
+    /// If the block hash is already present, this method keeps the existing block data.
+    ///
     /// Assumes that blocks are added in the order of their height between `finish_batch` calls
     /// for efficient pruning.
     pub fn add(&mut self, block: &SemanticallyVerifiedBlock) {
-        // Track known UTXOs in sent blocks.
-        let outpoints = block
-            .new_outputs
-            .iter()
-            .map(|(outpoint, ordered_utxo)| {
-                self.known_utxos
-                    .insert(*outpoint, ordered_utxo.utxo.clone());
-                outpoint
-            })
-            .cloned()
-            .collect();
-
-        self.curr_buf.push_back((block.hash, block.height));
-        self.sent.insert(block.hash, outpoints);
-
-        self.update_metrics_for_block(block.height);
+        self.add_block_outputs(block.hash, block.height, &block.new_outputs);
     }
 
     /// Stores the checkpoint verified `block`'s hash, height, and UTXOs, so they can be used to check if a
@@ -385,22 +371,35 @@ impl SentHashes {
     ///
     /// For more details see `add()`.
     pub fn add_finalized(&mut self, block: &CheckpointVerifiedBlock) {
+        self.add_block_outputs(block.hash, block.height, &block.new_outputs);
+    }
+
+    /// Stores one block and its UTXOs unless its hash is already present.
+    fn add_block_outputs(
+        &mut self,
+        hash: block::Hash,
+        height: block::Height,
+        new_outputs: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+    ) {
+        if self.sent.contains_key(&hash) {
+            return;
+        }
+
         // Track known UTXOs in sent blocks.
-        let outpoints = block
-            .new_outputs
+        let outpoints = new_outputs
             .iter()
             .map(|(outpoint, ordered_utxo)| {
                 self.known_utxos
-                    .insert(*outpoint, ordered_utxo.utxo.clone());
+                    .insert(hash, *outpoint, ordered_utxo.utxo.clone());
                 outpoint
             })
             .cloned()
             .collect();
 
-        self.curr_buf.push_back((block.hash, block.height));
-        self.sent.insert(block.hash, outpoints);
+        self.curr_buf.push_back((hash, height));
+        self.sent.insert(hash, outpoints);
 
-        self.update_metrics_for_block(block.height);
+        self.update_metrics_for_block(height);
     }
 
     /// Try to look up this UTXO in any sent block.
@@ -433,10 +432,8 @@ impl SentHashes {
                     buf.push_front((hash, height));
                     return true;
                 } else if let Some(expired_outpoints) = self.sent.remove(&hash) {
-                    // TODO: only remove UTXOs if there are no queued blocks with that UTXO
-                    //       (known_utxos is best-effort, so this is ok for now)
                     for outpoint in expired_outpoints.iter() {
-                        self.known_utxos.remove(outpoint);
+                        self.known_utxos.remove_provider(&hash, outpoint);
                     }
                 }
             }
@@ -456,8 +453,8 @@ impl SentHashes {
         self.sent.contains_key(hash)
     }
 
-    /// Removes a `hash` from `SentHashes`, dropping its outpoints from `known_utxos`
-    /// and its entry from whichever batch buffer holds it.
+    /// Removes a `hash` from `SentHashes`, removing it as a provider for its outpoints
+    /// and dropping its entry from whichever batch buffer holds it.
     ///
     /// Called when the block write task rejects a block, so that a subsequent
     /// re-delivery of a block with the same hash is not short-circuited as a
@@ -468,13 +465,16 @@ impl SentHashes {
         };
 
         for outpoint in &outpoints {
-            self.known_utxos.remove(outpoint);
+            self.known_utxos.remove_provider(hash, outpoint);
         }
 
         self.curr_buf.retain(|(h, _)| h != hash);
-        for buf in &mut self.bufs {
+        self.bufs.retain_mut(|buf| {
             buf.retain(|(h, _)| h != hash);
-        }
+            !buf.is_empty()
+        });
+
+        self.update_metrics_for_cache();
     }
 
     /// Returns true if the chain can be forked at the provided hash

--- a/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
+++ b/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
@@ -4,7 +4,11 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot;
 
-use zakura_chain::{block::Block, serialization::ZcashDeserializeInto};
+use zakura_chain::{
+    block::{self, Block},
+    serialization::ZcashDeserializeInto,
+    transparent,
+};
 use zakura_test::prelude::*;
 
 use crate::{
@@ -14,6 +18,7 @@ use crate::{
     },
     tests::FakeChainHelper,
     CommitBlockError, CommitSemanticallyVerifiedError,
+    SemanticallyVerifiedBlock,
 };
 
 // Quick helper trait for making queued blocks with throw away channels
@@ -26,6 +31,315 @@ impl IntoQueued for Arc<Block> {
         let (rsp_tx, _) = oneshot::channel();
         (self.prepare(), rsp_tx, None)
     }
+}
+
+impl IntoQueued for SemanticallyVerifiedBlock {
+    fn into_queued(self) -> QueuedSemanticallyVerified {
+        let (rsp_tx, _) = oneshot::channel();
+        (self, rsp_tx, None)
+    }
+}
+
+#[derive(Clone)]
+struct SharedUtxoProviders {
+    lower: SemanticallyVerifiedBlock,
+    higher: SemanticallyVerifiedBlock,
+    outpoint: transparent::OutPoint,
+    lower_utxo: transparent::Utxo,
+    higher_utxo: transparent::Utxo,
+    lower_parent_hash: block::Hash,
+    higher_parent_hash: block::Hash,
+}
+
+/// Returns two blocks on competing branches that provide the same non-coinbase outpoint.
+///
+/// `SemanticallyVerifiedBlock::new_outputs` explicitly permits unrelated outputs, so the
+/// fixture can exercise cache ownership without constructing fully valid competing blocks.
+fn shared_utxo_providers() -> Result<SharedUtxoProviders> {
+    let root: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+    let left_child: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
+
+    let lower_block = left_child.make_fake_child();
+    let right_child = root.make_fake_child();
+    let right_grandchild = right_child.make_fake_child();
+    let higher_block = right_grandchild.make_fake_child();
+
+    let source = left_child.prepare();
+    let (outpoint, source_output) = source
+        .new_outputs
+        .iter()
+        .find(|(_outpoint, ordered_utxo)| !ordered_utxo.utxo.from_coinbase)
+        .expect("mainnet block 419201 has non-coinbase transparent outputs");
+    let outpoint = *outpoint;
+    let output = source_output.utxo.output.clone();
+
+    let mut lower = lower_block.prepare();
+    let mut higher = higher_block.prepare();
+    assert!(lower.height < higher.height);
+    assert_ne!(lower.hash, higher.hash);
+
+    let lower_output = transparent::OrderedUtxo::new(output.clone(), lower.height, 1);
+    let higher_output = transparent::OrderedUtxo::new(output, higher.height, 1);
+    let lower_utxo = lower_output.utxo.clone();
+    let higher_utxo = higher_output.utxo.clone();
+
+    lower.new_outputs.insert(outpoint, lower_output);
+    higher.new_outputs.insert(outpoint, higher_output);
+
+    let lower_parent_hash = lower.block.header.previous_block_hash;
+    let higher_parent_hash = higher.block.header.previous_block_hash;
+    assert_ne!(lower_parent_hash, higher_parent_hash);
+
+    Ok(SharedUtxoProviders {
+        lower,
+        higher,
+        outpoint,
+        lower_utxo,
+        higher_utxo,
+        lower_parent_hash,
+        higher_parent_hash,
+    })
+}
+
+fn duplicate_only_output(
+    original: &SemanticallyVerifiedBlock,
+    other: &SemanticallyVerifiedBlock,
+) -> (transparent::OutPoint, transparent::OrderedUtxo) {
+    other
+        .new_outputs
+        .iter()
+        .find(|(outpoint, _output)| !original.new_outputs.contains_key(outpoint))
+        .map(|(outpoint, output)| (*outpoint, output.clone()))
+        .expect("competing blocks have at least one distinct output")
+}
+
+fn sent_buffers_contain(sent: &SentHashes, hash: block::Hash) -> bool {
+    sent.curr_buf
+        .iter()
+        .any(|(sent_hash, _height)| *sent_hash == hash)
+        || sent
+            .bufs
+            .iter()
+            .flatten()
+            .any(|(sent_hash, _height)| *sent_hash == hash)
+}
+
+#[test]
+fn dequeue_children_preserves_shared_utxo_until_last_provider() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    for remove_lower_first in [true, false] {
+        let providers = shared_utxo_providers()?;
+        let mut queue = QueuedBlocks::default();
+        queue.queue(providers.lower.clone().into_queued());
+        queue.queue(providers.higher.clone().into_queued());
+
+        let (first_parent, first_hash, remaining_utxo, last_parent, last_hash) =
+            if remove_lower_first {
+                (
+                    providers.lower_parent_hash,
+                    providers.lower.hash,
+                    providers.higher_utxo.clone(),
+                    providers.higher_parent_hash,
+                    providers.higher.hash,
+                )
+            } else {
+                (
+                    providers.higher_parent_hash,
+                    providers.higher.hash,
+                    providers.lower_utxo.clone(),
+                    providers.lower_parent_hash,
+                    providers.lower.hash,
+                )
+            };
+
+        let removed = queue.dequeue_children(first_parent);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0.hash, first_hash);
+        assert_eq!(queue.utxo(&providers.outpoint), Some(remaining_utxo));
+
+        let removed = queue.dequeue_children(last_parent);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0.hash, last_hash);
+        assert_eq!(queue.utxo(&providers.outpoint), None);
+        assert!(queue.blocks.is_empty());
+        assert!(queue.by_parent.is_empty());
+        assert!(queue.by_height.is_empty());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn queued_pruning_preserves_shared_utxo_until_last_provider() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+
+    let mut queue = QueuedBlocks::default();
+    queue.queue(providers.lower.clone().into_queued());
+    queue.queue(providers.higher.clone().into_queued());
+
+    queue.prune_by_height(providers.lower.height);
+    assert!(!queue.blocks.contains_key(&providers.lower.hash));
+    assert!(queue.blocks.contains_key(&providers.higher.hash));
+    assert_eq!(
+        queue.utxo(&providers.outpoint),
+        Some(providers.higher_utxo.clone())
+    );
+
+    queue.prune_by_height(providers.higher.height);
+    assert_eq!(queue.utxo(&providers.outpoint), None);
+    assert!(queue.blocks.is_empty());
+    assert!(queue.by_parent.is_empty());
+    assert!(queue.by_height.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn sent_pruning_preserves_shared_utxo_until_last_provider() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+
+    let mut sent = SentHashes::default();
+    sent.add(&providers.lower);
+    sent.add(&providers.higher);
+    sent.finish_batch();
+
+    sent.prune_by_height(providers.lower.height);
+    assert!(!sent.contains(&providers.lower.hash));
+    assert!(sent.contains(&providers.higher.hash));
+    assert_eq!(
+        sent.utxo(&providers.outpoint),
+        Some(providers.higher_utxo.clone())
+    );
+
+    sent.prune_by_height(providers.higher.height);
+    assert_eq!(sent.utxo(&providers.outpoint), None);
+    assert!(sent.sent.is_empty());
+    assert!(!sent_buffers_contain(&sent, providers.lower.hash));
+    assert!(!sent_buffers_contain(&sent, providers.higher.hash));
+
+    Ok(())
+}
+
+#[test]
+fn sent_rejection_preserves_shared_utxo_until_last_provider() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    for remove_lower_first in [true, false] {
+        let providers = shared_utxo_providers()?;
+        let mut sent = SentHashes::default();
+        sent.add(&providers.lower);
+        sent.add(&providers.higher);
+        sent.finish_batch();
+
+        let (first_hash, remaining_utxo, last_hash) = if remove_lower_first {
+            (
+                providers.lower.hash,
+                providers.higher_utxo.clone(),
+                providers.higher.hash,
+            )
+        } else {
+            (
+                providers.higher.hash,
+                providers.lower_utxo.clone(),
+                providers.lower.hash,
+            )
+        };
+
+        sent.remove(&first_hash);
+        assert!(!sent.contains(&first_hash));
+        assert!(!sent_buffers_contain(&sent, first_hash));
+        assert_eq!(sent.utxo(&providers.outpoint), Some(remaining_utxo));
+
+        sent.remove(&last_hash);
+        assert!(!sent.contains(&last_hash));
+        assert!(!sent_buffers_contain(&sent, last_hash));
+        assert_eq!(sent.utxo(&providers.outpoint), None);
+        assert!(sent.sent.is_empty());
+        assert!(sent.bufs.is_empty());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn duplicate_queued_block_is_idempotent() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+    let (duplicate_outpoint, duplicate_output) =
+        duplicate_only_output(&providers.lower, &providers.higher);
+
+    let mut duplicate = providers.lower.clone();
+    duplicate.new_outputs.clear();
+    duplicate
+        .new_outputs
+        .insert(duplicate_outpoint, duplicate_output);
+
+    let mut queue = QueuedBlocks::default();
+    queue.queue(providers.lower.clone().into_queued());
+    queue.queue(duplicate.into_queued());
+
+    assert_eq!(queue.blocks.len(), 1);
+    assert_eq!(queue.by_parent.len(), 1);
+    assert_eq!(queue.by_height.len(), 1);
+    assert_eq!(
+        queue.utxo(&providers.outpoint),
+        Some(providers.lower_utxo.clone())
+    );
+    assert_eq!(queue.utxo(&duplicate_outpoint), None);
+
+    queue.dequeue_children(providers.lower_parent_hash);
+    assert_eq!(queue.utxo(&providers.outpoint), None);
+    assert_eq!(queue.utxo(&duplicate_outpoint), None);
+    assert!(queue.blocks.is_empty());
+    assert!(queue.by_parent.is_empty());
+    assert!(queue.by_height.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn duplicate_sent_block_is_idempotent() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+    let (duplicate_outpoint, duplicate_output) =
+        duplicate_only_output(&providers.lower, &providers.higher);
+
+    let mut duplicate = providers.lower.clone();
+    duplicate.new_outputs.clear();
+    duplicate
+        .new_outputs
+        .insert(duplicate_outpoint, duplicate_output);
+
+    let mut sent = SentHashes::default();
+    sent.add(&providers.lower);
+    sent.add(&duplicate);
+
+    assert_eq!(sent.sent.len(), 1);
+    assert_eq!(
+        sent.curr_buf
+            .iter()
+            .filter(|(hash, _height)| *hash == providers.lower.hash)
+            .count(),
+        1
+    );
+    assert_eq!(
+        sent.utxo(&providers.outpoint),
+        Some(providers.lower_utxo.clone())
+    );
+    assert_eq!(sent.utxo(&duplicate_outpoint), None);
+
+    sent.remove(&providers.lower.hash);
+    assert_eq!(sent.utxo(&providers.outpoint), None);
+    assert_eq!(sent.utxo(&duplicate_outpoint), None);
+    assert!(sent.sent.is_empty());
+    assert!(!sent_buffers_contain(&sent, providers.lower.hash));
+
+    Ok(())
 }
 
 #[test]

--- a/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
+++ b/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
@@ -17,9 +17,7 @@ use crate::{
     arbitrary::Prepare,
     service::{
         non_finalized_state::{Chain, NonFinalizedState},
-        queued_blocks::{
-            QueuedBlocks, QueuedSemanticallyVerified, SentHashes, MAX_QUEUED_BLOCKS,
-        },
+        queued_blocks::{QueuedBlocks, QueuedSemanticallyVerified, SentHashes, MAX_QUEUED_BLOCKS},
     },
     tests::FakeChainHelper,
     CheckpointVerifiedBlock, CommitBlockError, CommitSemanticallyVerifiedError,
@@ -638,6 +636,72 @@ fn same_hash_replacement_keeps_the_new_body() -> Result<()> {
 }
 
 #[test]
+fn same_hash_replacement_preserves_other_utxo_providers() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    for replace_lower in [true, false] {
+        let providers = shared_utxo_providers()?;
+        let (original, other) = if replace_lower {
+            (&providers.lower, &providers.higher)
+        } else {
+            (&providers.higher, &providers.lower)
+        };
+        let replacement_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x51; 32]),
+            index: 0,
+        };
+        let replacement_output = original.new_outputs[&providers.outpoint].clone();
+        let mut replacement = original.clone();
+        replacement.new_outputs.clear();
+        replacement
+            .new_outputs
+            .insert(replacement_outpoint, replacement_output.clone());
+
+        let mut queue = QueuedBlocks::default();
+        queue.queue(original.clone().into_queued());
+        queue.queue(other.clone().into_queued());
+        let old = queue.replace(original.hash, replacement.into_queued());
+
+        assert_eq!(old.0, *original);
+        assert_eq!(queue.blocks.len(), 2);
+        assert_eq!(queue.by_parent.len(), 2);
+        assert_eq!(queue.by_height.len(), 2);
+        assert_eq!(
+            queue.utxo(&providers.outpoint),
+            Some(other.new_outputs[&providers.outpoint].utxo.clone())
+        );
+        for outpoint in original.new_outputs.keys() {
+            if !other.new_outputs.contains_key(outpoint) {
+                assert_eq!(queue.utxo(outpoint), None);
+            }
+        }
+        assert_eq!(
+            queue.utxo(&replacement_outpoint),
+            Some(replacement_output.utxo.clone())
+        );
+
+        let removed = queue.dequeue_children(other.block.header.previous_block_hash);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0.hash, other.hash);
+        assert_eq!(queue.utxo(&providers.outpoint), None);
+        assert_eq!(
+            queue.utxo(&replacement_outpoint),
+            Some(replacement_output.utxo)
+        );
+
+        let removed = queue.dequeue_children(original.block.header.previous_block_hash);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0.hash, original.hash);
+        assert!(queue.blocks.is_empty());
+        assert!(queue.by_parent.is_empty());
+        assert!(queue.by_height.is_empty());
+        assert!(queue.known_utxos.is_empty());
+    }
+
+    Ok(())
+}
+
+#[test]
 fn orphan_queue_has_a_fixed_entry_bound() -> Result<()> {
     let block: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
@@ -846,9 +910,9 @@ fn fail_descendants_preserves_shared_utxo_from_live_branch_until_removed() -> Re
 
     let mut queue = QueuedBlocks::default();
     let (lower_response, mut lower_receiver) = oneshot::channel();
-    queue.queue((providers.lower.clone(), lower_response));
+    queue.queue((providers.lower.clone(), lower_response, None));
     let (grandchild_response, mut grandchild_receiver) = oneshot::channel();
-    queue.queue((failed_grandchild, grandchild_response));
+    queue.queue((failed_grandchild, grandchild_response, None));
     queue.queue(providers.higher.clone().into_queued());
 
     let error = CommitSemanticallyVerifiedError::from(CommitBlockError::HeaderChainError {

--- a/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
+++ b/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
@@ -22,8 +22,7 @@ use crate::{
         },
     },
     tests::FakeChainHelper,
-    CheckpointVerifiedBlock,
-    CommitBlockError, CommitSemanticallyVerifiedError,
+    CheckpointVerifiedBlock, CommitBlockError, CommitSemanticallyVerifiedError,
     SemanticallyVerifiedBlock,
 };
 
@@ -830,6 +829,59 @@ fn dequeue_descendants_removes_the_complete_failed_subtree() -> Result<()> {
     for response in &mut responses {
         assert_eq!(response.try_recv(), Ok(Err(error.clone())));
     }
+    assert!(queue.blocks.is_empty());
+    assert!(queue.by_parent.is_empty());
+    assert!(queue.by_height.is_empty());
+    assert!(queue.known_utxos.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn fail_descendants_preserves_shared_utxo_from_live_branch_until_removed() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+    let failed_grandchild = providers.lower.block.clone().make_fake_child().prepare();
+    let failed_grandchild_hash = failed_grandchild.hash;
+
+    let mut queue = QueuedBlocks::default();
+    let (lower_response, mut lower_receiver) = oneshot::channel();
+    queue.queue((providers.lower.clone(), lower_response));
+    let (grandchild_response, mut grandchild_receiver) = oneshot::channel();
+    queue.queue((failed_grandchild, grandchild_response));
+    queue.queue(providers.higher.clone().into_queued());
+
+    let error = CommitSemanticallyVerifiedError::from(CommitBlockError::HeaderChainError {
+        error: format!("ancestor {} failed", providers.left_child.hash()),
+    });
+    let failed_hashes = queue.fail_descendants(providers.left_child.hash(), error.clone());
+
+    assert_eq!(failed_hashes.len(), 2);
+    assert!(failed_hashes.contains(&providers.lower.hash));
+    assert!(failed_hashes.contains(&failed_grandchild_hash));
+    assert_eq!(lower_receiver.try_recv(), Ok(Err(error.clone())));
+    assert_eq!(grandchild_receiver.try_recv(), Ok(Err(error)));
+    assert_eq!(queue.blocks.len(), 1);
+    assert!(queue.blocks.contains_key(&providers.higher.hash));
+    assert_eq!(queue.by_parent.len(), 1);
+    assert!(queue
+        .by_parent
+        .get(&providers.higher_parent_hash)
+        .is_some_and(|hashes| hashes.contains(&providers.higher.hash)));
+    assert_eq!(queue.by_height.len(), 1);
+    assert!(queue
+        .by_height
+        .get(&providers.higher.height)
+        .is_some_and(|hashes| hashes.contains(&providers.higher.hash)));
+    assert_eq!(
+        queue.utxo(&providers.outpoint),
+        Some(providers.higher_utxo.clone())
+    );
+
+    let remaining = queue.dequeue_children(providers.higher_parent_hash);
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].0.hash, providers.higher.hash);
+    assert_eq!(queue.utxo(&providers.outpoint), None);
     assert!(queue.blocks.is_empty());
     assert!(queue.by_parent.is_empty());
     assert!(queue.by_height.is_empty());

--- a/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
+++ b/crates/zakura-state/src/service/queued_blocks/tests/vectors.rs
@@ -6,17 +6,23 @@ use tokio::sync::oneshot;
 
 use zakura_chain::{
     block::{self, Block},
+    parameters::Network,
     serialization::ZcashDeserializeInto,
-    transparent,
+    transaction, transparent,
+    value_balance::ValueBalance,
 };
 use zakura_test::prelude::*;
 
 use crate::{
     arbitrary::Prepare,
-    service::queued_blocks::{
-        QueuedBlocks, QueuedSemanticallyVerified, SentHashes, MAX_QUEUED_BLOCKS,
+    service::{
+        non_finalized_state::{Chain, NonFinalizedState},
+        queued_blocks::{
+            QueuedBlocks, QueuedSemanticallyVerified, SentHashes, MAX_QUEUED_BLOCKS,
+        },
     },
     tests::FakeChainHelper,
+    CheckpointVerifiedBlock,
     CommitBlockError, CommitSemanticallyVerifiedError,
     SemanticallyVerifiedBlock,
 };
@@ -42,6 +48,10 @@ impl IntoQueued for SemanticallyVerifiedBlock {
 
 #[derive(Clone)]
 struct SharedUtxoProviders {
+    root: Arc<Block>,
+    left_child: Arc<Block>,
+    right_child: Arc<Block>,
+    right_grandchild: Arc<Block>,
     lower: SemanticallyVerifiedBlock,
     higher: SemanticallyVerifiedBlock,
     outpoint: transparent::OutPoint,
@@ -58,22 +68,27 @@ struct SharedUtxoProviders {
 fn shared_utxo_providers() -> Result<SharedUtxoProviders> {
     let root: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
-    let left_child: Arc<Block> =
+    let source: Arc<Block> =
         zakura_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
 
-    let lower_block = left_child.make_fake_child();
-    let right_child = root.make_fake_child();
-    let right_grandchild = right_child.make_fake_child();
-    let higher_block = right_grandchild.make_fake_child();
-
-    let source = left_child.prepare();
-    let (outpoint, source_output) = source
+    let source = source.prepare();
+    let source_output = source
         .new_outputs
-        .iter()
-        .find(|(_outpoint, ordered_utxo)| !ordered_utxo.utxo.from_coinbase)
+        .values()
+        .find(|ordered_utxo| !ordered_utxo.utxo.from_coinbase)
         .expect("mainnet block 419201 has non-coinbase transparent outputs");
-    let outpoint = *outpoint;
     let output = source_output.utxo.output.clone();
+
+    let left_child = root.make_fake_child().set_work(1);
+    let lower_block = left_child.make_fake_child().set_work(1);
+    let right_child = root.make_fake_child().set_work(10);
+    let right_grandchild = right_child.make_fake_child().set_work(10);
+    let higher_block = right_grandchild.make_fake_child().set_work(10);
+
+    let outpoint = transparent::OutPoint {
+        hash: transaction::Hash([0x49; 32]),
+        index: 0,
+    };
 
     let mut lower = lower_block.prepare();
     let mut higher = higher_block.prepare();
@@ -93,6 +108,10 @@ fn shared_utxo_providers() -> Result<SharedUtxoProviders> {
     assert_ne!(lower_parent_hash, higher_parent_hash);
 
     Ok(SharedUtxoProviders {
+        root,
+        left_child,
+        right_child,
+        right_grandchild,
         lower,
         higher,
         outpoint,
@@ -101,6 +120,77 @@ fn shared_utxo_providers() -> Result<SharedUtxoProviders> {
         lower_parent_hash,
         higher_parent_hash,
     })
+}
+
+fn non_finalized_state_with_shared_utxo_providers(
+    providers: &SharedUtxoProviders,
+) -> Result<NonFinalizedState> {
+    let network = Network::Mainnet;
+    let root_height = providers
+        .root
+        .coinbase_height()
+        .expect("mainnet block 419200 has a coinbase height");
+    let finalized_tip_height = (root_height - 1).expect("mainnet block 419200 is above genesis");
+    let root_chain = Chain::new(
+        &network,
+        finalized_tip_height,
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        Default::default(),
+        ValueBalance::fake_populated_pool(),
+    )
+    .push(
+        providers
+            .root
+            .clone()
+            .prepare()
+            .test_with_zero_spent_utxos(),
+    )?;
+
+    let lower_chain = root_chain
+        .clone()
+        .push(
+            providers
+                .left_child
+                .clone()
+                .prepare()
+                .test_with_zero_spent_utxos(),
+        )?
+        .push(providers.lower.test_with_zero_spent_utxos())?;
+    let higher_chain = root_chain
+        .push(
+            providers
+                .right_child
+                .clone()
+                .prepare()
+                .test_with_zero_spent_utxos(),
+        )?
+        .push(
+            providers
+                .right_grandchild
+                .clone()
+                .prepare()
+                .test_with_zero_spent_utxos(),
+        )?
+        .push(providers.higher.test_with_zero_spent_utxos())?;
+
+    let mut state = NonFinalizedState::new(&network);
+    state.insert_test_chain(Arc::new(lower_chain));
+    state.insert_test_chain(Arc::new(higher_chain));
+
+    assert_eq!(
+        state
+            .chain_iter()
+            .next()
+            .expect("the reconstructed state has two chains")
+            .non_finalized_tip_hash(),
+        providers.higher.hash,
+        "the higher branch must be visited first to exercise per-chain batches"
+    );
+
+    Ok(state)
 }
 
 fn duplicate_only_output(
@@ -115,15 +205,16 @@ fn duplicate_only_output(
         .expect("competing blocks have at least one distinct output")
 }
 
-fn sent_buffers_contain(sent: &SentHashes, hash: block::Hash) -> bool {
+fn sent_buffer_hash_count(sent: &SentHashes, hash: block::Hash) -> usize {
     sent.curr_buf
         .iter()
-        .any(|(sent_hash, _height)| *sent_hash == hash)
-        || sent
-            .bufs
-            .iter()
-            .flatten()
-            .any(|(sent_hash, _height)| *sent_hash == hash)
+        .chain(sent.bufs.iter().flatten())
+        .filter(|(sent_hash, _height)| *sent_hash == hash)
+        .count()
+}
+
+fn sent_buffers_contain(sent: &SentHashes, hash: block::Hash) -> bool {
+    sent_buffer_hash_count(sent, hash) > 0
 }
 
 #[test]
@@ -221,6 +312,53 @@ fn sent_pruning_preserves_shared_utxo_until_last_provider() -> Result<()> {
     assert!(sent.sent.is_empty());
     assert!(!sent_buffers_contain(&sent, providers.lower.hash));
     assert!(!sent_buffers_contain(&sent, providers.higher.hash));
+
+    Ok(())
+}
+
+#[test]
+fn sent_new_from_forks_preserves_shared_utxo_until_last_provider() -> Result<()> {
+    let _init_guard = zakura_test::init();
+    let providers = shared_utxo_providers()?;
+    let state = non_finalized_state_with_shared_utxo_providers(&providers)?;
+
+    let mut sent = SentHashes::new(&state);
+
+    assert!(sent.curr_buf.is_empty());
+    assert_eq!(sent.bufs.len(), 2);
+    assert_eq!(sent.sent.len(), 6);
+    assert_eq!(sent_buffer_hash_count(&sent, providers.root.hash()), 1);
+    assert_eq!(
+        sent.bufs[0].back(),
+        Some(&(providers.higher.hash, providers.higher.height))
+    );
+    assert_eq!(
+        sent.bufs[1].back(),
+        Some(&(providers.lower.hash, providers.lower.height))
+    );
+    assert!(sent
+        .bufs
+        .iter()
+        .all(|batch| batch.iter().zip(batch.iter().skip(1)).all(
+            |((_left_hash, left_height), (_right_hash, right_height))| left_height < right_height
+        )));
+
+    sent.prune_by_height(providers.lower.height);
+    assert!(!sent.contains(&providers.lower.hash));
+    assert!(sent.contains(&providers.higher.hash));
+    assert_eq!(sent.sent.len(), 1);
+    assert_eq!(
+        sent.utxo(&providers.outpoint),
+        Some(providers.higher_utxo.clone())
+    );
+    assert_eq!(sent_buffer_hash_count(&sent, providers.lower.hash), 0);
+    assert_eq!(sent_buffer_hash_count(&sent, providers.higher.hash), 1);
+
+    sent.prune_by_height(providers.higher.height);
+    assert_eq!(sent.utxo(&providers.outpoint), None);
+    assert!(sent.sent.is_empty());
+    assert!(sent.curr_buf.is_empty());
+    assert!(sent.bufs.is_empty());
 
     Ok(())
 }
@@ -338,6 +476,72 @@ fn duplicate_sent_block_is_idempotent() -> Result<()> {
     assert_eq!(sent.utxo(&duplicate_outpoint), None);
     assert!(sent.sent.is_empty());
     assert!(!sent_buffers_contain(&sent, providers.lower.hash));
+
+    Ok(())
+}
+
+#[test]
+fn finalized_sent_blocks_are_provider_aware_and_idempotent() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    for remove_lower_first in [true, false] {
+        let providers = shared_utxo_providers()?;
+        let (_other_outpoint, duplicate_output) =
+            duplicate_only_output(&providers.lower, &providers.higher);
+        let duplicate_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x50; 32]),
+            index: 0,
+        };
+
+        let mut duplicate = providers.lower.clone();
+        duplicate.new_outputs.clear();
+        duplicate
+            .new_outputs
+            .insert(duplicate_outpoint, duplicate_output);
+
+        let lower = CheckpointVerifiedBlock(providers.lower.clone());
+        let duplicate = CheckpointVerifiedBlock(duplicate);
+        let higher = CheckpointVerifiedBlock(providers.higher.clone());
+        let mut sent = SentHashes::default();
+        sent.add_finalized(&lower);
+        sent.add_finalized(&duplicate);
+        sent.add_finalized(&higher);
+        sent.finish_batch();
+
+        assert_eq!(sent.sent.len(), 2);
+        assert_eq!(sent_buffer_hash_count(&sent, providers.lower.hash), 1);
+        assert_eq!(sent_buffer_hash_count(&sent, providers.higher.hash), 1);
+        assert_eq!(sent.utxo(&duplicate_outpoint), None);
+
+        let (first_hash, remaining_utxo, last_hash) = if remove_lower_first {
+            (
+                providers.lower.hash,
+                providers.higher_utxo.clone(),
+                providers.higher.hash,
+            )
+        } else {
+            (
+                providers.higher.hash,
+                providers.lower_utxo.clone(),
+                providers.lower.hash,
+            )
+        };
+
+        sent.remove(&first_hash);
+        assert!(!sent.contains(&first_hash));
+        assert_eq!(sent_buffer_hash_count(&sent, first_hash), 0);
+        assert_eq!(sent.utxo(&providers.outpoint), Some(remaining_utxo));
+        assert_eq!(sent.utxo(&duplicate_outpoint), None);
+
+        sent.remove(&last_hash);
+        assert!(!sent.contains(&last_hash));
+        assert_eq!(sent_buffer_hash_count(&sent, last_hash), 0);
+        assert_eq!(sent.utxo(&providers.outpoint), None);
+        assert_eq!(sent.utxo(&duplicate_outpoint), None);
+        assert!(sent.sent.is_empty());
+        assert!(sent.curr_buf.is_empty());
+        assert!(sent.bufs.is_empty());
+    }
 
     Ok(())
 }

--- a/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
+++ b/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
@@ -331,9 +331,10 @@ mod tests {
             hash: transaction::Hash([0x50; 32]),
             index: 0,
         };
-        let provider_hash = block::Hash([1; 32]);
-        let unknown_hash = block::Hash([2; 32]);
-        let utxo = transparent::Utxo::new(
+        let first_hash = block::Hash([1; 32]);
+        let second_hash = block::Hash([2; 32]);
+        let unknown_hash = block::Hash([3; 32]);
+        let first_utxo = transparent::Utxo::new(
             transparent::Output {
                 value: Amount::zero(),
                 lock_script: transparent::Script::new(&[]),
@@ -341,13 +342,32 @@ mod tests {
             block::Height(1),
             false,
         );
+        let second_utxo =
+            transparent::Utxo::new(first_utxo.output.clone(), block::Height(2), false);
         let mut cache = UtxoProviderCache::default();
-        cache.insert(provider_hash, existing_outpoint, utxo.clone());
+        cache.insert(first_hash, existing_outpoint, first_utxo.clone());
 
         cache.remove_provider(&unknown_hash, &existing_outpoint);
-        cache.remove_provider(&provider_hash, &unknown_outpoint);
+        cache.remove_provider(&first_hash, &unknown_outpoint);
 
-        assert_eq!(cache.get(&existing_outpoint), Some(&utxo));
+        assert_eq!(cache.get(&existing_outpoint), Some(&first_utxo));
         assert!(cache.get(&unknown_outpoint).is_none());
+
+        cache.insert(second_hash, existing_outpoint, second_utxo.clone());
+        cache.remove_provider(&unknown_hash, &existing_outpoint);
+
+        let Some(UtxoProviders::Multiple(providers)) =
+            cache.providers_by_outpoint.get(&existing_outpoint)
+        else {
+            panic!("removing an unknown provider leaves both existing UTXO providers unchanged");
+        };
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers.get(&first_hash), Some(&first_utxo));
+        assert_eq!(providers.get(&second_hash), Some(&second_utxo));
+
+        cache.remove_provider(&first_hash, &existing_outpoint);
+        assert_eq!(cache.get(&existing_outpoint), Some(&second_utxo));
+        cache.remove_provider(&second_hash, &existing_outpoint);
+        assert!(cache.is_empty());
     }
 }

--- a/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
+++ b/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
@@ -94,6 +94,12 @@ impl UtxoProviderCache {
         self.providers_by_outpoint.len()
     }
 
+    /// Returns `true` when there are no cached outpoints.
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.providers_by_outpoint.is_empty()
+    }
+
     /// Removes every cached outpoint and provider.
     pub(super) fn clear(&mut self) {
         self.providers_by_outpoint.clear();

--- a/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
+++ b/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
@@ -1,0 +1,144 @@
+//! Provider-aware UTXOs cached from blocks that have not reached state yet.
+
+use std::collections::{hash_map::Entry, HashMap};
+
+use zakura_chain::{block, transparent};
+
+/// Caches each known UTXO together with every block that currently provides it.
+///
+/// Most outpoints have one provider, so [`UtxoProviders::Single`] avoids a separate
+/// allocation for the common case. Competing blocks that contain the same transaction
+/// promote the entry to [`UtxoProviders::Multiple`].
+#[derive(Debug, Default)]
+pub(super) struct UtxoProviderCache {
+    providers_by_outpoint: HashMap<transparent::OutPoint, UtxoProviders>,
+}
+
+#[derive(Debug)]
+enum UtxoProviders {
+    Single {
+        block_hash: block::Hash,
+        utxo: transparent::Utxo,
+    },
+    Multiple(HashMap<block::Hash, transparent::Utxo>),
+}
+
+impl UtxoProviderCache {
+    /// Inserts or replaces the UTXO supplied by `block_hash` at `outpoint`.
+    pub(super) fn insert(
+        &mut self,
+        block_hash: block::Hash,
+        outpoint: transparent::OutPoint,
+        utxo: transparent::Utxo,
+    ) {
+        match self.providers_by_outpoint.entry(outpoint) {
+            Entry::Vacant(entry) => {
+                entry.insert(UtxoProviders::Single { block_hash, utxo });
+            }
+            Entry::Occupied(mut entry) => entry.get_mut().insert(block_hash, utxo),
+        }
+    }
+
+    /// Removes only the UTXO supplied by `block_hash` at `outpoint`.
+    ///
+    /// The outpoint remains cached while any other provider remains.
+    pub(super) fn remove_provider(
+        &mut self,
+        block_hash: &block::Hash,
+        outpoint: &transparent::OutPoint,
+    ) {
+        let Entry::Occupied(mut entry) = self.providers_by_outpoint.entry(*outpoint) else {
+            return;
+        };
+
+        if entry.get_mut().remove(block_hash) {
+            entry.remove();
+        }
+    }
+
+    /// Returns a UTXO supplied by any live provider for `outpoint`.
+    pub(super) fn get(&self, outpoint: &transparent::OutPoint) -> Option<&transparent::Utxo> {
+        self.providers_by_outpoint
+            .get(outpoint)
+            .map(UtxoProviders::get)
+    }
+
+    /// Returns the number of distinct cached outpoints.
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.providers_by_outpoint.len()
+    }
+
+    /// Removes every cached outpoint and provider.
+    pub(super) fn clear(&mut self) {
+        self.providers_by_outpoint.clear();
+    }
+
+    /// Shrinks the distinct-outpoint index to fit its current contents.
+    pub(super) fn shrink_to_fit(&mut self) {
+        self.providers_by_outpoint.shrink_to_fit();
+    }
+}
+
+impl UtxoProviders {
+    fn insert(&mut self, block_hash: block::Hash, utxo: transparent::Utxo) {
+        match self {
+            Self::Single {
+                block_hash: current_hash,
+                utxo: current_utxo,
+            } if *current_hash == block_hash => {
+                *current_utxo = utxo;
+            }
+            Self::Single {
+                block_hash: current_hash,
+                utxo: current_utxo,
+            } => {
+                *self = Self::Multiple(HashMap::from([
+                    (*current_hash, current_utxo.clone()),
+                    (block_hash, utxo),
+                ]));
+            }
+            Self::Multiple(providers) => {
+                providers.insert(block_hash, utxo);
+            }
+        }
+    }
+
+    /// Removes `block_hash` and returns `true` when no provider remains.
+    fn remove(&mut self, block_hash: &block::Hash) -> bool {
+        match self {
+            Self::Single {
+                block_hash: current_hash,
+                ..
+            } => current_hash == block_hash,
+            Self::Multiple(providers) => {
+                if providers.remove(block_hash).is_none() {
+                    return false;
+                }
+
+                if providers.len() == 1 {
+                    let (remaining_hash, remaining_utxo) = providers
+                        .drain()
+                        .next()
+                        .expect("one UTXO provider remains after checking the provider count");
+                    *self = Self::Single {
+                        block_hash: remaining_hash,
+                        utxo: remaining_utxo,
+                    };
+                }
+
+                false
+            }
+        }
+    }
+
+    fn get(&self) -> &transparent::Utxo {
+        match self {
+            Self::Single { utxo, .. } => utxo,
+            Self::Multiple(providers) => providers
+                .values()
+                .next()
+                .expect("multiple UTXO providers is never empty"),
+        }
+    }
+}

--- a/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
+++ b/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
@@ -142,3 +142,70 @@ impl UtxoProviders {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use zakura_chain::{amount::Amount, transaction};
+
+    use super::*;
+
+    #[test]
+    fn three_providers_promote_and_collapse_provider_storage() {
+        let outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x49; 32]),
+            index: 0,
+        };
+        let output = transparent::Output {
+            value: Amount::zero(),
+            lock_script: transparent::Script::new(&[]),
+        };
+        let provider_hashes = [
+            block::Hash([1; 32]),
+            block::Hash([2; 32]),
+            block::Hash([3; 32]),
+        ];
+        let provider_utxos = [
+            transparent::Utxo::new(output.clone(), block::Height(1), false),
+            transparent::Utxo::new(output.clone(), block::Height(2), false),
+            transparent::Utxo::new(output, block::Height(3), false),
+        ];
+        let mut cache = UtxoProviderCache::default();
+
+        cache.insert(provider_hashes[0], outpoint, provider_utxos[0].clone());
+        assert!(matches!(
+            cache.providers_by_outpoint.get(&outpoint),
+            Some(UtxoProviders::Single { block_hash, utxo })
+                if *block_hash == provider_hashes[0] && *utxo == provider_utxos[0]
+        ));
+
+        cache.insert(provider_hashes[1], outpoint, provider_utxos[1].clone());
+        cache.insert(provider_hashes[2], outpoint, provider_utxos[2].clone());
+        let Some(UtxoProviders::Multiple(providers)) = cache.providers_by_outpoint.get(&outpoint)
+        else {
+            panic!("three UTXO providers use the multiple-provider representation");
+        };
+        assert_eq!(providers.len(), 3);
+        for (hash, utxo) in provider_hashes.iter().zip(provider_utxos.iter()) {
+            assert_eq!(providers.get(hash), Some(utxo));
+        }
+
+        cache.remove_provider(&provider_hashes[1], &outpoint);
+        let Some(UtxoProviders::Multiple(providers)) = cache.providers_by_outpoint.get(&outpoint)
+        else {
+            panic!("two UTXO providers keep the multiple-provider representation");
+        };
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers.get(&provider_hashes[0]), Some(&provider_utxos[0]));
+        assert_eq!(providers.get(&provider_hashes[2]), Some(&provider_utxos[2]));
+
+        cache.remove_provider(&provider_hashes[0], &outpoint);
+        assert!(matches!(
+            cache.providers_by_outpoint.get(&outpoint),
+            Some(UtxoProviders::Single { block_hash, utxo })
+                if *block_hash == provider_hashes[2] && *utxo == provider_utxos[2]
+        ));
+
+        cache.remove_provider(&provider_hashes[2], &outpoint);
+        assert!(!cache.providers_by_outpoint.contains_key(&outpoint));
+    }
+}

--- a/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
+++ b/crates/zakura-state/src/service/queued_blocks/utxo_provider_cache.rs
@@ -9,6 +9,11 @@ use zakura_chain::{block, transparent};
 /// Most outpoints have one provider, so [`UtxoProviders::Single`] avoids a separate
 /// allocation for the common case. Competing blocks that contain the same transaction
 /// promote the entry to [`UtxoProviders::Multiple`].
+///
+/// The single-provider representation retains its block hash so a later collision can
+/// preserve both providers' metadata and cleanup can expose the exact surviving value.
+/// A reference count paired with one value could not recover that value after its
+/// provider was removed.
 #[derive(Debug, Default)]
 pub(super) struct UtxoProviderCache {
     providers_by_outpoint: HashMap<transparent::OutPoint, UtxoProviders>,
@@ -21,6 +26,13 @@ enum UtxoProviders {
         utxo: transparent::Utxo,
     },
     Multiple(HashMap<block::Hash, transparent::Utxo>),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ProviderRemoval {
+    Missing,
+    ProvidersRemain,
+    LastProviderRemoved,
 }
 
 impl UtxoProviderCache {
@@ -47,16 +59,29 @@ impl UtxoProviderCache {
         block_hash: &block::Hash,
         outpoint: &transparent::OutPoint,
     ) {
+        debug_assert!(
+            self.providers_by_outpoint
+                .get(outpoint)
+                .is_some_and(|providers| providers.contains(block_hash)),
+            "provider ownership exists because callers remove outputs from the same registered block that inserted them"
+        );
+
         let Entry::Occupied(mut entry) = self.providers_by_outpoint.entry(*outpoint) else {
             return;
         };
 
-        if entry.get_mut().remove(block_hash) {
-            entry.remove();
+        match entry.get_mut().remove(block_hash) {
+            ProviderRemoval::Missing | ProviderRemoval::ProvidersRemain => {}
+            ProviderRemoval::LastProviderRemoved => {
+                entry.remove();
+            }
         }
     }
 
     /// Returns a UTXO supplied by any live provider for `outpoint`.
+    ///
+    /// When multiple providers remain, provider selection is arbitrary and callers
+    /// must not depend on which provider's metadata is returned.
     pub(super) fn get(&self, outpoint: &transparent::OutPoint) -> Option<&transparent::Utxo> {
         self.providers_by_outpoint
             .get(outpoint)
@@ -81,6 +106,16 @@ impl UtxoProviderCache {
 }
 
 impl UtxoProviders {
+    fn contains(&self, block_hash: &block::Hash) -> bool {
+        match self {
+            Self::Single {
+                block_hash: current_hash,
+                ..
+            } => current_hash == block_hash,
+            Self::Multiple(providers) => providers.contains_key(block_hash),
+        }
+    }
+
     fn insert(&mut self, block_hash: block::Hash, utxo: transparent::Utxo) {
         match self {
             Self::Single {
@@ -104,16 +139,17 @@ impl UtxoProviders {
         }
     }
 
-    /// Removes `block_hash` and returns `true` when no provider remains.
-    fn remove(&mut self, block_hash: &block::Hash) -> bool {
+    /// Removes `block_hash` and reports the resulting provider state.
+    fn remove(&mut self, block_hash: &block::Hash) -> ProviderRemoval {
         match self {
             Self::Single {
                 block_hash: current_hash,
                 ..
-            } => current_hash == block_hash,
+            } if current_hash == block_hash => ProviderRemoval::LastProviderRemoved,
+            Self::Single { .. } => ProviderRemoval::Missing,
             Self::Multiple(providers) => {
                 if providers.remove(block_hash).is_none() {
-                    return false;
+                    return ProviderRemoval::Missing;
                 }
 
                 if providers.len() == 1 {
@@ -127,7 +163,7 @@ impl UtxoProviders {
                     };
                 }
 
-                false
+                ProviderRemoval::ProvidersRemain
             }
         }
     }
@@ -145,6 +181,9 @@ impl UtxoProviders {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(debug_assertions)]
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
     use zakura_chain::{amount::Amount, transaction};
 
     use super::*;
@@ -207,5 +246,102 @@ mod tests {
 
         cache.remove_provider(&provider_hashes[2], &outpoint);
         assert!(!cache.providers_by_outpoint.contains_key(&outpoint));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn removing_unknown_provider_panics_without_changing_existing_providers() {
+        let outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x49; 32]),
+            index: 0,
+        };
+        let output = transparent::Output {
+            value: Amount::zero(),
+            lock_script: transparent::Script::new(&[]),
+        };
+        let first_hash = block::Hash([1; 32]);
+        let second_hash = block::Hash([2; 32]);
+        let unknown_hash = block::Hash([3; 32]);
+        let first_utxo = transparent::Utxo::new(output.clone(), block::Height(1), false);
+        let second_utxo = transparent::Utxo::new(output, block::Height(2), false);
+        let mut cache = UtxoProviderCache::default();
+        cache.insert(first_hash, outpoint, first_utxo.clone());
+        cache.insert(second_hash, outpoint, second_utxo.clone());
+
+        let removal = catch_unwind(AssertUnwindSafe(|| {
+            cache.remove_provider(&unknown_hash, &outpoint);
+        }));
+
+        assert!(removal.is_err());
+        let Some(UtxoProviders::Multiple(providers)) = cache.providers_by_outpoint.get(&outpoint)
+        else {
+            panic!("the failed removal leaves both existing UTXO providers unchanged");
+        };
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers.get(&first_hash), Some(&first_utxo));
+        assert_eq!(providers.get(&second_hash), Some(&second_utxo));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn removing_unknown_outpoint_panics_without_changing_existing_outpoints() {
+        let existing_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x49; 32]),
+            index: 0,
+        };
+        let unknown_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x50; 32]),
+            index: 0,
+        };
+        let provider_hash = block::Hash([1; 32]);
+        let utxo = transparent::Utxo::new(
+            transparent::Output {
+                value: Amount::zero(),
+                lock_script: transparent::Script::new(&[]),
+            },
+            block::Height(1),
+            false,
+        );
+        let mut cache = UtxoProviderCache::default();
+        cache.insert(provider_hash, existing_outpoint, utxo.clone());
+
+        let removal = catch_unwind(AssertUnwindSafe(|| {
+            cache.remove_provider(&provider_hash, &unknown_outpoint);
+        }));
+
+        assert!(removal.is_err());
+        assert_eq!(cache.get(&existing_outpoint), Some(&utxo));
+        assert!(cache.get(&unknown_outpoint).is_none());
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn removing_unknown_ownership_is_a_release_no_op() {
+        let existing_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x49; 32]),
+            index: 0,
+        };
+        let unknown_outpoint = transparent::OutPoint {
+            hash: transaction::Hash([0x50; 32]),
+            index: 0,
+        };
+        let provider_hash = block::Hash([1; 32]);
+        let unknown_hash = block::Hash([2; 32]);
+        let utxo = transparent::Utxo::new(
+            transparent::Output {
+                value: Amount::zero(),
+                lock_script: transparent::Script::new(&[]),
+            },
+            block::Height(1),
+            false,
+        );
+        let mut cache = UtxoProviderCache::default();
+        cache.insert(provider_hash, existing_outpoint, utxo.clone());
+
+        cache.remove_provider(&unknown_hash, &existing_outpoint);
+        cache.remove_provider(&provider_hash, &unknown_outpoint);
+
+        assert_eq!(cache.get(&existing_outpoint), Some(&utxo));
+        assert!(cache.get(&unknown_outpoint).is_none());
     }
 }

--- a/docs/changelog/unreleased/797.md
+++ b/docs/changelog/unreleased/797.md
@@ -3,3 +3,6 @@
 - Preserved shared cached UTXOs until all queued or sent provider blocks are removed,
   avoiding unnecessary verification retries on competing chains
   ([#797](https://github.com/zakura-core/zakura/pull/797)).
+- Corrected sent-block cache reconstruction across restored competing chains so height
+  pruning removes eligible blocks from every fork
+  ([#797](https://github.com/zakura-core/zakura/pull/797)).

--- a/docs/changelog/unreleased/797.md
+++ b/docs/changelog/unreleased/797.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Preserved shared cached UTXOs until all queued or sent provider blocks are removed,
+  avoiding unnecessary verification retries on competing chains
+  ([#797](https://github.com/zakura-core/zakura/pull/797)).


### PR DESCRIPTION
## Motivation

Queued and sent block caches stored one UTXO value per outpoint but removed entries per block. When competing blocks contained the same non-coinbase transaction, removing either provider deleted the shared outpoint even while another live block still provided it. AwaitUtxo could then wait and retry unnecessarily.

Restored sent-block forks were also flattened into one pruning batch, so height pruning could stop at an ineligible block from one fork and leave eligible blocks from another fork behind.

## Solution

Track each cached UTXO by outpoint and provider block hash. Storage preserves every live provider value so removing one provider exposes the exact metadata supplied by a survivor. Lookup intentionally returns an arbitrary live provider while a collision remains; it does not select a branch.

Use an inline single-provider representation for the common case, promote to a provider map only on collisions, and collapse it after removals. Missing ownership is asserted in debug builds and remains a no-op in release builds.

Make sent-block registration idempotent and reconstruct one ordered pruning batch per non-finalized chain so every restored fork is pruned independently.

Integrate queued-body replacement with provider ownership: replacing one block removes its old outputs without deleting outputs still supplied by a competing block. Preserve the admission handling and queue bound introduced by #748.

## Performance tradeoffs

The common case keeps one provider hash and UTXO inline, avoiding a separate allocation but adding one 32-byte block hash per distinct cached outpoint. Shared outpoints allocate a provider map and retain each provider-specific UTXO until the collision is resolved; the entry collapses back to inline storage when only one provider remains. A reference count would use less memory, but it could not recover the surviving provider's metadata when the currently exposed provider is removed.

## Testing

Verified at `0af90da75`, rebased onto `origin/main` at `9b83b94fd`.

- Added regression coverage for queued dequeue, queued height pruning, sent height pruning, rejected sent-block removal, and both supported provider-removal orders.
- Added duplicate queued and sent block consistency tests.
- Verified exact surviving provider metadata and final cache cleanup.
- Added fork reconstruction, checkpoint-verified provider, and three-provider promotion/collapse coverage.
- Added unknown-provider and unknown-outpoint invariant tests in debug builds. Release no-op coverage checks both `Single` and `Multiple`, preserves both provider-specific values after an unknown-provider removal, and verifies subsequent cleanup.
- Retained the recursive failed-subtree cleanup test from #831 and added coverage for shared-provider cleanup across a failed subtree and a live competing branch.
- Retained #748's body-replacement and queue-bound tests. Added replacement coverage for both providers, exact surviving metadata, stale-output removal, and final cache/index cleanup.
- cargo test -p zakura-state service::queued_blocks --lib --locked (20 passed)
- cargo test -p zakura-state service::queued_blocks --lib --release --locked (19 passed)
- cargo test -p zakura-state --lib --locked --quiet -- --test-threads=2 (574 passed, 4 ignored)
- cargo clippy -p zakura-state --all-targets --release --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- ./scripts/changelog.py check
- npx --yes markdownlint-cli@0.41.0 docs/changelog/unreleased/797.md --config .github/.markdownlint.yaml

## Changelog

Added docs/changelog/unreleased/797.md for shared-provider retention and complete height pruning across restored competing chains. Validated it with the changelog and Markdown checks above.

### Specifications & References

Closes #493.
