### PR TITLE
fix(sync): break the VCT root-repair livelock

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -45,7 +45,7 @@ const VCT_REPAIR_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from
 const VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(10);
 /// Time one repair generation may stay unassignable before the reactor reports it at error level.
-const VCT_REPAIR_NO_SUPPLIER_WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+const VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
 /// Minimum interval between unchanged header-snapshot refresh trace rows.
 ///
 /// The trace records every frontier advance and reanchor.
@@ -1551,7 +1551,19 @@ impl HeaderSyncReactor {
                     }
                 }
                 HeaderTargetAdmissionResult::ResourceStalled(_) => {
-                    self.vct_repair.remove(repair_owner);
+                    // A local resource alarm stalled the commit, so nothing judged the delivery.
+                    // Back the task off instead of dropping it: the committer no longer bumps the
+                    // repair generation while it polls, so a dropped task would wait for an
+                    // unrelated snapshot change that a stalled node has no way to produce.
+                    let deferred = self.vct_repair.get_mut(repair_owner).is_some_and(|task| {
+                        task.retry(source).is_ok()
+                            && task
+                                .defer_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
+                                .is_ok()
+                    });
+                    if !deferred {
+                        self.vct_repair.remove(repair_owner);
+                    }
                     metrics::counter!("sync.header.vct.repair.resource_stalled.total").increment(1);
                 }
             }
@@ -1764,28 +1776,7 @@ impl HeaderSyncReactor {
         outcome: Option<&'static str>,
     ) {
         self.startup.trace.emit_with(HEADER_SYNC_TABLE, |row| {
-            row.insert(
-                hs_trace::EVENT.into(),
-                hs_trace::HEADER_VCT_REPAIR_STATE.into(),
-            );
-            insert_header_scope(row, task.owner.header);
-            row.insert(hs_trace::SESSION_ID.into(), task.owner.session_id.into());
-            row.insert(
-                hs_trace::REQUEST_ID.into(),
-                task.owner.request_id.get().into(),
-            );
-            row.insert(hs_trace::HEIGHT.into(), u64::from(task.height.0).into());
-            row.insert(
-                hs_trace::REPAIR_GENERATION.into(),
-                task.repair_generation.into(),
-            );
-            row.insert(hs_trace::PHASE.into(), phase.into());
-            row.insert(
-                hs_trace::SUPPLIER_COUNT.into(),
-                u64::try_from(task.tried_sources.len())
-                    .unwrap_or(u64::MAX)
-                    .into(),
-            );
+            insert_vct_repair_identity(row, task, phase);
             row.insert(
                 hs_trace::OUTCOME.into(),
                 outcome.map_or(serde_json::Value::Null, Into::into),
@@ -1796,9 +1787,9 @@ impl HeaderSyncReactor {
     /// Record a repair generation that no connected peer can supply.
     ///
     /// The reactor samples the trace row and escalates to error level once the generation has
-    /// stayed unassignable for [`VCT_REPAIR_NO_SUPPLIER_WARN_AFTER`]. Without the tally an
+    /// stayed unassignable for [`VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER`]. Without the tally an
     /// operator sees only that the repair made no progress.
-    fn note_vct_repair_without_supplier(
+    fn note_vct_repair_no_supplier(
         &mut self,
         task: &RepairRequirement,
         predecessor: zakura_header_chain::Frontier,
@@ -1826,7 +1817,7 @@ impl HeaderSyncReactor {
         let trace_due = open_record.is_none()
             || now.saturating_duration_since(record.last_trace)
                 >= VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL;
-        let report_due = !record.reported && stalled_for >= VCT_REPAIR_NO_SUPPLIER_WARN_AFTER;
+        let report_due = !record.reported && stalled_for >= VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER;
 
         if trace_due {
             self.emit_vct_repair_no_supplier(task, predecessor, rejections, best_peer_tip);
@@ -1863,45 +1854,35 @@ impl HeaderSyncReactor {
         best_peer_tip: Option<(block::Height, block::Hash)>,
     ) {
         self.startup.trace.emit_with(HEADER_SYNC_TABLE, |row| {
-            row.insert(
-                hs_trace::EVENT.into(),
-                hs_trace::HEADER_VCT_REPAIR_STATE.into(),
-            );
-            insert_header_scope(row, task.owner.header);
-            row.insert(hs_trace::SESSION_ID.into(), task.owner.session_id.into());
-            row.insert(
-                hs_trace::REQUEST_ID.into(),
-                task.owner.request_id.get().into(),
-            );
-            row.insert(hs_trace::HEIGHT.into(), u64::from(task.height.0).into());
+            insert_vct_repair_identity(row, task, "no_supplier");
             row.insert(
                 hs_trace::PREDECESSOR_HEIGHT.into(),
                 u64::from(predecessor.height.0).into(),
             );
             row.insert(
-                hs_trace::REPAIR_GENERATION.into(),
-                task.repair_generation.into(),
-            );
-            row.insert(hs_trace::PHASE.into(), "no_supplier".into());
-            row.insert(
-                hs_trace::SUPPLIER_COUNT.into(),
-                u64::try_from(task.tried_sources.len())
-                    .unwrap_or(u64::MAX)
-                    .into(),
-            );
-            row.insert(hs_trace::CANDIDATE_COUNT.into(), 0.into());
-            row.insert(
                 hs_trace::PEERS_CONSIDERED.into(),
                 rejections.considered.into(),
             );
-            row.insert(hs_trace::REJECTED_HEIGHT.into(), rejections.below_target_height.into());
+            row.insert(
+                hs_trace::REJECTED_HEIGHT.into(),
+                rejections.below_target_height.into(),
+            );
             row.insert(
                 hs_trace::REJECTED_CAPACITY.into(),
                 rejections.insufficient_capacity.into(),
             );
-            row.insert(hs_trace::REJECTED_SCHEMA.into(), rejections.unsupported_schema.into());
-            row.insert(hs_trace::REJECTED_BUSY.into(), rejections.already_serving.into());
-            row.insert(hs_trace::REJECTED_TRIED.into(), rejections.already_tried.into());
+            row.insert(
+                hs_trace::REJECTED_SCHEMA.into(),
+                rejections.unsupported_schema.into(),
+            );
+            row.insert(
+                hs_trace::REJECTED_BUSY.into(),
+                rejections.already_serving.into(),
+            );
+            row.insert(
+                hs_trace::REJECTED_TRIED.into(),
+                rejections.already_tried.into(),
+            );
             row.insert(
                 hs_trace::BEST_PEER_HEIGHT.into(),
                 best_peer_tip.map_or(serde_json::Value::Null, |(height, _)| {
@@ -2717,43 +2698,41 @@ impl HeaderSyncReactor {
         // supplier proves branch membership by returning the exact target hash after the exact
         // predecessor hash; the admission path rejects anything else.
         let mut rejections = VctSupplierRejections::default();
-        let mut candidates: Vec<_> = self
-            .peer_state
-            .iter()
-            .filter_map(|(peer, state)| {
-                let status = state.last_status.as_ref()?;
-                rejections.considered = rejections.considered.saturating_add(1);
-                if status.selected_tip_height < context.target.height {
-                    rejections.below_target_height = rejections.below_target_height.saturating_add(1);
-                    return None;
-                }
-                if status.max_headers_per_response == 0
-                    || status.max_inflight_requests == 0
-                    || usize::try_from(status.max_message_bytes).unwrap_or(usize::MAX)
-                        < response_bytes
-                {
-                    rejections.insufficient_capacity = rejections.insufficient_capacity.saturating_add(1);
-                    return None;
-                }
-                if status.tree_aux_schema_mask & AuxSchema::V1.mask_bit() == 0 {
-                    rejections.unsupported_schema = rejections.unsupported_schema.saturating_add(1);
-                    return None;
-                }
-                if self.peer_work_queue.active(peer).is_some() {
-                    rejections.already_serving = rejections.already_serving.saturating_add(1);
-                    return None;
-                }
-                let source = source_id_from_peer(peer);
-                if task.tried_sources.contains(&source) {
-                    rejections.already_tried = rejections.already_tried.saturating_add(1);
-                    return None;
-                }
-                Some((peer.clone(), source, state.session.clone(), status.clone()))
-            })
-            .collect();
+        let mut candidates = Vec::new();
+        for (peer, state) in &self.peer_state {
+            let Some(status) = state.last_status.as_ref() else {
+                continue;
+            };
+            rejections.considered += 1;
+            if status.selected_tip_height < context.target.height {
+                rejections.below_target_height += 1;
+                continue;
+            }
+            if status.max_headers_per_response == 0
+                || status.max_inflight_requests == 0
+                || usize::try_from(status.max_message_bytes).unwrap_or(usize::MAX) < response_bytes
+            {
+                rejections.insufficient_capacity += 1;
+                continue;
+            }
+            if status.tree_aux_schema_mask & AuxSchema::V1.mask_bit() == 0 {
+                rejections.unsupported_schema += 1;
+                continue;
+            }
+            if self.peer_work_queue.active(peer).is_some() {
+                rejections.already_serving += 1;
+                continue;
+            }
+            let source = source_id_from_peer(peer);
+            if task.tried_sources.contains(&source) {
+                rejections.already_tried += 1;
+                continue;
+            }
+            candidates.push((peer.clone(), source, state.session.clone(), status.clone()));
+        }
         candidates.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
         if candidates.is_empty() {
-            self.note_vct_repair_without_supplier(&task, predecessor, &rejections, now);
+            self.note_vct_repair_no_supplier(&task, predecessor, &rejections, now);
             let _ = self
                 .vct_repair
                 .get_mut(task.owner)
@@ -2761,7 +2740,6 @@ impl HeaderSyncReactor {
                 .defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
             return;
         }
-        self.vct_repair_no_supplier = None;
         for (peer, source, session, mut status) in candidates {
             self.peer_work_queue.remove_unstarted(&peer);
             if self.peer_work_queue.reservable_header_count(1) != 1
@@ -2810,6 +2788,10 @@ impl HeaderSyncReactor {
                 self.peer_work_queue.cancel_request_reservation(&peer);
                 return;
             }
+            // The repair reached a supplier, so the unassignable clock starts over. Clearing it
+            // on a non-empty candidate set instead would restart the clock even when every
+            // candidate failed to send, and suppress the escalation the operator needs.
+            self.vct_repair_no_supplier = None;
             if let Some(task) = self.vct_repair.get(wire_owner) {
                 self.emit_vct_repair_state(task, "assignment", Some("assigned"));
             }
@@ -4496,6 +4478,39 @@ fn headers_outcome_label(outcome: HeadersOutcomeCode) -> &'static str {
         HeadersOutcomeCode::HistoryPruned => "history_pruned",
         HeadersOutcomeCode::Busy => "busy",
     }
+}
+
+/// Insert the fields every `header_vct_repair_state` row carries.
+///
+/// The event has two variants — the per-phase progress row and the no-supplier tally — and this
+/// keeps them from drifting apart in schema.
+fn insert_vct_repair_identity(
+    row: &mut serde_json::Map<String, serde_json::Value>,
+    task: &RepairRequirement,
+    phase: &'static str,
+) {
+    row.insert(
+        hs_trace::EVENT.into(),
+        hs_trace::HEADER_VCT_REPAIR_STATE.into(),
+    );
+    insert_header_scope(row, task.owner.header);
+    row.insert(hs_trace::SESSION_ID.into(), task.owner.session_id.into());
+    row.insert(
+        hs_trace::REQUEST_ID.into(),
+        task.owner.request_id.get().into(),
+    );
+    row.insert(hs_trace::HEIGHT.into(), u64::from(task.height.0).into());
+    row.insert(
+        hs_trace::REPAIR_GENERATION.into(),
+        task.repair_generation.into(),
+    );
+    row.insert(hs_trace::PHASE.into(), phase.into());
+    row.insert(
+        hs_trace::SUPPLIER_COUNT.into(),
+        u64::try_from(task.tried_sources.len())
+            .unwrap_or(u64::MAX)
+            .into(),
+    );
 }
 
 fn insert_header_scope(

--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -38,6 +38,14 @@ use crate::zakura::{
 const INTERNAL_VCT_REPAIR_SESSION_ID: u64 = u64::MAX;
 const LEASE_RELEASE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const VCT_REPAIR_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+/// Minimum interval between repeated unassignable-repair trace rows for one repair generation.
+///
+/// The reactor emits the first row immediately, then samples while nothing changes. The bound
+/// keeps a long unassignable repair from dominating the header-sync JSONL trace.
+const VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(10);
+/// Time one repair generation may stay unassignable before the reactor reports it at error level.
+const VCT_REPAIR_NO_SUPPLIER_WARN_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
 /// Minimum interval between unchanged header-snapshot refresh trace rows.
 ///
 /// The trace records every frontier advance and reanchor.
@@ -169,6 +177,7 @@ fn build_header_sync_reactor(
         request_deadlines: HashMap::new(),
         completed_targets: CompletedHeaderTargets::default(),
         vct_repair: RepairRequirementSlot::default(),
+        vct_repair_no_supplier: None,
         served_paths: HashMap::new(),
         served_path_deadlines: HashMap::new(),
         pending_lease_releases: VecDeque::new(),
@@ -265,6 +274,8 @@ struct HeaderSyncReactor {
     request_deadlines: HashMap<ZakuraPeerId, Instant>,
     completed_targets: CompletedHeaderTargets,
     vct_repair: RepairRequirementSlot,
+    /// Escalation state for a repair generation that no peer can supply.
+    vct_repair_no_supplier: Option<VctRepairNoSupplier>,
     served_paths: HashMap<ZakuraPeerId, ServedPathState>,
     served_path_deadlines: HashMap<ZakuraPeerId, Instant>,
     pending_lease_releases: VecDeque<PendingLeaseRelease>,
@@ -376,6 +387,39 @@ fn vct_repair_task(
     let scope = zakura_header_chain::BodyWorkAuthority::for_snapshot(snapshot);
     let owner = scope.bind(INTERNAL_VCT_REPAIR_SESSION_ID, request_id);
     Some(RepairRequirement::new(owner, height, status.generation))
+}
+
+/// Why each advertised peer failed to qualify as a VCT repair supplier.
+///
+/// The reactor reports the tally when no supplier qualifies. Without it the trace records only
+/// that the repair made no progress, not which requirement excluded the network.
+#[derive(Copy, Clone, Debug, Default)]
+struct VctSupplierRejections {
+    /// Peers that had advertised a status.
+    considered: u64,
+    /// Peers whose selected tip is below the repair target.
+    height: u64,
+    /// Peers that advertise no capacity for the one-header repair response.
+    capacity: u64,
+    /// Peers that do not support the V1 auxiliary schema.
+    schema: u64,
+    /// Peers already serving another header request.
+    busy: u64,
+    /// Peers already tried in the current supplier cycle.
+    tried: u64,
+}
+
+/// One repair generation that has found no eligible supplier.
+#[derive(Copy, Clone, Debug)]
+struct VctRepairNoSupplier {
+    /// Repair generation this record tracks.
+    generation: u64,
+    /// First observation of the unassignable generation.
+    since: Instant,
+    /// Last emitted trace row.
+    last_trace: Instant,
+    /// Whether the reactor already reported this generation at error level.
+    reported: bool,
 }
 
 #[cfg_attr(any(test, feature = "zakura-testkit"), allow(dead_code))]
@@ -1749,7 +1793,137 @@ impl HeaderSyncReactor {
         });
     }
 
+    /// Record a repair generation that no connected peer can supply.
+    ///
+    /// The reactor samples the trace row and escalates to error level once the generation has
+    /// stayed unassignable for [`VCT_REPAIR_NO_SUPPLIER_WARN_AFTER`]. Without the tally an
+    /// operator sees only that the repair made no progress.
+    fn note_vct_repair_without_supplier(
+        &mut self,
+        task: &RepairRequirement,
+        predecessor: zakura_header_chain::Frontier,
+        rejections: &VctSupplierRejections,
+        now: Instant,
+    ) {
+        metrics::counter!("sync.header.vct.repair.no_supplier.total").increment(1);
+        let best_peer_tip = self
+            .peer_state
+            .values()
+            .filter_map(|state| state.last_status.as_ref())
+            .map(|status| (status.selected_tip_height, status.selected_tip_hash))
+            .max_by_key(|(height, _)| *height);
+
+        let record = match self.vct_repair_no_supplier {
+            Some(record) if record.generation == task.repair_generation => record,
+            _ => VctRepairNoSupplier {
+                generation: task.repair_generation,
+                since: now,
+                last_trace: now,
+                reported: false,
+            },
+        };
+        let first_observation = self
+            .vct_repair_no_supplier
+            .is_none_or(|previous| previous.generation != task.repair_generation);
+        let trace_due = first_observation
+            || now.saturating_duration_since(record.last_trace)
+                >= VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL;
+        let stalled_for = now.saturating_duration_since(record.since);
+        let report_due = !record.reported && stalled_for >= VCT_REPAIR_NO_SUPPLIER_WARN_AFTER;
+
+        if trace_due {
+            self.emit_vct_repair_no_supplier(task, predecessor, rejections, best_peer_tip);
+        }
+        if report_due {
+            tracing::error!(
+                height = ?task.height,
+                predecessor_height = ?predecessor.height,
+                repair_generation = task.repair_generation,
+                branch_target = ?task.owner.branch.target_tip_hash,
+                ?best_peer_tip,
+                peers_considered = rejections.considered,
+                rejected_height = rejections.height,
+                rejected_capacity = rejections.capacity,
+                rejected_schema = rejections.schema,
+                rejected_busy = rejections.busy,
+                rejected_tried = rejections.tried,
+                ?stalled_for,
+                "VCT: no connected peer can supply the repair root; the parked checkpoint commit \
+                 cannot advance until an eligible supplier appears"
+            );
+        }
+
+        self.vct_repair_no_supplier = Some(VctRepairNoSupplier {
+            generation: task.repair_generation,
+            since: record.since,
+            last_trace: if trace_due { now } else { record.last_trace },
+            reported: record.reported || report_due,
+        });
+    }
+
+    fn emit_vct_repair_no_supplier(
+        &self,
+        task: &RepairRequirement,
+        predecessor: zakura_header_chain::Frontier,
+        rejections: &VctSupplierRejections,
+        best_peer_tip: Option<(block::Height, block::Hash)>,
+    ) {
+        self.startup.trace.emit_with(HEADER_SYNC_TABLE, |row| {
+            row.insert(
+                hs_trace::EVENT.into(),
+                hs_trace::HEADER_VCT_REPAIR_STATE.into(),
+            );
+            insert_header_scope(row, task.owner.header);
+            row.insert(hs_trace::SESSION_ID.into(), task.owner.session_id.into());
+            row.insert(
+                hs_trace::REQUEST_ID.into(),
+                task.owner.request_id.get().into(),
+            );
+            row.insert(hs_trace::HEIGHT.into(), u64::from(task.height.0).into());
+            row.insert(
+                hs_trace::PREDECESSOR_HEIGHT.into(),
+                u64::from(predecessor.height.0).into(),
+            );
+            row.insert(
+                hs_trace::REPAIR_GENERATION.into(),
+                task.repair_generation.into(),
+            );
+            row.insert(hs_trace::PHASE.into(), "no_supplier".into());
+            row.insert(
+                hs_trace::SUPPLIER_COUNT.into(),
+                u64::try_from(task.tried_sources.len())
+                    .unwrap_or(u64::MAX)
+                    .into(),
+            );
+            row.insert(hs_trace::CANDIDATE_COUNT.into(), 0.into());
+            row.insert(
+                hs_trace::PEERS_CONSIDERED.into(),
+                rejections.considered.into(),
+            );
+            row.insert(hs_trace::REJECTED_HEIGHT.into(), rejections.height.into());
+            row.insert(
+                hs_trace::REJECTED_CAPACITY.into(),
+                rejections.capacity.into(),
+            );
+            row.insert(hs_trace::REJECTED_SCHEMA.into(), rejections.schema.into());
+            row.insert(hs_trace::REJECTED_BUSY.into(), rejections.busy.into());
+            row.insert(hs_trace::REJECTED_TRIED.into(), rejections.tried.into());
+            row.insert(
+                hs_trace::BEST_PEER_HEIGHT.into(),
+                best_peer_tip.map_or(serde_json::Value::Null, |(height, _)| {
+                    u64::from(height.0).into()
+                }),
+            );
+            row.insert(
+                hs_trace::BEST_PEER_HASH.into(),
+                best_peer_tip.map_or(serde_json::Value::Null, |(_, hash)| hash.to_string().into()),
+            );
+            row.insert(hs_trace::OUTCOME.into(), "no_eligible_supplier".into());
+        });
+    }
+
     fn retire_vct_repair(&mut self) {
+        self.vct_repair_no_supplier = None;
         if let Some(task) = self.vct_repair.take() {
             if let Some(peer) = self
                 .peer_work_queue
@@ -2543,36 +2717,49 @@ impl HeaderSyncReactor {
         };
         let response_bytes = headers_response_bytes(&self.startup.network, AuxSchema::V1, 1)
             .expect("one fixed-width response fits in usize");
+        // A peer can serve the exact repair target from its retained header graph or from its
+        // finalized state, and those two bands are exhaustive below its selected tip. The filter
+        // therefore checks only reachable height, response capacity, and schema support. The
+        // supplier proves branch membership by returning the exact target hash after the exact
+        // predecessor hash; the admission path rejects anything else.
+        let mut rejections = VctSupplierRejections::default();
         let mut candidates: Vec<_> = self
             .peer_state
             .iter()
             .filter_map(|(peer, state)| {
                 let status = state.last_status.as_ref()?;
-                (status.selected_tip_hash == task.owner.branch.target_tip_hash
-                    && status.selected_tip_height >= context.target.height
-                    && status.oldest_retained_height <= predecessor.height
-                    && status.max_headers_per_response != 0
-                    && status.max_inflight_requests != 0
-                    && usize::try_from(status.max_message_bytes).unwrap_or(usize::MAX)
-                        >= response_bytes
-                    && status.tree_aux_schema_mask & AuxSchema::V1.mask_bit() != 0
-                    && self.peer_work_queue.active(peer).is_none())
-                .then(|| {
-                    (
-                        peer.clone(),
-                        source_id_from_peer(peer),
-                        state.session.clone(),
-                        status.clone(),
-                    )
-                })
+                rejections.considered = rejections.considered.saturating_add(1);
+                if status.selected_tip_height < context.target.height {
+                    rejections.height = rejections.height.saturating_add(1);
+                    return None;
+                }
+                if status.max_headers_per_response == 0
+                    || status.max_inflight_requests == 0
+                    || usize::try_from(status.max_message_bytes).unwrap_or(usize::MAX)
+                        < response_bytes
+                {
+                    rejections.capacity = rejections.capacity.saturating_add(1);
+                    return None;
+                }
+                if status.tree_aux_schema_mask & AuxSchema::V1.mask_bit() == 0 {
+                    rejections.schema = rejections.schema.saturating_add(1);
+                    return None;
+                }
+                if self.peer_work_queue.active(peer).is_some() {
+                    rejections.busy = rejections.busy.saturating_add(1);
+                    return None;
+                }
+                let source = source_id_from_peer(peer);
+                if task.tried_sources.contains(&source) {
+                    rejections.tried = rejections.tried.saturating_add(1);
+                    return None;
+                }
+                Some((peer.clone(), source, state.session.clone(), status.clone()))
             })
             .collect();
         candidates.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
-        let candidates: Vec<_> = candidates
-            .into_iter()
-            .filter(|(_, source, _, _)| !task.tried_sources.contains(source))
-            .collect();
         if candidates.is_empty() {
+            self.note_vct_repair_without_supplier(&task, predecessor, &rejections, now);
             let _ = self
                 .vct_repair
                 .get_mut(task.owner)
@@ -2580,6 +2767,7 @@ impl HeaderSyncReactor {
                 .defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
             return;
         }
+        self.vct_repair_no_supplier = None;
         for (peer, source, session, mut status) in candidates {
             self.peer_work_queue.remove_unstarted(&peer);
             if self.peer_work_queue.reservable_header_count(1) != 1

--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -398,15 +398,15 @@ struct VctSupplierRejections {
     /// Peers that had advertised a status.
     considered: u64,
     /// Peers whose selected tip is below the repair target.
-    height: u64,
+    below_target_height: u64,
     /// Peers that advertise no capacity for the one-header repair response.
-    capacity: u64,
+    insufficient_capacity: u64,
     /// Peers that do not support the V1 auxiliary schema.
-    schema: u64,
+    unsupported_schema: u64,
     /// Peers already serving another header request.
-    busy: u64,
+    already_serving: u64,
     /// Peers already tried in the current supplier cycle.
-    tried: u64,
+    already_tried: u64,
 }
 
 /// One repair generation that has found no eligible supplier.
@@ -1813,26 +1813,24 @@ impl HeaderSyncReactor {
             .map(|status| (status.selected_tip_height, status.selected_tip_hash))
             .max_by_key(|(height, _)| *height);
 
-        let record = match self.vct_repair_no_supplier {
-            Some(record) if record.generation == task.repair_generation => record,
-            _ => VctRepairNoSupplier {
-                generation: task.repair_generation,
-                since: now,
-                last_trace: now,
-                reported: false,
-            },
-        };
-        let first_observation = self
+        let open_record = self
             .vct_repair_no_supplier
-            .is_none_or(|previous| previous.generation != task.repair_generation);
-        let trace_due = first_observation
+            .filter(|record| record.generation == task.repair_generation);
+        let mut record = open_record.unwrap_or(VctRepairNoSupplier {
+            generation: task.repair_generation,
+            since: now,
+            last_trace: now,
+            reported: false,
+        });
+        let stalled_for = now.saturating_duration_since(record.since);
+        let trace_due = open_record.is_none()
             || now.saturating_duration_since(record.last_trace)
                 >= VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL;
-        let stalled_for = now.saturating_duration_since(record.since);
         let report_due = !record.reported && stalled_for >= VCT_REPAIR_NO_SUPPLIER_WARN_AFTER;
 
         if trace_due {
             self.emit_vct_repair_no_supplier(task, predecessor, rejections, best_peer_tip);
+            record.last_trace = now;
         }
         if report_due {
             tracing::error!(
@@ -1842,23 +1840,19 @@ impl HeaderSyncReactor {
                 branch_target = ?task.owner.branch.target_tip_hash,
                 ?best_peer_tip,
                 peers_considered = rejections.considered,
-                rejected_height = rejections.height,
-                rejected_capacity = rejections.capacity,
-                rejected_schema = rejections.schema,
-                rejected_busy = rejections.busy,
-                rejected_tried = rejections.tried,
+                rejected_height = rejections.below_target_height,
+                rejected_capacity = rejections.insufficient_capacity,
+                rejected_schema = rejections.unsupported_schema,
+                rejected_busy = rejections.already_serving,
+                rejected_tried = rejections.already_tried,
                 ?stalled_for,
                 "VCT: no connected peer can supply the repair root; the parked checkpoint commit \
                  cannot advance until an eligible supplier appears"
             );
+            record.reported = true;
         }
 
-        self.vct_repair_no_supplier = Some(VctRepairNoSupplier {
-            generation: task.repair_generation,
-            since: record.since,
-            last_trace: if trace_due { now } else { record.last_trace },
-            reported: record.reported || report_due,
-        });
+        self.vct_repair_no_supplier = Some(record);
     }
 
     fn emit_vct_repair_no_supplier(
@@ -1900,14 +1894,14 @@ impl HeaderSyncReactor {
                 hs_trace::PEERS_CONSIDERED.into(),
                 rejections.considered.into(),
             );
-            row.insert(hs_trace::REJECTED_HEIGHT.into(), rejections.height.into());
+            row.insert(hs_trace::REJECTED_HEIGHT.into(), rejections.below_target_height.into());
             row.insert(
                 hs_trace::REJECTED_CAPACITY.into(),
-                rejections.capacity.into(),
+                rejections.insufficient_capacity.into(),
             );
-            row.insert(hs_trace::REJECTED_SCHEMA.into(), rejections.schema.into());
-            row.insert(hs_trace::REJECTED_BUSY.into(), rejections.busy.into());
-            row.insert(hs_trace::REJECTED_TRIED.into(), rejections.tried.into());
+            row.insert(hs_trace::REJECTED_SCHEMA.into(), rejections.unsupported_schema.into());
+            row.insert(hs_trace::REJECTED_BUSY.into(), rejections.already_serving.into());
+            row.insert(hs_trace::REJECTED_TRIED.into(), rejections.already_tried.into());
             row.insert(
                 hs_trace::BEST_PEER_HEIGHT.into(),
                 best_peer_tip.map_or(serde_json::Value::Null, |(height, _)| {
@@ -2730,7 +2724,7 @@ impl HeaderSyncReactor {
                 let status = state.last_status.as_ref()?;
                 rejections.considered = rejections.considered.saturating_add(1);
                 if status.selected_tip_height < context.target.height {
-                    rejections.height = rejections.height.saturating_add(1);
+                    rejections.below_target_height = rejections.below_target_height.saturating_add(1);
                     return None;
                 }
                 if status.max_headers_per_response == 0
@@ -2738,20 +2732,20 @@ impl HeaderSyncReactor {
                     || usize::try_from(status.max_message_bytes).unwrap_or(usize::MAX)
                         < response_bytes
                 {
-                    rejections.capacity = rejections.capacity.saturating_add(1);
+                    rejections.insufficient_capacity = rejections.insufficient_capacity.saturating_add(1);
                     return None;
                 }
                 if status.tree_aux_schema_mask & AuxSchema::V1.mask_bit() == 0 {
-                    rejections.schema = rejections.schema.saturating_add(1);
+                    rejections.unsupported_schema = rejections.unsupported_schema.saturating_add(1);
                     return None;
                 }
                 if self.peer_work_queue.active(peer).is_some() {
-                    rejections.busy = rejections.busy.saturating_add(1);
+                    rejections.already_serving = rejections.already_serving.saturating_add(1);
                     return None;
                 }
                 let source = source_id_from_peer(peer);
                 if task.tried_sources.contains(&source) {
-                    rejections.tried = rejections.tried.saturating_add(1);
+                    rejections.already_tried = rejections.already_tried.saturating_add(1);
                     return None;
                 }
                 Some((peer.clone(), source, state.session.clone(), status.clone()))

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::zakura::testkit::{TraceCapture, TraceValue};
 
 #[test]
 fn vct_repair_signal_schedules_one_exact_current_height() {
@@ -443,109 +444,27 @@ async fn retired_vct_request_response_has_no_actions_or_peer_score() {
         .expect("the late-response reactor stops cleanly");
 }
 
-/// A supplier that has moved past the repair height must still be eligible.
-///
-/// This is the shape the stalled mainnet nodes saw: every peer advertised a different selected
-/// tip and had finalized past the repair predecessor. Requiring the supplier to sit on our own
-/// stalled tip, and to retain history below it, left the repair with no supplier at all.
-#[tokio::test]
-async fn vct_repair_accepts_a_supplier_ahead_of_the_stalled_branch() {
-    let shutdown = CancellationToken::new();
-    let mut startup = startup(shutdown.clone());
-    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
-    let mut repair_block_header = *regtest_genesis_block().header;
-    repair_block_header.previous_block_hash = anchor.hash;
-    repair_block_header.time += chrono::Duration::seconds(1);
-    let repair_block_header = Arc::new(repair_block_header);
-    let repair_header =
-        zakura_header_chain::Frontier::new(block::Height(1), repair_block_header.hash());
-    let selected_tip = zakura_header_chain::Frontier::new(block::Height(2), block::Hash([3; 32]));
-    let mut snapshot = committed_snapshot(anchor);
-    snapshot.frontiers.header_best = selected_tip;
-    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
-    startup.committed_snapshots = Some(snapshots_rx);
-    let (_repairs_tx, repairs_rx) = watch::channel(zakura_header_chain::VctRootRepairStatus {
-        state: zakura_header_chain::VctRootRepairState::Unavailable {
-            height: repair_header.height,
-        },
-        generation: 7,
-    });
-    startup.vct_root_repairs = Some(repairs_rx);
-    let (handle, mut actions, reactor) =
-        spawn_header_sync_reactor(startup).expect("the repair fixture starts");
-    let HeaderPortOperation::QueryVctRepairContext { owner, .. } = next_action(&mut actions).await
-    else {
-        panic!("the exact repair context query precedes ordinary maintenance");
-    };
-
-    let (send, mut outbound) = framed_channel(8);
-    let peer = peer();
-    handle
-        .send(Event::PeerConnected(PeerSession::from_parts(
-            peer.clone(),
-            send,
-            CancellationToken::new(),
-        )))
-        .await
-        .expect("the repair supplier connects");
-    let _status = outbound.recv().await.expect("the local status is sent");
-    handle
-        .send(Event::WireMessage {
-            peer: peer.clone(),
-            session_id: 0,
-            msg: HeaderSyncMessage::Status(Status {
-                work_anchor_height: anchor.height,
-                work_anchor_hash: anchor.hash,
-                // A tip we have never selected, well ahead of the stalled branch.
-                selected_tip_height: block::Height(9),
-                selected_tip_hash: block::Hash([9; 32]),
-                suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(9_u8),
-                // Finalized past the repair predecessor, so nothing below is retained.
-                oldest_retained_height: block::Height(5),
-                max_headers_per_response: 1,
-                max_inflight_requests: 1,
-                max_message_bytes: 2_000_000,
-                tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
-            }),
-        })
-        .await
-        .expect("the repair supplier status reaches the reactor");
-    handle
-        .send(Event::VctRepairContextReady {
-            owner,
-            result: VctRepairContextResult::Resolved(zakura_header_chain::VctRepairContext {
-                target: repair_header,
-                locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
-            }),
-        })
-        .await
-        .expect("the exact repair context reaches the reactor");
-
-    let request = outbound.recv().await.expect("the repair request is sent");
-    let HeaderSyncMessage::GetHeaders(request) = handle
-        .codec()
-        .decode_frame(request, None)
-        .expect("the canonical repair request decodes")
-    else {
-        panic!("the repair uses the canonical GetHeaders message");
-    };
-    assert_eq!(request.target_tip_hash, repair_header.hash);
-    assert_eq!(request.locator_hashes, vec![anchor.hash]);
-    assert_eq!(request.max_header_count, 1);
-    assert_eq!(request.tree_aux_schema, AuxSchema::V1);
-
-    shutdown.cancel();
-    reactor.await.expect("the reactor task joins");
+/// A VCT repair that has resolved its exact context, with one peer connected and advertised.
+struct RepairAwaitingSupplier {
+    handle: HeaderSyncHandle,
+    outbound: crate::zakura::FramedRecv,
+    reactor: JoinHandle<()>,
+    anchor: zakura_header_chain::Frontier,
+    repair_header: zakura_header_chain::Frontier,
 }
 
-/// A peer that cannot reach the repair height never receives a request, and the repair defers.
+/// Drive a VCT repair to the moment the reactor can choose a supplier.
 ///
-/// The deferral path also builds the rejection tally the operator needs: without it the trace
-/// records only that the repair made no progress, not which requirement excluded the network.
-#[tokio::test]
-async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
-    let shutdown = CancellationToken::new();
-    let mut startup = startup(shutdown.clone());
+/// The reactor starts with `header_best` two blocks past the anchor and an unavailable root at
+/// height 1, which is the stalled shape the fix addresses. One peer connects and advertises the
+/// status `supplier_status` builds from the anchor, then the exact repair context arrives. What
+/// the reactor does with that peer is the behavior each caller asserts.
+///
+/// The caller supplies `startup` so it can install a trace capture before the reactor runs.
+async fn repair_awaiting_supplier(
+    mut startup: HeaderSyncStartup,
+    supplier_status: impl FnOnce(zakura_header_chain::Frontier) -> Status,
+) -> RepairAwaitingSupplier {
     let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
     let mut repair_block_header = *regtest_genesis_block().header;
     repair_block_header.previous_block_hash = anchor.hash;
@@ -581,28 +500,16 @@ async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
             CancellationToken::new(),
         )))
         .await
-        .expect("the peer connects");
+        .expect("the repair supplier connects");
     let _status = outbound.recv().await.expect("the local status is sent");
     handle
         .send(Event::WireMessage {
             peer: peer.clone(),
             session_id: 0,
-            msg: HeaderSyncMessage::Status(Status {
-                work_anchor_height: anchor.height,
-                work_anchor_hash: anchor.hash,
-                // Below the repair target, so this peer cannot hold the header at all.
-                selected_tip_height: anchor.height,
-                selected_tip_hash: anchor.hash,
-                suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(1_u8),
-                oldest_retained_height: anchor.height,
-                max_headers_per_response: 1,
-                max_inflight_requests: 1,
-                max_message_bytes: 2_000_000,
-                tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
-            }),
+            msg: HeaderSyncMessage::Status(supplier_status(anchor)),
         })
         .await
-        .expect("the peer status reaches the reactor");
+        .expect("the repair supplier status reaches the reactor");
     handle
         .send(Event::VctRepairContextReady {
             owner,
@@ -614,6 +521,93 @@ async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
         .await
         .expect("the exact repair context reaches the reactor");
 
+    RepairAwaitingSupplier {
+        handle,
+        outbound,
+        reactor,
+        anchor,
+        repair_header,
+    }
+}
+
+/// A supplier that has moved past the repair height must still be eligible.
+///
+/// This is the shape the stalled mainnet nodes saw: every peer advertised a different selected
+/// tip and had finalized past the repair predecessor. Requiring the supplier to sit on our own
+/// stalled tip, and to retain history below it, left the repair with no supplier at all.
+#[tokio::test]
+async fn vct_repair_accepts_a_supplier_ahead_of_the_stalled_branch() {
+    let shutdown = CancellationToken::new();
+    let RepairAwaitingSupplier {
+        handle,
+        mut outbound,
+        reactor,
+        anchor,
+        repair_header,
+    } = repair_awaiting_supplier(startup(shutdown.clone()), |anchor| Status {
+        work_anchor_height: anchor.height,
+        work_anchor_hash: anchor.hash,
+        // A tip we have never selected, well ahead of the stalled branch.
+        selected_tip_height: block::Height(9),
+        selected_tip_hash: block::Hash([9; 32]),
+        suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(9_u8),
+        // Finalized past the repair predecessor, so nothing below is retained.
+        oldest_retained_height: block::Height(5),
+        max_headers_per_response: 1,
+        max_inflight_requests: 1,
+        max_message_bytes: 2_000_000,
+        tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+    })
+    .await;
+
+    let request = outbound.recv().await.expect("the repair request is sent");
+    let HeaderSyncMessage::GetHeaders(request) = handle
+        .codec()
+        .decode_frame(request, None)
+        .expect("the canonical repair request decodes")
+    else {
+        panic!("the repair uses the canonical GetHeaders message");
+    };
+    assert_eq!(request.target_tip_hash, repair_header.hash);
+    assert_eq!(request.locator_hashes, vec![anchor.hash]);
+    assert_eq!(request.max_header_count, 1);
+    assert_eq!(request.tree_aux_schema, AuxSchema::V1);
+
+    shutdown.cancel();
+    reactor.await.expect("the reactor task joins");
+}
+
+/// A peer that cannot reach the repair height never receives a request, and the repair defers.
+///
+/// The deferral also emits the rejection tally naming the requirement that excluded the peer.
+#[tokio::test]
+async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
+    let mut capture =
+        TraceCapture::for_test("vct_repair_defers_when_no_peer_reaches_the_repair_height")
+            .expect("trace capture starts");
+    let shutdown = CancellationToken::new();
+    let mut startup = startup(shutdown.clone());
+    startup.trace = crate::zakura::ZakuraTrace::new(capture.tracer(), "vct-repair-test");
+    let RepairAwaitingSupplier {
+        handle: _handle,
+        mut outbound,
+        reactor,
+        ..
+    } = repair_awaiting_supplier(startup, |anchor| Status {
+        work_anchor_height: anchor.height,
+        work_anchor_hash: anchor.hash,
+        // Below the repair target, so this peer cannot hold the header at all.
+        selected_tip_height: anchor.height,
+        selected_tip_hash: anchor.hash,
+        suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(1_u8),
+        oldest_retained_height: anchor.height,
+        max_headers_per_response: 1,
+        max_inflight_requests: 1,
+        max_message_bytes: 2_000_000,
+        tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+    })
+    .await;
+
     assert!(
         tokio::time::timeout(std::time::Duration::from_millis(200), outbound.recv())
             .await
@@ -623,4 +617,20 @@ async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
 
     shutdown.cancel();
     reactor.await.expect("the reactor task joins");
+
+    // The tally is the operator's evidence: without it the trace records only that the repair
+    // made no progress, not which requirement excluded the network.
+    capture.flush().await;
+    let reader = capture.reader().expect("the trace reloads");
+    reader.table(HEADER_SYNC_TABLE.table()).assert_row(
+        hs_trace::HEADER_VCT_REPAIR_STATE,
+        &[
+            (hs_trace::PHASE, TraceValue::Str("no_supplier")),
+            (hs_trace::PEERS_CONSIDERED, TraceValue::U64(1)),
+            (hs_trace::REJECTED_HEIGHT, TraceValue::U64(1)),
+            (hs_trace::REJECTED_CAPACITY, TraceValue::U64(0)),
+            (hs_trace::OUTCOME, TraceValue::Str("no_eligible_supplier")),
+        ],
+    );
+    let _ = capture.finish().await.expect("trace capture finishes");
 }

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
@@ -442,3 +442,185 @@ async fn retired_vct_request_response_has_no_actions_or_peer_score() {
         .await
         .expect("the late-response reactor stops cleanly");
 }
+
+/// A supplier that has moved past the repair height must still be eligible.
+///
+/// This is the shape the stalled mainnet nodes saw: every peer advertised a different selected
+/// tip and had finalized past the repair predecessor. Requiring the supplier to sit on our own
+/// stalled tip, and to retain history below it, left the repair with no supplier at all.
+#[tokio::test]
+async fn vct_repair_accepts_a_supplier_ahead_of_the_stalled_branch() {
+    let shutdown = CancellationToken::new();
+    let mut startup = startup(shutdown.clone());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut repair_block_header = *regtest_genesis_block().header;
+    repair_block_header.previous_block_hash = anchor.hash;
+    repair_block_header.time += chrono::Duration::seconds(1);
+    let repair_block_header = Arc::new(repair_block_header);
+    let repair_header =
+        zakura_header_chain::Frontier::new(block::Height(1), repair_block_header.hash());
+    let selected_tip = zakura_header_chain::Frontier::new(block::Height(2), block::Hash([3; 32]));
+    let mut snapshot = committed_snapshot(anchor);
+    snapshot.frontiers.header_best = selected_tip;
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_repairs_tx, repairs_rx) = watch::channel(zakura_header_chain::VctRootRepairStatus {
+        state: zakura_header_chain::VctRootRepairState::Unavailable {
+            height: repair_header.height,
+        },
+        generation: 7,
+    });
+    startup.vct_root_repairs = Some(repairs_rx);
+    let (handle, mut actions, reactor) =
+        spawn_header_sync_reactor(startup).expect("the repair fixture starts");
+    let HeaderPortOperation::QueryVctRepairContext { owner, .. } = next_action(&mut actions).await
+    else {
+        panic!("the exact repair context query precedes ordinary maintenance");
+    };
+
+    let (send, mut outbound) = framed_channel(8);
+    let peer = peer();
+    handle
+        .send(Event::PeerConnected(PeerSession::from_parts(
+            peer.clone(),
+            send,
+            CancellationToken::new(),
+        )))
+        .await
+        .expect("the repair supplier connects");
+    let _status = outbound.recv().await.expect("the local status is sent");
+    handle
+        .send(Event::WireMessage {
+            peer: peer.clone(),
+            session_id: 0,
+            msg: HeaderSyncMessage::Status(Status {
+                work_anchor_height: anchor.height,
+                work_anchor_hash: anchor.hash,
+                // A tip we have never selected, well ahead of the stalled branch.
+                selected_tip_height: block::Height(9),
+                selected_tip_hash: block::Hash([9; 32]),
+                suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(9_u8),
+                // Finalized past the repair predecessor, so nothing below is retained.
+                oldest_retained_height: block::Height(5),
+                max_headers_per_response: 1,
+                max_inflight_requests: 1,
+                max_message_bytes: 2_000_000,
+                tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+            }),
+        })
+        .await
+        .expect("the repair supplier status reaches the reactor");
+    handle
+        .send(Event::VctRepairContextReady {
+            owner,
+            result: VctRepairContextResult::Resolved(zakura_header_chain::VctRepairContext {
+                target: repair_header,
+                locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+            }),
+        })
+        .await
+        .expect("the exact repair context reaches the reactor");
+
+    let request = outbound.recv().await.expect("the repair request is sent");
+    let HeaderSyncMessage::GetHeaders(request) = handle
+        .codec()
+        .decode_frame(request, None)
+        .expect("the canonical repair request decodes")
+    else {
+        panic!("the repair uses the canonical GetHeaders message");
+    };
+    assert_eq!(request.target_tip_hash, repair_header.hash);
+    assert_eq!(request.locator_hashes, vec![anchor.hash]);
+    assert_eq!(request.max_header_count, 1);
+    assert_eq!(request.tree_aux_schema, AuxSchema::V1);
+
+    shutdown.cancel();
+    reactor.await.expect("the reactor task joins");
+}
+
+/// A peer that cannot reach the repair height never receives a request, and the repair defers.
+///
+/// The deferral path also builds the rejection tally the operator needs: without it the trace
+/// records only that the repair made no progress, not which requirement excluded the network.
+#[tokio::test]
+async fn vct_repair_defers_when_no_peer_reaches_the_repair_height() {
+    let shutdown = CancellationToken::new();
+    let mut startup = startup(shutdown.clone());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut repair_block_header = *regtest_genesis_block().header;
+    repair_block_header.previous_block_hash = anchor.hash;
+    repair_block_header.time += chrono::Duration::seconds(1);
+    let repair_block_header = Arc::new(repair_block_header);
+    let repair_header =
+        zakura_header_chain::Frontier::new(block::Height(1), repair_block_header.hash());
+    let mut snapshot = committed_snapshot(anchor);
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(2), block::Hash([3; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_repairs_tx, repairs_rx) = watch::channel(zakura_header_chain::VctRootRepairStatus {
+        state: zakura_header_chain::VctRootRepairState::Unavailable {
+            height: repair_header.height,
+        },
+        generation: 7,
+    });
+    startup.vct_root_repairs = Some(repairs_rx);
+    let (handle, mut actions, reactor) =
+        spawn_header_sync_reactor(startup).expect("the repair fixture starts");
+    let HeaderPortOperation::QueryVctRepairContext { owner, .. } = next_action(&mut actions).await
+    else {
+        panic!("the exact repair context query precedes ordinary maintenance");
+    };
+
+    let (send, mut outbound) = framed_channel(8);
+    let peer = peer();
+    handle
+        .send(Event::PeerConnected(PeerSession::from_parts(
+            peer.clone(),
+            send,
+            CancellationToken::new(),
+        )))
+        .await
+        .expect("the peer connects");
+    let _status = outbound.recv().await.expect("the local status is sent");
+    handle
+        .send(Event::WireMessage {
+            peer: peer.clone(),
+            session_id: 0,
+            msg: HeaderSyncMessage::Status(Status {
+                work_anchor_height: anchor.height,
+                work_anchor_hash: anchor.hash,
+                // Below the repair target, so this peer cannot hold the header at all.
+                selected_tip_height: anchor.height,
+                selected_tip_hash: anchor.hash,
+                suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(1_u8),
+                oldest_retained_height: anchor.height,
+                max_headers_per_response: 1,
+                max_inflight_requests: 1,
+                max_message_bytes: 2_000_000,
+                tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+            }),
+        })
+        .await
+        .expect("the peer status reaches the reactor");
+    handle
+        .send(Event::VctRepairContextReady {
+            owner,
+            result: VctRepairContextResult::Resolved(zakura_header_chain::VctRepairContext {
+                target: repair_header,
+                locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+            }),
+        })
+        .await
+        .expect("the exact repair context reaches the reactor");
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(200), outbound.recv())
+            .await
+            .is_err(),
+        "an unreachable repair height must not produce a wire request"
+    );
+
+    shutdown.cancel();
+    reactor.await.expect("the reactor task joins");
+}

--- a/crates/zakura-network/src/zakura/trace.rs
+++ b/crates/zakura-network/src/zakura/trace.rs
@@ -87,6 +87,16 @@ pub(crate) mod header_sync_trace {
     pub(crate) const REPAIR_GENERATION: &str = "repair_generation";
     pub(crate) const PHASE: &str = "phase";
     pub(crate) const SUPPLIER_COUNT: &str = "supplier_count";
+    pub(crate) const PREDECESSOR_HEIGHT: &str = "predecessor_height";
+    pub(crate) const CANDIDATE_COUNT: &str = "candidate_count";
+    pub(crate) const PEERS_CONSIDERED: &str = "peers_considered";
+    pub(crate) const REJECTED_HEIGHT: &str = "rejected_height";
+    pub(crate) const REJECTED_CAPACITY: &str = "rejected_capacity";
+    pub(crate) const REJECTED_SCHEMA: &str = "rejected_schema";
+    pub(crate) const REJECTED_BUSY: &str = "rejected_busy";
+    pub(crate) const REJECTED_TRIED: &str = "rejected_tried";
+    pub(crate) const BEST_PEER_HEIGHT: &str = "best_peer_height";
+    pub(crate) const BEST_PEER_HASH: &str = "best_peer_hash";
 
     pub(crate) const HEADER_PEER_CONNECTED: &str = "header_peer_connected";
     pub(crate) const HEADER_PEER_DISCONNECTED: &str = "header_peer_disconnected";

--- a/crates/zakura-network/src/zakura/trace.rs
+++ b/crates/zakura-network/src/zakura/trace.rs
@@ -88,7 +88,6 @@ pub(crate) mod header_sync_trace {
     pub(crate) const PHASE: &str = "phase";
     pub(crate) const SUPPLIER_COUNT: &str = "supplier_count";
     pub(crate) const PREDECESSOR_HEIGHT: &str = "predecessor_height";
-    pub(crate) const CANDIDATE_COUNT: &str = "candidate_count";
     pub(crate) const PEERS_CONSIDERED: &str = "peers_considered";
     pub(crate) const REJECTED_HEIGHT: &str = "rejected_height";
     pub(crate) const REJECTED_CAPACITY: &str = "rejected_capacity";

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -880,6 +880,14 @@ struct CanonicalHeaderPathAdvance {
 }
 
 #[derive(Debug)]
+/// Identity a canonical header path lease is issued under.
+#[derive(Copy, Clone)]
+struct RetainedPathRequester {
+    peer: SourceId,
+    session_id: u64,
+    scope: HeaderWorkAuthority,
+}
+
 struct RetainedPathReservation {
     leases: Arc<Mutex<RetainedPathLeaseRegistry>>,
     peer: SourceId,
@@ -1663,6 +1671,82 @@ impl HeaderChainReader {
         }))
     }
 
+    /// Lease a canonical path that ends at a finalized target below the header frontier.
+    ///
+    /// Refusing a finalized target would strand any node whose VCT repair height every peer has
+    /// already finalized: the requester has no other way to obtain that exact header and its
+    /// authenticated roots. Finalized rows are immutable, so the path is a plain contiguous run
+    /// from the locator's canonical ancestor up to the target.
+    fn acquire_finalized_target_path(
+        &self,
+        reservation: RetainedPathReservation,
+        requester: RetainedPathRequester,
+        target_tip_hash: block::Hash,
+        locator_hashes: &[block::Hash],
+        snapshot: &EngineSnapshot,
+    ) -> Result<RetainedPathLeaseOutcome, HeaderChainStoreError> {
+        let RetainedPathRequester {
+            peer,
+            session_id,
+            scope,
+        } = requester;
+        let Some(target) = self.finalized_frontier(target_tip_hash)? else {
+            return Ok(RetainedPathLeaseOutcome::TargetNotRetained);
+        };
+        if target.height >= snapshot.frontiers.finalized.height {
+            // A header at or above the finalized frontier belongs to the graph. Its absence there
+            // means the branch moved under the request, so the requester must re-derive it.
+            return Ok(RetainedPathLeaseOutcome::TargetNotRetained);
+        }
+        let mut common_ancestor = None;
+        for locator_hash in locator_hashes {
+            if let Some(frontier) = self.finalized_frontier(*locator_hash)? {
+                if frontier.height < target.height {
+                    common_ancestor = Some(frontier);
+                    break;
+                }
+            }
+        }
+        let Some(common_ancestor) = common_ancestor else {
+            return Ok(RetainedPathLeaseOutcome::NoLocatorIntersection);
+        };
+        let next = common_ancestor.height.next().map_err(|_| {
+            StoreError::Incoherent("canonical header cursor start height overflowed")
+        })?;
+        let retained_path: Arc<[block::Hash]> = Arc::from(Vec::new());
+        let _writer = self
+            .store
+            .writer
+            .lock()
+            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?;
+        let current_snapshot = self
+            .transition_engine
+            .lock()
+            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?
+            .snapshot();
+        if current_snapshot.state_version != snapshot.state_version
+            || scope != HeaderWorkAuthority::for_target(&current_snapshot, target_tip_hash)
+        {
+            return Ok(RetainedPathLeaseOutcome::Busy);
+        }
+        reservation.commit(
+            RetainedPathLeaseSpec {
+                peer,
+                session_id,
+                target,
+                common_ancestor,
+                scope,
+                position: CanonicalHeaderPathPosition::Finalized {
+                    next,
+                    end: target.height,
+                },
+                retained_ancestor: None,
+                retained_path,
+            },
+            Instant::now(),
+        )
+    }
+
     pub(crate) fn acquire_retained_path(
         &self,
         peer: SourceId,
@@ -1692,7 +1776,7 @@ impl HeaderChainReader {
             reservation_id,
             active: true,
         };
-        let (snapshot, target, mut reverse_path) = {
+        let (snapshot, retained_target) = {
             let engine = self
                 .transition_engine
                 .lock()
@@ -1701,25 +1785,43 @@ impl HeaderChainReader {
             if scope != HeaderWorkAuthority::for_target(&snapshot, target_tip_hash) {
                 return Ok(RetainedPathLeaseOutcome::Busy);
             }
-            let Some(target_node) = engine.graph().header_node(target_tip_hash) else {
-                return Ok(RetainedPathLeaseOutcome::TargetNotRetained);
-            };
-            let target = Frontier::new(target_node.height, target_tip_hash);
-            let mut reverse_path = vec![target];
-            let mut current = target_node;
-            while current.height > snapshot.frontiers.finalized.height {
-                let Some(parent) = engine.graph().header_node(current.parent_hash) else {
-                    return Ok(RetainedPathLeaseOutcome::HistoryPruned);
-                };
-                if parent.height.next().ok() != Some(current.height) {
-                    return Err(HeaderChainStoreError::Store(StoreError::Incoherent(
-                        "retained target path has non-contiguous heights",
-                    )));
+            match engine.graph().header_node(target_tip_hash) {
+                None => (snapshot, None),
+                Some(target_node) => {
+                    let target = Frontier::new(target_node.height, target_tip_hash);
+                    let mut reverse_path = vec![target];
+                    let mut current = target_node;
+                    while current.height > snapshot.frontiers.finalized.height {
+                        let Some(parent) = engine.graph().header_node(current.parent_hash) else {
+                            return Ok(RetainedPathLeaseOutcome::HistoryPruned);
+                        };
+                        if parent.height.next().ok() != Some(current.height) {
+                            return Err(HeaderChainStoreError::Store(StoreError::Incoherent(
+                                "retained target path has non-contiguous heights",
+                            )));
+                        }
+                        reverse_path.push(Frontier::new(parent.height, parent.hash));
+                        current = parent;
+                    }
+                    (snapshot, Some((target, reverse_path)))
                 }
-                reverse_path.push(Frontier::new(parent.height, parent.hash));
-                current = parent;
             }
-            (snapshot, target, reverse_path)
+        };
+        let Some((target, mut reverse_path)) = retained_target else {
+            // The header graph holds only the retained suffix. A VCT repair asks for the exact
+            // header at one stalled height, which every peer that moved past it has finalized,
+            // so the target is absent here but present and immutable in the finalized indexes.
+            return self.acquire_finalized_target_path(
+                reservation,
+                RetainedPathRequester {
+                    peer,
+                    session_id,
+                    scope,
+                },
+                target_tip_hash,
+                locator_hashes,
+                &snapshot,
+            );
         };
         if reverse_path.last().copied() != Some(snapshot.frontiers.finalized) {
             return Ok(RetainedPathLeaseOutcome::HistoryPruned);

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -880,14 +880,6 @@ struct CanonicalHeaderPathAdvance {
 }
 
 #[derive(Debug)]
-/// Identity a canonical header path lease is issued under.
-#[derive(Copy, Clone)]
-struct RetainedPathRequester {
-    peer: SourceId,
-    session_id: u64,
-    scope: HeaderWorkAuthority,
-}
-
 struct RetainedPathReservation {
     leases: Arc<Mutex<RetainedPathLeaseRegistry>>,
     peer: SourceId,
@@ -1680,16 +1672,13 @@ impl HeaderChainReader {
     fn acquire_finalized_target_path(
         &self,
         reservation: RetainedPathReservation,
-        requester: RetainedPathRequester,
+        session_id: u64,
+        scope: HeaderWorkAuthority,
         target_tip_hash: block::Hash,
         locator_hashes: &[block::Hash],
         snapshot: &EngineSnapshot,
     ) -> Result<RetainedPathLeaseOutcome, HeaderChainStoreError> {
-        let RetainedPathRequester {
-            peer,
-            session_id,
-            scope,
-        } = requester;
+        let peer = reservation.peer;
         let Some(target) = self.finalized_frontier(target_tip_hash)? else {
             return Ok(RetainedPathLeaseOutcome::TargetNotRetained);
         };
@@ -1813,11 +1802,8 @@ impl HeaderChainReader {
             // so the target is absent here but present and immutable in the finalized indexes.
             return self.acquire_finalized_target_path(
                 reservation,
-                RetainedPathRequester {
-                    peer,
-                    session_id,
-                    scope,
-                },
+                session_id,
+                scope,
                 target_tip_hash,
                 locator_hashes,
                 &snapshot,

--- a/crates/zakura-state/src/service/finalized_state/header_chain.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain.rs
@@ -1663,6 +1663,36 @@ impl HeaderChainReader {
         }))
     }
 
+    /// Commit a lease only if the branch has not moved since the caller read its snapshot.
+    ///
+    /// The caller derives the path from a snapshot it holds no lock over. Taking the writer lock
+    /// and re-reading the transition engine closes that window: an unchanged state version and an
+    /// unchanged work authority for the target together mean the derived path is still canonical.
+    /// A branch that moved yields `Busy`, and the dropped reservation frees the peer's slot.
+    fn commit_lease_if_branch_unchanged(
+        &self,
+        reservation: RetainedPathReservation,
+        base_state_version: zakura_header_chain::StateVersion,
+        spec: RetainedPathLeaseSpec,
+    ) -> Result<RetainedPathLeaseOutcome, HeaderChainStoreError> {
+        let _writer = self
+            .store
+            .writer
+            .lock()
+            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?;
+        let current_snapshot = self
+            .transition_engine
+            .lock()
+            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?
+            .snapshot();
+        if current_snapshot.state_version != base_state_version
+            || spec.scope != HeaderWorkAuthority::for_target(&current_snapshot, spec.target.hash)
+        {
+            return Ok(RetainedPathLeaseOutcome::Busy);
+        }
+        reservation.commit(spec, Instant::now())
+    }
+
     /// Lease a canonical path that ends at a finalized target below the header frontier.
     ///
     /// Refusing a finalized target would strand any node whose VCT repair height every peer has
@@ -1702,23 +1732,9 @@ impl HeaderChainReader {
         let next = common_ancestor.height.next().map_err(|_| {
             StoreError::Incoherent("canonical header cursor start height overflowed")
         })?;
-        let retained_path: Arc<[block::Hash]> = Arc::from(Vec::new());
-        let _writer = self
-            .store
-            .writer
-            .lock()
-            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?;
-        let current_snapshot = self
-            .transition_engine
-            .lock()
-            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?
-            .snapshot();
-        if current_snapshot.state_version != snapshot.state_version
-            || scope != HeaderWorkAuthority::for_target(&current_snapshot, target_tip_hash)
-        {
-            return Ok(RetainedPathLeaseOutcome::Busy);
-        }
-        reservation.commit(
+        self.commit_lease_if_branch_unchanged(
+            reservation,
+            snapshot.state_version,
             RetainedPathLeaseSpec {
                 peer,
                 session_id,
@@ -1730,12 +1746,23 @@ impl HeaderChainReader {
                     end: target.height,
                 },
                 retained_ancestor: None,
-                retained_path,
+                retained_path: Arc::from(Vec::new()),
             },
-            Instant::now(),
         )
     }
 
+    /// Lease a canonical header path from a locator intersection up to an exact target.
+    ///
+    /// The target resolves from the retained header graph, or, when it sits below the finalized
+    /// frontier, from the canonical finalized indexes. A VCT repair asks for one stalled height
+    /// that every peer past it has already finalized, so refusing the second band would strand
+    /// the requester.
+    ///
+    /// Returns `TargetNotRetained` when neither band holds the target, `NoLocatorIntersection`
+    /// when no locator hash is a canonical ancestor of it, `HistoryPruned` when the retained
+    /// path no longer reaches the finalized frontier, and `Busy` when the peer already holds a
+    /// lease or the branch moved under the request. On success the peer owns one lease until it
+    /// releases the lease or the idle deadline expires.
     pub(crate) fn acquire_retained_path(
         &self,
         peer: SourceId,
@@ -1858,22 +1885,9 @@ impl HeaderChainReader {
         {
             position = CanonicalHeaderPathPosition::Complete;
         }
-        let _writer = self
-            .store
-            .writer
-            .lock()
-            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?;
-        let current_snapshot = self
-            .transition_engine
-            .lock()
-            .map_err(|_| HeaderChainStoreError::WriterPoisoned)?
-            .snapshot();
-        if current_snapshot.state_version != snapshot.state_version
-            || scope != HeaderWorkAuthority::for_target(&current_snapshot, target_tip_hash)
-        {
-            return Ok(RetainedPathLeaseOutcome::Busy);
-        }
-        reservation.commit(
+        self.commit_lease_if_branch_unchanged(
+            reservation,
+            snapshot.state_version,
             RetainedPathLeaseSpec {
                 peer,
                 session_id,
@@ -1884,7 +1898,6 @@ impl HeaderChainReader {
                 retained_ancestor,
                 retained_path,
             },
-            Instant::now(),
         )
     }
 

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
@@ -924,3 +924,135 @@ async fn retained_path_leases_are_exact_bounded_session_scoped_and_expiring() {
         )))
     ));
 }
+
+#[tokio::test(start_paused = true)]
+async fn retained_path_serves_an_exact_finalized_target_below_the_header_frontier() {
+    let db_config = Config::ephemeral();
+    let (engine_config, anchor, metadata) = fixture();
+    let db = open(&db_config, engine_config.network());
+    let store = HeaderChainStore::new(db.clone());
+    store
+        .initialize(metadata, anchor.clone())
+        .expect("the empty schema initializes");
+
+    let genesis = VerifiedHeaderRef {
+        height: anchor.height,
+        hash: anchor.hash,
+        header: anchor.header.clone(),
+    };
+    let mut path = Vec::new();
+    let mut parent = genesis.clone();
+    for marker in 1..=3 {
+        let mut header = *parent.header;
+        header.previous_block_hash = parent.hash;
+        header.time += chrono::Duration::seconds(1);
+        header.nonce.0[0] = marker;
+        let header = Arc::new(header);
+        let height = parent
+            .height
+            .next()
+            .expect("the three-header fixture stays in range");
+        let hash = header.hash();
+        let child = VerifiedHeaderRef {
+            height,
+            hash,
+            header,
+        };
+        path.push(child.clone());
+        parent = child;
+    }
+
+    let hash_by_height = db
+        .cf_handle("hash_by_height")
+        .expect("the finalized hash index exists");
+    let height_by_hash = db
+        .cf_handle("height_by_hash")
+        .expect("the finalized height index exists");
+    let block_header_by_height = db
+        .cf_handle("block_header_by_height")
+        .expect("the finalized header column exists");
+    let mut batch = DiskWriteBatch::new();
+    for header in std::iter::once(&genesis).chain(path[..2].iter()) {
+        batch.zs_insert(&hash_by_height, header.height, header.hash);
+        batch.zs_insert(&height_by_hash, header.hash, header.height);
+        batch.zs_insert(
+            &block_header_by_height,
+            header.height,
+            header.header.as_ref(),
+        );
+    }
+    db.write(batch)
+        .expect("the canonical finalized header fixture commits");
+
+    let finalized = Frontier::new(path[1].height, path[1].hash);
+    let (runtime, _) = store
+        .startup_reconciled(
+            &engine_config,
+            finalized,
+            path[..2].to_vec(),
+            path[2..].to_vec(),
+        )
+        .expect("the finalized prefix and retained suffix reconcile");
+    let reader = runtime.reader();
+
+    // A VCT repair asks for the exact header at one stalled height. The header graph holds only
+    // the retained suffix, so a supplier that has finalized past that height serves it from the
+    // finalized indexes.
+    let target = Frontier::new(path[0].height, path[0].hash);
+    assert!(target.height < finalized.height);
+    let scope = zakura_header_chain::HeaderWorkAuthority::for_target(
+        &runtime.publisher().snapshot(),
+        target.hash,
+    );
+    let owner = SourceId::from_digest([0x81; 32]);
+    let RetainedPathLeaseOutcome::Acquired(lease) = reader
+        .acquire_retained_path(owner, 11, target.hash, &[genesis.hash], scope)
+        .expect("the finalized target resolves through the finalized indexes")
+    else {
+        panic!("the finalized target should acquire a lease");
+    };
+    assert_eq!(
+        lease.common_ancestor,
+        Frontier::new(genesis.height, genesis.hash)
+    );
+    assert_eq!(lease.target, target);
+
+    let RetainedPathReadOutcome::Page(page) = reader
+        .read_retained_path(owner, 11, lease.lease_id, scope, genesis.hash, 4)
+        .expect("the finalized target page is coherent")
+    else {
+        panic!("the finalized target lease should remain available");
+    };
+    assert_eq!(
+        page.headers.as_slice(),
+        std::slice::from_ref(&path[0].header)
+    );
+    assert_eq!(page.target, target);
+    assert!(page.complete);
+    assert!(reader
+        .release_retained_path(owner, 11, lease.lease_id, scope)
+        .expect("the finalized target cursor releases"));
+
+    // A locator at or above the target leaves no ancestor to continue from.
+    let above_owner = SourceId::from_digest([0x82; 32]);
+    assert!(matches!(
+        reader
+            .acquire_retained_path(above_owner, 11, target.hash, &[path[1].hash], scope)
+            .expect("the locator lookup is coherent"),
+        RetainedPathLeaseOutcome::NoLocatorIntersection
+    ));
+
+    // An unknown target stays unservable.
+    let unknown_owner = SourceId::from_digest([0x83; 32]);
+    let unknown = zakura_chain::block::Hash([0x9c; 32]);
+    let unknown_scope = zakura_header_chain::HeaderWorkAuthority::for_target(
+        &runtime.publisher().snapshot(),
+        unknown,
+    );
+    assert!(matches!(
+        reader
+            .acquire_retained_path(unknown_owner, 11, unknown, &[genesis.hash], unknown_scope)
+            .expect("the unknown target lookup is coherent"),
+        RetainedPathLeaseOutcome::TargetNotRetained
+    ));
+}

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
@@ -188,8 +188,17 @@ fn selected_body_window_reads_four_thousand_hashes_in_one_coherent_range() {
     );
 }
 
-#[tokio::test(start_paused = true)]
-async fn retained_path_serves_a_locator_before_the_header_retention_window() {
+/// A reconciled store over a genesis and three descendant headers.
+///
+/// The genesis and the first two path headers are finalized and indexed in the canonical
+/// finalized columns; the third sits in the retained header graph above the finalized frontier.
+/// Returns the runtime, its open database, the genesis header, and the three-header path.
+fn reconciled_store_with_finalized_prefix() -> (
+    HeaderChainRuntime,
+    DiskDb,
+    VerifiedHeaderRef,
+    Vec<VerifiedHeaderRef>,
+) {
     let db_config = Config::ephemeral();
     let (engine_config, anchor, metadata) = fixture();
     let db = open(&db_config, engine_config.network());
@@ -256,6 +265,15 @@ async fn retained_path_serves_a_locator_before_the_header_retention_window() {
             path[2..].to_vec(),
         )
         .expect("the finalized prefix and retained suffix reconcile");
+    (runtime, db, genesis, path)
+}
+
+#[tokio::test(start_paused = true)]
+async fn retained_path_serves_a_locator_before_the_header_retention_window() {
+    let (runtime, db, genesis, path) = reconciled_store_with_finalized_prefix();
+    let hash_by_height = db
+        .cf_handle("hash_by_height")
+        .expect("the finalized hash index exists");
     let reader = runtime.reader();
     let target = Frontier::new(path[2].height, path[2].hash);
     let scope = zakura_header_chain::HeaderWorkAuthority::for_target(
@@ -927,72 +945,8 @@ async fn retained_path_leases_are_exact_bounded_session_scoped_and_expiring() {
 
 #[tokio::test(start_paused = true)]
 async fn retained_path_serves_an_exact_finalized_target_below_the_header_frontier() {
-    let db_config = Config::ephemeral();
-    let (engine_config, anchor, metadata) = fixture();
-    let db = open(&db_config, engine_config.network());
-    let store = HeaderChainStore::new(db.clone());
-    store
-        .initialize(metadata, anchor.clone())
-        .expect("the empty schema initializes");
-
-    let genesis = VerifiedHeaderRef {
-        height: anchor.height,
-        hash: anchor.hash,
-        header: anchor.header.clone(),
-    };
-    let mut path = Vec::new();
-    let mut parent = genesis.clone();
-    for marker in 1..=3 {
-        let mut header = *parent.header;
-        header.previous_block_hash = parent.hash;
-        header.time += chrono::Duration::seconds(1);
-        header.nonce.0[0] = marker;
-        let header = Arc::new(header);
-        let height = parent
-            .height
-            .next()
-            .expect("the three-header fixture stays in range");
-        let hash = header.hash();
-        let child = VerifiedHeaderRef {
-            height,
-            hash,
-            header,
-        };
-        path.push(child.clone());
-        parent = child;
-    }
-
-    let hash_by_height = db
-        .cf_handle("hash_by_height")
-        .expect("the finalized hash index exists");
-    let height_by_hash = db
-        .cf_handle("height_by_hash")
-        .expect("the finalized height index exists");
-    let block_header_by_height = db
-        .cf_handle("block_header_by_height")
-        .expect("the finalized header column exists");
-    let mut batch = DiskWriteBatch::new();
-    for header in std::iter::once(&genesis).chain(path[..2].iter()) {
-        batch.zs_insert(&hash_by_height, header.height, header.hash);
-        batch.zs_insert(&height_by_hash, header.hash, header.height);
-        batch.zs_insert(
-            &block_header_by_height,
-            header.height,
-            header.header.as_ref(),
-        );
-    }
-    db.write(batch)
-        .expect("the canonical finalized header fixture commits");
-
+    let (runtime, _db, genesis, path) = reconciled_store_with_finalized_prefix();
     let finalized = Frontier::new(path[1].height, path[1].hash);
-    let (runtime, _) = store
-        .startup_reconciled(
-            &engine_config,
-            finalized,
-            path[..2].to_vec(),
-            path[2..].to_vec(),
-        )
-        .expect("the finalized prefix and retained suffix reconcile");
     let reader = runtime.reader();
 
     // A VCT repair asks for the exact header at one stalled height. The header graph holds only

--- a/crates/zakura-state/src/service/write.rs
+++ b/crates/zakura-state/src/service/write.rs
@@ -68,14 +68,18 @@ use vct_write_retry::{VctWriteRetryCause, VctWriteRetryManager};
 pub use zakura_header_chain::{VctRootRepairState, VctRootRepairStatus};
 
 fn missing_vct_successor_retry(
-    auxiliary_window: &VctAuxiliaryWindow,
+    successor_height: Option<Height>,
     current_height: Height,
 ) -> (Height, VctWriteRetryCause) {
-    if let Some(successor_height) = auxiliary_window.successor_height {
+    if let Some(successor_height) = successor_height {
+        // The successor header exists but carries no auxiliary record. The committer disputed
+        // nothing, so this poll continues the open repair episode instead of starting a new one.
+        // A new episode would retire the header-sync repair task and discard its supplier
+        // backoff on every poll.
         return (
             successor_height,
             VctWriteRetryCause::MissingRoot {
-                replacement_required: true,
+                replacement_required: false,
             },
         );
     }
@@ -2111,8 +2115,10 @@ impl WriteBlockWorkerTask {
                 let auxiliary_window = vct_auxiliary_window
                     .as_ref()
                     .expect("exact VCT roots require an auxiliary window");
-                let (height, retry_cause) =
-                    missing_vct_successor_retry(auxiliary_window, ordered_block.0.height);
+                let (height, retry_cause) = missing_vct_successor_retry(
+                    auxiliary_window.successor_height,
+                    ordered_block.0.height,
+                );
                 let wait =
                     vct_write_retry_manager.on_retryable_error(height, retry_cause, ordered_block);
                 std::thread::park_timeout(wait);

--- a/crates/zakura-state/src/service/write/tests/attachment_and_vct_aux.rs
+++ b/crates/zakura-state/src/service/write/tests/attachment_and_vct_aux.rs
@@ -156,20 +156,21 @@ fn vct_aux_selection_prefers_authenticated_complete_nonrejected_provenance() {
         successor: None,
     };
     assert_eq!(
-        missing_vct_successor_retry(&window, block::Height(1)),
+        missing_vct_successor_retry(window.successor_height, block::Height(1)),
         (block::Height(2), VctWriteRetryCause::MissingSuccessor),
         "an absent successor header waits for header admission"
     );
     window.successor_height = Some(block::Height(2));
     assert_eq!(
-        missing_vct_successor_retry(&window, block::Height(1)),
+        missing_vct_successor_retry(window.successor_height, block::Height(1)),
         (
             block::Height(2),
             VctWriteRetryCause::MissingRoot {
-                replacement_required: true
+                replacement_required: false
             }
         ),
-        "a retained successor without usable auxiliary data requests replacement"
+        "a retained successor without usable auxiliary data polls the open repair episode; \
+         a new episode would retire the header-sync repair task twice a second"
     );
     window.successor_height = None;
     let expected_roots = authenticated

--- a/docs/changelog/unreleased/800.md
+++ b/docs/changelog/unreleased/800.md
@@ -1,0 +1,23 @@
+## Fixed
+
+- Fixed a sync halt on nodes running the Zakura header chain with verified commitment
+  trees. A checkpoint commit that parked on a missing commitment root could never obtain a
+  replacement: the repair supplier filter required a peer sitting on the stalled node's own
+  header tip and retaining history below the stalled height, which no synced peer satisfies,
+  and the serving path resolved a repair target only through the retained header graph, which
+  no synced peer still holds it in. The filter now selects any peer that can reach the repair
+  height, and the serving path resolves an exact canonical finalized target through the
+  finalized indexes
+  ([#800](https://github.com/zakura-core/zakura/pull/800)).
+- Fixed the committer declaring a new repair episode on every 500 ms poll of an absent
+  successor auxiliary record. Each episode retired the header-sync repair task and discarded
+  its supplier backoff, so a stalled node spun at 2 Hz and wrote gigabytes of trace. Such a
+  poll now continues the open episode
+  ([#800](https://github.com/zakura-core/zakura/pull/800)).
+
+## Changed
+
+- A commitment-root repair that no connected peer can supply now reports which requirement
+  excluded the network, counts `sync.header.vct.repair.no_supplier.total`, and escalates to
+  error level after 60 seconds
+  ([#800](https://github.com/zakura-core/zakura/pull/800)).

--- a/docs/changelog/unreleased/800.md
+++ b/docs/changelog/unreleased/800.md
@@ -5,14 +5,18 @@
   replacement: the repair supplier filter required a peer sitting on the stalled node's own
   header tip and retaining history below the stalled height, which no synced peer satisfies,
   and the serving path resolved a repair target only through the retained header graph, which
-  no synced peer still holds it in. The filter now selects any peer that can reach the repair
-  height, and the serving path resolves an exact canonical finalized target through the
+  no synced peer still holds the target in. The filter now selects any peer that can reach the
+  repair height, and the serving path resolves an exact canonical finalized target through the
   finalized indexes
   ([#800](https://github.com/zakura-core/zakura/pull/800)).
 - Fixed the committer declaring a new repair episode on every 500 ms poll of an absent
   successor auxiliary record. Each episode retired the header-sync repair task and discarded
   its supplier backoff, so a stalled node spun at 2 Hz and wrote gigabytes of trace. Such a
   poll now continues the open episode
+  ([#800](https://github.com/zakura-core/zakura/pull/800)).
+- Fixed a resource-stalled repair admission dropping the repair task. The committer no longer
+  bumps the repair generation while it polls, so a dropped task waited for a snapshot change
+  that a stalled node cannot produce. The task now backs off and retries another supplier
   ([#800](https://github.com/zakura-core/zakura/pull/800)).
 
 ## Changed


### PR DESCRIPTION
## What broke

Two continuous-sync nodes (`temp-zakura-sync-test-1`, `temp-zakura-sync-test-2`) wedged on
`origin/main` @ `5c33befdf`, ~8k blocks short of the network tip, and stayed down:

```
14:09:57 WARN  vct_write_retry: VCT: supplied root not yet verifiable; retrying checkpoint
               commit in place height=3452169 retry_cause=MissingRoot{replacement_required:true}
14:10:27 ERROR vct_write_retry: VCT: checkpoint commit stalled waiting for a verifiable supplied
               root or successor witness; the node will not recompute against the frozen frontier
```

The committer parks a checkpoint block waiting for a VCT root and asks header sync to supply
it. Header sync scheduled the repair, resolved its context, and then found zero eligible
suppliers — 10,872 `header_vct_repair_state` trace rows across 1,238 repair generations, every
one with `supplier_count: 0`, never reaching `assignment`.

This is a policy-level liveness deadlock. Three defects combined; fixing any one alone does not
restore liveness.

## The three defects

### 1. The supplier filter selects for a peer that cannot exist

`try_assign_vct_repair` required:

```rust
status.selected_tip_hash == task.owner.branch.target_tip_hash
status.oldest_retained_height <= predecessor.height
```

`task.owner.branch.target_tip_hash` is **our own** `frontiers.header_best.hash`
(`BodyWorkAuthority::for_snapshot`), so the first predicate demands a peer sitting on our
stalled tip. `oldest_retained_height` is the peer's finalized anchor, so the second demands a
peer whose finalized frontier is *below* our stall height — a peer less synced than we are.

Measured on node 2: our branch target was `0000…129e39…` @ 3455238; every peer advertised
`0000…4554fc…` @ 3460252 with anchor 3459251. Both predicates are unsatisfiable against a
healthy network, and get more unsatisfiable the longer the node is stuck.

The tip-hash predicate is not even guarding the thing being requested: the wire request carries
`target_tip_hash = context.target.hash`, the header **at the repair height**, not our tip.

### 2. The serving path refuses a finalized target

`acquire_retained_path` resolved the target only through the in-memory header graph, which holds
the retained suffix. A repair target is deep-finalized on any healthy peer, so every supplier
would have answered `TargetNotRetained` even with defect 1 fixed.

### 3. The committer's 500 ms poll destroys the reactor's backoff

`missing_vct_successor_retry` returned `MissingRoot { replacement_required: true }` whenever the
successor header existed but its auxiliary record did not — a branch that disputes nothing. That
forced a repair-generation bump on every poll, which retired and re-inserted the reactor's task,
discarding its `SupplierBackoff` and re-querying context. Result: a 2 Hz spin, the 1 s
`VCT_REPAIR_RETRY_INTERVAL` never applied, and a 2.4 GB `header_sync.jsonl` in eight hours.

The backoff is self-healing on its own — `resume_retry_cycle` clears `tried_sources` when
`SupplierBackoff` elapses — so the churn bought nothing and cost the backoff.

## What this changes

- **`reactor.rs`** — drop both unsatisfiable predicates. A peer serves the exact target either
  from its retained graph or from its finalized state, and those bands are exhaustive below its
  selected tip, so `selected_tip_height >= context.target.height` plus the capacity, schema, and
  idle checks is the complete condition. Branch membership is proved by the response: the
  supplier must return the exact target hash after the exact predecessor hash, and the existing
  admission path rejects anything else. The enforcement site is `handle_headers`, which checks
  the response target against the locally derived target, the returned common ancestor against
  the exact predecessor frontier sent, exactly one entry, complete, schema V1, and
  `entries[0].header.hash() == target`. A header hash pins `previous_block_hash`, so an
  off-branch or substitute header cannot pass. A peer that cannot serve the height answers
  `TargetNotRetained` / `HistoryPruned`, is recorded as a failed source, and the cycle is bounded
  by `MAX_SUPPLIERS_PER_CYCLE = 3` and the 1 s backoff.
- **`header_chain.rs`** — resolve an exact canonical finalized target through the finalized
  indexes when the header graph does not hold it, and serve it as a contiguous finalized run from
  the locator's canonical ancestor up to the target. An unknown hash, or one at or above the
  finalized frontier, still returns `TargetNotRetained`.
- **`write.rs`** — a missing successor auxiliary record continues the open repair episode instead
  of declaring a new one. Only a genuinely rejected delivery (`attributed_failure_repair_height`)
  starts a new episode. `missing_vct_successor_retry` now takes the successor height rather than
  the whole window, which is what it always used.
- **Observability** — an unassignable repair reports which requirement excluded the network
  (peers considered, plus counts rejected by height, capacity, schema, busy, already-tried),
  counts `sync.header.vct.repair.no_supplier.total`, escalates to error level after 60 s on one
  generation, and samples its trace row at 10 s. Previously an operator saw only
  `supplier_count: 0`, which counts `tried_sources` — not candidates — and so said nothing about
  why the network was excluded.
- **Audit fixes.** A `ResourceStalled` admission dropped the repair task. With defect 3 fixed the
  committer no longer bumps the repair generation while it polls, so nothing rescheduled a
  dropped task except an unrelated snapshot change, which a stalled node cannot produce. The task
  now backs off and retries another supplier. Separately, the no-supplier escalation clock reset
  on a non-empty candidate set, so a candidate that failed to send restarted the 60 s clock and
  suppressed the report; it now clears only once a request is actually assigned.

No wire-format change and no disk-format change. A new requester asking an old supplier for a
finalized target gets `TargetNotRetained`, which is already a handled outcome.

## Not changed, deliberately

- **No local recomputation inside the frozen VCT band.** The node deliberately lacks the
  intermediate frontiers there; safe recomputation would need a replay from a known frontier and
  may be impossible after pruning. The committer's refusal is correct.
- **No new advertised status field.** `oldest_retained_height` already carries the band split.
- **No reschedule on `VctRepairContextResult::Stale`.** That arm still waits for the next
  committed snapshot. A stale context means the state rejected our owner, so rescheduling from
  the reactor's own snapshot would re-derive the same stale owner and spin.
- **Roots serving needed no work.** `serve_block_roots` already joins tree-derived roots below
  the VCT upgrade height with indexed roots at and above it, and `finalized_tree_aux_for_page`
  already serves any page ending at or below the finalized tip. Both shapes are covered by
  existing tests (`serve_block_roots_serves_at_or_above_upgrade_from_index`,
  `finalized_pages_load_contiguous_tree_aux_from_state`).

## Tests

- `retained_path_serves_an_exact_finalized_target_below_the_header_frontier` — real RocksDB
  fixture: a finalized target below the header frontier acquires a lease, serves one complete
  page ending at the target, and still returns `NoLocatorIntersection` for a locator at or above
  the target and `TargetNotRetained` for an unknown hash.
- `vct_repair_accepts_a_supplier_ahead_of_the_stalled_branch` — the outage shape: the peer
  advertises a different selected tip, ahead of us, with `oldest_retained_height` above the
  repair predecessor. The repair request is now sent.
- `vct_repair_defers_when_no_peer_reaches_the_repair_height` — a peer below the repair height
  produces no wire request. The test captures the trace and asserts the `no_supplier` row's
  rejection tally, rather than only asserting the absent request.
- `vct_aux_selection_prefers_authenticated_complete_nonrejected_provenance` — updated to assert
  a missing successor record polls the open episode.

`cargo test -p zakura-state --lib` (519 passed) and `cargo test -p zakura-network` (1093 passed)
are green; `cargo clippy --all-targets` and `cargo fmt --check` on both crates are clean.

## Not included

A full two-node cluster end-to-end test — supplier ahead on a different branch, target and roots
only in supplier finalized state, parked commit resumes, repeated 500 ms polls leave the repair
generation unchanged — is not in this PR. The testkit has no VCT-stalled node fixture, so it is a
substantially larger piece of work than the fix. The seams it would cover are each covered by the
unit and reactor tests above.

## Validation still owed

The two wedged databases should resume in place on a fixed binary: the parked block and its
header state are intact, and the repair simply becomes assignable. That is not confirmed yet —
both nodes are still down (`Restart=no`). Opening for code review while that runs; please treat
the in-place resume as an open item on the PR rather than a blocker on reviewing the change.

