### PR TITLE
fix(ops): coalesce synchronized fleet stalls

### DIFF
--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -7,6 +7,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT_PATH = Path(__file__).with_name("zakura-cluster-watchdog.py")
@@ -21,7 +22,12 @@ def make_args(**overrides):
     defaults = {
         "down_after": 600.0,
         "stalled_after": 600.0,
+        "shared_stalled_after": 1800.0,
         "starting_grace": 120.0,
+        "dashboard_down_after": 600.0,
+        "request_timeout": 20.0,
+        "slack_timeout": 20.0,
+        "suppression_file": Path("/nonexistent/zakura-watchdog-suppression"),
         "slack_webhook": None,
         "dry_run": True,
     }
@@ -69,6 +75,7 @@ class StallRecoveryTests(unittest.TestCase):
         self.assertEqual(self.posted, [], "posted a recovery at an unchanged height")
         self.assertTrue(bucket["fleet/node-a"]["alerting"], "alert should stay latched")
         self.assertEqual(bucket["fleet/node-a"]["alert_height"], 4129396)
+
 
     def test_repeated_timer_resets_never_clear_the_stall(self):
         bucket = {}
@@ -194,6 +201,113 @@ class StallRecoveryTests(unittest.TestCase):
             "STALLED", "RECOVERED", 2000.0, False, make_args(), 4129396,
         )
         self.assertEqual(self.posted, [])
+
+
+class SharedStallTests(unittest.TestCase):
+    NOW = 2_000.0
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self._real_post = watchdog.post_slack
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        self.fleet = watchdog.Fleet(
+            name="testnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        self.args = make_args()
+        self.state = {
+            "version": watchdog.STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
+
+    def tearDown(self):
+        watchdog.post_slack = self._real_post
+
+    @staticmethod
+    def row(name, height, seconds_since_advanced, health="stale"):
+        return {
+            "name": name,
+            "height": height,
+            "health": health,
+            "detail": "height has not advanced within stale window",
+            "seconds_since_advanced": seconds_since_advanced,
+        }
+
+    def run_snapshot(self, rows, now=None):
+        instance = watchdog.Watchdog([self.fleet], self.args)
+        snapshot = {"rows": rows}
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot),
+            patch.object(watchdog.time, "time", return_value=now or self.NOW),
+        ):
+            instance.run_once(self.state)
+
+    def test_common_height_posts_one_fleet_alert(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_817),
+                self.row("node-b", 4_302_737, 1_816),
+                self.row("node-c", 4_302_737, 1_803),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("3 nodes agree at height 4302737", self.posted[0])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_short_common_idle_does_not_alert(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 617),
+                self.row("node-b", 4_302_737, 616),
+                self.row("node-c", 4_302_737, 603),
+            ]
+        )
+
+        self.assertEqual(self.posted, [])
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_common_height_recovery_posts_once_after_progress(self):
+        stalled = [
+            self.row("node-a", 4_302_737, 1_817),
+            self.row("node-b", 4_302_737, 1_816),
+        ]
+        self.run_snapshot(stalled)
+        self.posted.clear()
+
+        advanced = [
+            self.row("node-a", 4_302_790, 5, "healthy"),
+            self.row("node-b", 4_302_790, 5, "healthy"),
+        ]
+        self.run_snapshot(advanced, now=self.NOW + 60)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("network height advanced", self.posted[0])
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_divergence_recovers_fleet_and_alerts_lagging_node(self):
+        stalled = [
+            self.row("node-a", 4_302_737, 1_817),
+            self.row("node-b", 4_302_737, 1_816),
+        ]
+        self.run_snapshot(stalled)
+        self.posted.clear()
+
+        diverged = [
+            self.row("node-a", 4_302_800, 5, "healthy"),
+            self.row("node-b", 4_302_737, 1_876),
+        ]
+        self.run_snapshot(diverged, now=self.NOW + 60)
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertIn("network height advanced", self.posted[0])
+        self.assertIn("`node-b` stalled", self.posted[1])
 
 
 if __name__ == "__main__":
@@ -324,4 +438,3 @@ class ReleaseStateConfigTests(unittest.TestCase):
     def test_missing_url_is_rejected(self):
         with self.assertRaises(SystemExit):
             self.load('[[release_state]]\nname = "m"\n')
-

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -123,16 +123,27 @@ def load_fleets(config_path: Path) -> list[Fleet]:
 
 def load_state(state_path: Path) -> dict[str, Any]:
     if not state_path.exists():
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {
+            "version": STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
 
     with state_path.open(encoding="utf-8") as state_file:
         state = json.load(state_file)
 
     if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {
+            "version": STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
 
     state.setdefault("nodes", {})
     state.setdefault("fleets", {})
+    state.setdefault("shared_stalls", {})
     state.setdefault("release_state", {})
     return state
 
@@ -286,6 +297,42 @@ def node_condition(
     return ("ok", now, 0)
 
 
+def shared_stall(
+    rows: list[dict[str, Any]],
+    now: float,
+    grace_since: float,
+    args: argparse.Namespace,
+) -> tuple[float, float, int] | None:
+    """Return a common stalled height when every observable node agrees on it."""
+    observed: list[tuple[float, float]] = []
+
+    for row in rows:
+        health = str(row.get("health") or "unknown")
+        if health in DOWN_HEALTH or health == "starting":
+            continue
+
+        height = coerce_float(row.get("height"))
+        if height is None:
+            return None
+
+        condition, bad_since, _threshold = node_condition(
+            row, now, grace_since, args
+        )
+        if condition != "stalled":
+            return None
+        observed.append((height, bad_since))
+
+    if len(observed) < 2:
+        return None
+
+    heights = {height for height, _bad_since in observed}
+    if len(heights) != 1:
+        return None
+
+    height = observed[0][0]
+    return height, min(bad_since for _height, bad_since in observed), len(observed)
+
+
 def stall_cleared(entry: dict[str, Any], height: float | None) -> bool:
     """True when a stalled alert may be retired.
 
@@ -422,6 +469,26 @@ def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
     )
 
 
+def shared_stall_alert_text(
+    fleet: Fleet, height: float, node_count: int, age: float
+) -> str:
+    return (
+        f":rotating_light: *Zakura {fleet.name}* network height has not advanced "
+        f"for {format_duration(age)}\n"
+        f"{node_count} nodes agree at height {int(height)}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
+def shared_stall_recovery_text(fleet: Fleet, height: float | None) -> str:
+    height_text = str(int(height)) if height is not None else "-"
+    return (
+        f":white_check_mark: *Zakura {fleet.name}* network height advanced\n"
+        f"height: {height_text}\n"
+        f"dashboard: {fleet.dashboard_url}"
+    )
+
+
 def release_state_condition(
     target: ReleaseState, pointer: dict[str, Any], meta: dict[str, Any], now: float
 ) -> tuple[str, str]:
@@ -515,9 +582,26 @@ class Watchdog:
             if not isinstance(rows, list):
                 rows = []
 
-            for row in rows:
-                if isinstance(row, dict):
-                    self.handle_node(state, fleet, row, now, suppressed)
+            node_rows = [row for row in rows if isinstance(row, dict)]
+            grace_since = max(
+                self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
+            )
+            common_stall = shared_stall(
+                node_rows, now, grace_since, self.args
+            )
+            self.handle_shared_stall(state, fleet, node_rows, common_stall, now, suppressed)
+
+            for row in node_rows:
+                condition, _bad_since, _threshold = node_condition(
+                    row, now, grace_since, self.args
+                )
+                self.handle_node(
+                    state,
+                    fleet,
+                    row,
+                    now,
+                    suppressed or (common_stall is not None and condition == "stalled"),
+                )
 
         for target in self.release_state:
             self.handle_release_state(state, target, now, suppressed)
@@ -623,6 +707,58 @@ class Watchdog:
             self.args,
         )
 
+    def handle_shared_stall(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        rows: list[dict[str, Any]],
+        common_stall: tuple[float, float, int] | None,
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        bucket = state.setdefault("shared_stalls", {})
+        previous = dict(bucket.get(fleet.name, {}))
+        heights = [
+            height
+            for row in rows
+            if (height := coerce_float(row.get("height"))) is not None
+        ]
+        current_height = max(heights, default=None)
+
+        if common_stall is None:
+            update_alert_state(
+                bucket,
+                fleet.name,
+                "ok",
+                now,
+                0,
+                "",
+                shared_stall_recovery_text(fleet, current_height),
+                now,
+                False,
+                self.args,
+                current_height,
+            )
+            return
+
+        height, bad_since, node_count = common_stall
+        if previous.get("condition") == "stalled":
+            bad_since = min(float(previous.get("bad_since", bad_since)), bad_since)
+        age = now - bad_since
+        update_alert_state(
+            bucket,
+            fleet.name,
+            "stalled",
+            bad_since,
+            self.args.shared_stalled_after,
+            shared_stall_alert_text(fleet, height, node_count, age),
+            shared_stall_recovery_text(fleet, height),
+            now,
+            suppressed,
+            self.args,
+            height,
+        )
+
     def handle_node(
         self,
         state: dict[str, Any],
@@ -679,6 +815,12 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=600.0,
         help="alert after no block progress for this many seconds",
+    )
+    parser.add_argument(
+        "--shared-stalled-after",
+        type=float,
+        default=1800.0,
+        help="alert after every observable node shares one stalled height this long",
     )
     parser.add_argument(
         "--dashboard-down-after",


### PR DESCRIPTION
## Summary

- coalesce nodes that share one stalled height into one fleet-level condition
- wait 30 minutes before paging for a fleet-wide halt
- keep the 10-minute threshold for a single lagging node
- alert a lagging node immediately if the fleet diverges after a shared halt

## Incident evidence

The testnet watchdog paged two or three nodes at the same height, then posted recovery one minute later. Those alerts described one shared network-height pause as several node failures.

## Validation

- `python3 -m py_compile deploy/runner/zakura-cluster-watchdog.py deploy/runner/test_zakura_cluster_watchdog.py`
- `python3 -m unittest discover -s deploy/runner -p "test_zakura_cluster_watchdog.py"` (27 tests)
- `git diff --check`