### PR TITLE
fix(sync): retry transient block failures in place

### DIFF
--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -94,6 +94,14 @@ fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresse
 /// accountability in `zakura-network` disconnects such peers so this bound is rarely reached.
 const MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 8;
 
+/// Controls how many times the syncer requeues a required block hash after a transient peer or
+/// transport failure exhausts the block download service's internal retries.
+///
+/// A connection closing does not invalidate the selected chain or any other block already in the
+/// checkpoint verifier. Requeueing only the affected hash preserves that work. The bound still
+/// lets a persistently failing block restart the round and obtain fresh tips and peers.
+const TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
+
 /// Controls how many times the syncer immediately requeues a required block after a peer supplies
 /// a body whose coinbase height contradicts our own tip
 /// ([`BlockDownloadVerifyError::TipChildHeightMismatch`]).
@@ -878,6 +886,9 @@ where
     /// `notfound` ([`NotFoundKind::Response`]). Bounded by [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     missing_block_retry_counts: HashMap<block::Hash, usize>,
 
+    /// Per-hash retry counts for transient peer and transport download failures.
+    transient_block_retry_counts: HashMap<block::Hash, usize>,
+
     /// Queue-level retry counts for required blocks whose body claimed a coinbase height that
     /// contradicts our own tip. Bounded by [`POISONED_BLOCK_RETRY_LIMIT`].
     poisoned_block_retry_counts: HashMap<block::Hash, usize>,
@@ -1049,6 +1060,7 @@ where
             prospective_tips: HashSet::new(),
             recent_syncs,
             missing_block_retry_counts: HashMap::new(),
+            transient_block_retry_counts: HashMap::new(),
             poisoned_block_retry_counts: HashMap::new(),
             registry_miss_retry_counts: HashMap::new(),
             registry_miss_retry: HashMap::new(),
@@ -1409,6 +1421,7 @@ where
     ) -> Result<(), Report> {
         self.prospective_tips = HashSet::new();
         self.missing_block_retry_counts.clear();
+        self.transient_block_retry_counts.clear();
         self.poisoned_block_retry_counts.clear();
         self.registry_miss_retry_counts.clear();
         self.registry_miss_retry.clear();
@@ -2472,7 +2485,8 @@ where
         Self::handle_response(response, self.expose_peer_addresses)
     }
 
-    /// Handles a downloaded block response, requeueing required missing or poisoned block hashes.
+    /// Handles a downloaded block response and requeues a required hash when retrying one block can
+    /// preserve the rest of the round.
     ///
     /// A [`BlockDownloadVerifyError::TipChildHeightMismatch`] means a peer returned a body under
     /// the correct block hash but with a rewritten coinbase height. That satisfies the network
@@ -2488,6 +2502,10 @@ where
     /// rather than discarding the whole round. The requeues are bounded by
     /// [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     ///
+    /// A transient peer or transport error also affects only one requested hash. The syncer
+    /// requeues that hash after the download service exhausts its internal retries. The requeues
+    /// are bounded by [`TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT`].
+    ///
     /// A [`NotFoundKind::Registry`] miss means the peer set found that *every* ready peer is marked
     /// missing the block, so it can't be served right now. Rather than blocking the loop on an inline
     /// `sleep`, the hash is recorded in [`Self::registry_miss_retry`] with a backoff deadline; while
@@ -2502,6 +2520,7 @@ where
     ) -> Result<(), Report> {
         if let Ok((_height, hash)) = response.as_ref() {
             self.missing_block_retry_counts.remove(hash);
+            self.transient_block_retry_counts.remove(hash);
             self.poisoned_block_retry_counts.remove(hash);
             self.registry_miss_retry_counts.remove(hash);
             self.registry_miss_retry.remove(hash);
@@ -2652,6 +2671,48 @@ where
                     );
                 }
             }
+        }
+
+        if let Some(hash) = response.as_ref().err().and_then(|error| match error {
+            BlockDownloadVerifyError::DownloadFailed { hash, .. }
+                if error.not_found_download().is_none() =>
+            {
+                Some(*hash)
+            }
+            _ => None,
+        }) {
+            let retry_count = self.transient_block_retry_counts.entry(hash).or_default();
+
+            if *retry_count < TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT {
+                *retry_count += 1;
+
+                info!(
+                    ?hash,
+                    retry_attempt = *retry_count,
+                    retry_limit = TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT,
+                    "transient sync block download failed, retrying required block"
+                );
+                metrics::counter!("sync.transient.block.requeued.count").increment(1);
+
+                match self.downloads.download_and_verify(hash).await {
+                    Ok(())
+                    | Err(BlockDownloadVerifyError::DuplicateBlockQueuedForDownload { .. }) => {
+                        return Ok(())
+                    }
+                    Err(error) => self.handle_block_response(Err(error))?,
+                }
+
+                return Ok(());
+            }
+
+            self.transient_block_retry_counts.remove(&hash);
+
+            warn!(
+                ?hash,
+                retry_limit = TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT,
+                "transient sync block download retry budget exhausted, restarting sync"
+            );
+            metrics::counter!("sync.transient.block.retry.limit.count").increment(1);
         }
 
         self.handle_block_response(response)?;

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -2144,6 +2144,88 @@ async fn not_found_download_restarts_sync() {
     );
 }
 
+/// A peer connection failure affects one block request, so the syncer requeues that hash without
+/// canceling the other checkpoint verification tasks.
+#[tokio::test]
+async fn transient_download_failure_requeues_block() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xCE; 32]);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: client_dropped_error(),
+        hash: block_hash,
+    };
+
+    let requeue = tokio::spawn(async move {
+        let result = chain_sync
+            .handle_block_response_with_missing_retry(Err(error))
+            .await;
+        (chain_sync, result)
+    });
+
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block_hash).collect()))
+        .await
+        .respond(Err(client_dropped_error()));
+
+    let (chain_sync, result) = requeue
+        .await
+        .expect("transient block retry task should not panic");
+    result.expect("a transient block failure within budget should preserve the round");
+    assert_eq!(
+        chain_sync.transient_block_retry_counts.get(&block_hash),
+        Some(&1),
+        "the transient block retry should consume one retry"
+    );
+
+    block_verifier_router.expect_no_requests().await;
+}
+
+/// A persistently failing block still restarts the round after its queue-level retry budget.
+#[tokio::test]
+async fn transient_download_failure_restarts_after_retry_limit() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xCF; 32]);
+    chain_sync
+        .transient_block_retry_counts
+        .insert(block_hash, sync::TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: client_dropped_error(),
+        hash: block_hash,
+    };
+
+    let result = chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a transient block failure should restart sync after its retry budget"
+    );
+    assert!(
+        !chain_sync
+            .transient_block_retry_counts
+            .contains_key(&block_hash),
+        "an exhausted transient retry budget should be cleared"
+    );
+    peer_set.expect_no_requests().await;
+}
+
 /// Unit test for the refactored [`ChainSync::build_extend`]: it must *discover* the next batch of
 /// download hashes from a prospective tip, performing the FindBlocks fan-out and parsing the
 /// response, **without** dispatching any block downloads or otherwise touching syncer state.
@@ -3038,6 +3120,10 @@ fn not_found_block_error(_hash: block::Hash) -> crate::BoxError {
 /// `NotFoundRegistry`), as opposed to a single peer's `notfound`.
 fn not_found_registry_error(_hash: block::Hash) -> crate::BoxError {
     zn::SharedPeerError::from(zn::PeerError::NotFoundRegistry(Vec::new())).into()
+}
+
+fn client_dropped_error() -> crate::BoxError {
+    zn::SharedPeerError::from(zn::PeerError::ClientDropped).into()
 }
 
 #[test]

--- a/docs/changelog/unreleased/803.md
+++ b/docs/changelog/unreleased/803.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed the legacy block syncer restarting an entire sync round after one transient peer or
+  transport failure. The syncer now retries the affected block hash with a bounded budget and
+  preserves the other download and checkpoint verification tasks
+  ([#803](https://github.com/zakura-core/zakura/pull/803)).


### PR DESCRIPTION
## Summary

- retry one required block after a transient peer or transport failure
- preserve the other download and checkpoint verification tasks in the sync round
- restart the round when the same hash exhausts its bounded retry budget

## Incident evidence

The preserved `temp-zakura-sync-test-5` database reproduced a legacy sync round failure after restart. One block request ended with:

`SharedPeerError(ClientDropped, Other)`

The syncer treated that request failure as a round-wide error. It canceled 1,311 other tasks while checkpoint commits were still advancing. The next round started from checkpoint height 3,428,356 and continued syncing, which showed that the selected chain and checkpoint verifier remained valid.

This failure uses the legacy block sync path. PR #800 changes the Zakura header and VCT repair path, so it does not cover this failure.

Diagnostic run: https://github.com/zakura-core/zakura/actions/runs/32989882566

## Tests

- `cargo test -p zakura transient_download_failure --lib`
- `cargo test -p zakura not_found_download --lib`
- `cargo test -p zakura registry_miss_ --lib`
- `cargo test -p zakura components::sync::tests::vectors --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
