### PR TITLE
fix(sync): try every VCT repair supplier

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -2679,14 +2679,6 @@ impl HeaderSyncReactor {
         let RepairPolicyState::Ready { context } = &task.state else {
             return;
         };
-        if task.supplier_cycle_exhausted() {
-            let _ = self
-                .vct_repair
-                .get_mut(task.owner)
-                .expect("the ready repair was cloned above")
-                .defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
-            return;
-        }
         let Some(predecessor) = context.locator.entries().first().copied() else {
             return;
         };
@@ -2761,10 +2753,6 @@ impl HeaderSyncReactor {
                     self.emit_queue_send_failed(&peer, &session, "GetHeaders", &error, None);
                     if let Some(current) = self.vct_repair.get_mut(task.owner) {
                         let _ = current.record_failed_source(source);
-                        if current.supplier_cycle_exhausted() {
-                            let _ = current.defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
-                            return;
-                        }
                     }
                     continue;
                 }

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
@@ -157,7 +157,7 @@ fn initial_vct_wire_assignment_arms_the_request_deadline() {
 }
 
 #[test]
-fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
+fn supplier_cycle_tries_a_fresh_peer_after_three_failures() {
     let mut startup = startup(CancellationToken::new());
     let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
     let mut snapshot = committed_snapshot(anchor);
@@ -168,7 +168,7 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
     let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
     startup.committed_snapshots = Some(snapshots_rx);
     let (_handle, _actions, mut reactor) =
-        build_header_sync_reactor(startup).expect("the bounded repair fixture builds");
+        build_header_sync_reactor(startup).expect("the repair fixture builds");
     let peer = peer();
     let (send, _outbound) = framed_channel(8);
     reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
@@ -194,7 +194,6 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
             .tried_sources
             .insert(zakura_header_chain::SourceId::from_digest([byte; 32]));
     }
-    assert!(repair.supplier_cycle_exhausted());
     reactor.vct_repair.insert(repair);
 
     reactor.handle_wire_message(
@@ -214,20 +213,23 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
         }),
     );
 
-    assert!(reactor.peer_work_queue.active(&peer).is_none());
+    let active = reactor
+        .peer_work_queue
+        .active(&peer)
+        .expect("the fresh fourth supplier receives the repair request");
+    assert!(matches!(
+        active.purpose,
+        HeaderTargetPurpose::SelectedAuxiliaryRepair { .. }
+    ));
     let task = reactor
         .vct_repair
         .current()
-        .expect("the bounded cycle keeps the repair requirement");
+        .expect("the assigned cycle keeps the repair requirement");
     assert!(matches!(
         &task.state,
-        RepairPolicyState::SupplierBackoff {
-            context: retained,
-            ..
-        } if retained == &context
+        RepairPolicyState::Assigned { context: retained } if retained == &context
     ));
     assert_eq!(task.tried_sources.len(), 3);
-    assert!(task.supplier_cycle_exhausted());
 }
 
 #[test]

--- a/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
@@ -7,9 +7,6 @@ use tokio::time::Instant;
 use zakura_chain::block;
 use zakura_header_chain::{BodyWorkOwner, EngineSnapshot, SourceId, VctRepairContext};
 
-/// Maximum distinct suppliers retained and tried before one repair backoff cycle.
-const MAX_SUPPLIERS_PER_CYCLE: usize = 3;
-
 /// Structurally complete state of one auxiliary repair task.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(in crate::zakura::header_sync) enum RepairPolicyState {
@@ -157,9 +154,7 @@ impl RepairRequirement {
             _ => return Err(RepairPolicyError::IllegalState),
         };
         self.attempts = self.attempts.saturating_add(1);
-        if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
-            self.tried_sources.insert(source);
-        }
+        self.tried_sources.insert(source);
         self.state = RepairPolicyState::Ready { context };
         Ok(())
     }
@@ -170,18 +165,11 @@ impl RepairRequirement {
             return Err(RepairPolicyError::IllegalState);
         }
         self.attempts = self.attempts.saturating_add(1);
-        if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
-            self.tried_sources.insert(source);
-        }
+        self.tried_sources.insert(source);
         Ok(())
     }
 
-    /// Whether this repair must pause before trying another supplier.
-    pub fn supplier_cycle_exhausted(&self) -> bool {
-        self.tried_sources.len() >= MAX_SUPPLIERS_PER_CYCLE
-    }
-
-    /// Pause after a complete or bounded supplier cycle, then make every supplier eligible again.
+    /// Pause after a complete supplier cycle, then make every supplier eligible again.
     pub fn defer_retry_until(&mut self, deadline: Instant) -> Result<(), RepairPolicyError> {
         let RepairPolicyState::Ready { context } = &self.state else {
             return Err(RepairPolicyError::IllegalState);
@@ -432,34 +420,26 @@ mod tests {
     }
 
     #[test]
-    fn supplier_cycle_retains_at_most_three_distinct_sources() {
+    fn supplier_cycle_retains_every_distinct_source_until_backoff() {
         let mut task = task(&snapshot());
         let context = context();
         mark_context_requested(&mut task);
         task.resolve(context.clone())
             .expect("the exact context resolves");
 
-        for byte in [1_u8, 2, 3] {
+        for byte in [1_u8, 2, 3, 4] {
             task.assign(task.owner).expect("ready work can go on wire");
             task.retry(SourceId::from_digest([byte; 32]))
                 .expect("each distinct supplier can fail");
         }
-        assert!(task.supplier_cycle_exhausted());
-        assert_eq!(task.tried_sources.len(), 3);
-        assert_eq!(task.attempts, 3);
-
-        task.record_failed_source(SourceId::from_digest([4; 32]))
-            .expect("ready work can record another failed supplier");
-        assert!(task.supplier_cycle_exhausted());
-        assert_eq!(task.tried_sources.len(), 3);
-        assert!(!task.tried_sources.contains(&SourceId::from_digest([4; 32])));
+        assert_eq!(task.tried_sources.len(), 4);
+        assert!(task.tried_sources.contains(&SourceId::from_digest([4; 32])));
         assert_eq!(task.attempts, 4);
 
         let deadline = Instant::now() + std::time::Duration::from_secs(1);
         task.defer_retry_until(deadline)
-            .expect("a bounded supplier cycle backs off");
+            .expect("a complete supplier cycle backs off");
         task.resume_retry_cycle(deadline);
-        assert!(!task.supplier_cycle_exhausted());
         assert!(task.tried_sources.is_empty());
         assert_eq!(task.state, RepairPolicyState::Ready { context });
     }

--- a/docs/changelog/unreleased/804.md
+++ b/docs/changelog/unreleased/804.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed a commitment-root repair retrying the same first three suppliers forever. The repair
+  now tries every eligible connected supplier before it starts another supplier cycle
+  ([#804](https://github.com/zakura-core/zakura/pull/804)).


### PR DESCRIPTION
## Summary

- retain every failed supplier for the current VCT repair cycle
- try a fresh fourth supplier after three deterministic failures
- clear the complete supplier set only when the cycle backs off

## Incident evidence

The PR 800 preserved-state validation connected two upgraded failed nodes to each other. One upgraded node completed a repair while it was among the first three connected suppliers. After three old suppliers connected, both nodes repeatedly retried only those same suppliers. Each old supplier returned `TargetNotRetained`. The upgraded fourth supplier remained connected and eligible but never received a repair request.

This PR stacks on #800 because it fixes the supplier rotation exposed by the PR 800 validation.

## Tests

- `cargo test -p zakura-network supplier_cycle_tries_a_fresh_peer_after_three_failures --lib`
- `cargo test -p zakura-network supplier_cycle_retains_every_distinct_source_until_backoff --lib`
- `cargo test -p zakura-network zakura::header_sync --lib`
- `cargo fmt --all -- --check`
- `git diff --check`