### PR TITLE
fix(state): prioritize VCT committer repairs

### DIFF
--- a/crates/zakura-state/src/service/write/vct_write_retry.rs
+++ b/crates/zakura-state/src/service/write/vct_write_retry.rs
@@ -233,20 +233,17 @@ impl VctWriteRetryManager {
         self.publish_effective_repair_status(None);
     }
 
-    /// Publishes the lowest outstanding repair height.
+    /// Publishes the repair that can unblock the writer.
     ///
-    /// The repair channel stores one latest value. The manager publishes the lower height because
-    /// its replacement unblocks the higher repair.
+    /// The repair channel stores one latest value. A committer repair takes priority because the
+    /// authentication sweep runs only after the checkpoint queue becomes empty. The sweep cannot
+    /// clear its repair while a missing committer root keeps that queue nonempty.
     fn publish_effective_repair_status(
         &mut self,
         requester_with_new_episode: Option<VctRepairRequester>,
     ) {
         let effective_repair = match (self.committer_repair_height, self.sweep_repair_height) {
-            (Some(committer), Some(sweep)) if committer <= sweep => {
-                Some((committer, VctRepairRequester::Committer))
-            }
-            (Some(_), Some(sweep)) => Some((sweep, VctRepairRequester::Sweep)),
-            (Some(committer), None) => Some((committer, VctRepairRequester::Committer)),
+            (Some(committer), _) => Some((committer, VctRepairRequester::Committer)),
             (None, Some(sweep)) => Some((sweep, VctRepairRequester::Sweep)),
             (None, None) => None,
         };

--- a/crates/zakura-state/src/service/write/vct_write_retry/tests.rs
+++ b/crates/zakura-state/src/service/write/vct_write_retry/tests.rs
@@ -241,6 +241,44 @@ fn a_hidden_higher_sweep_need_keeps_the_lower_committer_episode() {
 }
 
 #[test]
+fn a_committer_need_preempts_a_lower_sweep_need() {
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteRetryManager::new(tx);
+    let sweep_height = Height(42);
+    let committer_height = Height(84);
+
+    manager.request_sweep_repair(sweep_height);
+    let sweep_status = *rx.borrow_and_update();
+    assert_eq!(
+        sweep_status.state,
+        VctRootRepairState::Unavailable {
+            height: sweep_height
+        }
+    );
+
+    manager.request_committer_repair_for_test(committer_height);
+    let committer_status = *rx.borrow_and_update();
+    assert_eq!(
+        committer_status.state,
+        VctRootRepairState::Unavailable {
+            height: committer_height
+        },
+        "the committer must advance before the checkpoint queue can empty and run the sweep"
+    );
+    assert_eq!(committer_status.generation, sweep_status.generation + 1);
+
+    manager.on_commit_success();
+    let resumed_sweep = *rx.borrow_and_update();
+    assert_eq!(
+        resumed_sweep.state,
+        VctRootRepairState::Unavailable {
+            height: sweep_height
+        }
+    );
+    assert_eq!(resumed_sweep.generation, committer_status.generation + 1);
+}
+
+#[test]
 fn root_repair_signal_ignores_await_successor_and_clears_on_commit() {
     let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
     let mut manager = VctWriteRetryManager::new(tx);

--- a/docs/changelog/unreleased/806.md
+++ b/docs/changelog/unreleased/806.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed an older commitment-root authentication-sweep repair masking the next checkpoint
+  committer repair. The committer repair now takes priority until the checkpoint queue can empty
+  and resume the authentication sweep
+  ([#806](https://github.com/zakura-core/zakura/pull/806)).


### PR DESCRIPTION
## Summary

- prioritize a missing committer root over an older authentication-sweep repair
- resume the sweep repair after the blocked checkpoint commits
- cover the observed higher-committer, lower-sweep priority inversion

## Preserved-state evidence

PR #804 let both preserved nodes accept repairs. Each node then committed one or more blocks and stalled again. The active sweep repair remained below the next committer repair. The writer only runs the sweep after the checkpoint queue becomes empty, so the sweep could not clear while the committer kept that queue nonempty.

## Validation

- cargo test -p zakura-state service::write --lib
- cargo fmt --all -- --check
- git diff --check

Stacked on #804.