### PR TITLE
test(block-sync): harden retry filter boundaries

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -75,7 +75,7 @@ fn fill_stop_trace_due(last: Option<Instant>, now: Instant) -> bool {
 /// Return the first contiguous run that the predicate accepts.
 ///
 /// The function evaluates each visited item once. This property matters when
-/// the predicate reads shared retry state that another peer routine can update.
+/// the predicate reads shared retry state that the reactor or sequencer can update.
 fn first_allowed_run<T>(
     items: &[T],
     mut is_allowed: impl FnMut(&T) -> bool,
@@ -955,7 +955,14 @@ impl PeerRoutine {
                 }
             }
             self.trace_work_taken(servable_low, servable_high, items.len());
-            let scope = items[0].1.scope;
+            debug_assert!(
+                !items.is_empty(),
+                "retry filtering must retain a nonempty allowed run"
+            );
+            let Some((first_height, first_item)) = items.first().copied() else {
+                break FillStop::Internal;
+            };
+            let scope = first_item.scope;
             debug_assert!(items.iter().all(|(_, item)| item.scope == scope));
 
             // Reserve the summed per-block size estimate for this request (not
@@ -969,7 +976,7 @@ impl PeerRoutine {
             // chunk we actually kept can begin above the floor-rescue window. Label the
             // request by its *actual* lowest height, so a purely speculative take is never
             // funded as a floor reservation or given the short floor-rescue leash.
-            let request_priority = classify_priority(view.download_floor, items[0].0);
+            let request_priority = classify_priority(view.download_floor, first_height);
 
             let reserved_bytes = items.iter().fold(0u64, |acc, (_, item)| {
                 acc.saturating_add(item.estimated_bytes)
@@ -1014,9 +1021,9 @@ impl PeerRoutine {
             };
             let request = BlockRangeRequest {
                 owner,
-                start_height: items[0].0,
+                start_height: first_height,
                 count,
-                anchor_hash: items[0].1.hash,
+                anchor_hash: first_item.hash,
                 // The summed size-estimate reservation for this request (released
                 // on a send failure below); equals the sum of the per-height
                 // `expected_blocks` estimates.
@@ -2227,18 +2234,77 @@ mod tests {
     use crate::zakura::trace::ZakuraTrace;
     use crate::zakura::ZakuraPeerId;
 
+    fn reference_first_allowed_run(allowed: &[bool]) -> Option<std::ops::Range<usize>> {
+        let start = allowed.iter().position(|allowed| *allowed)?;
+        let len = allowed[start..]
+            .iter()
+            .take_while(|allowed| **allowed)
+            .count();
+        Some(start..start + len)
+    }
+
     #[test]
-    fn retry_filter_evaluates_each_item_once() {
-        let items = [0usize, 1, 2, 3];
-        let mut calls = [0usize; 4];
+    fn retry_filter_retains_each_small_allowed_run() {
+        for len in 0..=6 {
+            for mask in 0..(1usize << len) {
+                let allowed: Vec<_> = (0..len)
+                    .map(|index| mask & (1usize << index) != 0)
+                    .collect();
+                let expected = reference_first_allowed_run(&allowed);
+                let items: Vec<_> = (0..len).collect();
+                let mut calls = vec![0usize; len];
 
-        let keep = super::first_allowed_run(&items, |item| {
-            calls[*item] += 1;
-            matches!(*item, 1 | 2)
-        });
+                let keep = super::first_allowed_run(&items, |item| {
+                    calls[*item] += 1;
+                    allowed[*item]
+                });
 
-        assert_eq!(keep, Some(1..3));
-        assert_eq!(calls, [1, 1, 1, 1]);
+                assert_eq!(keep, expected, "len={len}, mask={mask:#08b}");
+
+                let visited_len = match &expected {
+                    Some(range) if range.end < len => range.end + 1,
+                    Some(range) => range.end,
+                    None => len,
+                };
+                for (index, calls) in calls.into_iter().enumerate() {
+                    assert_eq!(
+                        calls,
+                        usize::from(index < visited_len),
+                        "len={len}, mask={mask:#08b}, index={index}"
+                    );
+                }
+
+                let mut retained = items;
+                let mut returned = Vec::new();
+                match keep {
+                    Some(keep) => {
+                        let keep_len = keep.len();
+                        if keep.start > 0 {
+                            returned.extend(retained.drain(..keep.start));
+                        }
+                        if keep_len < retained.len() {
+                            returned.extend(retained.split_off(keep_len));
+                        }
+                    }
+                    None => {
+                        returned.extend(retained.iter().copied());
+                        retained.clear();
+                    }
+                }
+
+                let expected_retained: Vec<_> = expected.clone().into_iter().flatten().collect();
+                let expected_returned: Vec<_> = (0..len)
+                    .filter(|index| !expected.as_ref().is_some_and(|range| range.contains(index)))
+                    .collect();
+                assert_eq!(retained, expected_retained, "len={len}, mask={mask:#08b}");
+                assert_eq!(returned, expected_returned, "len={len}, mask={mask:#08b}");
+                assert_eq!(
+                    retained.is_empty(),
+                    expected.is_none(),
+                    "len={len}, mask={mask:#08b}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/docs/changelog/unreleased/808.md
+++ b/docs/changelog/unreleased/808.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This stacked PR hardens an internal block-sync invariant and expands its tests.
+PR #807 contains the operator-visible changelog entry for the retry-filter fix.


### PR DESCRIPTION
## Summary

- Test every retry-filter decision pattern through six items.
- Verify the predicate evaluates each visited item once.
- Exercise the production drain and split retention geometry.
- Guard request construction against an unexpected empty filtered range.
- Name the reactor and sequencer as the concurrent retry-state writers.

## Stack

- Depends on #807.
- Targets `fix/empty-retry-filter` so #807 remains unchanged.

## Validation

- `cargo test -p zakura-network zakura::block_sync` (278 passed)
- `cargo test -p zakura-network` (1,092 passed, 3 ignored; acceptance test passed)
- `cargo fmt --all -- --check`
- `git diff --check`