### PR TITLE
fix(sync): bound VCT supplier rotation

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -38,14 +38,13 @@ use crate::zakura::{
 const INTERNAL_VCT_REPAIR_SESSION_ID: u64 = u64::MAX;
 const LEASE_RELEASE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const VCT_REPAIR_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
-/// Minimum interval between repeated unassignable-repair trace rows for one repair generation.
+/// Minimum interval between repeated stalled-repair trace rows for one repair generation.
 ///
 /// The reactor emits the first row immediately, then samples while nothing changes. The bound
-/// keeps a long unassignable repair from dominating the header-sync JSONL trace.
-const VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL: std::time::Duration =
-    std::time::Duration::from_secs(10);
-/// Time one repair generation may stay unassignable before the reactor reports it at error level.
-const VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+/// keeps a long stalled repair from dominating the header-sync JSONL trace.
+const VCT_REPAIR_STALL_TRACE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+/// Time one repair generation may stay stalled before the reactor reports it at error level.
+const VCT_REPAIR_STALL_REPORT_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
 /// Minimum interval between unchanged header-snapshot refresh trace rows.
 ///
 /// The trace records every frontier advance and reanchor.
@@ -177,7 +176,7 @@ fn build_header_sync_reactor(
         request_deadlines: HashMap::new(),
         completed_targets: CompletedHeaderTargets::default(),
         vct_repair: RepairRequirementSlot::default(),
-        vct_repair_no_supplier: None,
+        vct_repair_stall: None,
         served_paths: HashMap::new(),
         served_path_deadlines: HashMap::new(),
         pending_lease_releases: VecDeque::new(),
@@ -274,8 +273,8 @@ struct HeaderSyncReactor {
     request_deadlines: HashMap<ZakuraPeerId, Instant>,
     completed_targets: CompletedHeaderTargets,
     vct_repair: RepairRequirementSlot,
-    /// Escalation state for a repair generation that no peer can supply.
-    vct_repair_no_supplier: Option<VctRepairNoSupplier>,
+    /// Escalation state for a repair generation that has not completed.
+    vct_repair_stall: Option<VctRepairStall>,
     served_paths: HashMap<ZakuraPeerId, ServedPathState>,
     served_path_deadlines: HashMap<ZakuraPeerId, Instant>,
     pending_lease_releases: VecDeque<PendingLeaseRelease>,
@@ -326,6 +325,23 @@ enum HeaderRequestTerminal {
 }
 
 impl HeaderRequestTerminal {
+    /// Whether this outcome is evidence against the selected supplier.
+    fn rotates_vct_supplier(self) -> bool {
+        matches!(
+            self,
+            Self::TargetNotRetained
+                | Self::NoLocatorIntersection
+                | Self::HistoryPruned
+                | Self::Busy
+                | Self::Disconnected
+                | Self::MalformedResponse
+                | Self::SendError
+                | Self::SessionReplaced
+                | Self::TargetRejected
+                | Self::TimedOut
+        )
+    }
+
     fn needs_terminal_trace(self) -> bool {
         !matches!(
             self,
@@ -407,14 +423,16 @@ struct VctSupplierRejections {
     already_serving: u64,
     /// Peers already tried in the current supplier cycle.
     already_tried: u64,
+    /// Eligible peers whose request could not enter the ordered send queue.
+    send_failed: u64,
 }
 
-/// One repair generation that has found no eligible supplier.
+/// One repair generation that has not completed despite supplier scheduling.
 #[derive(Copy, Clone, Debug)]
-struct VctRepairNoSupplier {
+struct VctRepairStall {
     /// Repair generation this record tracks.
     generation: u64,
-    /// First observation of the unassignable generation.
+    /// First failed supplier-cycle observation for this generation.
     since: Instant,
     /// Last emitted trace row.
     last_trace: Instant,
@@ -1541,6 +1559,7 @@ impl HeaderSyncReactor {
                     if let Some(task) = self.vct_repair.get(repair_owner) {
                         self.emit_vct_repair_state(task, "admission", Some("applied"));
                     }
+                    self.vct_repair_stall = None;
                     metrics::counter!("sync.header.vct.repair.admitted.total").increment(1);
                 }
                 HeaderTargetAdmissionResult::Failed(error) => {
@@ -1556,10 +1575,8 @@ impl HeaderSyncReactor {
                     // repair generation while it polls, so a dropped task would wait for an
                     // unrelated snapshot change that a stalled node has no way to produce.
                     let deferred = self.vct_repair.get_mut(repair_owner).is_some_and(|task| {
-                        task.retry(source).is_ok()
-                            && task
-                                .defer_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
-                                .is_ok()
+                        task.defer_local_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
+                            .is_ok()
                     });
                     if !deferred {
                         self.vct_repair.remove(repair_owner);
@@ -1682,12 +1699,22 @@ impl HeaderSyncReactor {
                     Some(&error),
                 );
                 if is_repair {
+                    let terminal = match error.attribution {
+                        zakura_header_chain::Attribution::HeaderPeer(attributed)
+                        | zakura_header_chain::Attribution::BodyPeer(attributed)
+                        | zakura_header_chain::Attribution::AuxPeer(attributed)
+                            if attributed == source =>
+                        {
+                            HeaderRequestTerminal::TargetRejected
+                        }
+                        _ => HeaderRequestTerminal::LocalError,
+                    };
                     self.retry_vct_repair(
                         owner
                             .body_owner()
                             .expect("an auxiliary repair has body authority"),
                         source,
-                        HeaderRequestTerminal::TargetRejected,
+                        terminal,
                     );
                 } else {
                     self.retire_peer_work(&peer, HeaderRequestTerminal::TargetRejected);
@@ -1757,15 +1784,30 @@ impl HeaderSyncReactor {
         if let Some(peer) = peer {
             self.request_deadlines.remove(&peer);
         }
-        if self
-            .vct_repair
-            .get_mut(owner)
-            .is_some_and(|task| task.retry(source).is_ok())
-        {
-            if let Some(task) = self.vct_repair.current() {
-                self.emit_vct_repair_state(task, "retry", Some("supplier_retry"));
+        let supplier_failure = terminal_outcome.rotates_vct_supplier();
+        let retry_scheduled = self.vct_repair.get_mut(owner).is_some_and(|task| {
+            if supplier_failure {
+                task.retry(source).is_ok()
+            } else {
+                task.defer_local_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
+                    .is_ok()
             }
-            self.try_assign_vct_repair();
+        });
+        if retry_scheduled {
+            if let Some(task) = self.vct_repair.current() {
+                self.emit_vct_repair_state(
+                    task,
+                    "retry",
+                    Some(if supplier_failure {
+                        "supplier_retry"
+                    } else {
+                        "local_backoff"
+                    }),
+                );
+            }
+            if supplier_failure {
+                self.try_assign_vct_repair();
+            }
         }
     }
 
@@ -1784,19 +1826,24 @@ impl HeaderSyncReactor {
         });
     }
 
-    /// Record a repair generation that no connected peer can supply.
+    /// Record a repair generation after supplier scheduling fails to complete it.
     ///
     /// The reactor samples the trace row and escalates to error level once the generation has
-    /// stayed unassignable for [`VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER`]. Without the tally an
+    /// stayed stalled for [`VCT_REPAIR_STALL_REPORT_AFTER`]. Without the tally an
     /// operator sees only that the repair made no progress.
-    fn note_vct_repair_no_supplier(
+    fn note_vct_repair_stall(
         &mut self,
         task: &RepairRequirement,
         predecessor: zakura_header_chain::Frontier,
         rejections: &VctSupplierRejections,
+        outcome: &'static str,
         now: Instant,
     ) {
-        metrics::counter!("sync.header.vct.repair.no_supplier.total").increment(1);
+        metrics::counter!("sync.header.vct.repair.stalled.total", "outcome" => outcome)
+            .increment(1);
+        if outcome == "no_eligible_supplier" {
+            metrics::counter!("sync.header.vct.repair.no_supplier.total").increment(1);
+        }
         let best_peer_tip = self
             .peer_state
             .values()
@@ -1805,9 +1852,9 @@ impl HeaderSyncReactor {
             .max_by_key(|(height, _)| *height);
 
         let open_record = self
-            .vct_repair_no_supplier
+            .vct_repair_stall
             .filter(|record| record.generation == task.repair_generation);
-        let mut record = open_record.unwrap_or(VctRepairNoSupplier {
+        let mut record = open_record.unwrap_or(VctRepairStall {
             generation: task.repair_generation,
             since: now,
             last_trace: now,
@@ -1815,12 +1862,11 @@ impl HeaderSyncReactor {
         });
         let stalled_for = now.saturating_duration_since(record.since);
         let trace_due = open_record.is_none()
-            || now.saturating_duration_since(record.last_trace)
-                >= VCT_REPAIR_NO_SUPPLIER_TRACE_INTERVAL;
-        let report_due = !record.reported && stalled_for >= VCT_REPAIR_NO_SUPPLIER_REPORT_AFTER;
+            || now.saturating_duration_since(record.last_trace) >= VCT_REPAIR_STALL_TRACE_INTERVAL;
+        let report_due = !record.reported && stalled_for >= VCT_REPAIR_STALL_REPORT_AFTER;
 
         if trace_due {
-            self.emit_vct_repair_no_supplier(task, predecessor, rejections, best_peer_tip);
+            self.emit_vct_repair_stall(task, predecessor, rejections, best_peer_tip, outcome);
             record.last_trace = now;
         }
         if report_due {
@@ -1836,25 +1882,35 @@ impl HeaderSyncReactor {
                 rejected_schema = rejections.unsupported_schema,
                 rejected_busy = rejections.already_serving,
                 rejected_tried = rejections.already_tried,
+                send_failed = rejections.send_failed,
                 ?stalled_for,
-                "VCT: no connected peer can supply the repair root; the parked checkpoint commit \
-                 cannot advance until an eligible supplier appears"
+                "VCT: supplier scheduling has not completed the repair root; the parked \
+                 checkpoint commit cannot advance"
             );
             record.reported = true;
         }
 
-        self.vct_repair_no_supplier = Some(record);
+        self.vct_repair_stall = Some(record);
     }
 
-    fn emit_vct_repair_no_supplier(
+    fn emit_vct_repair_stall(
         &self,
         task: &RepairRequirement,
         predecessor: zakura_header_chain::Frontier,
         rejections: &VctSupplierRejections,
         best_peer_tip: Option<(block::Height, block::Hash)>,
+        outcome: &'static str,
     ) {
         self.startup.trace.emit_with(HEADER_SYNC_TABLE, |row| {
-            insert_vct_repair_identity(row, task, "no_supplier");
+            insert_vct_repair_identity(
+                row,
+                task,
+                if outcome == "no_eligible_supplier" {
+                    "no_supplier"
+                } else {
+                    "stall"
+                },
+            );
             row.insert(
                 hs_trace::PREDECESSOR_HEIGHT.into(),
                 u64::from(predecessor.height.0).into(),
@@ -1893,12 +1949,12 @@ impl HeaderSyncReactor {
                 hs_trace::BEST_PEER_HASH.into(),
                 best_peer_tip.map_or(serde_json::Value::Null, |(_, hash)| hash.to_string().into()),
             );
-            row.insert(hs_trace::OUTCOME.into(), "no_eligible_supplier".into());
+            row.insert(hs_trace::OUTCOME.into(), outcome.into());
         });
     }
 
     fn retire_vct_repair(&mut self) {
-        self.vct_repair_no_supplier = None;
+        self.vct_repair_stall = None;
         if let Some(task) = self.vct_repair.take() {
             if let Some(peer) = self
                 .peer_work_queue
@@ -2679,14 +2735,6 @@ impl HeaderSyncReactor {
         let RepairPolicyState::Ready { context } = &task.state else {
             return;
         };
-        if task.supplier_cycle_exhausted() {
-            let _ = self
-                .vct_repair
-                .get_mut(task.owner)
-                .expect("the ready repair was cloned above")
-                .defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
-            return;
-        }
         let Some(predecessor) = context.locator.entries().first().copied() else {
             return;
         };
@@ -2730,9 +2778,39 @@ impl HeaderSyncReactor {
             }
             candidates.push((peer.clone(), source, state.session.clone(), status.clone()));
         }
-        candidates.sort_by(|left, right| left.0.as_bytes().cmp(right.0.as_bytes()));
+        candidates.sort_by(|left, right| {
+            left.1
+                .cmp(&right.1)
+                .then_with(|| left.0.as_bytes().cmp(right.0.as_bytes()))
+        });
+        if let Some(cursor) = task.supplier_cursor {
+            let first_after_cursor =
+                candidates.partition_point(|(_, source, _, _)| *source <= cursor);
+            candidates.rotate_left(first_after_cursor);
+        }
+        if task.supplier_cycle_exhausted() {
+            self.note_vct_repair_stall(
+                &task,
+                predecessor,
+                &rejections,
+                "supplier_cycle_exhausted",
+                now,
+            );
+            let _ = self
+                .vct_repair
+                .get_mut(task.owner)
+                .expect("the ready repair was cloned above")
+                .defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
+            return;
+        }
         if candidates.is_empty() {
-            self.note_vct_repair_no_supplier(&task, predecessor, &rejections, now);
+            self.note_vct_repair_stall(
+                &task,
+                predecessor,
+                &rejections,
+                "no_eligible_supplier",
+                now,
+            );
             let _ = self
                 .vct_repair
                 .get_mut(task.owner)
@@ -2759,11 +2837,11 @@ impl HeaderSyncReactor {
                 Err(error) => {
                     self.peer_work_queue.cancel_request_reservation(&peer);
                     self.emit_queue_send_failed(&peer, &session, "GetHeaders", &error, None);
+                    rejections.send_failed += 1;
                     if let Some(current) = self.vct_repair.get_mut(task.owner) {
                         let _ = current.record_failed_source(source);
                         if current.supplier_cycle_exhausted() {
-                            let _ = current.defer_retry_until(now + VCT_REPAIR_RETRY_INTERVAL);
-                            return;
+                            break;
                         }
                     }
                     continue;
@@ -2788,10 +2866,6 @@ impl HeaderSyncReactor {
                 self.peer_work_queue.cancel_request_reservation(&peer);
                 return;
             }
-            // The repair reached a supplier, so the unassignable clock starts over. Clearing it
-            // on a non-empty candidate set instead would restart the clock even when every
-            // candidate failed to send, and suppress the escalation the operator needs.
-            self.vct_repair_no_supplier = None;
             if let Some(task) = self.vct_repair.get(wire_owner) {
                 self.emit_vct_repair_state(task, "assignment", Some("assigned"));
             }
@@ -2840,6 +2914,17 @@ impl HeaderSyncReactor {
                 "requested exact selected VCT metadata repair"
             );
             return;
+        }
+        if let Some(current) = self.vct_repair.get(task.owner).cloned() {
+            if rejections.send_failed > 0 || current.supplier_cycle_exhausted() {
+                self.note_vct_repair_stall(
+                    &current,
+                    predecessor,
+                    &rejections,
+                    "supplier_send_failed",
+                    now,
+                );
+            }
         }
         let _ = self
             .vct_repair

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::zakura::header_sync::scheduler::repair::MAX_SUPPLIERS_PER_CYCLE;
 
 #[test]
 fn request_timeout_retires_owned_work_and_wakes_maintenance() {
@@ -157,7 +158,7 @@ fn initial_vct_wire_assignment_arms_the_request_deadline() {
 }
 
 #[test]
-fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
+fn bounded_supplier_cycles_rotate_to_the_fourth_supplier() {
     let mut startup = startup(CancellationToken::new());
     let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
     let mut snapshot = committed_snapshot(anchor);
@@ -168,15 +169,22 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
     let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
     startup.committed_snapshots = Some(snapshots_rx);
     let (_handle, _actions, mut reactor) =
-        build_header_sync_reactor(startup).expect("the bounded repair fixture builds");
-    let peer = peer();
-    let (send, _outbound) = framed_channel(8);
-    reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
-        peer.clone(),
-        7,
-        send,
-        CancellationToken::new(),
-    ));
+        build_header_sync_reactor(startup).expect("the bounded round-robin repair fixture builds");
+    let peers: Vec<_> = [1_u8, 2, 3, 4]
+        .into_iter()
+        .map(|byte| ZakuraPeerId::new(vec![byte; 32]).expect("the peer ID has the required length"))
+        .collect();
+    let mut _outbounds = Vec::new();
+    for (index, peer) in peers.iter().enumerate() {
+        let (send, outbound) = framed_channel(8);
+        reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+            peer.clone(),
+            7 + u64::try_from(index).expect("four peer indexes fit in u64"),
+            send,
+            CancellationToken::new(),
+        ));
+        _outbounds.push(outbound);
+    }
     let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(&snapshot).bind(
         INTERNAL_VCT_REPAIR_SESSION_ID,
         std::num::NonZeroU64::new(1).expect("one is nonzero"),
@@ -185,18 +193,138 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
         target: repair_target,
         locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
     };
-    let mut repair = RepairRequirement::new(owner, repair_target.height, 11);
-    repair.state = RepairPolicyState::Ready {
+    let mut task = RepairRequirement::new(owner, repair_target.height, 11);
+    task.state = RepairPolicyState::Ready {
         context: context.clone(),
     };
-    for byte in [0x11_u8, 0x22, 0x33] {
-        repair
-            .tried_sources
-            .insert(zakura_header_chain::SourceId::from_digest([byte; 32]));
+    reactor.vct_repair.insert(task);
+    let status = Status {
+        work_anchor_height: anchor.height,
+        work_anchor_hash: anchor.hash,
+        selected_tip_height: snapshot.frontiers.header_best.height,
+        selected_tip_hash: snapshot.frontiers.header_best.hash,
+        suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(2_u8),
+        oldest_retained_height: anchor.height,
+        max_headers_per_response: 1,
+        max_inflight_requests: 1,
+        max_message_bytes: 2_000_000,
+        tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+    };
+    for (index, peer) in peers.iter().enumerate() {
+        reactor.handle_wire_message(
+            peer.clone(),
+            7 + u64::try_from(index).expect("four peer indexes fit in u64"),
+            HeaderSyncMessage::Status(status.clone()),
+        );
     }
-    assert!(repair.supplier_cycle_exhausted());
-    reactor.vct_repair.insert(repair);
 
+    for peer in &peers[..3] {
+        let active = reactor
+            .peer_work_queue
+            .active(peer)
+            .expect("the next round-robin supplier owns the repair")
+            .clone();
+        assert!(matches!(
+            active.purpose,
+            HeaderTargetPurpose::SelectedAuxiliaryRepair { .. }
+        ));
+        reactor.handle_headers_outcome(
+            peer.clone(),
+            active.owner.session_id(),
+            active.owner.header_authority(),
+            HeadersOutcome {
+                request_id: active.request_id.get(),
+                target_tip_hash: repair_target.hash,
+                outcome: HeadersOutcomeCode::TargetNotRetained,
+            },
+        );
+    }
+
+    assert!(peers
+        .iter()
+        .all(|peer| reactor.peer_work_queue.active(peer).is_none()));
+    let task = reactor
+        .vct_repair
+        .current()
+        .expect("the bounded cycle keeps the repair requirement");
+    let retry_at = match &task.state {
+        RepairPolicyState::SupplierBackoff {
+            context: retained,
+            retry_at,
+        } if retained == &context => *retry_at,
+        other => panic!("three supplier failures must back off, got {other:?}"),
+    };
+    assert_eq!(task.tried_sources.len(), 3);
+    assert!(task.supplier_cycle_exhausted());
+    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    let stall = reactor
+        .vct_repair_stall
+        .expect("a complete failed cycle starts the generation stall clock");
+
+    reactor
+        .vct_repair
+        .current_mut()
+        .expect("the repair remains scheduled")
+        .resume_retry_cycle(retry_at);
+    reactor.try_assign_vct_repair();
+
+    let active = reactor
+        .peer_work_queue
+        .active(&peers[3])
+        .expect("the next cycle starts after the persistent supplier cursor");
+    assert!(matches!(
+        active.purpose,
+        HeaderTargetPurpose::SelectedAuxiliaryRepair { .. }
+    ));
+    let task = reactor
+        .vct_repair
+        .current()
+        .expect("the fourth supplier owns the current repair");
+    assert!(task.tried_sources.is_empty());
+    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    assert_eq!(
+        reactor
+            .vct_repair_stall
+            .expect("assignment preserves the generation stall clock")
+            .since,
+        stall.since
+    );
+}
+
+#[test]
+fn replacement_session_keeps_the_authenticated_supplier_identity() {
+    let mut startup = startup(CancellationToken::new());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut snapshot = committed_snapshot(anchor);
+    let repair_target =
+        zakura_header_chain::Frontier::new(block::Height(1), block::Hash([0x41; 32]));
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(2), block::Hash([0x42; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_handle, _actions, mut reactor) =
+        build_header_sync_reactor(startup).expect("the replacement fixture builds");
+    let peer = peer();
+    let source = source_id_from_peer(&peer);
+    let (first_send, _first_outbound) = framed_channel(8);
+    reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+        peer.clone(),
+        7,
+        first_send,
+        CancellationToken::new(),
+    ));
+    let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(&snapshot).bind(
+        INTERNAL_VCT_REPAIR_SESSION_ID,
+        std::num::NonZeroU64::new(1).expect("one is nonzero"),
+    );
+    let mut task = RepairRequirement::new(owner, repair_target.height, 11);
+    task.state = RepairPolicyState::Ready {
+        context: zakura_header_chain::VctRepairContext {
+            target: repair_target,
+            locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+        },
+    };
+    reactor.vct_repair.insert(task);
     reactor.handle_wire_message(
         peer.clone(),
         7,
@@ -213,21 +341,128 @@ fn bounded_supplier_cycle_backs_off_while_fresh_peers_remain() {
             tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
         }),
     );
+    assert!(reactor.peer_work_queue.active(&peer).is_some());
 
+    let (replacement_send, _replacement_outbound) = framed_channel(8);
+    reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+        peer.clone(),
+        8,
+        replacement_send,
+        CancellationToken::new(),
+    ));
+
+    assert_eq!(reactor.peer_state.len(), 1);
     assert!(reactor.peer_work_queue.active(&peer).is_none());
     let task = reactor
         .vct_repair
         .current()
-        .expect("the bounded cycle keeps the repair requirement");
+        .expect("the replacement keeps the repair scheduled");
+    assert_eq!(task.tried_sources, [source].into_iter().collect());
+    assert_eq!(task.supplier_cursor, Some(source));
     assert!(matches!(
-        &task.state,
-        RepairPolicyState::SupplierBackoff {
-            context: retained,
-            ..
-        } if retained == &context
+        task.state,
+        RepairPolicyState::SupplierBackoff { .. }
     ));
-    assert_eq!(task.tried_sources.len(), 3);
-    assert!(task.supplier_cycle_exhausted());
+}
+
+#[test]
+fn send_failures_preserve_the_stall_clock_across_bounded_cycles() {
+    let mut startup = startup(CancellationToken::new());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut snapshot = committed_snapshot(anchor);
+    let repair_target =
+        zakura_header_chain::Frontier::new(block::Height(1), block::Hash([0x41; 32]));
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(2), block::Hash([0x42; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_handle, _actions, mut reactor) =
+        build_header_sync_reactor(startup).expect("the send-failure fixture builds");
+    let peers: Vec<_> = [1_u8, 2, 3, 4]
+        .into_iter()
+        .map(|byte| ZakuraPeerId::new(vec![byte; 32]).expect("the peer ID is bounded"))
+        .collect();
+    let status = Status {
+        work_anchor_height: anchor.height,
+        work_anchor_hash: anchor.hash,
+        selected_tip_height: snapshot.frontiers.header_best.height,
+        selected_tip_hash: snapshot.frontiers.header_best.hash,
+        suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(2_u8),
+        oldest_retained_height: anchor.height,
+        max_headers_per_response: 1,
+        max_inflight_requests: 1,
+        max_message_bytes: 2_000_000,
+        tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+    };
+    for (index, peer) in peers.iter().enumerate() {
+        let session_id = 7 + u64::try_from(index).expect("four peer indexes fit in u64");
+        let (send, outbound) = framed_channel(8);
+        reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+            peer.clone(),
+            session_id,
+            send,
+            CancellationToken::new(),
+        ));
+        reactor.handle_wire_message(
+            peer.clone(),
+            session_id,
+            HeaderSyncMessage::Status(status.clone()),
+        );
+        drop(outbound);
+    }
+    let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(&snapshot).bind(
+        INTERNAL_VCT_REPAIR_SESSION_ID,
+        std::num::NonZeroU64::new(1).expect("one is nonzero"),
+    );
+    let context = zakura_header_chain::VctRepairContext {
+        target: repair_target,
+        locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+    };
+    let mut task = RepairRequirement::new(owner, repair_target.height, 11);
+    task.state = RepairPolicyState::Ready {
+        context: context.clone(),
+    };
+    reactor.vct_repair.insert(task);
+
+    reactor.try_assign_vct_repair();
+
+    let first_retry_at = match &reactor
+        .vct_repair
+        .current()
+        .expect("send failures keep the repair")
+        .state
+    {
+        RepairPolicyState::SupplierBackoff { retry_at, .. } => *retry_at,
+        other => panic!("three send failures must back off, got {other:?}"),
+    };
+    let task = reactor.vct_repair.current().expect("the repair remains");
+    assert_eq!(task.tried_sources.len(), MAX_SUPPLIERS_PER_CYCLE);
+    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    let stall = reactor
+        .vct_repair_stall
+        .expect("send failures start the stall clock");
+
+    reactor
+        .vct_repair
+        .current_mut()
+        .expect("the repair remains")
+        .resume_retry_cycle(first_retry_at);
+    reactor.try_assign_vct_repair();
+
+    let task = reactor.vct_repair.current().expect("the repair remains");
+    assert!(matches!(
+        task.state,
+        RepairPolicyState::SupplierBackoff { .. }
+    ));
+    assert_eq!(task.tried_sources.len(), MAX_SUPPLIERS_PER_CYCLE);
+    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[1])));
+    assert_eq!(
+        reactor
+            .vct_repair_stall
+            .expect("the next send cycle preserves the stall clock")
+            .since,
+        stall.since
+    );
 }
 
 #[test]

--- a/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
@@ -8,7 +8,7 @@ use zakura_chain::block;
 use zakura_header_chain::{BodyWorkOwner, EngineSnapshot, SourceId, VctRepairContext};
 
 /// Maximum distinct suppliers retained and tried before one repair backoff cycle.
-const MAX_SUPPLIERS_PER_CYCLE: usize = 3;
+pub(in crate::zakura::header_sync) const MAX_SUPPLIERS_PER_CYCLE: usize = 3;
 
 /// Structurally complete state of one auxiliary repair task.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -37,6 +37,13 @@ pub(in crate::zakura::header_sync) enum RepairPolicyState {
         /// Exact selected request context.
         context: VctRepairContext,
         /// Earliest time another full supplier cycle may begin.
+        retry_at: Instant,
+    },
+    /// A local failure paused the repair without completing its supplier cycle.
+    LocalBackoff {
+        /// Exact selected request context.
+        context: VctRepairContext,
+        /// Earliest time local scheduling may resume.
         retry_at: Instant,
     },
     /// A shared active target owns supplier, wire, preparation, and admission progress.
@@ -77,6 +84,8 @@ pub(in crate::zakura::header_sync) struct RepairRequirement {
     pub attempts: u64,
     /// Suppliers already tried in the current cycle.
     pub tried_sources: HashSet<SourceId>,
+    /// Last supplier tried across every cycle for deterministic round-robin rotation.
+    pub supplier_cursor: Option<SourceId>,
 }
 
 impl RepairRequirement {
@@ -89,6 +98,7 @@ impl RepairRequirement {
             state: RepairPolicyState::NeedsContext,
             attempts: 0,
             tried_sources: HashSet::new(),
+            supplier_cursor: None,
         }
     }
 
@@ -159,6 +169,7 @@ impl RepairRequirement {
         self.attempts = self.attempts.saturating_add(1);
         if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
             self.tried_sources.insert(source);
+            self.supplier_cursor = Some(source);
         }
         self.state = RepairPolicyState::Ready { context };
         Ok(())
@@ -172,7 +183,21 @@ impl RepairRequirement {
         self.attempts = self.attempts.saturating_add(1);
         if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
             self.tried_sources.insert(source);
+            self.supplier_cursor = Some(source);
         }
+        Ok(())
+    }
+
+    /// Back off an assigned repair after a local failure without rejecting its supplier.
+    pub fn defer_local_retry_until(&mut self, retry_at: Instant) -> Result<(), RepairPolicyError> {
+        let RepairPolicyState::Assigned { context } = &self.state else {
+            return Err(RepairPolicyError::IllegalState);
+        };
+        self.attempts = self.attempts.saturating_add(1);
+        self.state = RepairPolicyState::LocalBackoff {
+            context: context.clone(),
+            retry_at,
+        };
         Ok(())
     }
 
@@ -210,6 +235,11 @@ impl RepairRequirement {
                 };
                 self.tried_sources.clear();
             }
+            RepairPolicyState::LocalBackoff { context, retry_at } if *retry_at <= now => {
+                self.state = RepairPolicyState::Ready {
+                    context: context.clone(),
+                };
+            }
             _ => {}
         }
     }
@@ -219,7 +249,8 @@ impl RepairRequirement {
         match self.state {
             RepairPolicyState::QueryingContext { deadline, .. } => Some(deadline),
             RepairPolicyState::ContextBackoff { retry_at }
-            | RepairPolicyState::SupplierBackoff { retry_at, .. } => Some(retry_at),
+            | RepairPolicyState::SupplierBackoff { retry_at, .. }
+            | RepairPolicyState::LocalBackoff { retry_at, .. } => Some(retry_at),
             _ => None,
         }
     }
@@ -432,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn supplier_cycle_retains_at_most_three_distinct_sources() {
+    fn supplier_cycle_bounds_identity_churn_and_preserves_cursor() {
         let mut task = task(&snapshot());
         let context = context();
         mark_context_requested(&mut task);
@@ -447,13 +478,17 @@ mod tests {
         assert!(task.supplier_cycle_exhausted());
         assert_eq!(task.tried_sources.len(), 3);
         assert_eq!(task.attempts, 3);
+        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
 
-        task.record_failed_source(SourceId::from_digest([4; 32]))
-            .expect("ready work can record another failed supplier");
+        for byte in 4_u8..=64 {
+            task.record_failed_source(SourceId::from_digest([byte; 32]))
+                .expect("late churn cannot enlarge an exhausted cycle");
+        }
         assert!(task.supplier_cycle_exhausted());
         assert_eq!(task.tried_sources.len(), 3);
         assert!(!task.tried_sources.contains(&SourceId::from_digest([4; 32])));
-        assert_eq!(task.attempts, 4);
+        assert_eq!(task.attempts, 64);
+        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
 
         let deadline = Instant::now() + std::time::Duration::from_secs(1);
         task.defer_retry_until(deadline)
@@ -461,6 +496,41 @@ mod tests {
         task.resume_retry_cycle(deadline);
         assert!(!task.supplier_cycle_exhausted());
         assert!(task.tried_sources.is_empty());
+        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
+        assert_eq!(task.state, RepairPolicyState::Ready { context });
+    }
+
+    #[test]
+    fn local_retry_preserves_supplier_eligibility_and_cursor() {
+        let mut task = task(&snapshot());
+        let context = context();
+        mark_context_requested(&mut task);
+        task.resolve(context.clone())
+            .expect("the exact context resolves");
+        task.assign(task.owner).expect("ready work can go on wire");
+        let failed_source = SourceId::from_digest([1; 32]);
+        task.retry(failed_source)
+            .expect("one supplier failure starts the current cycle");
+        task.assign(task.owner)
+            .expect("another supplier can own the current cycle");
+        let retry_at = Instant::now() + std::time::Duration::from_secs(1);
+
+        task.defer_local_retry_until(retry_at)
+            .expect("a local failure backs off assigned work");
+
+        assert_eq!(task.tried_sources, [failed_source].into_iter().collect());
+        assert_eq!(task.supplier_cursor, Some(failed_source));
+        assert_eq!(task.attempts, 2);
+        assert_eq!(
+            task.state,
+            RepairPolicyState::LocalBackoff {
+                context: context.clone(),
+                retry_at,
+            }
+        );
+        task.resume_retry_cycle(retry_at);
+        assert_eq!(task.tried_sources, [failed_source].into_iter().collect());
+        assert_eq!(task.supplier_cursor, Some(failed_source));
         assert_eq!(task.state, RepairPolicyState::Ready { context });
     }
 
@@ -513,6 +583,10 @@ mod tests {
                 context: context.clone(),
             },
             RepairPolicyState::SupplierBackoff {
+                context: context.clone(),
+                retry_at: deadline,
+            },
+            RepairPolicyState::LocalBackoff {
                 context: context.clone(),
                 retry_at: deadline,
             },

--- a/docs/changelog/unreleased/810.md
+++ b/docs/changelog/unreleased/810.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed VCT repair supplier rotation so bounded retry cycles reach every connected supplier
+  without allowing peer identity churn to grow scheduler state without limit
+  ([#810](https://github.com/zakura-core/zakura/pull/810)).


### PR DESCRIPTION
## Summary

- keep each VCT repair cycle bounded to three distinct authenticated suppliers
- preserve a round-robin SourceId cursor so the next cycle starts after the last failed supplier
- keep generation stall evidence across failed supplier and ordered-send cycles
- back off local failures without rejecting the supplier or clearing the current supplier cycle

This replaces the unbounded supplier-set design in #804. It keeps the identity-churn bound while fixing deterministic starvation of a fourth supplier.

## Tests

- cargo test -p zakura-network bounded_supplier_cycles_rotate_to_the_fourth_supplier --lib
- cargo test -p zakura-network send_failures_preserve_the_stall_clock_across_bounded_cycles --lib
- cargo test -p zakura-network replacement_session_keeps_the_authenticated_supplier_identity --lib
- cargo test -p zakura-network local_retry_preserves_supplier_eligibility_and_cursor --lib
- cargo test -p zakura-network supplier_cycle_bounds_identity_churn_and_preserves_cursor --lib
- cargo test -p zakura-network zakura::header_sync --lib
- cargo fmt --all -- --check
- git diff --check