### PR TITLE
fix(ops): publish atomic stall alert diagnostics

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -202,6 +202,7 @@ jobs:
           # Read-only fields below: consumed by the status dashboard's SSH probe,
           # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"
+          metrics_endpoint = "127.0.0.1:9999"
           log_file        = "/root/logs/zakura-tracing.log"
           # Verified on the fleet: the nine regional nodes keep state here, the
           # compat host does not. Used only for the dashboard's disk probe.
@@ -584,6 +585,7 @@ jobs:
           ssh_string = "root@159.203.113.196"
           probe_kind = "zcashd"
           service_name = ""
+          metrics_endpoint = ""
           # Managed/path install from zcashd-compat-manifest.json (v1.0.0-compat-rc0).
           bin_path = "/mnt/data/import-zebra/zcashd-compat/bin/v1.0.0-compat-rc0/x86_64-pc-linux-gnu/zcashd"
           log_file = ""

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -95,6 +95,12 @@ Alerts fire only after a sustained condition:
 - at least two observable nodes share one height and block hash for at least 30 minutes
 - a dashboard endpoint is unreachable for at least 10 minutes
 
+Stall alerts include a fixed set of sync-pipeline and VCT repair metrics. The
+fleet `/data` response copies only those numeric fields into each row. The
+watchdog therefore uses the same collector snapshot for the stall condition and
+its diagnostics. The diagnostic object contains no per-node history, logs, or
+addresses.
+
 The watchdog coalesces a verifiable shared tip into one fleet alert. A missing
 or different block hash keeps the individual node alerts. Down alerts take
 precedence over stalled alerts, so each node has at most one active alert. The

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -83,6 +83,33 @@ def public_row(
     }
 
 
+class NodeConfigTests(unittest.TestCase):
+    def test_blank_metrics_endpoint_stays_disabled(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[defaults]\nmetrics_endpoint = "127.0.0.1:9999"\n'
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                'metrics_endpoint = ""\n'
+            )
+            config.flush()
+
+            [configured] = status.load_nodes(Path(config.name))
+
+        self.assertEqual(configured.metrics_endpoint, "")
+
+    def test_explicit_metrics_endpoint_is_preserved(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                'metrics_endpoint = "127.0.0.1:9999"\n'
+            )
+            config.flush()
+
+            [configured] = status.load_nodes(Path(config.name))
+
+        self.assertEqual(configured.metrics_endpoint, "127.0.0.1:9999")
+
+
 class RemoteProbeTests(unittest.TestCase):
     """Run the probe the way a node does: as a standalone script over stdin.
 
@@ -218,6 +245,58 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
                 "sync_header_verification_lag": 3.0,
                 "zcash_net_in_bytes_total": 12345.0,
             },
+        )
+
+    def test_metrics_scrape_keeps_stall_alert_series(self):
+        self.exposition += b"""checkpoint_processing_next_height 101
+checkpoint_verified_height 99
+state_finalized_block_height 98
+state_vct_root_stalled_height 100
+state_vct_root_repair_requested 4
+state_vct_root_retry_count 3
+state_vct_aux_sweep_frontier_height 97
+sync_header_vct_repair_requested_total 8
+sync_header_vct_repair_scheduled_total 7
+sync_header_vct_repair_admitted_total 6
+sync_header_vct_repair_context_unavailable_total 5
+sync_header_vct_repair_timed_out_total 4
+sync_header_vct_repair_resource_stalled_total 3
+sync_header_vct_repair_no_supplier_total 999
+sync_block_applying 0
+sync_block_best_header_tip_height 102
+sync_block_verified_tip_height 98
+sync_block_fill_stop 1
+sync_block_outstanding 0
+sync_block_missing_bodies 4000
+"""
+
+        probe = self.run_probe(metrics_endpoint=self.endpoint)
+
+        expected = {
+            "checkpoint_processing_next_height": 101.0,
+            "checkpoint_verified_height": 99.0,
+            "state_finalized_block_height": 98.0,
+            "state_vct_root_stalled_height": 100.0,
+            "state_vct_root_repair_requested": 4.0,
+            "state_vct_root_retry_count": 3.0,
+            "state_vct_aux_sweep_frontier_height": 97.0,
+            "sync_header_vct_repair_requested_total": 8.0,
+            "sync_header_vct_repair_scheduled_total": 7.0,
+            "sync_header_vct_repair_admitted_total": 6.0,
+            "sync_header_vct_repair_context_unavailable_total": 5.0,
+            "sync_header_vct_repair_timed_out_total": 4.0,
+            "sync_header_vct_repair_resource_stalled_total": 3.0,
+            "sync_block_applying": 0.0,
+            "sync_block_best_header_tip_height": 102.0,
+            "sync_block_verified_tip_height": 98.0,
+            "sync_block_fill_stop": 1.0,
+            "sync_block_outstanding": 0.0,
+            "sync_block_missing_bodies": 4_000.0,
+        }
+        for name, value in expected.items():
+            self.assertEqual(probe["metrics"].get(name), value)
+        self.assertNotIn(
+            "sync_header_vct_repair_no_supplier_total", probe["metrics"]
         )
 
     def test_peer_versions_come_from_the_user_agent_label(self):
@@ -808,6 +887,43 @@ class NodeDetailTests(unittest.TestCase):
         self.assertEqual(row["vitals"]["disk_free_pct"], 25.0)
         self.assertEqual(row["vitals"]["restart_count"], 2)
         self.assertEqual(row["peer_count"], 74)
+
+    def test_fleet_payload_carries_atomic_bounded_alert_diagnostics(self):
+        collected = collector()
+        metrics = {
+            "checkpoint_verified_height": 4_199_999.0,
+            "sync_block_applying": 0.0,
+            "sync_block_outstanding": 0.0,
+            "sync_block_missing_bodies": 4_000.0,
+            "sync_block_fill_stop": float("nan"),
+            "sync_block_verified_tip_height": float("inf"),
+            "not_an_alert_metric": 123.0,
+        }
+        collected.rows = [
+            collected.row_for(node(), self.probe(metrics=metrics), now=1_000.0)
+        ]
+        collected.last_poll = 1_001.0
+
+        snapshot = collected.snapshot()
+        diagnostics = snapshot["rows"][0]["alert_diagnostics"]
+
+        self.assertEqual(snapshot["last_poll"], 1_001.0)
+        self.assertEqual(diagnostics["last_poll"], snapshot["last_poll"])
+        self.assertEqual(diagnostics["metrics_at"], 1_000.0)
+        self.assertTrue(diagnostics["metrics_available"])
+        self.assertEqual(
+            diagnostics["metrics"],
+            {
+                "checkpoint_verified_height": 4_199_999.0,
+                "sync_block_applying": 0.0,
+                "sync_block_outstanding": 0.0,
+                "sync_block_missing_bodies": 4_000.0,
+            },
+        )
+        self.assertNotIn("not_an_alert_metric", json.dumps(diagnostics))
+        self.assertNotIn("log_errors", json.dumps(diagnostics))
+        self.assertNotIn("root@node-a", json.dumps(diagnostics))
+        self.assertLess(len(json.dumps(diagnostics)), 1_000)
 
     def test_node_payload_carries_the_deep_fields(self):
         collected = collector()

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -203,6 +203,131 @@ class StallRecoveryTests(unittest.TestCase):
         self.assertEqual(self.posted, [])
 
 
+class StallDiagnosticTests(unittest.TestCase):
+    def setUp(self):
+        self.fleet = watchdog.Fleet(
+            name="mainnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+
+    @staticmethod
+    def diagnostics(**metrics):
+        return {
+            "last_poll": 1_000.0,
+            "metrics_at": 999.0,
+            "metrics_available": True,
+            "metrics": metrics,
+        }
+
+    def test_node_alert_formats_atomic_pipeline_and_repair_metrics(self):
+        row = {
+            "name": "canada-0",
+            "health": "stale",
+            "height": 3_461_397,
+            "headers": 3_461_900,
+            "header_lag": 503,
+            "peer_count": 7,
+            "commit": "5c33befdfae0a9e047079c96b9254d9d894c3885",
+            "version": "1.3.0-rc2",
+            "detail": "height has not advanced within stale window",
+            "alert_diagnostics": self.diagnostics(
+                checkpoint_verified_height=3_461_397.0,
+                sync_estimated_network_tip_height=3_461_901.0,
+                sync_estimated_distance_to_tip=504.0,
+                sync_block_applying=0.0,
+                sync_block_best_header_tip_height=3_461_900.0,
+                sync_block_verified_tip_height=3_461_397.0,
+                sync_block_fill_stop=1.0,
+                sync_block_outstanding=0.0,
+                sync_block_missing_bodies=4_000.0,
+                state_vct_root_stalled_height=3_461_398.0,
+                sync_header_vct_repair_context_unavailable_total=5.0,
+                sync_header_vct_repair_timed_out_total=2.0,
+            ),
+        }
+        row["alert_diagnostics"].update({"health": "healthy", "height": 9_999_999})
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 617.0)
+
+        self.assertIn("health: stale - height: 3461397", text)
+        self.assertIn("headers 3461900 | header lag 503 | peers 7", text)
+        self.assertIn("checkpoint verified 3461397", text)
+        self.assertIn("block applying 0", text)
+        self.assertIn("block header tip 3461900", text)
+        self.assertIn("block verified tip 3461397", text)
+        self.assertIn("block fill stop 1", text)
+        self.assertIn("block outstanding 0 | missing bodies 4000", text)
+        self.assertIn("context unavailable 5 | timed out 2", text)
+        self.assertNotIn("no supplier", text)
+
+    def test_missing_diagnostics_do_not_hide_the_stall(self):
+        row = {
+            "name": "canada-0",
+            "health": "stale",
+            "height": 3_461_397,
+            "detail": "height has not advanced within stale window",
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 617.0)
+
+        self.assertIn("`canada-0` stalled", text)
+        self.assertIn("metrics: absent from fleet snapshot", text)
+
+    def test_due_alert_uses_one_fleet_request(self):
+        posted = []
+        instance = watchdog.Watchdog([self.fleet], make_args())
+        snapshot = {
+            "last_poll": 1_000.0,
+            "rows": [
+                {
+                    "name": "canada-0",
+                    "health": "stale",
+                    "height": 3_461_397,
+                    "block_hash": "aaaa",
+                    "seconds_since_advanced": 700.0,
+                    "alert_diagnostics": self.diagnostics(
+                        sync_block_missing_bodies=4_000.0
+                    ),
+                }
+            ],
+        }
+
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot) as fetch,
+            patch.object(watchdog.time, "time", return_value=1_000.0),
+            patch.object(
+                watchdog,
+                "post_slack",
+                side_effect=lambda text, _args: (posted.append(text), True)[1],
+            ),
+        ):
+            instance.run_once({"nodes": {}, "fleets": {}, "shared_stalls": {}})
+
+        fetch.assert_called_once_with(self.fleet.url, instance.args.request_timeout)
+        self.assertEqual(len(posted), 1)
+        self.assertIn("missing bodies 4000", posted[0])
+
+    def test_diagnostic_rendering_is_bounded(self):
+        fields = watchdog.STALL_PIPELINE_METRICS + watchdog.STALL_REPAIR_METRICS
+        metrics = {
+            name: float(index) for index, (_label, name) in enumerate(fields)
+        }
+        row = {
+            "name": "node-a",
+            "health": "stale",
+            "height": 1,
+            "detail": "stalled",
+            "version": "x" * 10_000,
+            "alert_diagnostics": self.diagnostics(**metrics),
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 700.0)
+
+        self.assertLess(len(text), 2_000)
+        self.assertNotIn("x" * 65, text)
+
+
 class SharedStallTests(unittest.TestCase):
     NOW = 2_000.0
 
@@ -267,6 +392,44 @@ class SharedStallTests(unittest.TestCase):
         self.assertTrue(
             all(not entry["alerting"] for entry in self.state["nodes"].values())
         )
+
+    def test_shared_alert_lists_only_participating_nodes(self):
+        node_a = self.row("node-a", 4_302_737, 1_817)
+        node_b = self.row("node-b", 4_302_737, 1_816)
+        for row in (node_a, node_b):
+            row["alert_diagnostics"] = StallDiagnosticTests.diagnostics(
+                checkpoint_verified_height=4_302_737.0
+            )
+        down = self.row("down-node", 7, 1_900, health="down", block_hash="bbbb")
+
+        self.run_snapshot([down, node_a, node_b])
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("- node-a:", self.posted[0])
+        self.assertIn("- node-b:", self.posted[0])
+        self.assertNotIn("- down-node:", self.posted[0])
+
+    def test_shared_alert_limits_rendered_participants(self):
+        rows = [
+            {
+                **self.row(f"node-{index:02}", 100, 1_900, block_hash="aaaa"),
+                "alert_diagnostics": StallDiagnosticTests.diagnostics(
+                    sync_block_missing_bodies=4_000.0
+                ),
+            }
+            for index in range(12)
+        ]
+
+        text = watchdog.shared_stall_alert_text(
+            self.fleet, 100, "aaaa", len(rows), 1_900.0, rows
+        )
+
+        self.assertEqual(
+            sum(line.startswith("- node-") for line in text.splitlines()),
+            watchdog.MAX_SHARED_DIAGNOSTIC_ROWS,
+        )
+        self.assertIn("- 4 more participating nodes not shown", text)
+        self.assertLess(len(text), 3_000)
 
     def test_short_common_idle_does_not_alert(self):
         self.run_snapshot(

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -16,6 +16,7 @@ import argparse
 import concurrent.futures
 import ipaddress
 import json
+import math
 import re
 import shlex
 import subprocess
@@ -84,6 +85,38 @@ NODE_DETAIL_KEYS = (
     "mempool_bytes",
     "node_errors",
     "node_errors_at",
+)
+# Fixed numeric fields copied into each fleet row for stall alerts. The
+# watchdog gets these fields from the same collector snapshot as the node
+# condition, so it never needs to fetch the larger per-node detail payload.
+ALERT_DIAGNOSTIC_METRICS = (
+    "sync_estimated_distance_to_tip",
+    "sync_estimated_network_tip_height",
+    "checkpoint_processing_next_height",
+    "checkpoint_verified_height",
+    "state_finalized_block_height",
+    "sync_header_chain_frontier_header_best_height",
+    "sync_header_chain_frontier_verified_best_height",
+    "sync_header_chain_frontier_finalized_height",
+    "sync_header_work_last_progress_age_seconds",
+    "sync_header_work_oldest_missing_height",
+    "sync_header_work_in_flight_count",
+    "sync_block_applying",
+    "sync_block_best_header_tip_height",
+    "sync_block_verified_tip_height",
+    "sync_block_fill_stop",
+    "sync_block_outstanding",
+    "sync_block_missing_bodies",
+    "state_vct_root_stalled_height",
+    "state_vct_root_repair_requested",
+    "state_vct_root_retry_count",
+    "state_vct_aux_sweep_frontier_height",
+    "sync_header_vct_repair_requested_total",
+    "sync_header_vct_repair_scheduled_total",
+    "sync_header_vct_repair_admitted_total",
+    "sync_header_vct_repair_context_unavailable_total",
+    "sync_header_vct_repair_timed_out_total",
+    "sync_header_vct_repair_resource_stalled_total",
 )
 RECENT_REORG_LIMIT = 40
 # Sampled best-chain ancestor offsets used to estimate fork depth between tips.
@@ -283,6 +316,13 @@ out = {
 WANTED_METRICS = frozenset((
     "sync_estimated_distance_to_tip",
     "sync_estimated_network_tip_height",
+    "checkpoint_processing_next_height",
+    "checkpoint_verified_height",
+    "state_finalized_block_height",
+    "state_vct_root_stalled_height",
+    "state_vct_root_repair_requested",
+    "state_vct_root_retry_count",
+    "state_vct_aux_sweep_frontier_height",
     "sync_downloads_in_flight",
     "sync_downloaded_block_count",
     "sync_verified_block_count",
@@ -307,6 +347,12 @@ WANTED_METRICS = frozenset((
     "sync_header_root_auth_work_pending_batches",
     "sync_header_peer_violation",
     "sync_header_fill_stop",
+    "sync_header_vct_repair_requested_total",
+    "sync_header_vct_repair_scheduled_total",
+    "sync_header_vct_repair_admitted_total",
+    "sync_header_vct_repair_context_unavailable_total",
+    "sync_header_vct_repair_timed_out_total",
+    "sync_header_vct_repair_resource_stalled_total",
     "sync_block_applying",
     "sync_block_outstanding",
     "sync_block_backlog_at_cap",
@@ -347,7 +393,6 @@ WANTED_METRICS = frozenset((
     "candidate_set_pending",
     "candidate_set_failed",
     "candidate_set_disconnected",
-    "state_finalized_block_height",
     "zakura_state_rocksdb_total_disk_size_bytes",
     "zcash_chain_verified_block_total",
     "zcash_mempool_size_transactions",
@@ -1357,7 +1402,7 @@ class ClusterCollector:
         """
         with self.lock:
             rows = [
-                {key: value for key, value in row.items() if key not in NODE_DETAIL_KEYS}
+                fleet_row(row, self.last_poll)
                 for row in self.rows
             ]
             last_poll = self.last_poll
@@ -1517,6 +1562,41 @@ def coerce_int(value) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        return value if math.isfinite(value) else None
+    except OverflowError:
+        return None
+
+
+def alert_diagnostics(row: dict, last_poll: float | None) -> dict:
+    metrics = row.get("metrics")
+    selected = {}
+    if isinstance(metrics, dict):
+        for name in ALERT_DIAGNOSTIC_METRICS:
+            value = finite_number(metrics.get(name))
+            if value is not None:
+                selected[name] = value
+
+    return {
+        "last_poll": finite_number(last_poll),
+        "metrics_at": finite_number(row.get("metrics_at")),
+        "metrics_available": isinstance(metrics, dict)
+        and not bool(row.get("metrics_error")),
+        "metrics": selected,
+    }
+
+
+def fleet_row(row: dict, last_poll: float | None) -> dict:
+    summary = {
+        key: value for key, value in row.items() if key not in NODE_DETAIL_KEYS
+    }
+    summary["alert_diagnostics"] = alert_diagnostics(row, last_poll)
+    return summary
 
 
 def empty_chain_summary() -> dict:

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import time
@@ -26,6 +27,38 @@ from typing import Any
 
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
+MAX_SHARED_DIAGNOSTIC_ROWS = 8
+STALL_PIPELINE_METRICS = (
+    ("network tip", "sync_estimated_network_tip_height"),
+    ("distance", "sync_estimated_distance_to_tip"),
+    ("checkpoint next", "checkpoint_processing_next_height"),
+    ("checkpoint verified", "checkpoint_verified_height"),
+    ("state finalized", "state_finalized_block_height"),
+    ("header best", "sync_header_chain_frontier_header_best_height"),
+    ("header verified", "sync_header_chain_frontier_verified_best_height"),
+    ("header finalized", "sync_header_chain_frontier_finalized_height"),
+    ("header progress age", "sync_header_work_last_progress_age_seconds"),
+    ("oldest missing", "sync_header_work_oldest_missing_height"),
+    ("header in flight", "sync_header_work_in_flight_count"),
+    ("block applying", "sync_block_applying"),
+    ("block header tip", "sync_block_best_header_tip_height"),
+    ("block verified tip", "sync_block_verified_tip_height"),
+    ("block fill stop", "sync_block_fill_stop"),
+    ("block outstanding", "sync_block_outstanding"),
+    ("missing bodies", "sync_block_missing_bodies"),
+)
+STALL_REPAIR_METRICS = (
+    ("stalled height", "state_vct_root_stalled_height"),
+    ("state requests", "state_vct_root_repair_requested"),
+    ("state retries", "state_vct_root_retry_count"),
+    ("sweep frontier", "state_vct_aux_sweep_frontier_height"),
+    ("requested", "sync_header_vct_repair_requested_total"),
+    ("scheduled", "sync_header_vct_repair_scheduled_total"),
+    ("admitted", "sync_header_vct_repair_admitted_total"),
+    ("context unavailable", "sync_header_vct_repair_context_unavailable_total"),
+    ("timed out", "sync_header_vct_repair_timed_out_total"),
+    ("resource stalled", "sync_header_vct_repair_resource_stalled_total"),
+)
 
 
 @dataclass(frozen=True)
@@ -213,6 +246,81 @@ def format_duration(seconds: float) -> str:
 
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h" if minutes == 0 else f"{hours}h {minutes}m"
+
+
+def format_metric(value: object) -> str | None:
+    number = coerce_float(value)
+    if number is None or not math.isfinite(number):
+        return None
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def named_metrics(
+    source: dict[str, Any], fields: tuple[tuple[str, str], ...]
+) -> str:
+    values = []
+    for label, key in fields:
+        value = format_metric(source.get(key))
+        if value is not None:
+            values.append(f"{label} {value}")
+    return " | ".join(values)
+
+
+def bounded_text(value: object, limit: int) -> str:
+    return " ".join(str(value or "").split())[:limit]
+
+
+def alert_metrics(row: dict[str, Any]) -> tuple[dict[str, Any], bool | None]:
+    diagnostics = row.get("alert_diagnostics")
+    if not isinstance(diagnostics, dict):
+        return {}, None
+    metrics = diagnostics.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+    available = diagnostics.get("metrics_available")
+    return metrics, available if isinstance(available, bool) else None
+
+
+def node_diagnostic_lines(row: dict[str, Any]) -> list[str]:
+    identity = named_metrics(
+        row,
+        (
+            ("headers", "headers"),
+            ("header lag", "header_lag"),
+            ("peers", "peer_count"),
+        ),
+    )
+    commit = bounded_text(row.get("commit"), 12)
+    version = bounded_text(row.get("version"), 64)
+    build = " | ".join(
+        value
+        for value in (
+            f"commit {commit}" if commit else "",
+            f"version {version}" if version else "",
+        )
+        if value
+    )
+    metrics, available = alert_metrics(row)
+    pipeline = named_metrics(metrics, STALL_PIPELINE_METRICS)
+    repair = named_metrics(metrics, STALL_REPAIR_METRICS)
+
+    lines = []
+    if identity or build:
+        lines.append("node: " + " | ".join(value for value in (identity, build) if value))
+    if pipeline:
+        lines.append(f"pipeline: {pipeline}")
+    if repair:
+        lines.append(f"repair: {repair}")
+    if not pipeline and not repair:
+        if available is False:
+            lines.append("metrics: unavailable")
+        elif available is None:
+            lines.append("metrics: absent from fleet snapshot")
+        else:
+            lines.append("metrics: no alert diagnostics emitted")
+    return lines
 
 
 def suppression_until(path: Path) -> float | None:
@@ -451,12 +559,14 @@ def node_alert_text(fleet: Fleet, row: dict[str, Any], condition: str, age: floa
     detail = row.get("detail") or "no detail"
     height_text = str(height) if height is not None else "-"
 
-    return (
+    lines = [
         f":rotating_light: *Zakura {fleet.name}* - `{name}` {condition} "
-        f"for {format_duration(age)}\n"
-        f"health: {health} - height: {height_text} - detail: {detail}\n"
-        f"dashboard: {fleet.dashboard_url}"
-    )
+        f"for {format_duration(age)}",
+        f"health: {health} - height: {height_text} - detail: {detail}",
+        *node_diagnostic_lines(row),
+        f"dashboard: {fleet.dashboard_url}",
+    ]
+    return "\n".join(lines)
 
 
 def node_recovery_text(fleet: Fleet, row: dict[str, Any], previous: dict[str, Any]) -> str:
@@ -492,15 +602,58 @@ def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
 
 
 def shared_stall_alert_text(
-    fleet: Fleet, height: float, block_hash: str, node_count: int, age: float
+    fleet: Fleet,
+    height: float,
+    block_hash: str,
+    node_count: int,
+    age: float,
+    rows: list[dict[str, Any]],
 ) -> str:
-    return (
+    lines = [
         f":rotating_light: *Zakura {fleet.name}* network height has not advanced "
-        f"for {format_duration(age)}\n"
-        f"{node_count} nodes agree at height {int(height)}\n"
-        f"tip hash: {block_hash}\n"
-        f"dashboard: {fleet.dashboard_url}"
-    )
+        f"for {format_duration(age)}",
+        f"{node_count} nodes agree at height {int(height)}",
+        f"tip hash: {block_hash}",
+    ]
+    for row in rows[:MAX_SHARED_DIAGNOSTIC_ROWS]:
+        summary = named_metrics(
+            row,
+            (
+                ("height", "height"),
+                ("headers", "headers"),
+                ("header lag", "header_lag"),
+                ("peers", "peer_count"),
+            ),
+        )
+        metrics, _available = alert_metrics(row)
+        pipeline = named_metrics(
+            metrics,
+            (
+                ("checkpoint", "checkpoint_verified_height"),
+                ("network tip", "sync_estimated_network_tip_height"),
+                ("distance", "sync_estimated_distance_to_tip"),
+                ("applying", "sync_block_applying"),
+                ("outstanding", "sync_block_outstanding"),
+                ("missing", "sync_block_missing_bodies"),
+            ),
+        )
+        commit = bounded_text(row.get("commit"), 12)
+        summary = " | ".join(
+            value
+            for value in (
+                summary,
+                pipeline,
+                f"commit {commit}" if commit else "",
+            )
+            if value
+        )
+        name = bounded_text(row.get("name") or "unknown", 64)
+        lines.append(f"- {name}: {summary or 'no diagnostics'}")
+    hidden = max(0, node_count - MAX_SHARED_DIAGNOSTIC_ROWS)
+    if hidden:
+        lines.append(f"- {hidden} more participating nodes not shown")
+    lines.append(f"dashboard: {fleet.dashboard_url}")
+    return "\n".join(lines)
 
 
 def shared_stall_recovery_text(
@@ -825,19 +978,25 @@ class Watchdog:
                         f"{format_duration(age)}"
                     )
                 next_entry["suppression_logged"] = True
-            elif post_slack(
-                shared_stall_alert_text(
+            else:
+                participant_names = set(common_stall.node_names)
+                participant_rows = [
+                    row
+                    for row in rows
+                    if str(row.get("name") or "unknown") in participant_names
+                ]
+                alert_text = shared_stall_alert_text(
                     fleet,
                     common_stall.height,
                     common_stall.block_hash,
                     len(common_stall.node_names),
                     age,
-                ),
-                self.args,
-            ):
-                next_entry["alerting"] = True
-                next_entry["last_alert_at"] = now
-                next_entry["alert_height"] = common_stall.height
+                    participant_rows,
+                )
+                if post_slack(alert_text, self.args):
+                    next_entry["alerting"] = True
+                    next_entry["last_alert_at"] = now
+                    next_entry["alert_height"] = common_stall.height
 
         bucket[fleet.name] = next_entry
 


### PR DESCRIPTION
## Summary

- copy a fixed set of numeric stall diagnostics into each atomic fleet snapshot row
- format node and shared-stall alerts without per-alert detail requests
- show only shared-stall participants and cap shared diagnostic rows at eight
- collect emitted VCT retry metrics and the block-pipeline failure signals
- configure the mainnet loopback metrics endpoint explicitly while preserving blank endpoint overrides

## Design

The fleet response attaches `alert_diagnostics` to each row while it holds the collector lock. Each object carries the fleet `last_poll`, the metrics sample time, one availability flag, and a fixed numeric metric map. The watchdog reads only that object. It never fetches per-node detail, history, logs, or addresses for an alert.

## Validation

- `python3 -m unittest deploy/runner/test_zakura_cluster_watchdog.py` (40 passed)
- `python3 -m unittest discover -s deploy/runner -p test_zakura_cluster_status.py` (55 passed)
- `python3 -m py_compile deploy/runner/zakura-cluster-status.py deploy/runner/zakura-cluster-watchdog.py deploy/runner/test_zakura_cluster_status.py deploy/runner/test_zakura_cluster_watchdog.py`
- `actionlint .github/workflows/zakura-mainnet-deploy.yml`
- `git diff --check`

Stacked on the shared-stall event identity fix.