### PR TITLE
fix(state): prioritize VCT committer repair

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/vct_repair.rs
@@ -59,6 +59,98 @@ fn vct_repair_signal_schedules_one_exact_current_height() {
 }
 
 #[tokio::test]
+async fn committer_repair_replaces_and_then_restores_a_sweep_repair() {
+    let shutdown = CancellationToken::new();
+    let mut startup = startup(shutdown.clone());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut snapshot = committed_snapshot(anchor);
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(20), block::Hash([2; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot));
+    startup.committed_snapshots = Some(snapshots_rx);
+
+    let sweep_height = block::Height(11);
+    let committer_height = block::Height(12);
+    let (repairs_tx, repairs_rx) = watch::channel(zakura_header_chain::VctRootRepairStatus {
+        state: zakura_header_chain::VctRootRepairState::Unavailable {
+            height: sweep_height,
+        },
+        generation: 7,
+    });
+    startup.vct_root_repairs = Some(repairs_rx);
+    let (handle, mut actions, reactor) =
+        spawn_header_sync_reactor(startup).expect("the repair replacement fixture starts");
+
+    let HeaderPortOperation::QueryVctRepairContext {
+        owner: sweep_owner,
+        height,
+    } = next_action(&mut actions).await
+    else {
+        panic!("the sweep repair requests its context");
+    };
+    assert_eq!(height, sweep_height);
+
+    repairs_tx
+        .send(zakura_header_chain::VctRootRepairStatus {
+            state: zakura_header_chain::VctRootRepairState::Unavailable {
+                height: committer_height,
+            },
+            generation: 8,
+        })
+        .expect("the committer repair replaces the sweep repair");
+    let HeaderPortOperation::QueryVctRepairContext {
+        owner: committer_owner,
+        height,
+    } = next_action(&mut actions).await
+    else {
+        panic!("the committer repair requests its context");
+    };
+    assert_eq!(height, committer_height);
+    assert_ne!(committer_owner, sweep_owner);
+
+    handle
+        .send(Event::VctRepairContextReady {
+            owner: sweep_owner,
+            result: VctRepairContextResult::Resolved(zakura_header_chain::VctRepairContext {
+                target: zakura_header_chain::Frontier::new(sweep_height, block::Hash([11; 32])),
+                locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+            }),
+        })
+        .await
+        .expect("the late sweep completion reaches the reactor");
+    assert!(
+        time::timeout(std::time::Duration::from_millis(20), actions.recv())
+            .await
+            .is_err(),
+        "a completion from the retired sweep repair cannot schedule work"
+    );
+
+    repairs_tx
+        .send(zakura_header_chain::VctRootRepairStatus {
+            state: zakura_header_chain::VctRootRepairState::Unavailable {
+                height: sweep_height,
+            },
+            generation: 9,
+        })
+        .expect("clearing the committer repair restores the sweep repair");
+    let HeaderPortOperation::QueryVctRepairContext {
+        owner: restored_sweep_owner,
+        height,
+    } = next_action(&mut actions).await
+    else {
+        panic!("the restored sweep repair requests new context");
+    };
+    assert_eq!(height, sweep_height);
+    assert_ne!(restored_sweep_owner, sweep_owner);
+    assert_ne!(restored_sweep_owner, committer_owner);
+
+    shutdown.cancel();
+    reactor
+        .await
+        .expect("the repair replacement reactor stops cleanly");
+}
+
+#[tokio::test]
 async fn vct_repair_uses_one_exact_canonical_auxiliary_request() {
     let shutdown = CancellationToken::new();
     let mut startup = startup(shutdown.clone());

--- a/crates/zakura-state/src/service/write/vct_authentication_sweep/tests.rs
+++ b/crates/zakura-state/src/service/write/vct_authentication_sweep/tests.rs
@@ -982,7 +982,7 @@ fn a_committer_stall_below_the_sweep_takes_priority() {
     assert_eq!(
         fixture.repair_state(),
         VctRootRepairState::Unavailable { height: stalled },
-        "the lower need is the one whose replacement unblocks the other"
+        "the committer repair must unblock the checkpoint queue before the sweep can resume"
     );
 
     fixture.repair.on_commit_success();

--- a/crates/zakura-state/src/service/write/vct_write_retry.rs
+++ b/crates/zakura-state/src/service/write/vct_write_retry.rs
@@ -233,20 +233,17 @@ impl VctWriteRetryManager {
         self.publish_effective_repair_status(None);
     }
 
-    /// Publishes the lowest outstanding repair height.
+    /// Publishes the repair that can unblock the writer.
     ///
-    /// The repair channel stores one latest value. The manager publishes the lower height because
-    /// its replacement unblocks the higher repair.
+    /// The repair channel stores one latest value. A committer repair takes priority because the
+    /// authentication sweep runs only after the checkpoint queue becomes empty. The sweep cannot
+    /// clear its repair while a missing committer root keeps that queue nonempty.
     fn publish_effective_repair_status(
         &mut self,
         requester_with_new_episode: Option<VctRepairRequester>,
     ) {
         let effective_repair = match (self.committer_repair_height, self.sweep_repair_height) {
-            (Some(committer), Some(sweep)) if committer <= sweep => {
-                Some((committer, VctRepairRequester::Committer))
-            }
-            (Some(_), Some(sweep)) => Some((sweep, VctRepairRequester::Sweep)),
-            (Some(committer), None) => Some((committer, VctRepairRequester::Committer)),
+            (Some(committer), _) => Some((committer, VctRepairRequester::Committer)),
             (None, Some(sweep)) => Some((sweep, VctRepairRequester::Sweep)),
             (None, None) => None,
         };

--- a/crates/zakura-state/src/service/write/vct_write_retry/tests.rs
+++ b/crates/zakura-state/src/service/write/vct_write_retry/tests.rs
@@ -241,6 +241,48 @@ fn a_hidden_higher_sweep_need_keeps_the_lower_committer_episode() {
 }
 
 #[test]
+fn a_missing_committer_root_preempts_a_lower_sweep_need() {
+    let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
+    let mut manager = VctWriteRetryManager::new(tx);
+    let sweep_height = Height(42);
+    let committer_height = Height(84);
+
+    manager.request_sweep_repair(sweep_height);
+    let sweep_status = *rx.borrow_and_update();
+    assert_eq!(
+        sweep_status.state,
+        VctRootRepairState::Unavailable {
+            height: sweep_height
+        }
+    );
+
+    manager.on_retryable_error(committer_height, MISSING_ROOT, queued_block(1));
+    let committer_status = *rx.borrow_and_update();
+    assert_eq!(
+        committer_status.state,
+        VctRootRepairState::Unavailable {
+            height: committer_height
+        },
+        "the committer must advance before the checkpoint queue can empty and run the sweep"
+    );
+    assert_eq!(committer_status.generation, sweep_status.generation + 1);
+    assert!(
+        manager.take_retryable_block().is_some(),
+        "the production missing-root path parks the blocked checkpoint"
+    );
+
+    manager.on_commit_success();
+    let resumed_sweep = *rx.borrow_and_update();
+    assert_eq!(
+        resumed_sweep.state,
+        VctRootRepairState::Unavailable {
+            height: sweep_height
+        }
+    );
+    assert_eq!(resumed_sweep.generation, committer_status.generation + 1);
+}
+
+#[test]
 fn root_repair_signal_ignores_await_successor_and_clears_on_commit() {
     let (tx, mut rx) = tokio::sync::watch::channel(VctRootRepairStatus::default());
     let mut manager = VctWriteRetryManager::new(tx);

--- a/docs/changelog/unreleased/813.md
+++ b/docs/changelog/unreleased/813.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed an older commitment-root authentication-sweep repair masking the next checkpoint
+  committer repair. The committer repair now takes priority until the checkpoint queue can empty
+  and resume the authentication sweep
+  ([#813](https://github.com/zakura-core/zakura/pull/813)).


### PR DESCRIPTION
## Summary

- prioritize a missing committer root over an older authentication-sweep repair
- restore the sweep repair after the blocked checkpoint commits
- cover production missing-root and reactor replacement behavior

## Design

The state writer publishes one effective VCT repair. The committer repair takes priority because the authentication sweep runs only after the checkpoint queue becomes empty. The patch keeps the existing single-slot design and changes only its arbitration rule.

## Validation

- cargo test -p zakura-state a_missing_committer_root_preempts_a_lower_sweep_need --lib
- cargo test -p zakura-state --lib service::write
- cargo test -p zakura-network committer_repair_replaces_and_then_restores_a_sweep_repair --lib
- cargo test -p zakura-network --lib zakura::header_sync
- cargo fmt --all -- --check
- git diff --check

Stacked on #810. This PR replaces #806 without changing it.