### PR TITLE
fix(sync): preserve VCT retry attribution

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -177,6 +177,7 @@ fn build_header_sync_reactor(
         completed_targets: CompletedHeaderTargets::default(),
         vct_repair: RepairRequirementSlot::default(),
         vct_repair_stall: None,
+        vct_supplier_order: VecDeque::new(),
         served_paths: HashMap::new(),
         served_path_deadlines: HashMap::new(),
         pending_lease_releases: VecDeque::new(),
@@ -275,6 +276,10 @@ struct HeaderSyncReactor {
     vct_repair: RepairRequirementSlot,
     /// Escalation state for a repair generation that has not completed.
     vct_repair_stall: Option<VctRepairStall>,
+    /// Admitted authenticated peers in stable supplier selection order.
+    ///
+    /// The admitted peer limits bound this queue. New identities enter behind established peers.
+    vct_supplier_order: VecDeque<ZakuraPeerId>,
     served_paths: HashMap<ZakuraPeerId, ServedPathState>,
     served_path_deadlines: HashMap<ZakuraPeerId, Instant>,
     pending_lease_releases: VecDeque<PendingLeaseRelease>,
@@ -314,6 +319,7 @@ enum HeaderRequestTerminal {
     LocalError,
     MalformedResponse,
     RepairObsolete,
+    ResourceStalled,
     SendError,
     SessionReplaced,
     Shutdown,
@@ -325,23 +331,6 @@ enum HeaderRequestTerminal {
 }
 
 impl HeaderRequestTerminal {
-    /// Whether this outcome is evidence against the selected supplier.
-    fn rotates_vct_supplier(self) -> bool {
-        matches!(
-            self,
-            Self::TargetNotRetained
-                | Self::NoLocatorIntersection
-                | Self::HistoryPruned
-                | Self::Busy
-                | Self::Disconnected
-                | Self::MalformedResponse
-                | Self::SendError
-                | Self::SessionReplaced
-                | Self::TargetRejected
-                | Self::TimedOut
-        )
-    }
-
     fn needs_terminal_trace(self) -> bool {
         !matches!(
             self,
@@ -364,6 +353,7 @@ impl HeaderRequestTerminal {
             Self::LocalError => "local_error",
             Self::MalformedResponse => "malformed_response",
             Self::RepairObsolete => "repair_obsolete",
+            Self::ResourceStalled => "resource_stalled",
             Self::SendError => "send_error",
             Self::SessionReplaced => "session_replaced",
             Self::Shutdown => "shutdown",
@@ -373,6 +363,62 @@ impl HeaderRequestTerminal {
             Self::TargetRejected => "target_rejected",
             Self::TimedOut => "timed_out",
         }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum VctRepairRetryAttribution {
+    Supplier,
+    Local,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct VctRepairRetry {
+    source: zakura_header_chain::SourceId,
+    terminal: HeaderRequestTerminal,
+    attribution: VctRepairRetryAttribution,
+}
+
+impl VctRepairRetry {
+    fn supplier(source: zakura_header_chain::SourceId, terminal: HeaderRequestTerminal) -> Self {
+        Self {
+            source,
+            terminal,
+            attribution: VctRepairRetryAttribution::Supplier,
+        }
+    }
+
+    fn local(source: zakura_header_chain::SourceId, terminal: HeaderRequestTerminal) -> Self {
+        Self {
+            source,
+            terminal,
+            attribution: VctRepairRetryAttribution::Local,
+        }
+    }
+}
+
+fn vct_error_retry(
+    source: zakura_header_chain::SourceId,
+    terminal: HeaderRequestTerminal,
+    error: &zakura_header_chain::HeaderChainError,
+) -> VctRepairRetry {
+    let attributed_source = match error.attribution {
+        zakura_header_chain::Attribution::HeaderPeer(attributed)
+        | zakura_header_chain::Attribution::BodyPeer(attributed)
+        | zakura_header_chain::Attribution::AuxPeer(attributed) => Some(attributed),
+        zakura_header_chain::Attribution::None => None,
+    };
+    if attributed_source == Some(source) {
+        VctRepairRetry::supplier(source, terminal)
+    } else {
+        VctRepairRetry::local(source, HeaderRequestTerminal::LocalError)
+    }
+}
+
+fn vct_send_retry_attribution(error: &OrderedSendError) -> VctRepairRetryAttribution {
+    match error {
+        OrderedSendError::Full | OrderedSendError::Closed => VctRepairRetryAttribution::Supplier,
+        OrderedSendError::Encode(_) => VctRepairRetryAttribution::Local,
     }
 }
 
@@ -405,6 +451,20 @@ fn vct_repair_task(
     Some(RepairRequirement::new(owner, height, status.generation))
 }
 
+fn vct_repair_predecessor(task: &RepairRequirement) -> Option<zakura_header_chain::Frontier> {
+    let context = match &task.state {
+        RepairPolicyState::Ready { context }
+        | RepairPolicyState::SupplierBackoff { context, .. }
+        | RepairPolicyState::LocalBackoff { context, .. }
+        | RepairPolicyState::Assigned { context } => context,
+        RepairPolicyState::NeedsContext
+        | RepairPolicyState::QueryingContext { .. }
+        | RepairPolicyState::ContextBackoff { .. }
+        | RepairPolicyState::Completed => return None,
+    };
+    context.locator.entries().first().copied()
+}
+
 /// Why each advertised peer failed to qualify as a VCT repair supplier.
 ///
 /// The reactor reports the tally when no supplier qualifies. Without it the trace records only
@@ -427,17 +487,69 @@ struct VctSupplierRejections {
     send_failed: u64,
 }
 
-/// One repair generation that has not completed despite supplier scheduling.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum VctRepairStallOutcome {
+    LocalFailure,
+    LocalSendFailure,
+    NoEligibleSupplier,
+    SupplierCycleExhausted,
+    SupplierFailure,
+    SupplierSendFailure,
+}
+
+impl VctRepairStallOutcome {
+    fn label(self) -> &'static str {
+        match self {
+            Self::LocalFailure => "local_failure",
+            Self::LocalSendFailure => "local_send_failed",
+            Self::NoEligibleSupplier => "no_eligible_supplier",
+            Self::SupplierCycleExhausted => "supplier_cycle_exhausted",
+            Self::SupplierFailure => "supplier_failure",
+            Self::SupplierSendFailure => "supplier_send_failed",
+        }
+    }
+
+    fn attribution(self) -> &'static str {
+        match self {
+            Self::LocalFailure | Self::LocalSendFailure => "local",
+            Self::NoEligibleSupplier
+            | Self::SupplierCycleExhausted
+            | Self::SupplierFailure
+            | Self::SupplierSendFailure => "supplier",
+        }
+    }
+}
+
+/// One repair generation that has not completed after its first failed attempt.
 #[derive(Copy, Clone, Debug)]
 struct VctRepairStall {
     /// Repair generation this record tracks.
     generation: u64,
-    /// First failed supplier-cycle observation for this generation.
+    /// First failed attempt for this generation.
     since: Instant,
-    /// Last emitted trace row.
-    last_trace: Instant,
+    /// Last emitted trace row, or none before the immediate first row.
+    last_trace: Option<Instant>,
     /// Whether the reactor already reported this generation at error level.
     reported: bool,
+    /// Latest exact predecessor for diagnostic output.
+    predecessor: zakura_header_chain::Frontier,
+    /// Latest supplier rejection tally.
+    rejections: VctSupplierRejections,
+    /// Latest local or supplier outcome that kept the repair stalled.
+    outcome: VctRepairStallOutcome,
+}
+
+impl VctRepairStall {
+    fn next_deadline(self) -> Instant {
+        let trace_at = self
+            .last_trace
+            .map_or(self.since, |last| last + VCT_REPAIR_STALL_TRACE_INTERVAL);
+        if self.reported {
+            trace_at
+        } else {
+            trace_at.min(self.since + VCT_REPAIR_STALL_REPORT_AFTER)
+        }
+    }
 }
 
 #[cfg_attr(any(test, feature = "zakura-testkit"), allow(dead_code))]
@@ -742,7 +854,8 @@ impl HeaderSyncReactor {
                 Instant::now(),
             )
         });
-        if self.peer_state.contains_key(&peer) {
+        let replaces_existing_peer = self.peer_state.contains_key(&peer);
+        if replaces_existing_peer {
             self.retire_peer_work(&peer, HeaderRequestTerminal::SessionReplaced);
             self.release_served_path(&peer);
         }
@@ -759,8 +872,13 @@ impl HeaderSyncReactor {
             if let Some((owner, source)) = replaced_repair
                 .and_then(|(owner, source)| owner.body_owner().map(|owner| (owner, source)))
             {
-                self.retry_vct_repair(owner, source, HeaderRequestTerminal::SessionReplaced);
+                self.retry_vct_repair(
+                    owner,
+                    VctRepairRetry::supplier(source, HeaderRequestTerminal::SessionReplaced),
+                );
             }
+        } else {
+            self.vct_supplier_order.push_back(peer.clone());
         }
         self.publish_peer_state();
         let admitted = self
@@ -806,8 +924,12 @@ impl HeaderSyncReactor {
         });
         self.retire_peer_work(peer, HeaderRequestTerminal::Disconnected);
         self.peer_state.remove(peer);
+        self.vct_supplier_order.retain(|queued| queued != peer);
         if let Some((owner, source)) = abandoned_repair {
-            self.retry_vct_repair(owner, source, HeaderRequestTerminal::Disconnected);
+            self.retry_vct_repair(
+                owner,
+                VctRepairRetry::supplier(source, HeaderRequestTerminal::Disconnected),
+            );
         }
         self.publish_peer_state();
         self.emit_peer_lifecycle(
@@ -1155,8 +1277,10 @@ impl HeaderSyncReactor {
                         .owner
                         .body_owner()
                         .expect("an auxiliary repair has body authority"),
-                    active.source,
-                    HeaderRequestTerminal::MalformedResponse,
+                    VctRepairRetry::supplier(
+                        active.source,
+                        HeaderRequestTerminal::MalformedResponse,
+                    ),
                 );
                 self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage);
                 return;
@@ -1300,13 +1424,19 @@ impl HeaderSyncReactor {
                     return;
                 };
                 if !matches!(task.state, RepairPolicyState::Assigned { .. }) {
-                    self.retry_vct_repair(owner, source, HeaderRequestTerminal::RepairObsolete);
+                    self.retry_vct_repair(
+                        owner,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::RepairObsolete),
+                    );
                     return;
                 }
             }
             if !self.dispatch_action(action) {
                 if let Some((owner, source)) = repair {
-                    self.retry_vct_repair(owner, source, HeaderRequestTerminal::LocalError);
+                    self.retry_vct_repair(
+                        owner,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::LocalError),
+                    );
                 } else {
                     self.retire_peer_work(&peer, HeaderRequestTerminal::LocalError);
                 }
@@ -1425,8 +1555,7 @@ impl HeaderSyncReactor {
                     .owner
                     .body_owner()
                     .expect("an auxiliary repair has body authority"),
-                active.source,
-                terminal_outcome,
+                VctRepairRetry::supplier(active.source, terminal_outcome),
             );
         } else {
             self.retire_peer_work(&peer, terminal_outcome);
@@ -1491,8 +1620,7 @@ impl HeaderSyncReactor {
                         owner
                             .body_owner()
                             .expect("an auxiliary repair has body authority"),
-                        source,
-                        HeaderRequestTerminal::RepairObsolete,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::RepairObsolete),
                     ),
                 }
                 return;
@@ -1539,13 +1667,13 @@ impl HeaderSyncReactor {
             &peer,
             match &result {
                 HeaderTargetAdmissionResult::Applied => HeaderRequestTerminal::TargetAdmitted,
-                HeaderTargetAdmissionResult::Failed(_)
-                | HeaderTargetAdmissionResult::ResourceStalled(_) => {
-                    HeaderRequestTerminal::TargetRejected
+                HeaderTargetAdmissionResult::Failed(_) => HeaderRequestTerminal::TargetRejected,
+                HeaderTargetAdmissionResult::ResourceStalled(_) => {
+                    HeaderRequestTerminal::ResourceStalled
                 }
             },
         );
-        if let Some(repair_generation) = repair_generation {
+        if repair_generation.is_some() {
             let repair_owner = owner
                 .body_owner()
                 .expect("an auxiliary repair admission has body authority");
@@ -1563,24 +1691,21 @@ impl HeaderSyncReactor {
                     metrics::counter!("sync.header.vct.repair.admitted.total").increment(1);
                 }
                 HeaderTargetAdmissionResult::Failed(error) => {
-                    self.vct_repair.remove(repair_owner);
+                    self.retry_vct_repair(
+                        repair_owner,
+                        vct_error_retry(source, HeaderRequestTerminal::TargetRejected, &error),
+                    );
                     self.handle_typed_failure(peer, source, &error);
-                    if repair_generation == self.vct_repair_status.generation {
-                        self.schedule_current_vct_repair();
-                    }
                 }
                 HeaderTargetAdmissionResult::ResourceStalled(_) => {
                     // A local resource alarm stalled the commit, so nothing judged the delivery.
                     // Back the task off instead of dropping it: the committer no longer bumps the
                     // repair generation while it polls, so a dropped task would wait for an
                     // unrelated snapshot change that a stalled node has no way to produce.
-                    let deferred = self.vct_repair.get_mut(repair_owner).is_some_and(|task| {
-                        task.defer_local_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
-                            .is_ok()
-                    });
-                    if !deferred {
-                        self.vct_repair.remove(repair_owner);
-                    }
+                    self.retry_vct_repair(
+                        repair_owner,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::ResourceStalled),
+                    );
                     metrics::counter!("sync.header.vct.repair.resource_stalled.total").increment(1);
                 }
             }
@@ -1631,8 +1756,7 @@ impl HeaderSyncReactor {
                     owner
                         .body_owner()
                         .expect("an auxiliary repair has body authority"),
-                    source,
-                    HeaderRequestTerminal::RepairObsolete,
+                    VctRepairRetry::local(source, HeaderRequestTerminal::RepairObsolete),
                 );
             } else {
                 self.retire_peer_work(&peer, HeaderRequestTerminal::SnapshotObsolete);
@@ -1658,8 +1782,7 @@ impl HeaderSyncReactor {
                     if !valid {
                         self.retry_vct_repair(
                             repair_owner,
-                            source,
-                            HeaderRequestTerminal::RepairObsolete,
+                            VctRepairRetry::local(source, HeaderRequestTerminal::RepairObsolete),
                         );
                         return;
                     }
@@ -1683,8 +1806,7 @@ impl HeaderSyncReactor {
                         owner
                             .body_owner()
                             .expect("an auxiliary repair has body authority"),
-                        source,
-                        HeaderRequestTerminal::LocalError,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::LocalError),
                     );
                 } else {
                     self.retire_peer_work(&peer, HeaderRequestTerminal::LocalError);
@@ -1699,22 +1821,11 @@ impl HeaderSyncReactor {
                     Some(&error),
                 );
                 if is_repair {
-                    let terminal = match error.attribution {
-                        zakura_header_chain::Attribution::HeaderPeer(attributed)
-                        | zakura_header_chain::Attribution::BodyPeer(attributed)
-                        | zakura_header_chain::Attribution::AuxPeer(attributed)
-                            if attributed == source =>
-                        {
-                            HeaderRequestTerminal::TargetRejected
-                        }
-                        _ => HeaderRequestTerminal::LocalError,
-                    };
                     self.retry_vct_repair(
                         owner
                             .body_owner()
                             .expect("an auxiliary repair has body authority"),
-                        source,
-                        terminal,
+                        vct_error_retry(source, HeaderRequestTerminal::TargetRejected, &error),
                     );
                 } else {
                     self.retire_peer_work(&peer, HeaderRequestTerminal::TargetRejected);
@@ -1765,11 +1876,11 @@ impl HeaderSyncReactor {
     fn retry_vct_repair(
         &mut self,
         owner: zakura_header_chain::BodyWorkOwner,
-        source: zakura_header_chain::SourceId,
-        terminal_outcome: HeaderRequestTerminal,
+        retry: VctRepairRetry,
     ) {
+        let source = retry.source;
         if let Some(active) = self.peer_work_queue.active_owner(owner.into()).cloned() {
-            self.emit_request_terminal(&active, terminal_outcome);
+            self.emit_request_terminal(&active, retry.terminal);
         }
         self.cancel_owned_request(source, owner.into());
         self.peer_work_queue.remove_owner(owner.into());
@@ -1784,31 +1895,63 @@ impl HeaderSyncReactor {
         if let Some(peer) = peer {
             self.request_deadlines.remove(&peer);
         }
-        let supplier_failure = terminal_outcome.rotates_vct_supplier();
-        let retry_scheduled = self.vct_repair.get_mut(owner).is_some_and(|task| {
-            if supplier_failure {
-                task.retry(source).is_ok()
-            } else {
-                task.defer_local_retry_until(Instant::now() + VCT_REPAIR_RETRY_INTERVAL)
-                    .is_ok()
-            }
-        });
+        let now = Instant::now();
+        let retry_scheduled =
+            self.vct_repair
+                .get_mut(owner)
+                .is_some_and(|task| match retry.attribution {
+                    VctRepairRetryAttribution::Supplier => task.retry(source).is_ok(),
+                    VctRepairRetryAttribution::Local => task
+                        .defer_local_retry_until(now + VCT_REPAIR_RETRY_INTERVAL)
+                        .is_ok(),
+                });
         if retry_scheduled {
-            if let Some(task) = self.vct_repair.current() {
+            if retry.attribution == VctRepairRetryAttribution::Supplier {
+                self.rotate_vct_supplier(source);
+            }
+            if let Some(task) = self.vct_repair.current().cloned() {
                 self.emit_vct_repair_state(
-                    task,
+                    &task,
                     "retry",
-                    Some(if supplier_failure {
-                        "supplier_retry"
-                    } else {
-                        "local_backoff"
+                    Some(match retry.attribution {
+                        VctRepairRetryAttribution::Supplier => "supplier_retry",
+                        VctRepairRetryAttribution::Local => "local_backoff",
                     }),
                 );
+                if let Some(predecessor) = vct_repair_predecessor(&task) {
+                    self.note_vct_repair_stall(
+                        &task,
+                        predecessor,
+                        VctSupplierRejections::default(),
+                        match retry.attribution {
+                            VctRepairRetryAttribution::Supplier => {
+                                VctRepairStallOutcome::SupplierFailure
+                            }
+                            VctRepairRetryAttribution::Local => VctRepairStallOutcome::LocalFailure,
+                        },
+                        now,
+                    );
+                }
             }
-            if supplier_failure {
+            if retry.attribution == VctRepairRetryAttribution::Supplier {
                 self.try_assign_vct_repair();
             }
         }
+    }
+
+    fn rotate_vct_supplier(&mut self, source: zakura_header_chain::SourceId) {
+        let Some(index) = self
+            .vct_supplier_order
+            .iter()
+            .position(|peer| source_id_from_peer(peer) == source)
+        else {
+            return;
+        };
+        let peer = self
+            .vct_supplier_order
+            .remove(index)
+            .expect("the supplier index came from this bounded queue");
+        self.vct_supplier_order.push_back(peer);
     }
 
     fn emit_vct_repair_state(
@@ -1826,7 +1969,7 @@ impl HeaderSyncReactor {
         });
     }
 
-    /// Record a repair generation after supplier scheduling fails to complete it.
+    /// Record the latest reason a repair generation has not completed.
     ///
     /// The reactor samples the trace row and escalates to error level once the generation has
     /// stayed stalled for [`VCT_REPAIR_STALL_REPORT_AFTER`]. Without the tally an
@@ -1835,15 +1978,58 @@ impl HeaderSyncReactor {
         &mut self,
         task: &RepairRequirement,
         predecessor: zakura_header_chain::Frontier,
-        rejections: &VctSupplierRejections,
-        outcome: &'static str,
+        rejections: VctSupplierRejections,
+        outcome: VctRepairStallOutcome,
         now: Instant,
     ) {
-        metrics::counter!("sync.header.vct.repair.stalled.total", "outcome" => outcome)
-            .increment(1);
-        if outcome == "no_eligible_supplier" {
+        metrics::counter!(
+            "sync.header.vct.repair.stalled.total",
+            "outcome" => outcome.label(),
+            "attribution" => outcome.attribution(),
+        )
+        .increment(1);
+        if outcome == VctRepairStallOutcome::NoEligibleSupplier {
             metrics::counter!("sync.header.vct.repair.no_supplier.total").increment(1);
         }
+        match self.vct_repair_stall.as_mut() {
+            Some(record) if record.generation == task.repair_generation => {
+                record.predecessor = predecessor;
+                record.rejections = rejections;
+                record.outcome = outcome;
+            }
+            _ => {
+                self.vct_repair_stall = Some(VctRepairStall {
+                    generation: task.repair_generation,
+                    since: now,
+                    last_trace: None,
+                    reported: false,
+                    predecessor,
+                    rejections,
+                    outcome,
+                });
+            }
+        }
+        self.refresh_vct_repair_stall(now);
+    }
+
+    fn refresh_vct_repair_stall(&mut self, now: Instant) {
+        let Some(record) = self.vct_repair_stall else {
+            return;
+        };
+        let Some(task) = self
+            .vct_repair
+            .current()
+            .filter(|task| task.repair_generation == record.generation)
+            .cloned()
+        else {
+            self.vct_repair_stall = None;
+            return;
+        };
+        let stalled_for = now.saturating_duration_since(record.since);
+        let trace_due = record.last_trace.is_none_or(|last| {
+            now.saturating_duration_since(last) >= VCT_REPAIR_STALL_TRACE_INTERVAL
+        });
+        let report_due = !record.reported && stalled_for >= VCT_REPAIR_STALL_REPORT_AFTER;
         let best_peer_tip = self
             .peer_state
             .values()
@@ -1851,61 +2037,54 @@ impl HeaderSyncReactor {
             .map(|status| (status.selected_tip_height, status.selected_tip_hash))
             .max_by_key(|(height, _)| *height);
 
-        let open_record = self
-            .vct_repair_stall
-            .filter(|record| record.generation == task.repair_generation);
-        let mut record = open_record.unwrap_or(VctRepairStall {
-            generation: task.repair_generation,
-            since: now,
-            last_trace: now,
-            reported: false,
-        });
-        let stalled_for = now.saturating_duration_since(record.since);
-        let trace_due = open_record.is_none()
-            || now.saturating_duration_since(record.last_trace) >= VCT_REPAIR_STALL_TRACE_INTERVAL;
-        let report_due = !record.reported && stalled_for >= VCT_REPAIR_STALL_REPORT_AFTER;
-
         if trace_due {
-            self.emit_vct_repair_stall(task, predecessor, rejections, best_peer_tip, outcome);
-            record.last_trace = now;
+            self.emit_vct_repair_stall(&task, record, best_peer_tip);
         }
         if report_due {
             tracing::error!(
                 height = ?task.height,
-                predecessor_height = ?predecessor.height,
+                predecessor_height = ?record.predecessor.height,
                 repair_generation = task.repair_generation,
                 branch_target = ?task.owner.branch.target_tip_hash,
                 ?best_peer_tip,
-                peers_considered = rejections.considered,
-                rejected_height = rejections.below_target_height,
-                rejected_capacity = rejections.insufficient_capacity,
-                rejected_schema = rejections.unsupported_schema,
-                rejected_busy = rejections.already_serving,
-                rejected_tried = rejections.already_tried,
-                send_failed = rejections.send_failed,
+                outcome = record.outcome.label(),
+                attribution = record.outcome.attribution(),
+                peers_considered = record.rejections.considered,
+                rejected_height = record.rejections.below_target_height,
+                rejected_capacity = record.rejections.insufficient_capacity,
+                rejected_schema = record.rejections.unsupported_schema,
+                rejected_busy = record.rejections.already_serving,
+                rejected_tried = record.rejections.already_tried,
+                send_failed = record.rejections.send_failed,
                 ?stalled_for,
-                "VCT: supplier scheduling has not completed the repair root; the parked \
-                 checkpoint commit cannot advance"
+                "VCT: repair has not completed; the parked checkpoint commit cannot advance"
             );
-            record.reported = true;
         }
-
-        self.vct_repair_stall = Some(record);
+        if let Some(current) = self
+            .vct_repair_stall
+            .as_mut()
+            .filter(|current| current.generation == record.generation)
+        {
+            if trace_due {
+                current.last_trace = Some(now);
+            }
+            if report_due {
+                current.reported = true;
+            }
+        }
     }
 
     fn emit_vct_repair_stall(
         &self,
         task: &RepairRequirement,
-        predecessor: zakura_header_chain::Frontier,
-        rejections: &VctSupplierRejections,
+        record: VctRepairStall,
         best_peer_tip: Option<(block::Height, block::Hash)>,
-        outcome: &'static str,
     ) {
         self.startup.trace.emit_with(HEADER_SYNC_TABLE, |row| {
             insert_vct_repair_identity(
                 row,
                 task,
-                if outcome == "no_eligible_supplier" {
+                if record.outcome == VctRepairStallOutcome::NoEligibleSupplier {
                     "no_supplier"
                 } else {
                     "stall"
@@ -1913,31 +2092,31 @@ impl HeaderSyncReactor {
             );
             row.insert(
                 hs_trace::PREDECESSOR_HEIGHT.into(),
-                u64::from(predecessor.height.0).into(),
+                u64::from(record.predecessor.height.0).into(),
             );
             row.insert(
                 hs_trace::PEERS_CONSIDERED.into(),
-                rejections.considered.into(),
+                record.rejections.considered.into(),
             );
             row.insert(
                 hs_trace::REJECTED_HEIGHT.into(),
-                rejections.below_target_height.into(),
+                record.rejections.below_target_height.into(),
             );
             row.insert(
                 hs_trace::REJECTED_CAPACITY.into(),
-                rejections.insufficient_capacity.into(),
+                record.rejections.insufficient_capacity.into(),
             );
             row.insert(
                 hs_trace::REJECTED_SCHEMA.into(),
-                rejections.unsupported_schema.into(),
+                record.rejections.unsupported_schema.into(),
             );
             row.insert(
                 hs_trace::REJECTED_BUSY.into(),
-                rejections.already_serving.into(),
+                record.rejections.already_serving.into(),
             );
             row.insert(
                 hs_trace::REJECTED_TRIED.into(),
-                rejections.already_tried.into(),
+                record.rejections.already_tried.into(),
             );
             row.insert(
                 hs_trace::BEST_PEER_HEIGHT.into(),
@@ -1949,7 +2128,11 @@ impl HeaderSyncReactor {
                 hs_trace::BEST_PEER_HASH.into(),
                 best_peer_tip.map_or(serde_json::Value::Null, |(_, hash)| hash.to_string().into()),
             );
-            row.insert(hs_trace::OUTCOME.into(), outcome.into());
+            row.insert(hs_trace::OUTCOME.into(), record.outcome.label().into());
+            row.insert(
+                hs_trace::ATTRIBUTION.into(),
+                record.outcome.attribution().into(),
+            );
         });
     }
 
@@ -2747,7 +2930,10 @@ impl HeaderSyncReactor {
         // predecessor hash; the admission path rejects anything else.
         let mut rejections = VctSupplierRejections::default();
         let mut candidates = Vec::new();
-        for (peer, state) in &self.peer_state {
+        for peer in &self.vct_supplier_order {
+            let Some(state) = self.peer_state.get(peer) else {
+                continue;
+            };
             let Some(status) = state.last_status.as_ref() else {
                 continue;
             };
@@ -2778,22 +2964,12 @@ impl HeaderSyncReactor {
             }
             candidates.push((peer.clone(), source, state.session.clone(), status.clone()));
         }
-        candidates.sort_by(|left, right| {
-            left.1
-                .cmp(&right.1)
-                .then_with(|| left.0.as_bytes().cmp(right.0.as_bytes()))
-        });
-        if let Some(cursor) = task.supplier_cursor {
-            let first_after_cursor =
-                candidates.partition_point(|(_, source, _, _)| *source <= cursor);
-            candidates.rotate_left(first_after_cursor);
-        }
         if task.supplier_cycle_exhausted() {
             self.note_vct_repair_stall(
                 &task,
                 predecessor,
-                &rejections,
-                "supplier_cycle_exhausted",
+                rejections,
+                VctRepairStallOutcome::SupplierCycleExhausted,
                 now,
             );
             let _ = self
@@ -2807,8 +2983,8 @@ impl HeaderSyncReactor {
             self.note_vct_repair_stall(
                 &task,
                 predecessor,
-                &rejections,
-                "no_eligible_supplier",
+                rejections,
+                VctRepairStallOutcome::NoEligibleSupplier,
                 now,
             );
             let _ = self
@@ -2838,10 +3014,38 @@ impl HeaderSyncReactor {
                     self.peer_work_queue.cancel_request_reservation(&peer);
                     self.emit_queue_send_failed(&peer, &session, "GetHeaders", &error, None);
                     rejections.send_failed += 1;
-                    if let Some(current) = self.vct_repair.get_mut(task.owner) {
-                        let _ = current.record_failed_source(source);
-                        if current.supplier_cycle_exhausted() {
-                            break;
+                    match vct_send_retry_attribution(&error) {
+                        VctRepairRetryAttribution::Supplier => {
+                            if let Some(current) = self.vct_repair.get_mut(task.owner) {
+                                let _ = current.record_failed_source(source);
+                            }
+                            self.rotate_vct_supplier(source);
+                            if self
+                                .vct_repair
+                                .get(task.owner)
+                                .is_some_and(RepairRequirement::supplier_cycle_exhausted)
+                            {
+                                break;
+                            }
+                        }
+                        VctRepairRetryAttribution::Local => {
+                            let deferred =
+                                self.vct_repair.get_mut(task.owner).is_some_and(|task| {
+                                    task.defer_local_retry_until(now + VCT_REPAIR_RETRY_INTERVAL)
+                                        .is_ok()
+                                });
+                            if deferred {
+                                if let Some(current) = self.vct_repair.get(task.owner).cloned() {
+                                    self.note_vct_repair_stall(
+                                        &current,
+                                        predecessor,
+                                        rejections,
+                                        VctRepairStallOutcome::LocalSendFailure,
+                                        now,
+                                    );
+                                }
+                            }
+                            return;
                         }
                     }
                     continue;
@@ -2901,7 +3105,10 @@ impl HeaderSyncReactor {
             {
                 session.cancel_request(request_id);
                 self.peer_work_queue.cancel_request_reservation(&peer);
-                self.retry_vct_repair(wire_owner, source, HeaderRequestTerminal::LocalError);
+                self.retry_vct_repair(
+                    wire_owner,
+                    VctRepairRetry::local(source, HeaderRequestTerminal::LocalError),
+                );
                 return;
             }
             self.request_deadlines
@@ -2920,8 +3127,8 @@ impl HeaderSyncReactor {
                 self.note_vct_repair_stall(
                     &current,
                     predecessor,
-                    &rejections,
-                    "supplier_send_failed",
+                    rejections,
+                    VctRepairStallOutcome::SupplierSendFailure,
                     now,
                 );
             }
@@ -3052,6 +3259,7 @@ impl HeaderSyncReactor {
 
     fn refresh_statuses(&mut self) {
         let now = Instant::now();
+        self.refresh_vct_repair_stall(now);
         self.retry_pending_lease_releases(now);
         self.retire_timed_out_requests(now);
         self.release_idle_served_paths(now);
@@ -3095,6 +3303,7 @@ impl HeaderSyncReactor {
                     .current()
                     .and_then(RepairRequirement::next_deadline),
             )
+            .chain(self.vct_repair_stall.map(VctRepairStall::next_deadline))
             .chain(self.served_path_deadlines.values().copied())
             .chain(self.lease_release_retry_at)
             .min()
@@ -3121,14 +3330,25 @@ impl HeaderSyncReactor {
                             .body_owner()
                             .expect("an auxiliary repair has body authority"),
                         active.source,
+                        active.phase,
                     )
                 })
             });
-            if let Some((owner, source)) = repair {
+            if let Some((owner, source, phase)) = repair {
                 if let Some(task) = self.vct_repair.get(owner) {
                     self.emit_vct_repair_state(task, "timeout", Some("timed_out"));
                 }
-                self.retry_vct_repair(owner, source, HeaderRequestTerminal::TimedOut);
+                self.retry_vct_repair(
+                    owner,
+                    match phase {
+                        HeaderTargetPhase::Receiving => {
+                            VctRepairRetry::supplier(source, HeaderRequestTerminal::TimedOut)
+                        }
+                        HeaderTargetPhase::Preparing | HeaderTargetPhase::Applying => {
+                            VctRepairRetry::local(source, HeaderRequestTerminal::TimedOut)
+                        }
+                    },
+                );
                 metrics::counter!("sync.header.vct.repair.timed_out.total").increment(1);
             } else {
                 let session_id = self
@@ -4153,7 +4373,10 @@ impl HeaderSyncReactor {
                     })
                 });
                 if let Some((owner, source)) = repair {
-                    self.retry_vct_repair(owner, source, HeaderRequestTerminal::LocalError);
+                    self.retry_vct_repair(
+                        owner,
+                        VctRepairRetry::local(source, HeaderRequestTerminal::LocalError),
+                    );
                 } else {
                     self.retire_peer_work(peer, HeaderRequestTerminal::LocalError);
                 }

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/timeouts.rs
@@ -1,6 +1,47 @@
 use super::*;
 use crate::zakura::header_sync::scheduler::repair::MAX_SUPPLIERS_PER_CYCLE;
 
+fn seed_vct_active_request(
+    reactor: &mut HeaderSyncReactor,
+    snapshot: &zakura_header_chain::EngineSnapshot,
+    peer: ZakuraPeerId,
+    session_id: u64,
+    phase: HeaderTargetPhase,
+) -> (
+    zakura_header_chain::SourceId,
+    zakura_header_chain::HeaderSyncWorkOwner,
+    zakura_header_chain::VctRepairContext,
+) {
+    let (source, header_owner, _) =
+        seed_applying_request(reactor, snapshot, peer.clone(), session_id);
+    let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(snapshot)
+        .bind(header_owner.session_id(), header_owner.request_id());
+    let active = reactor
+        .peer_work_queue
+        .active_mut(&peer)
+        .expect("the fixture has one active request");
+    active.owner = owner.into();
+    let target = zakura_header_chain::Frontier::new(
+        active.target.status.selected_tip_height,
+        active.target.status.selected_tip_hash,
+    );
+    active.purpose = HeaderTargetPurpose::SelectedAuxiliaryRepair {
+        selected_target: target,
+        repair_generation: 11,
+    };
+    active.phase = phase;
+    let context = zakura_header_chain::VctRepairContext {
+        target,
+        locator: zakura_header_chain::HeaderLocator::for_continuation(snapshot.frontiers.finalized),
+    };
+    let mut task = RepairRequirement::new(owner, target.height, 11);
+    task.state = RepairPolicyState::Assigned {
+        context: context.clone(),
+    };
+    reactor.vct_repair.insert(task);
+    (source, owner.into(), context)
+}
+
 #[test]
 fn request_timeout_retires_owned_work_and_wakes_maintenance() {
     let mut startup = startup(CancellationToken::new());
@@ -69,6 +110,11 @@ fn vct_request_timeout_keeps_required_work_and_rotates_the_supplier() {
         selected_target: target,
         repair_generation: 11,
     };
+    reactor
+        .peer_work_queue
+        .active_mut(&peer)
+        .expect("the fixture has one repair request")
+        .phase = HeaderTargetPhase::Receiving;
     reactor.request_deadlines.insert(peer, deadline);
 
     assert!(reactor.next_maintenance_deadline() <= deadline);
@@ -88,6 +134,213 @@ fn vct_request_timeout_keeps_required_work_and_rotates_the_supplier() {
     assert_eq!(task.attempts, 1);
     assert!(task.tried_sources.contains(&source));
     assert!(task.next_deadline().is_some());
+}
+
+#[test]
+fn vct_local_phase_timeouts_preserve_the_supplier_cycle() {
+    for phase in [HeaderTargetPhase::Preparing, HeaderTargetPhase::Applying] {
+        let mut startup = startup(CancellationToken::new());
+        let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+        let snapshot = committed_snapshot(anchor);
+        let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+        startup.committed_snapshots = Some(snapshots_rx);
+        let (_handle, _actions, mut reactor) =
+            build_header_sync_reactor(startup).expect("the local timeout fixture builds");
+        let peer = peer();
+        let (source, _owner, context) =
+            seed_vct_active_request(&mut reactor, &snapshot, peer.clone(), 7, phase);
+        let prior = zakura_header_chain::SourceId::from_digest([0x22; 32]);
+        let task = reactor
+            .vct_repair
+            .current_mut()
+            .expect("the fixture has one repair task");
+        task.tried_sources.insert(prior);
+        task.attempts = 1;
+        let deadline = Instant::now();
+        reactor.request_deadlines.insert(peer, deadline);
+
+        reactor.retire_timed_out_requests(deadline);
+
+        let task = reactor
+            .vct_repair
+            .current()
+            .expect("a local timeout keeps the current repair");
+        assert!(matches!(
+            &task.state,
+            RepairPolicyState::LocalBackoff {
+                context: retained,
+                retry_at,
+            } if retained == &context && *retry_at > deadline
+        ));
+        assert_eq!(task.tried_sources, [prior].into_iter().collect());
+        assert!(!task.tried_sources.contains(&source));
+        assert_eq!(task.attempts, 2);
+        assert_eq!(
+            reactor
+                .vct_repair_stall
+                .expect("the local timeout starts the generation stall clock")
+                .outcome,
+            VctRepairStallOutcome::LocalFailure
+        );
+    }
+}
+
+#[test]
+fn vct_admission_failures_preserve_retry_policy_state() {
+    for supplier_attributed in [false, true] {
+        let mut startup = startup(CancellationToken::new());
+        let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+        let snapshot = committed_snapshot(anchor);
+        let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+        startup.committed_snapshots = Some(snapshots_rx);
+        let (_handle, _actions, mut reactor) =
+            build_header_sync_reactor(startup).expect("the admission failure fixture builds");
+        let peer = peer();
+        let (source, owner, context) = seed_vct_active_request(
+            &mut reactor,
+            &snapshot,
+            peer.clone(),
+            7,
+            HeaderTargetPhase::Applying,
+        );
+        let prior = zakura_header_chain::SourceId::from_digest([0x22; 32]);
+        let task = reactor
+            .vct_repair
+            .current_mut()
+            .expect("the fixture has one repair task");
+        task.tried_sources.insert(prior);
+        task.attempts = 1;
+        let error = if supplier_attributed {
+            invalid_header_failure(source, owner)
+        } else {
+            local_failure(owner)
+        };
+
+        reactor.handle_header_target_admission_ready(
+            peer,
+            source,
+            owner,
+            HeaderTargetAdmissionResult::Failed(error),
+        );
+
+        let task = reactor
+            .vct_repair
+            .current()
+            .expect("an admission failure cannot recreate the repair task");
+        assert_eq!(task.attempts, 2);
+        assert!(task.tried_sources.contains(&prior));
+        if supplier_attributed {
+            assert!(task.tried_sources.contains(&source));
+            assert!(matches!(
+                &task.state,
+                RepairPolicyState::SupplierBackoff {
+                    context: retained,
+                    ..
+                } if retained == &context
+            ));
+            assert_eq!(
+                reactor
+                    .vct_repair_stall
+                    .expect("the supplier failure keeps generation evidence")
+                    .outcome,
+                VctRepairStallOutcome::NoEligibleSupplier
+            );
+        } else {
+            assert!(!task.tried_sources.contains(&source));
+            assert!(matches!(
+                &task.state,
+                RepairPolicyState::LocalBackoff {
+                    context: retained,
+                    ..
+                } if retained == &context
+            ));
+            assert_eq!(
+                reactor
+                    .vct_repair_stall
+                    .expect("the local failure keeps generation evidence")
+                    .outcome,
+                VctRepairStallOutcome::LocalFailure
+            );
+        }
+    }
+}
+
+#[test]
+fn vct_send_failures_have_explicit_attribution() {
+    assert_eq!(
+        vct_send_retry_attribution(&OrderedSendError::Full),
+        VctRepairRetryAttribution::Supplier
+    );
+    assert_eq!(
+        vct_send_retry_attribution(&OrderedSendError::Closed),
+        VctRepairRetryAttribution::Supplier
+    );
+    assert_eq!(
+        vct_send_retry_attribution(&OrderedSendError::Encode("fixture failure".into())),
+        VctRepairRetryAttribution::Local
+    );
+}
+
+#[test]
+fn resource_stall_has_an_exact_terminal_label() {
+    assert_eq!(
+        HeaderRequestTerminal::ResourceStalled.label(),
+        "resource_stalled"
+    );
+}
+
+#[test]
+fn generation_stall_escalation_owns_a_maintenance_deadline() {
+    let mut startup = startup(CancellationToken::new());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut snapshot = committed_snapshot(anchor);
+    let repair_target =
+        zakura_header_chain::Frontier::new(block::Height(1), block::Hash([0x41; 32]));
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(2), block::Hash([0x42; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_handle, _actions, mut reactor) =
+        build_header_sync_reactor(startup).expect("the escalation fixture builds");
+    let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(&snapshot).bind(
+        INTERNAL_VCT_REPAIR_SESSION_ID,
+        std::num::NonZeroU64::new(1).expect("one is nonzero"),
+    );
+    let context = zakura_header_chain::VctRepairContext {
+        target: repair_target,
+        locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+    };
+    let mut task = RepairRequirement::new(owner, repair_target.height, 11);
+    task.state = RepairPolicyState::LocalBackoff {
+        context,
+        retry_at: Instant::now() + std::time::Duration::from_secs(120),
+    };
+    reactor.vct_repair.insert(task.clone());
+    let now = Instant::now();
+
+    reactor.note_vct_repair_stall(
+        &task,
+        anchor,
+        VctSupplierRejections::default(),
+        VctRepairStallOutcome::LocalFailure,
+        now,
+    );
+
+    let stall = reactor
+        .vct_repair_stall
+        .expect("the failed generation owns escalation state");
+    assert_eq!(stall.last_trace, Some(now));
+    assert_eq!(
+        reactor.next_maintenance_deadline(),
+        now + VCT_REPAIR_STALL_TRACE_INTERVAL
+    );
+    let report_at = now + VCT_REPAIR_STALL_REPORT_AFTER;
+    reactor.refresh_vct_repair_stall(report_at);
+    let stall = reactor
+        .vct_repair_stall
+        .expect("reporting keeps sampled generation state");
+    assert!(stall.reported);
+    assert_eq!(stall.outcome, VctRepairStallOutcome::LocalFailure);
 }
 
 #[test]
@@ -256,7 +509,17 @@ fn bounded_supplier_cycles_rotate_to_the_fourth_supplier() {
     };
     assert_eq!(task.tried_sources.len(), 3);
     assert!(task.supplier_cycle_exhausted());
-    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    assert_eq!(
+        reactor.vct_supplier_order,
+        [
+            peers[3].clone(),
+            peers[0].clone(),
+            peers[1].clone(),
+            peers[2].clone(),
+        ]
+        .into_iter()
+        .collect::<VecDeque<_>>()
+    );
     let stall = reactor
         .vct_repair_stall
         .expect("a complete failed cycle starts the generation stall clock");
@@ -281,7 +544,7 @@ fn bounded_supplier_cycles_rotate_to_the_fourth_supplier() {
         .current()
         .expect("the fourth supplier owns the current repair");
     assert!(task.tried_sources.is_empty());
-    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    assert_eq!(reactor.vct_supplier_order.front(), Some(&peers[3]));
     assert_eq!(
         reactor
             .vct_repair_stall
@@ -289,6 +552,136 @@ fn bounded_supplier_cycles_rotate_to_the_fourth_supplier() {
             .since,
         stall.since
     );
+}
+
+#[test]
+fn established_supplier_precedes_new_identities_after_adversarial_churn() {
+    let mut startup = startup(CancellationToken::new());
+    let anchor = zakura_header_chain::Frontier::new(startup.anchor.0, startup.anchor.1);
+    let mut snapshot = committed_snapshot(anchor);
+    let repair_target =
+        zakura_header_chain::Frontier::new(block::Height(1), block::Hash([0x41; 32]));
+    snapshot.frontiers.header_best =
+        zakura_header_chain::Frontier::new(block::Height(2), block::Hash([0x42; 32]));
+    let (_snapshots_tx, snapshots_rx) = watch::channel(Some(snapshot.clone()));
+    startup.committed_snapshots = Some(snapshots_rx);
+    let (_handle, _actions, mut reactor) =
+        build_header_sync_reactor(startup).expect("the churn fixture builds");
+    let established: Vec<_> = [1_u8, 2, 3, 200]
+        .into_iter()
+        .map(|byte| ZakuraPeerId::new(vec![byte; 32]).expect("the peer ID is bounded"))
+        .collect();
+    let mut _outbounds = Vec::new();
+    for (index, peer) in established.iter().enumerate() {
+        let (send, outbound) = framed_channel(8);
+        reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+            peer.clone(),
+            10 + u64::try_from(index).expect("the peer index fits in u64"),
+            send,
+            CancellationToken::new(),
+        ));
+        _outbounds.push(outbound);
+    }
+    let owner = zakura_header_chain::BodyWorkAuthority::for_snapshot(&snapshot).bind(
+        INTERNAL_VCT_REPAIR_SESSION_ID,
+        std::num::NonZeroU64::new(1).expect("one is nonzero"),
+    );
+    let context = zakura_header_chain::VctRepairContext {
+        target: repair_target,
+        locator: zakura_header_chain::HeaderLocator::for_continuation(anchor),
+    };
+    let mut task = RepairRequirement::new(owner, repair_target.height, 11);
+    task.state = RepairPolicyState::Ready {
+        context: context.clone(),
+    };
+    reactor.vct_repair.insert(task);
+    let status = Status {
+        work_anchor_height: anchor.height,
+        work_anchor_hash: anchor.hash,
+        selected_tip_height: snapshot.frontiers.header_best.height,
+        selected_tip_hash: snapshot.frontiers.header_best.hash,
+        suffix_cumulative_work: zakura_chain::work::difficulty::U256::from(2_u8),
+        oldest_retained_height: anchor.height,
+        max_headers_per_response: 1,
+        max_inflight_requests: 1,
+        max_message_bytes: 2_000_000,
+        tree_aux_schema_mask: AuxSchema::V1.mask_bit(),
+    };
+    for (index, peer) in established.iter().enumerate() {
+        reactor.handle_wire_message(
+            peer.clone(),
+            10 + u64::try_from(index).expect("the peer index fits in u64"),
+            HeaderSyncMessage::Status(status.clone()),
+        );
+    }
+    for peer in &established[..3] {
+        let active = reactor
+            .peer_work_queue
+            .active(peer)
+            .expect("the next established supplier owns the repair")
+            .clone();
+        reactor.handle_headers_outcome(
+            peer.clone(),
+            active.owner.session_id(),
+            active.owner.header_authority(),
+            HeadersOutcome {
+                request_id: active.request_id.get(),
+                target_tip_hash: repair_target.hash,
+                outcome: HeadersOutcomeCode::TargetNotRetained,
+            },
+        );
+    }
+    let retry_at = match reactor
+        .vct_repair
+        .current()
+        .expect("the failed cycle keeps the repair")
+        .state
+    {
+        RepairPolicyState::SupplierBackoff { retry_at, .. } => retry_at,
+        ref other => panic!("the bounded cycle must back off, got {other:?}"),
+    };
+    for (index, peer) in established[..3].iter().enumerate() {
+        reactor.handle_peer_disconnected(
+            peer,
+            10 + u64::try_from(index).expect("the peer index fits in u64"),
+            "test churn",
+        );
+    }
+
+    let churn: Vec<_> = [4_u8, 5, 6]
+        .into_iter()
+        .map(|byte| ZakuraPeerId::new(vec![byte; 32]).expect("the churn identity is bounded"))
+        .collect();
+    for (index, peer) in churn.iter().enumerate() {
+        let (send, outbound) = framed_channel(8);
+        let session_id = 20 + u64::try_from(index).expect("the churn index fits in u64");
+        reactor.handle_peer_connected(PeerSession::from_parts_with_session_id(
+            peer.clone(),
+            session_id,
+            send,
+            CancellationToken::new(),
+        ));
+        reactor.handle_wire_message(
+            peer.clone(),
+            session_id,
+            HeaderSyncMessage::Status(status.clone()),
+        );
+        _outbounds.push(outbound);
+    }
+
+    assert_eq!(reactor.vct_supplier_order.front(), Some(&established[3]));
+    assert_eq!(reactor.vct_supplier_order.len(), reactor.peer_state.len());
+    reactor
+        .vct_repair
+        .current_mut()
+        .expect("the repair remains scheduled")
+        .resume_retry_cycle(retry_at);
+    reactor.try_assign_vct_repair();
+
+    assert!(reactor.peer_work_queue.active(&established[3]).is_some());
+    assert!(churn
+        .iter()
+        .all(|peer| reactor.peer_work_queue.active(peer).is_none()));
 }
 
 #[test]
@@ -358,7 +751,10 @@ fn replacement_session_keeps_the_authenticated_supplier_identity() {
         .current()
         .expect("the replacement keeps the repair scheduled");
     assert_eq!(task.tried_sources, [source].into_iter().collect());
-    assert_eq!(task.supplier_cursor, Some(source));
+    assert_eq!(
+        reactor.vct_supplier_order,
+        [peer].into_iter().collect::<VecDeque<_>>()
+    );
     assert!(matches!(
         task.state,
         RepairPolicyState::SupplierBackoff { .. }
@@ -437,7 +833,17 @@ fn send_failures_preserve_the_stall_clock_across_bounded_cycles() {
     };
     let task = reactor.vct_repair.current().expect("the repair remains");
     assert_eq!(task.tried_sources.len(), MAX_SUPPLIERS_PER_CYCLE);
-    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[2])));
+    assert_eq!(
+        reactor.vct_supplier_order,
+        [
+            peers[3].clone(),
+            peers[0].clone(),
+            peers[1].clone(),
+            peers[2].clone(),
+        ]
+        .into_iter()
+        .collect::<VecDeque<_>>()
+    );
     let stall = reactor
         .vct_repair_stall
         .expect("send failures start the stall clock");
@@ -455,7 +861,17 @@ fn send_failures_preserve_the_stall_clock_across_bounded_cycles() {
         RepairPolicyState::SupplierBackoff { .. }
     ));
     assert_eq!(task.tried_sources.len(), MAX_SUPPLIERS_PER_CYCLE);
-    assert_eq!(task.supplier_cursor, Some(source_id_from_peer(&peers[1])));
+    assert_eq!(
+        reactor.vct_supplier_order,
+        [
+            peers[2].clone(),
+            peers[3].clone(),
+            peers[0].clone(),
+            peers[1].clone(),
+        ]
+        .into_iter()
+        .collect::<VecDeque<_>>()
+    );
     assert_eq!(
         reactor
             .vct_repair_stall

--- a/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
+++ b/crates/zakura-network/src/zakura/header_sync/scheduler/repair.rs
@@ -84,8 +84,6 @@ pub(in crate::zakura::header_sync) struct RepairRequirement {
     pub attempts: u64,
     /// Suppliers already tried in the current cycle.
     pub tried_sources: HashSet<SourceId>,
-    /// Last supplier tried across every cycle for deterministic round-robin rotation.
-    pub supplier_cursor: Option<SourceId>,
 }
 
 impl RepairRequirement {
@@ -98,7 +96,6 @@ impl RepairRequirement {
             state: RepairPolicyState::NeedsContext,
             attempts: 0,
             tried_sources: HashSet::new(),
-            supplier_cursor: None,
         }
     }
 
@@ -169,7 +166,6 @@ impl RepairRequirement {
         self.attempts = self.attempts.saturating_add(1);
         if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
             self.tried_sources.insert(source);
-            self.supplier_cursor = Some(source);
         }
         self.state = RepairPolicyState::Ready { context };
         Ok(())
@@ -183,21 +179,20 @@ impl RepairRequirement {
         self.attempts = self.attempts.saturating_add(1);
         if self.tried_sources.len() < MAX_SUPPLIERS_PER_CYCLE {
             self.tried_sources.insert(source);
-            self.supplier_cursor = Some(source);
         }
         Ok(())
     }
 
-    /// Back off an assigned repair after a local failure without rejecting its supplier.
+    /// Back off ready or assigned repair work after a local failure.
     pub fn defer_local_retry_until(&mut self, retry_at: Instant) -> Result<(), RepairPolicyError> {
-        let RepairPolicyState::Assigned { context } = &self.state else {
-            return Err(RepairPolicyError::IllegalState);
+        let context = match &self.state {
+            RepairPolicyState::Ready { context } | RepairPolicyState::Assigned { context } => {
+                context.clone()
+            }
+            _ => return Err(RepairPolicyError::IllegalState),
         };
         self.attempts = self.attempts.saturating_add(1);
-        self.state = RepairPolicyState::LocalBackoff {
-            context: context.clone(),
-            retry_at,
-        };
+        self.state = RepairPolicyState::LocalBackoff { context, retry_at };
         Ok(())
     }
 
@@ -463,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    fn supplier_cycle_bounds_identity_churn_and_preserves_cursor() {
+    fn supplier_cycle_bounds_identity_churn() {
         let mut task = task(&snapshot());
         let context = context();
         mark_context_requested(&mut task);
@@ -478,7 +473,6 @@ mod tests {
         assert!(task.supplier_cycle_exhausted());
         assert_eq!(task.tried_sources.len(), 3);
         assert_eq!(task.attempts, 3);
-        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
 
         for byte in 4_u8..=64 {
             task.record_failed_source(SourceId::from_digest([byte; 32]))
@@ -488,7 +482,6 @@ mod tests {
         assert_eq!(task.tried_sources.len(), 3);
         assert!(!task.tried_sources.contains(&SourceId::from_digest([4; 32])));
         assert_eq!(task.attempts, 64);
-        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
 
         let deadline = Instant::now() + std::time::Duration::from_secs(1);
         task.defer_retry_until(deadline)
@@ -496,12 +489,11 @@ mod tests {
         task.resume_retry_cycle(deadline);
         assert!(!task.supplier_cycle_exhausted());
         assert!(task.tried_sources.is_empty());
-        assert_eq!(task.supplier_cursor, Some(SourceId::from_digest([3; 32])));
         assert_eq!(task.state, RepairPolicyState::Ready { context });
     }
 
     #[test]
-    fn local_retry_preserves_supplier_eligibility_and_cursor() {
+    fn local_retry_preserves_supplier_eligibility() {
         let mut task = task(&snapshot());
         let context = context();
         mark_context_requested(&mut task);
@@ -519,7 +511,6 @@ mod tests {
             .expect("a local failure backs off assigned work");
 
         assert_eq!(task.tried_sources, [failed_source].into_iter().collect());
-        assert_eq!(task.supplier_cursor, Some(failed_source));
         assert_eq!(task.attempts, 2);
         assert_eq!(
             task.state,
@@ -530,7 +521,32 @@ mod tests {
         );
         task.resume_retry_cycle(retry_at);
         assert_eq!(task.tried_sources, [failed_source].into_iter().collect());
-        assert_eq!(task.supplier_cursor, Some(failed_source));
+        assert_eq!(task.state, RepairPolicyState::Ready { context });
+    }
+
+    #[test]
+    fn ready_local_retry_preserves_supplier_eligibility() {
+        let mut task = task(&snapshot());
+        let context = context();
+        mark_context_requested(&mut task);
+        task.resolve(context.clone())
+            .expect("the exact context resolves");
+        let failed_source = SourceId::from_digest([1; 32]);
+        task.tried_sources.insert(failed_source);
+        let retry_at = Instant::now() + std::time::Duration::from_secs(1);
+
+        task.defer_local_retry_until(retry_at)
+            .expect("ready work can back off after a local send failure");
+
+        assert_eq!(task.tried_sources, [failed_source].into_iter().collect());
+        assert_eq!(
+            task.state,
+            RepairPolicyState::LocalBackoff {
+                context: context.clone(),
+                retry_at,
+            }
+        );
+        task.resume_retry_cycle(retry_at);
         assert_eq!(task.state, RepairPolicyState::Ready { context });
     }
 

--- a/docs/changelog/unreleased/815.md
+++ b/docs/changelog/unreleased/815.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed VCT repair retries that could discard scheduler state, penalize the wrong supplier, or
+  delay stall escalation. Repairs now preserve local and supplier attribution and use bounded
+  admission-order supplier rotation
+  ([#815](https://github.com/zakura-core/zakura/pull/815)).


### PR DESCRIPTION
## Motivation

PR #810 bounded VCT supplier cycles, but reactor retry paths still inferred supplier blame from broad terminal outcomes. Admission failures also recreated the repair task and discarded its policy state. Source-ID sorting let newly inserted identities move ahead of established suppliers, and the stall escalation depended on unrelated maintenance deadlines.

## Solution

This PR adds explicit local and supplier retry attribution at each VCT reactor boundary. It preserves repair context, attempt counts, and tried suppliers across admission failures. Receiving timeouts and unavailable ordered sends rotate suppliers, while Preparing, Applying, and encoding failures keep the supplier eligible under local backoff.

The scheduler now uses one bounded admission-order queue for authenticated peers. Supplier failures rotate one admitted peer to the back. Replacements keep their position, disconnects remove their entry, and new identities enter behind established peers.

The repair-generation stall record now owns its trace and escalation deadlines. It records typed local or supplier outcomes in traces and error diagnostics. Resource-stalled admissions use the exact `resource_stalled` terminal label.

## Testing

- `cargo test -p zakura-network`
- `cargo test -p zakura-state vct_ --lib`
- `cargo clippy -p zakura-network --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The new tests cover adversarial identity insertion and removal, replacement sessions, bounded send-failure cycles, timeout attribution by phase, admission-failure state preservation, ordered-send attribution, the resource-stalled label, and the independent escalation deadline.

## Changelog

Added `docs/changelog/unreleased/815.md`.

### Specifications & References

- Stacked on #813.
- Corrects the remaining scheduler and reactor blockers found while auditing #810.

### Follow-up Work

No known merge-blocking follow-up remains in this scope.
