### PR TITLE
fix(ops): harden stall diagnostic alerts

### DIFF
--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -925,6 +925,22 @@ class NodeDetailTests(unittest.TestCase):
         self.assertNotIn("root@node-a", json.dumps(diagnostics))
         self.assertLess(len(json.dumps(diagnostics)), 1_000)
 
+    def test_whole_probe_failure_marks_metrics_unavailable(self):
+        collected = collector()
+        error = "ssh exited 255: connection refused"
+
+        row = collected.row_for(node(), {"error": error}, now=1_000.0)
+        collected.rows = [row]
+        collected.last_poll = 1_001.0
+        diagnostics = collected.snapshot()["rows"][0]["alert_diagnostics"]
+
+        self.assertEqual(row["detail"], error)
+        self.assertEqual(row["metrics_error"], error)
+        self.assertIsNone(row["metrics_at"])
+        self.assertFalse(diagnostics["metrics_available"])
+        self.assertIsNone(diagnostics["metrics_at"])
+        self.assertEqual(diagnostics["metrics"], {})
+
     def test_node_payload_carries_the_deep_fields(self):
         collected = collector()
         collected.rows = [collected.row_for(node(), self.probe(), now=1_000.0)]

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
@@ -327,6 +328,68 @@ class StallDiagnosticTests(unittest.TestCase):
         self.assertLess(len(text), 2_000)
         self.assertNotIn("x" * 65, text)
 
+    def test_node_detail_is_plain_text_and_bounded(self):
+        detail = (
+            "connection failed\n<!channel> *second_line* `command` "
+            + "x" * 10_000
+        )
+        row = {
+            "name": "node-a",
+            "health": "down",
+            "detail": detail,
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "down", 700.0)
+        detail_line = next(
+            line for line in text.splitlines() if line.startswith("health:")
+        )
+
+        self.assertIn("connection failed", detail_line)
+        self.assertIn("second＿line", detail_line)
+        self.assertNotIn("<!channel>", detail_line)
+        self.assertNotIn("*second_line*", detail_line)
+        self.assertNotIn("`command`", detail_line)
+        self.assertLessEqual(
+            len(detail_line), watchdog.MAX_NODE_DETAIL_CHARS + 64
+        )
+
+
+class SlackPayloadTests(unittest.TestCase):
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return b"ok"
+
+    def test_webhook_payload_caps_the_final_message(self):
+        text = "useful prefix\n" + "x" * (watchdog.MAX_SLACK_MESSAGE_CHARS * 2)
+
+        with patch.object(
+            watchdog.urllib.request,
+            "urlopen",
+            return_value=self.Response(),
+        ) as urlopen:
+            posted = watchdog.post_slack_webhook(
+                "https://hooks.slack.invalid/test", text, make_args()
+            )
+
+        request = urlopen.call_args.args[0]
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertTrue(posted)
+        self.assertEqual(len(payload["text"]), watchdog.MAX_SLACK_MESSAGE_CHARS)
+        self.assertTrue(payload["text"].startswith("useful prefix\n"))
+        self.assertTrue(payload["text"].endswith(watchdog.SLACK_TRUNCATION_SUFFIX))
+        self.assertLess(
+            len(request.data), watchdog.MAX_SLACK_MESSAGE_CHARS + 64
+        )
+
 
 class SharedStallTests(unittest.TestCase):
     NOW = 2_000.0
@@ -414,7 +477,13 @@ class SharedStallTests(unittest.TestCase):
             {
                 **self.row(f"node-{index:02}", 100, 1_900, block_hash="aaaa"),
                 "alert_diagnostics": StallDiagnosticTests.diagnostics(
-                    sync_block_missing_bodies=4_000.0
+                    sync_block_missing_bodies=4_000.0,
+                    state_vct_root_stalled_height=101.0,
+                    state_vct_root_retry_count=3.0,
+                    state_vct_aux_sweep_frontier_height=99.0,
+                    sync_header_vct_repair_context_unavailable_total=2.0,
+                    sync_header_vct_repair_timed_out_total=1.0,
+                    sync_header_vct_repair_resource_stalled_total=0.0,
                 ),
             }
             for index in range(12)
@@ -429,7 +498,27 @@ class SharedStallTests(unittest.TestCase):
             watchdog.MAX_SHARED_DIAGNOSTIC_ROWS,
         )
         self.assertIn("- 4 more participating nodes not shown", text)
+        self.assertEqual(text.count("metrics ok"), watchdog.MAX_SHARED_DIAGNOSTIC_ROWS)
+        self.assertIn("vct stalled 101 | vct retries 3 | sweep 99", text)
+        self.assertIn("repair unavailable 2 | repair timed out 1", text)
         self.assertLess(len(text), 3_000)
+
+    def test_shared_alert_marks_unavailable_and_absent_metrics(self):
+        unavailable = self.row("node-a", 100, 1_900, block_hash="aaaa")
+        unavailable["alert_diagnostics"] = {
+            "last_poll": 1_000.0,
+            "metrics_at": None,
+            "metrics_available": False,
+            "metrics": {},
+        }
+        absent = self.row("node-b", 100, 1_900, block_hash="aaaa")
+
+        text = watchdog.shared_stall_alert_text(
+            self.fleet, 100, "aaaa", 2, 1_900.0, [unavailable, absent]
+        )
+
+        self.assertIn("- node-a: height 100 | metrics unavailable", text)
+        self.assertIn("- node-b: height 100 | metrics absent", text)
 
     def test_short_common_idle_does_not_alert(self):
         self.run_snapshot(

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -1315,15 +1315,16 @@ class ClusterCollector:
         if probe.get("metrics_skipped"):
             metrics_snapshot = self.last_metrics.get(node.name, {})
         else:
+            probe_error = probe.get("error")
             metrics_snapshot = {
                 "metrics": probe.get("metrics") or {},
-                "metrics_error": probe.get("metrics_error"),
+                "metrics_error": probe.get("metrics_error") or probe_error,
                 "metrics_version": probe.get("metrics_version") or "",
                 "metrics_bytes": coerce_int(probe.get("metrics_bytes")),
                 "metrics_series": coerce_int(probe.get("metrics_series")),
                 "metrics_scrape_seconds": probe.get("metrics_scrape_seconds"),
                 "peer_user_agents": probe.get("peer_user_agents") or [],
-                "metrics_at": now,
+                "metrics_at": None if probe_error else now,
             }
             self.last_metrics[node.name] = metrics_snapshot
 

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -28,6 +28,21 @@ from typing import Any
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
 MAX_SHARED_DIAGNOSTIC_ROWS = 8
+MAX_NODE_DETAIL_CHARS = 512
+MAX_SLACK_MESSAGE_CHARS = 35_000
+SLACK_TRUNCATION_SUFFIX = "\n[alert truncated]"
+SLACK_PLAIN_TEXT_TRANSLATION = str.maketrans(
+    {
+        "&": "＆",
+        "<": "‹",
+        ">": "›",
+        "*": "∗",
+        "_": "＿",
+        "~": "～",
+        "`": "ˋ",
+        "@": "＠",
+    }
+)
 STALL_PIPELINE_METRICS = (
     ("network tip", "sync_estimated_network_tip_height"),
     ("distance", "sync_estimated_distance_to_tip"),
@@ -58,6 +73,14 @@ STALL_REPAIR_METRICS = (
     ("context unavailable", "sync_header_vct_repair_context_unavailable_total"),
     ("timed out", "sync_header_vct_repair_timed_out_total"),
     ("resource stalled", "sync_header_vct_repair_resource_stalled_total"),
+)
+SHARED_REPAIR_METRICS = (
+    ("vct stalled", "state_vct_root_stalled_height"),
+    ("vct retries", "state_vct_root_retry_count"),
+    ("sweep", "state_vct_aux_sweep_frontier_height"),
+    ("repair unavailable", "sync_header_vct_repair_context_unavailable_total"),
+    ("repair timed out", "sync_header_vct_repair_timed_out_total"),
+    ("repair resource stalled", "sync_header_vct_repair_resource_stalled_total"),
 )
 
 
@@ -283,6 +306,17 @@ def bounded_text(value: object, limit: int) -> str:
     return " ".join(str(value or "").split())[:limit]
 
 
+def slack_plain_text(value: object, limit: int) -> str:
+    return bounded_text(value, limit).translate(SLACK_PLAIN_TEXT_TRANSLATION)
+
+
+def bounded_slack_message(text: str) -> str:
+    if len(text) <= MAX_SLACK_MESSAGE_CHARS:
+        return text
+    keep = MAX_SLACK_MESSAGE_CHARS - len(SLACK_TRUNCATION_SUFFIX)
+    return text[:keep] + SLACK_TRUNCATION_SUFFIX
+
+
 def alert_metrics(row: dict[str, Any]) -> tuple[dict[str, Any], bool | None]:
     diagnostics = row.get("alert_diagnostics")
     if not isinstance(diagnostics, dict):
@@ -292,6 +326,18 @@ def alert_metrics(row: dict[str, Any]) -> tuple[dict[str, Any], bool | None]:
         metrics = {}
     available = diagnostics.get("metrics_available")
     return metrics, available if isinstance(available, bool) else None
+
+
+def metrics_availability_marker(
+    metrics: dict[str, Any], available: bool | None
+) -> str:
+    if available is False:
+        return "metrics unavailable"
+    if available is None:
+        return "metrics absent"
+    if not metrics:
+        return "metrics empty"
+    return "metrics ok"
 
 
 def node_diagnostic_lines(row: dict[str, Any]) -> list[str]:
@@ -365,6 +411,7 @@ def slack_webhook_url() -> str:
 
 
 def post_slack(text: str, args: argparse.Namespace) -> bool:
+    text = bounded_slack_message(text)
     webhook = slack_webhook_url()
     if args.dry_run:
         print(f"dry-run Slack message:\n{text}\n")
@@ -382,6 +429,7 @@ def post_slack(text: str, args: argparse.Namespace) -> bool:
 
 
 def post_slack_webhook(webhook: str, text: str, args: argparse.Namespace) -> bool:
+    text = bounded_slack_message(text)
     payload = json.dumps({"text": text}).encode("utf-8")
     request = urllib.request.Request(
         webhook,
@@ -598,7 +646,7 @@ def node_alert_text(fleet: Fleet, row: dict[str, Any], condition: str, age: floa
     name = row.get("name") or "unknown"
     health = row.get("health") or "unknown"
     height = row.get("height")
-    detail = row.get("detail") or "no detail"
+    detail = slack_plain_text(row.get("detail") or "no detail", MAX_NODE_DETAIL_CHARS)
     height_text = str(height) if height is not None else "-"
 
     lines = [
@@ -667,7 +715,7 @@ def shared_stall_alert_text(
                 ("peers", "peer_count"),
             ),
         )
-        metrics, _available = alert_metrics(row)
+        metrics, available = alert_metrics(row)
         pipeline = named_metrics(
             metrics,
             (
@@ -679,12 +727,15 @@ def shared_stall_alert_text(
                 ("missing", "sync_block_missing_bodies"),
             ),
         )
+        repair = named_metrics(metrics, SHARED_REPAIR_METRICS)
         commit = bounded_text(row.get("commit"), 12)
         summary = " | ".join(
             value
             for value in (
                 summary,
+                metrics_availability_marker(metrics, available),
                 pipeline,
+                repair,
                 f"commit {commit}" if commit else "",
             )
             if value


### PR DESCRIPTION
## Motivation

A whole SSH probe failure produced an empty metrics map without a metrics error. The fleet snapshot therefore reported metrics as available even though no scrape ran. Shared alerts also omitted metrics availability and VCT repair state. Arbitrary node error detail could inject Slack markup or exceed Slack's message limit.

## Solution

- preserve whole-probe errors in the existing metrics error field and leave the metrics timestamp unset
- show an explicit metrics marker and a compact VCT repair subset on each bounded shared-alert row
- collapse, bound, and neutralize Slack markup in node detail
- cap every final webhook message at 35,000 characters

The atomic diagnostics schema and the alert ownership reconciler remain unchanged. This PR is stacked on #814.

## Testing

- `python3 -m unittest deploy/runner/test_zakura_cluster_watchdog.py` (56 passed)
- `python3 -m unittest discover -s deploy/runner -p test_zakura_cluster_status.py` (56 passed)
- `python3 -m py_compile deploy/runner/zakura-cluster-status.py deploy/runner/zakura-cluster-watchdog.py deploy/runner/test_zakura_cluster_status.py deploy/runner/test_zakura_cluster_watchdog.py`
- `systemd-analyze verify deploy/runner/zakura-fleet-watchdog.service`
- `git diff --check 1ac4e977903e7ca8cae2b72283cf8809e4c5587c...HEAD`

The new tests reproduce a whole-probe failure, cover missing shared metrics, exercise the VCT subset at the eight-row bound, neutralize injected detail markup, and inspect the final serialized webhook payload length.

## Changelog

No Rust source or Cargo manifest changed.

### Follow-up Work

A versioned node diagnostic contract could replace the duplicated raw metric-name maps in a later PR.