### PR TITLE
fix(sync): retry transient block failures in place

### DIFF
--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -25,8 +25,8 @@ use tokio::{
     time::{sleep, sleep_until, timeout},
 };
 use tower::{
-    builder::ServiceBuilder, hedge::Hedge, limit::ConcurrencyLimit, retry::Retry, timeout::Timeout,
-    Service, ServiceExt,
+    builder::ServiceBuilder, hedge::Hedge, limit::ConcurrencyLimit, timeout::Timeout, Service,
+    ServiceExt,
 };
 
 use zakura_chain::{
@@ -63,15 +63,15 @@ pub use status::SyncStatus;
 /// Controls the number of peers used for each ObtainTips and ExtendTips request.
 const FANOUT: usize = 3;
 
-/// Controls how many times we will retry each block download.
+/// Maximum peer requests issued by one block download queue attempt.
 ///
-/// Failing block downloads is important because it defends against peers who
-/// feed us bad hashes. But spurious failures of valid blocks cause the syncer to
-/// restart from the previous checkpoint, potentially re-downloading blocks.
-///
-/// We also hedge requests, so we may retry up to twice this many times. Hedged
-/// retries may be concurrent, inner retries are sequential.
-const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
+/// The hedge service issues the original request and at most one concurrent hedge. Failure-specific
+/// retries belong to the sync queue, which prevents a generic service retry from multiplying this
+/// bound.
+const MAX_BLOCK_PEER_REQUESTS_PER_QUEUE_ATTEMPT: usize = 2;
+
+/// Successful requests required before the block download service starts hedging.
+const BLOCK_DOWNLOAD_HEDGE_MIN_DATA_POINTS: u64 = 20;
 
 fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresses: bool) -> String {
     error
@@ -95,12 +95,17 @@ fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresse
 const MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 8;
 
 /// Controls how many times the syncer requeues a required block hash after a transient peer or
-/// transport failure exhausts the block download service's internal retries.
+/// transport failure.
 ///
 /// A connection closing does not invalidate the selected chain or any other block already in the
 /// checkpoint verifier. Requeueing only the affected hash preserves that work. The bound still
-/// lets a persistently failing block restart the round and obtain fresh tips and peers.
+/// lets a persistently failing block restart the round and obtain fresh tips and peers. One initial
+/// attempt plus these three retries, with at most two peer requests per attempt, creates a hard
+/// ceiling of eight peer requests for each transient hash in one sync round.
 const TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
+
+const MAX_TRANSIENT_BLOCK_PEER_REQUESTS_PER_SYNC_ROUND: usize =
+    (TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT + 1) * MAX_BLOCK_PEER_REQUESTS_PER_QUEUE_ATTEMPT;
 
 /// Controls how many times the syncer immediately requeues a required block after a peer supplies
 /// a body whose coinbase height contradicts our own tip
@@ -858,15 +863,8 @@ where
 
     /// A service which downloads and verifies blocks, using the provided
     /// network and verifier services.
-    downloads: Pin<
-        Box<
-            Downloads<
-                Hedge<ConcurrencyLimit<Retry<zn::RetryLimit, Timeout<ZN>>>, AlwaysHedge>,
-                Timeout<ZV>,
-                ZSTip,
-            >,
-        >,
-    >,
+    downloads:
+        Pin<Box<Downloads<Hedge<ConcurrencyLimit<Timeout<ZN>>, AlwaysHedge>, Timeout<ZV>, ZSTip>>>,
 
     /// The cached block chain state.
     state: ZS,
@@ -999,23 +997,15 @@ where
 
         let tip_network = Timeout::new(peers.clone(), TIPS_RESPONSE_TIMEOUT);
 
-        // The Hedge middleware is the outermost layer, hedging requests
-        // between two retry-wrapped networks.  The innermost timeout
-        // layer is relatively unimportant, because slow requests will
-        // probably be preemptively hedged.
-        //
-        // The Hedge goes outside the Retry, because the Retry layer
-        // abstracts away spurious failures from individual peers
-        // making a less-fallible network service, and the Hedge layer
-        // tries to reduce latency of that less-fallible service.
+        // The hedge middleware issues at most two peer requests for each queue attempt: the
+        // original request and one hedge. The sync queue owns failure-specific retry policy.
         let block_network = Hedge::new(
             ServiceBuilder::new()
                 .concurrency_limit(download_concurrency_limit)
-                .retry(zn::RetryLimit::new(BLOCK_DOWNLOAD_RETRY_LIMIT))
                 .timeout(BLOCK_DOWNLOAD_TIMEOUT)
                 .service(peers),
             AlwaysHedge,
-            20,
+            BLOCK_DOWNLOAD_HEDGE_MIN_DATA_POINTS,
             0.95,
             2 * SYNC_RESTART_DELAY,
         );
@@ -2495,16 +2485,15 @@ where
     /// newest block would wait for the next discovery round, which is exactly the delay the attack
     /// is trying to cause.
     ///
-    /// The block download service already retries each `BlocksByHash` request and may hedge it to
-    /// another peer. If a peer still responds `notfound` ([`NotFoundKind::Response`]), the syncer
+    /// The block download service may hedge each `BlocksByHash` request to another peer. If a peer
+    /// still responds `notfound` ([`NotFoundKind::Response`]), the syncer
     /// requeues the required hash — which routes to a different peer, since the peer set now marks
     /// the responding peer as missing it — and keeps the in-flight download/verify pipeline alive,
     /// rather than discarding the whole round. The requeues are bounded by
     /// [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     ///
     /// A transient peer or transport error also affects only one requested hash. The syncer
-    /// requeues that hash after the download service exhausts its internal retries. The requeues
-    /// are bounded by [`TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT`].
+    /// requeues that hash. The requeues are bounded by [`TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     ///
     /// A [`NotFoundKind::Registry`] miss means the peer set found that *every* ready peer is marked
     /// missing the block, so it can't be served right now. Rather than blocking the loop on an inline
@@ -2710,6 +2699,7 @@ where
             warn!(
                 ?hash,
                 retry_limit = TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT,
+                peer_request_ceiling = MAX_TRANSIENT_BLOCK_PEER_REQUESTS_PER_SYNC_ROUND,
                 "transient sync block download retry budget exhausted, restarting sync"
             );
             metrics::counter!("sync.transient.block.retry.limit.count").increment(1);

--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -94,6 +94,14 @@ fn block_error_peer_label(error: &BlockDownloadVerifyError, expose_peer_addresse
 /// accountability in `zakura-network` disconnects such peers so this bound is rarely reached.
 const MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 8;
 
+/// Controls how many times the syncer requeues a required block hash after a transient peer or
+/// transport failure exhausts the block download service's internal retries.
+///
+/// A connection closing does not invalidate the selected chain or any other block already in the
+/// checkpoint verifier. Requeueing only the affected hash preserves that work. The bound still
+/// lets a persistently failing block restart the round and obtain fresh tips and peers.
+const TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
+
 /// Controls how many times the syncer immediately requeues a required block after a peer supplies
 /// a body whose coinbase height contradicts our own tip
 /// ([`BlockDownloadVerifyError::TipChildHeightMismatch`]).
@@ -878,6 +886,9 @@ where
     /// `notfound` ([`NotFoundKind::Response`]). Bounded by [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     missing_block_retry_counts: HashMap<block::Hash, usize>,
 
+    /// Per-hash retry counts for transient peer and transport download failures.
+    transient_block_retry_counts: HashMap<block::Hash, usize>,
+
     /// Queue-level retry counts for required blocks whose body claimed a coinbase height that
     /// contradicts our own tip. Bounded by [`POISONED_BLOCK_RETRY_LIMIT`].
     poisoned_block_retry_counts: HashMap<block::Hash, usize>,
@@ -1049,6 +1060,7 @@ where
             prospective_tips: HashSet::new(),
             recent_syncs,
             missing_block_retry_counts: HashMap::new(),
+            transient_block_retry_counts: HashMap::new(),
             poisoned_block_retry_counts: HashMap::new(),
             registry_miss_retry_counts: HashMap::new(),
             registry_miss_retry: HashMap::new(),
@@ -1409,6 +1421,7 @@ where
     ) -> Result<(), Report> {
         self.prospective_tips = HashSet::new();
         self.missing_block_retry_counts.clear();
+        self.transient_block_retry_counts.clear();
         self.poisoned_block_retry_counts.clear();
         self.registry_miss_retry_counts.clear();
         self.registry_miss_retry.clear();
@@ -2472,7 +2485,8 @@ where
         Self::handle_response(response, self.expose_peer_addresses)
     }
 
-    /// Handles a downloaded block response, requeueing required missing or poisoned block hashes.
+    /// Handles a downloaded block response and requeues a required hash when retrying one block can
+    /// preserve the rest of the round.
     ///
     /// A [`BlockDownloadVerifyError::TipChildHeightMismatch`] means a peer returned a body under
     /// the correct block hash but with a rewritten coinbase height. That satisfies the network
@@ -2488,6 +2502,10 @@ where
     /// rather than discarding the whole round. The requeues are bounded by
     /// [`MISSING_BLOCK_DOWNLOAD_RETRY_LIMIT`].
     ///
+    /// A transient peer or transport error also affects only one requested hash. The syncer
+    /// requeues that hash after the download service exhausts its internal retries. The requeues
+    /// are bounded by [`TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT`].
+    ///
     /// A [`NotFoundKind::Registry`] miss means the peer set found that *every* ready peer is marked
     /// missing the block, so it can't be served right now. Rather than blocking the loop on an inline
     /// `sleep`, the hash is recorded in [`Self::registry_miss_retry`] with a backoff deadline; while
@@ -2502,6 +2520,7 @@ where
     ) -> Result<(), Report> {
         if let Ok((_height, hash)) = response.as_ref() {
             self.missing_block_retry_counts.remove(hash);
+            self.transient_block_retry_counts.remove(hash);
             self.poisoned_block_retry_counts.remove(hash);
             self.registry_miss_retry_counts.remove(hash);
             self.registry_miss_retry.remove(hash);
@@ -2652,6 +2671,48 @@ where
                     );
                 }
             }
+        }
+
+        if let Some(hash) = response.as_ref().err().and_then(|error| match error {
+            BlockDownloadVerifyError::DownloadFailed { hash, .. }
+                if error.not_found_download().is_none() =>
+            {
+                Some(*hash)
+            }
+            _ => None,
+        }) {
+            let retry_count = self.transient_block_retry_counts.entry(hash).or_default();
+
+            if *retry_count < TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT {
+                *retry_count += 1;
+
+                info!(
+                    ?hash,
+                    retry_attempt = *retry_count,
+                    retry_limit = TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT,
+                    "transient sync block download failed, retrying required block"
+                );
+                metrics::counter!("sync.transient.block.requeued.count").increment(1);
+
+                match self.downloads.download_and_verify(hash).await {
+                    Ok(())
+                    | Err(BlockDownloadVerifyError::DuplicateBlockQueuedForDownload { .. }) => {
+                        return Ok(())
+                    }
+                    Err(error) => self.handle_block_response(Err(error))?,
+                }
+
+                return Ok(());
+            }
+
+            self.transient_block_retry_counts.remove(&hash);
+
+            warn!(
+                ?hash,
+                retry_limit = TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT,
+                "transient sync block download retry budget exhausted, restarting sync"
+            );
+            metrics::counter!("sync.transient.block.retry.limit.count").increment(1);
         }
 
         self.handle_block_response(response)?;

--- a/crates/zakurad/src/components/sync/downloads.rs
+++ b/crates/zakurad/src/components/sync/downloads.rs
@@ -37,7 +37,8 @@ use crate::components::{
         legacy_trace::{
             LegacyBlockOutcome, LegacyDiagnosticSnapshot, LegacySyncTrace, LegacyTaskState,
         },
-        FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT, FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT,
+        BLOCK_DOWNLOAD_TIMEOUT, FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT,
+        FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT,
     },
 };
 
@@ -506,9 +507,9 @@ where
 
     /// Queue a block for download and verification.
     ///
-    /// This method waits for the network to become ready, and returns an error
-    /// only if the network service fails. It returns immediately after queuing
-    /// the request.
+    /// This method waits up to [`BLOCK_DOWNLOAD_TIMEOUT`] for the network to become ready. It
+    /// returns an error if readiness fails or times out. It returns immediately after queuing the
+    /// request.
     #[instrument(level = "debug", skip(self), fields(%hash))]
     pub async fn download_and_verify(
         &mut self,
@@ -534,13 +535,20 @@ where
         // if we waited for readiness and did the service call in the spawned
         // tasks, all of the spawned tasks would race each other waiting for the
         // network to become ready.
-        let network = match self.network.ready().await {
-            Ok(network) => network,
-            Err(error) => {
+        let network = match timeout(BLOCK_DOWNLOAD_TIMEOUT, self.network.ready()).await {
+            Ok(Ok(network)) => network,
+            Ok(Err(error)) => {
                 let state = take_task_state(&self.task_states, hash);
                 self.trace
                     .block_finish(hash, LegacyBlockOutcome::Error(&error), state);
                 return Err(BlockDownloadVerifyError::NetworkServiceError { error });
+            }
+            Err(error) => {
+                let error = BlockDownloadVerifyError::from(error);
+                let state = take_task_state(&self.task_states, hash);
+                self.trace
+                    .block_finish(hash, LegacyBlockOutcome::Error(&error), state);
+                return Err(error);
             }
         };
         let block_req = network.call(zn::Request::BlocksByHash(std::iter::once(hash).collect()));

--- a/crates/zakurad/src/components/sync/tests/timing.rs
+++ b/crates/zakurad/src/components/sync/tests/timing.rs
@@ -19,8 +19,8 @@ use zakura_state::ChainTipSender;
 
 use crate::{
     components::sync::{
-        ChainSync, BLOCK_DOWNLOAD_RETRY_LIMIT, BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT,
-        GENESIS_TIMEOUT_RETRY, SYNC_RESTART_DELAY, SYNC_RESTART_SLEEP,
+        ChainSync, BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT, GENESIS_TIMEOUT_RETRY,
+        MAX_BLOCK_PEER_REQUESTS_PER_QUEUE_ATTEMPT, SYNC_RESTART_DELAY, SYNC_RESTART_SLEEP,
     },
     config::ZakuradConfig,
 };
@@ -41,10 +41,10 @@ fn ensure_timeouts_consistent() {
         "the post-round sync sleep should be shorter than the sync restart timeout"
     );
 
-    // We multiply by 2, because the Hedge can wait up to BLOCK_DOWNLOAD_TIMEOUT
-    // seconds before retrying.
+    // The hedge can wait up to one block timeout before issuing its second and final peer request.
+    // The two-request bound fits in a `u64`.
     const BLOCK_DOWNLOAD_HEDGE_TIMEOUT: u64 =
-        2 * BLOCK_DOWNLOAD_RETRY_LIMIT as u64 * BLOCK_DOWNLOAD_TIMEOUT.as_secs();
+        MAX_BLOCK_PEER_REQUESTS_PER_QUEUE_ATTEMPT as u64 * BLOCK_DOWNLOAD_TIMEOUT.as_secs();
 
     // This constraint avoids spurious failures due to block download timeouts
     assert!(
@@ -179,7 +179,10 @@ fn request_genesis_is_rate_limited() {
 
     let peer_requests_counter = peer_requests_counter.load(Ordering::SeqCst);
     assert!(peer_requests_counter >= RETRIES_TO_RUN);
-    assert!(peer_requests_counter <= RETRIES_TO_RUN * (BLOCK_DOWNLOAD_RETRY_LIMIT as u8) * 2);
+    // The two-request bound fits in a `u8`.
+    assert!(
+        peer_requests_counter <= RETRIES_TO_RUN * MAX_BLOCK_PEER_REQUESTS_PER_QUEUE_ATTEMPT as u8
+    );
     assert_eq!(
         state_requests_counter.load(Ordering::SeqCst),
         RETRIES_TO_RUN

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -2264,6 +2264,85 @@ async fn transient_download_failure_restarts_after_retry_limit() {
     peer_set.expect_no_requests().await;
 }
 
+/// One initial transient attempt and three queue retries issue eight requests when every hedge runs.
+#[tokio::test(start_paused = true)]
+async fn transient_download_failure_has_eight_peer_request_ceiling() -> Result<(), crate::BoxError>
+{
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    // Fill the latency histogram so every failing queue attempt issues its one allowed hedge.
+    let prime_block: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let prime_hash = prime_block.hash();
+    for _ in 0..sync::BLOCK_DOWNLOAD_HEDGE_MIN_DATA_POINTS {
+        chain_sync.downloads.download_and_verify(prime_hash).await?;
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(iter::once(prime_hash).collect()))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                prime_block.clone(),
+                None,
+            ))]));
+        block_verifier_router
+            .expect_request_that(|request| request.block().hash() == prime_hash)
+            .await
+            .respond(prime_hash);
+        assert!(
+            chain_sync
+                .downloads
+                .next()
+                .await
+                .expect("priming download should complete")
+                .is_ok(),
+            "priming download should succeed"
+        );
+    }
+    tokio::time::advance(2 * sync::SYNC_RESTART_DELAY).await;
+
+    let failed_hash = block::Hash::from([0xCF; 32]);
+    let sync_round = chain_sync.sync_round(iter::once(failed_hash).collect(), None);
+    let fail_peer_requests = async {
+        let request = zn::Request::BlocksByHash(iter::once(failed_hash).collect());
+        let queue_attempts = sync::TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT + 1;
+        let mut peer_request_count = 0;
+
+        for _ in 0..queue_attempts {
+            let original = peer_set.expect_request(request.clone()).await;
+            let hedge = peer_set.expect_request(request.clone()).await;
+            peer_request_count += 2;
+
+            original.respond(Err(client_dropped_error()));
+            hedge.respond(Err(client_dropped_error()));
+        }
+
+        peer_request_count
+    };
+
+    let (result, peer_request_count) = tokio::join!(sync_round, fail_peer_requests);
+    assert!(
+        result.is_err(),
+        "the exhausted transient retry budget should restart the sync round"
+    );
+    assert_eq!(
+        peer_request_count,
+        sync::MAX_TRANSIENT_BLOCK_PEER_REQUESTS_PER_SYNC_ROUND
+    );
+    assert!(chain_sync.transient_block_retry_counts.is_empty());
+
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
 /// A transient failure for one hash preserves other work in the sync round and retries only the
 /// failed hash.
 #[tokio::test]
@@ -2287,12 +2366,11 @@ async fn transient_download_failure_preserves_sync_round() -> Result<(), crate::
 
     let sync_round = chain_sync.sync_round(reserve, None);
     let drive_services = async {
-        // Exhaust the retry layer inside one download service call. The unrelated request can
-        // arrive between these attempts because the sync round dispatches both hashes concurrently.
-        let service_attempts = sync::BLOCK_DOWNLOAD_RETRY_LIMIT + 1;
-        let mut failed_attempts = 0;
+        // Fail one download queue attempt. The unrelated request can arrive first because the sync
+        // round dispatches both hashes concurrently.
+        let mut failed_attempt_sent = false;
         let mut unrelated_response_sent = false;
-        while failed_attempts < service_attempts || !unrelated_response_sent {
+        while !failed_attempt_sent || !unrelated_response_sent {
             let response = peer_set
                 .expect_request_that(|request| match request {
                     zn::Request::BlocksByHash(hashes) => {
@@ -2312,7 +2390,11 @@ async fn transient_download_failure_preserves_sync_round() -> Result<(), crate::
             };
 
             if requested_hash == retried_hash {
-                failed_attempts += 1;
+                assert!(
+                    !failed_attempt_sent,
+                    "the failed block should use one request"
+                );
+                failed_attempt_sent = true;
                 response.respond(Err(client_dropped_error()));
             } else {
                 assert!(
@@ -2326,7 +2408,6 @@ async fn transient_download_failure_preserves_sync_round() -> Result<(), crate::
                 ))]));
             }
         }
-        assert_eq!(failed_attempts, service_attempts);
 
         // Commit the unrelated block before answering the queue-level retry. This proves that the
         // transient error did not cancel other work in the round.

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -9,12 +9,13 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
+    task::{Context, Poll},
     time::Duration,
 };
 
 use color_eyre::Report;
 use futures::{Future, FutureExt, StreamExt};
-use tower::timeout::Timeout;
+use tower::{timeout::Timeout, Service};
 
 use zakura_chain::{
     block::{self, Block, Height},
@@ -53,6 +54,23 @@ type TestChainSync = ChainSync<
     MockService<zakura_consensus::Request, block::Hash, PanicAssertion>,
     MockChainTip,
 >;
+
+#[derive(Clone, Debug)]
+struct NeverReadyNetwork;
+
+impl Service<zn::Request> for NeverReadyNetwork {
+    type Response = zn::Response;
+    type Error = crate::BoxError;
+    type Future = futures::future::Pending<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn call(&mut self, _request: zn::Request) -> Self::Future {
+        futures::future::pending()
+    }
+}
 
 /// Maximum time to wait for a request to any test service.
 ///
@@ -2144,10 +2162,11 @@ async fn not_found_download_restarts_sync() {
     );
 }
 
-/// A peer connection failure affects one block request, so the syncer requeues that hash without
-/// canceling the other checkpoint verification tasks.
+/// A peer connection failure affects one block request, so the syncer requeues that hash and clears
+/// the retry count after the replacement succeeds.
 #[tokio::test]
-async fn transient_download_failure_requeues_block() {
+async fn transient_download_failure_requeues_and_clears_on_success() -> Result<(), crate::BoxError>
+{
     let (
         mut chain_sync,
         _sync_status,
@@ -2157,35 +2176,54 @@ async fn transient_download_failure_requeues_block() {
         _mock_chain_tip_sender,
     ) = setup_chain_sync();
 
-    let block_hash = block::Hash::from([0xCE; 32]);
+    let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let block_hash = block.hash();
     let error = BlockDownloadVerifyError::DownloadFailed {
         error: client_dropped_error(),
         hash: block_hash,
     };
 
-    let requeue = tokio::spawn(async move {
-        let result = chain_sync
-            .handle_block_response_with_missing_retry(Err(error))
-            .await;
-        (chain_sync, result)
-    });
-
-    peer_set
-        .expect_request(zn::Request::BlocksByHash(iter::once(block_hash).collect()))
+    chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
         .await
-        .respond(Err(client_dropped_error()));
-
-    let (chain_sync, result) = requeue
-        .await
-        .expect("transient block retry task should not panic");
-    result.expect("a transient block failure within budget should preserve the round");
+        .expect("a transient block failure within budget should preserve the round");
     assert_eq!(
         chain_sync.transient_block_retry_counts.get(&block_hash),
         Some(&1),
         "the transient block retry should consume one retry"
     );
 
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block_hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((block.clone(), None))]));
+
+    block_verifier_router
+        .expect_request(zakura_consensus::Request::Commit(block))
+        .await
+        .respond(block_hash);
+
+    let response = chain_sync
+        .downloads
+        .next()
+        .await
+        .expect("the replacement download should complete");
+    chain_sync
+        .handle_block_response_with_missing_retry(response)
+        .await?;
+
+    assert!(
+        !chain_sync
+            .transient_block_retry_counts
+            .contains_key(&block_hash),
+        "a successful replacement should clear its transient retry count"
+    );
+    assert_eq!(chain_sync.downloads.in_flight(), 0);
+
+    peer_set.expect_no_requests().await;
     block_verifier_router.expect_no_requests().await;
+
+    Ok(())
 }
 
 /// A persistently failing block still restarts the round after its queue-level retry budget.
@@ -3314,6 +3352,36 @@ async fn empty_block_response_is_retryable_download_failure() {
         matches!(result, Err(BlockDownloadVerifyError::DownloadFailed { .. })),
         "an empty block response must be a retryable DownloadFailed, got {result:?}",
     );
+}
+
+/// A replacement download must not wait forever when every peer is unready.
+#[tokio::test(start_paused = true)]
+async fn block_download_network_readiness_times_out() {
+    let _init_guard = zakura_test::init();
+
+    let verifier =
+        MockService::build().for_unit_tests::<zakura_consensus::Request, block::Hash, _>();
+    let (chain_tip, _chain_tip_sender) = MockChainTip::new();
+    let (past_lookahead_limit_sender, _past_lookahead_limit_receiver) =
+        tokio::sync::watch::channel(false);
+    let mut downloads = Downloads::new(
+        NeverReadyNetwork,
+        verifier,
+        chain_tip,
+        past_lookahead_limit_sender,
+        sync::MIN_CONCURRENCY_LIMIT,
+        Height(0),
+        LegacySyncTrace::new(None, false),
+    );
+    let hash = block::Hash::from([0xCE; 32]);
+
+    let result = downloads.download_and_verify(hash).await;
+
+    assert!(
+        matches!(result, Err(BlockDownloadVerifyError::Timeout)),
+        "network readiness should time out, got {result:?}"
+    );
+    assert_eq!(downloads.in_flight(), 0);
 }
 
 /// Builds a [`Downloads`] wired to `peer_set`, `verifier`, and `chain_tip`.

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -2144,6 +2144,189 @@ async fn not_found_download_restarts_sync() {
     );
 }
 
+/// A peer connection failure affects one block request, so the syncer requeues that hash without
+/// canceling the other checkpoint verification tasks.
+#[tokio::test]
+async fn transient_download_failure_requeues_block() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xCE; 32]);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: client_dropped_error(),
+        hash: block_hash,
+    };
+
+    let requeue = tokio::spawn(async move {
+        let result = chain_sync
+            .handle_block_response_with_missing_retry(Err(error))
+            .await;
+        (chain_sync, result)
+    });
+
+    peer_set
+        .expect_request(zn::Request::BlocksByHash(iter::once(block_hash).collect()))
+        .await
+        .respond(Err(client_dropped_error()));
+
+    let (chain_sync, result) = requeue
+        .await
+        .expect("transient block retry task should not panic");
+    result.expect("a transient block failure within budget should preserve the round");
+    assert_eq!(
+        chain_sync.transient_block_retry_counts.get(&block_hash),
+        Some(&1),
+        "the transient block retry should consume one retry"
+    );
+
+    block_verifier_router.expect_no_requests().await;
+}
+
+/// A persistently failing block still restarts the round after its queue-level retry budget.
+#[tokio::test]
+async fn transient_download_failure_restarts_after_retry_limit() {
+    let (
+        mut chain_sync,
+        _sync_status,
+        _block_verifier_router,
+        mut peer_set,
+        _state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let block_hash = block::Hash::from([0xCF; 32]);
+    chain_sync
+        .transient_block_retry_counts
+        .insert(block_hash, sync::TRANSIENT_BLOCK_DOWNLOAD_RETRY_LIMIT);
+    let error = BlockDownloadVerifyError::DownloadFailed {
+        error: client_dropped_error(),
+        hash: block_hash,
+    };
+
+    let result = chain_sync
+        .handle_block_response_with_missing_retry(Err(error))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a transient block failure should restart sync after its retry budget"
+    );
+    assert!(
+        !chain_sync
+            .transient_block_retry_counts
+            .contains_key(&block_hash),
+        "an exhausted transient retry budget should be cleared"
+    );
+    peer_set.expect_no_requests().await;
+}
+
+/// A transient failure for one hash preserves other work in the sync round and retries only the
+/// failed hash.
+#[tokio::test]
+async fn transient_download_failure_preserves_sync_round() -> Result<(), crate::BoxError> {
+    let (
+        mut chain_sync,
+        _sync_status,
+        mut block_verifier_router,
+        mut peer_set,
+        mut state_service,
+        _mock_chain_tip_sender,
+    ) = setup_chain_sync();
+
+    let retried_block: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let retried_hash = retried_block.hash();
+    let unrelated_block: Arc<Block> =
+        zakura_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
+    let unrelated_hash = unrelated_block.hash();
+    let reserve = [retried_hash, unrelated_hash].into_iter().collect();
+
+    let sync_round = chain_sync.sync_round(reserve, None);
+    let drive_services = async {
+        // Exhaust the retry layer inside one download service call. The unrelated request can
+        // arrive between these attempts because the sync round dispatches both hashes concurrently.
+        let service_attempts = sync::BLOCK_DOWNLOAD_RETRY_LIMIT + 1;
+        let mut failed_attempts = 0;
+        let mut unrelated_response_sent = false;
+        while failed_attempts < service_attempts || !unrelated_response_sent {
+            let response = peer_set
+                .expect_request_that(|request| match request {
+                    zn::Request::BlocksByHash(hashes) => {
+                        hashes == &HashSet::from([retried_hash])
+                            || hashes == &HashSet::from([unrelated_hash])
+                    }
+                    _ => false,
+                })
+                .await;
+
+            let requested_hash = match response.request() {
+                zn::Request::BlocksByHash(hashes) => *hashes
+                    .iter()
+                    .next()
+                    .expect("single-hash block request is nonempty"),
+                _ => unreachable!("request matcher accepts only block requests"),
+            };
+
+            if requested_hash == retried_hash {
+                failed_attempts += 1;
+                response.respond(Err(client_dropped_error()));
+            } else {
+                assert!(
+                    !unrelated_response_sent,
+                    "the unrelated block should be requested once"
+                );
+                unrelated_response_sent = true;
+                response.respond(zn::Response::Blocks(vec![Available((
+                    unrelated_block.clone(),
+                    None,
+                ))]));
+            }
+        }
+        assert_eq!(failed_attempts, service_attempts);
+
+        // Commit the unrelated block before answering the queue-level retry. This proves that the
+        // transient error did not cancel other work in the round.
+        block_verifier_router
+            .expect_request_that(|request| request.block().hash() == unrelated_hash)
+            .await
+            .respond(unrelated_hash);
+
+        peer_set
+            .expect_request(zn::Request::BlocksByHash(
+                iter::once(retried_hash).collect(),
+            ))
+            .await
+            .respond(zn::Response::Blocks(vec![Available((
+                retried_block.clone(),
+                None,
+            ))]));
+        block_verifier_router
+            .expect_request_that(|request| request.block().hash() == retried_hash)
+            .await
+            .respond(retried_hash);
+    };
+
+    let (result, ()) = tokio::join!(sync_round, drive_services);
+    result.expect("replacement download should complete the original sync round");
+    assert!(
+        chain_sync.transient_block_retry_counts.is_empty(),
+        "a successful replacement should clear its transient retry state"
+    );
+    assert_eq!(chain_sync.downloads.in_flight(), 0);
+
+    peer_set.expect_no_requests().await;
+    block_verifier_router.expect_no_requests().await;
+    state_service.expect_no_requests().await;
+
+    Ok(())
+}
+
 /// Unit test for the refactored [`ChainSync::build_extend`]: it must *discover* the next batch of
 /// download hashes from a prospective tip, performing the FindBlocks fan-out and parsing the
 /// response, **without** dispatching any block downloads or otherwise touching syncer state.
@@ -3038,6 +3221,10 @@ fn not_found_block_error(_hash: block::Hash) -> crate::BoxError {
 /// `NotFoundRegistry`), as opposed to a single peer's `notfound`.
 fn not_found_registry_error(_hash: block::Hash) -> crate::BoxError {
     zn::SharedPeerError::from(zn::PeerError::NotFoundRegistry(Vec::new())).into()
+}
+
+fn client_dropped_error() -> crate::BoxError {
+    zn::SharedPeerError::from(zn::PeerError::ClientDropped).into()
 }
 
 #[test]

--- a/docs/changelog/unreleased/819.md
+++ b/docs/changelog/unreleased/819.md
@@ -2,5 +2,6 @@
 
 - Fixed the legacy block syncer restarting an entire sync round after one transient peer or
   transport failure. The syncer now retries the affected block hash with a bounded budget and
-  preserves the other download and checkpoint verification tasks
+  preserves the other download and checkpoint verification tasks. A replacement download also
+  stops waiting and restarts the round if the network stays unready past the download timeout
   ([#819](https://github.com/zakura-core/zakura/pull/819)).

--- a/docs/changelog/unreleased/819.md
+++ b/docs/changelog/unreleased/819.md
@@ -2,6 +2,7 @@
 
 - Fixed the legacy block syncer restarting an entire sync round after one transient peer or
   transport failure. The syncer now retries the affected block hash with a bounded budget and
-  preserves the other download and checkpoint verification tasks. A replacement download also
-  stops waiting and restarts the round if the network stays unready past the download timeout
+  preserves the other download and checkpoint verification tasks. The syncer limits each transient
+  hash to eight peer requests per sync round. A replacement download also stops waiting and
+  restarts the round if the network stays unready past the download timeout
   ([#819](https://github.com/zakura-core/zakura/pull/819)).

--- a/docs/changelog/unreleased/819.md
+++ b/docs/changelog/unreleased/819.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed the legacy block syncer restarting an entire sync round after one transient peer or
+  transport failure. The syncer now retries the affected block hash with a bounded budget and
+  preserves the other download and checkpoint verification tasks
+  ([#819](https://github.com/zakura-core/zakura/pull/819)).


### PR DESCRIPTION
## Motivation

A transient legacy block download failure restarted the entire sync round. The restart canceled unrelated downloads and checkpoint verification work even when the selected chain remained valid.

The first version of this PR requeued the failed hash. However, the block download service still placed a generic Tower retry layer inside its hedge layer. That service retry multiplied the queue retry budget and allowed about 32 peer requests for one persistently failing hash.

## Solution

Track a bounded transient retry budget per block hash. Requeue only the failed hash after a transient peer or transport failure. Preserve every unrelated task in the current sync round. Restart the round after three queue retries for the same hash.

Remove the generic Tower retry layer from the legacy block download service. Keep the 20-second timeout, concurrency limit, and one hedge. Each queue attempt now issues at most two peer requests: the original request and one hedge. One initial attempt plus three queue retries creates a hard ceiling of eight peer requests for each transient hash in one sync round.

Keep the existing queue policies for single-peer `notfound` responses, registry-wide misses, poisoned block bodies, readiness timeouts, and sync round restarts. Clear transient retry and in-flight state when the replacement succeeds or when a new sync round starts.

This change does not modify the wire protocol, database format, or configuration.

## Testing

- `cargo test -p zakura components::sync::tests --lib` (81 passed)
- `env -u RUST_LOG cargo test -p zakura --lib` (411 passed)
- `cargo clippy -p zakura --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`

The request-ceiling test fills and rotates the real hedge latency histogram. It then forces the original request and hedge to fail on the initial attempt and all three queue retries. The test observes exactly eight peer requests before the sync round restarts.

The two-hash sync-round test commits an unrelated block before answering the queue replacement. It then commits the replacement and verifies that the original round completes with empty transient retry state and no downloader task left in flight.

The existing legacy sync tests cover missing blocks, registry misses, poisoned bodies, readiness timeouts, round restarts, genesis rate limiting, and timeout consistency with the two-request hedge bound.

## Changelog

This PR fixes an operator-visible legacy sync restart and bounds transient retry amplification.

### Specifications & References

- Consolidates #803 and #811.

### Follow-up Work

None.
