### PR TITLE
fix(ops): complete fleet stall alert handling

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -202,6 +202,7 @@ jobs:
           # Read-only fields below: consumed by the status dashboard's SSH probe,
           # not written to any node (manage_config = false).
           rpc_listen_addr = "0.0.0.0:8232"
+          metrics_endpoint = "127.0.0.1:9999"
           log_file        = "/root/logs/zakura-tracing.log"
           # Verified on the fleet: the nine regional nodes keep state here, the
           # compat host does not. Used only for the dashboard's disk probe.
@@ -584,6 +585,7 @@ jobs:
           ssh_string = "root@159.203.113.196"
           probe_kind = "zcashd"
           service_name = ""
+          metrics_endpoint = ""
           # Managed/path install from zcashd-compat-manifest.json (v1.0.0-compat-rc0).
           bin_path = "/mnt/data/import-zebra/zcashd-compat/bin/v1.0.0-compat-rc0/x86_64-pc-linux-gnu/zcashd"
           log_file = ""

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -312,8 +312,9 @@ node shares the same height and block hash. The fleet must have at least two
 observable nodes. A missing or different block hash keeps the 10-minute node
 alerts. Down alerts take precedence over stalled alerts, so a node only produces
 one active alert at a time. The watchdog also alerts if a dashboard endpoint is
-unreachable for at least 10 minutes. It posts one recovery message when a node
-or dashboard recovers. Persistent failures do not post on every poll cycle.
+unreachable, malformed, or serves a stale collector snapshot for at least 10
+minutes. It posts one recovery message when a node or dashboard recovers.
+Persistent failures do not post on every poll cycle.
 
 Restart deploys write a 20-minute suppression marker before touching the fleet.
 The mainnet workflow writes it locally on `us-east-0`; the testnet workflow

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -307,9 +307,12 @@ when either of these conditions stays true for at least 10 minutes:
 - `health` is `down` or `rpc_error`
 - `seconds_since_advanced` is at least 600 seconds
 
-Down alerts take precedence over stalled alerts, so a node only produces one
-active alert at a time. The watchdog also alerts if a dashboard endpoint is
-unreachable for at least 10 minutes, and posts one recovery message when a node
+The watchdog waits 30 minutes and posts one fleet alert when every observable
+node shares the same height and block hash. The fleet must have at least two
+observable nodes. A missing or different block hash keeps the 10-minute node
+alerts. Down alerts take precedence over stalled alerts, so a node only produces
+one active alert at a time. The watchdog also alerts if a dashboard endpoint is
+unreachable for at least 10 minutes. It posts one recovery message when a node
 or dashboard recovers. Persistent failures do not post on every poll cycle.
 
 Restart deploys write a 20-minute suppression marker before touching the fleet.

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -91,12 +91,22 @@ The default config in `fleet-watchdog.toml` watches:
 Alerts fire only after a sustained condition:
 
 - `health` is `down` or `rpc_error` for at least 10 minutes
-- `seconds_since_advanced` is at least 600 seconds for at least 10 minutes
+- one node's height has not advanced for at least 10 minutes
+- every observable node shares one height and block hash for at least 30 minutes,
+  with at least two observable nodes
 - a dashboard endpoint is unreachable for at least 10 minutes
 
-Down alerts take precedence over stalled alerts, so each node has at most one
-active alert. The watchdog posts only on transitions: first failure after the
-threshold, then recovery. Persistent failures do not post every poll.
+Stall alerts include a fixed set of sync-pipeline and VCT repair metrics. The
+fleet `/data` response copies only those numeric fields into each row. The
+watchdog therefore uses the same collector snapshot for the stall condition and
+its diagnostics. The diagnostic object contains no per-node history, logs, or
+addresses.
+
+The watchdog coalesces a verifiable shared tip into one fleet alert. A missing
+or different block hash keeps the individual node alerts. Down alerts take
+precedence over stalled alerts, so each node has at most one active alert. The
+watchdog posts only on transitions: first failure after the threshold, then
+recovery. Persistent failures do not post every poll.
 
 Slack delivery is **webhook-only**. Set:
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -94,7 +94,8 @@ Alerts fire only after a sustained condition:
 - one node's height has not advanced for at least 10 minutes
 - every observable node shares one height and block hash for at least 30 minutes,
   with at least two observable nodes
-- a dashboard endpoint is unreachable for at least 10 minutes
+- a dashboard endpoint is unreachable, malformed, or serves a stale collector
+  snapshot for at least 10 minutes
 
 Stall alerts include a fixed set of sync-pipeline and VCT repair metrics. The
 fleet `/data` response copies only those numeric fields into each row. The

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -83,6 +83,33 @@ def public_row(
     }
 
 
+class NodeConfigTests(unittest.TestCase):
+    def test_blank_metrics_endpoint_stays_disabled(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[defaults]\nmetrics_endpoint = "127.0.0.1:9999"\n'
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                'metrics_endpoint = ""\n'
+            )
+            config.flush()
+
+            [configured] = status.load_nodes(Path(config.name))
+
+        self.assertEqual(configured.metrics_endpoint, "")
+
+    def test_explicit_metrics_endpoint_is_preserved(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                'metrics_endpoint = "127.0.0.1:9999"\n'
+            )
+            config.flush()
+
+            [configured] = status.load_nodes(Path(config.name))
+
+        self.assertEqual(configured.metrics_endpoint, "127.0.0.1:9999")
+
+
 class RemoteProbeTests(unittest.TestCase):
     """Run the probe the way a node does: as a standalone script over stdin.
 
@@ -218,6 +245,58 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
                 "sync_header_verification_lag": 3.0,
                 "zcash_net_in_bytes_total": 12345.0,
             },
+        )
+
+    def test_metrics_scrape_keeps_stall_alert_series(self):
+        self.exposition += b"""checkpoint_processing_next_height 101
+checkpoint_verified_height 99
+state_finalized_block_height 98
+state_vct_root_stalled_height 100
+state_vct_root_repair_requested 4
+state_vct_root_retry_count 3
+state_vct_aux_sweep_frontier_height 97
+sync_header_vct_repair_requested_total 8
+sync_header_vct_repair_scheduled_total 7
+sync_header_vct_repair_admitted_total 6
+sync_header_vct_repair_context_unavailable_total 5
+sync_header_vct_repair_timed_out_total 4
+sync_header_vct_repair_resource_stalled_total 3
+sync_header_vct_repair_no_supplier_total 999
+sync_block_applying 0
+sync_block_best_header_tip_height 102
+sync_block_verified_tip_height 98
+sync_block_fill_stop 1
+sync_block_outstanding 0
+sync_block_missing_bodies 4000
+"""
+
+        probe = self.run_probe(metrics_endpoint=self.endpoint)
+
+        expected = {
+            "checkpoint_processing_next_height": 101.0,
+            "checkpoint_verified_height": 99.0,
+            "state_finalized_block_height": 98.0,
+            "state_vct_root_stalled_height": 100.0,
+            "state_vct_root_repair_requested": 4.0,
+            "state_vct_root_retry_count": 3.0,
+            "state_vct_aux_sweep_frontier_height": 97.0,
+            "sync_header_vct_repair_requested_total": 8.0,
+            "sync_header_vct_repair_scheduled_total": 7.0,
+            "sync_header_vct_repair_admitted_total": 6.0,
+            "sync_header_vct_repair_context_unavailable_total": 5.0,
+            "sync_header_vct_repair_timed_out_total": 4.0,
+            "sync_header_vct_repair_resource_stalled_total": 3.0,
+            "sync_block_applying": 0.0,
+            "sync_block_best_header_tip_height": 102.0,
+            "sync_block_verified_tip_height": 98.0,
+            "sync_block_fill_stop": 1.0,
+            "sync_block_outstanding": 0.0,
+            "sync_block_missing_bodies": 4_000.0,
+        }
+        for name, value in expected.items():
+            self.assertEqual(probe["metrics"].get(name), value)
+        self.assertNotIn(
+            "sync_header_vct_repair_no_supplier_total", probe["metrics"]
         )
 
     def test_peer_versions_come_from_the_user_agent_label(self):
@@ -808,6 +887,75 @@ class NodeDetailTests(unittest.TestCase):
         self.assertEqual(row["vitals"]["disk_free_pct"], 25.0)
         self.assertEqual(row["vitals"]["restart_count"], 2)
         self.assertEqual(row["peer_count"], 74)
+
+    def test_fleet_payload_carries_atomic_bounded_alert_diagnostics(self):
+        collected = collector()
+        metrics = {
+            "checkpoint_verified_height": 4_199_999.0,
+            "sync_block_applying": 0.0,
+            "sync_block_outstanding": 0.0,
+            "sync_block_missing_bodies": 4_000.0,
+            "sync_block_fill_stop": float("nan"),
+            "sync_block_verified_tip_height": float("inf"),
+            "not_an_alert_metric": 123.0,
+        }
+        collected.rows = [
+            collected.row_for(node(), self.probe(metrics=metrics), now=1_000.0)
+        ]
+        collected.last_poll = 1_001.0
+
+        snapshot = collected.snapshot()
+        diagnostics = snapshot["rows"][0]["alert_diagnostics"]
+
+        self.assertEqual(snapshot["last_poll"], 1_001.0)
+        self.assertEqual(diagnostics["last_poll"], snapshot["last_poll"])
+        self.assertEqual(diagnostics["metrics_at"], 1_000.0)
+        self.assertTrue(diagnostics["metrics_available"])
+        self.assertEqual(
+            diagnostics["metrics"],
+            {
+                "checkpoint_verified_height": 4_199_999.0,
+                "sync_block_applying": 0.0,
+                "sync_block_outstanding": 0.0,
+                "sync_block_missing_bodies": 4_000.0,
+            },
+        )
+        self.assertNotIn("not_an_alert_metric", json.dumps(diagnostics))
+        self.assertNotIn("log_errors", json.dumps(diagnostics))
+        self.assertNotIn("root@node-a", json.dumps(diagnostics))
+        self.assertLess(len(json.dumps(diagnostics)), 1_000)
+
+    def test_whole_probe_failure_marks_metrics_unavailable(self):
+        collected = collector()
+        error = "ssh exited 255: connection refused"
+
+        row = collected.row_for(node(), {"error": error}, now=1_000.0)
+        collected.rows = [row]
+        collected.last_poll = 1_001.0
+        diagnostics = collected.snapshot()["rows"][0]["alert_diagnostics"]
+
+        self.assertEqual(row["detail"], error)
+        self.assertEqual(row["metrics_error"], error)
+        self.assertIsNone(row["metrics_at"])
+        self.assertFalse(diagnostics["metrics_available"])
+        self.assertIsNone(diagnostics["metrics_at"])
+        self.assertEqual(diagnostics["metrics"], {})
+
+    def test_missing_metrics_timestamp_marks_metrics_unavailable(self):
+        diagnostics = status.alert_diagnostics(
+            {
+                "metrics": {"sync_block_missing_bodies": 4_000.0},
+                "metrics_at": None,
+            },
+            last_poll=1_001.0,
+        )
+
+        self.assertFalse(diagnostics["metrics_available"])
+        self.assertIsNone(diagnostics["metrics_at"])
+        self.assertEqual(
+            diagnostics["metrics"],
+            {"sync_block_missing_bodies": 4_000.0},
+        )
 
     def test_node_payload_carries_the_deep_fields(self):
         collected = collector()

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -460,6 +460,146 @@ class SlackPayloadTests(unittest.TestCase):
         self.assertIn(watchdog.SLACK_TRUNCATION_MARKER, posted_text)
         self.assertTrue(posted_text.endswith("dashboard: http://dashboard.invalid/"))
 
+    def test_duplicate_owner_recovery_bounds_and_sanitizes_identities(self):
+        fleet = watchdog.Fleet(
+            name="<!channel>" + "f" * 10_000,
+            url="http://source.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+
+        text = watchdog.duplicate_stall_recovery_text(
+            fleet,
+            "<duplicate>" + "d" * 10_000,
+            "`owner`" + "o" * 10_000,
+            "9" * 10_000,
+        )
+        posted_text = self.posted_text(text)
+
+        self.assertLessEqual(len(posted_text), watchdog.MAX_SLACK_MESSAGE_CHARS)
+        self.assertNotIn("<!channel>", posted_text)
+        self.assertNotIn("<duplicate>", posted_text)
+        self.assertNotIn("`owner`", posted_text)
+        self.assertNotIn("f" * (watchdog.MAX_ALERT_NAME_CHARS + 1), posted_text)
+        self.assertNotIn("d" * (watchdog.MAX_ALERT_NAME_CHARS + 1), posted_text)
+        self.assertNotIn("o" * (watchdog.MAX_ALERT_NAME_CHARS + 1), posted_text)
+        self.assertIn("height: -", posted_text)
+        self.assertTrue(posted_text.endswith("dashboard: http://dashboard.invalid/"))
+
+
+class FleetSnapshotTests(unittest.TestCase):
+    NOW = 2_000.0
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self.fleet = watchdog.Fleet(
+            name="testnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        self.instance = watchdog.Watchdog([self.fleet], make_args())
+
+    @staticmethod
+    def state():
+        return {
+            "version": watchdog.STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
+
+    @staticmethod
+    def healthy_row():
+        return {
+            "name": "node-a",
+            "health": "healthy",
+            "height": 100,
+            "block_hash": "aaaa",
+            "seconds_since_advanced": 1.0,
+        }
+
+    def run_snapshot(self, snapshot, state=None):
+        if state is None:
+            state = self.state()
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot),
+            patch.object(watchdog.time, "time", return_value=self.NOW),
+            patch.object(
+                watchdog,
+                "post_slack",
+                side_effect=lambda text, _args: (self.posted.append(text), True)[1],
+            ),
+        ):
+            self.instance.run_once(state)
+        return state
+
+    def test_stale_snapshot_alerts_from_the_last_successful_poll(self):
+        state = self.run_snapshot(
+            {
+                "last_poll": self.NOW - 600.0,
+                "rows": [self.healthy_row()],
+            }
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("dashboard unavailable for 10m", self.posted[0])
+        self.assertIn("snapshot is stale", self.posted[0])
+        self.assertTrue(state["fleets"]["testnet"]["alerting"])
+        self.assertEqual(state["nodes"], {})
+        self.assertEqual(state["shared_stalls"], {})
+
+    def test_stale_snapshot_keeps_the_earliest_fleet_failure_time(self):
+        state = self.state()
+        state["fleets"]["testnet"] = {
+            "condition": "unreachable",
+            "bad_since": self.NOW - 100.0,
+            "alerting": False,
+        }
+
+        self.run_snapshot(
+            {
+                "last_poll": self.NOW - 600.0,
+                "rows": [self.healthy_row()],
+            },
+            state,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertEqual(state["fleets"]["testnet"]["bad_since"], self.NOW - 600.0)
+
+    def test_malformed_or_empty_rows_start_a_fleet_failure(self):
+        duplicate = self.healthy_row()
+        for rows in (
+            None,
+            [],
+            ["not an object"],
+            [{"health": "healthy"}],
+            [duplicate, dict(duplicate)],
+        ):
+            with self.subTest(rows=rows):
+                state = self.run_snapshot({"last_poll": self.NOW, "rows": rows})
+                self.assertEqual(
+                    state["fleets"]["testnet"]["condition"], "unreachable"
+                )
+                self.assertFalse(state["fleets"]["testnet"]["alerting"])
+                self.assertEqual(state["nodes"], {})
+
+    def test_invalid_last_poll_starts_a_fleet_failure(self):
+        for last_poll in (None, float("nan"), float("inf"), True):
+            with self.subTest(last_poll=last_poll):
+                state = self.run_snapshot(
+                    {"last_poll": last_poll, "rows": [self.healthy_row()]}
+                )
+                self.assertEqual(
+                    state["fleets"]["testnet"]["condition"], "unreachable"
+                )
+                self.assertEqual(state["nodes"], {})
+
+    def test_older_snapshot_without_last_poll_remains_compatible(self):
+        state = self.run_snapshot({"rows": [self.healthy_row()]})
+
+        self.assertEqual(state["fleets"]["testnet"]["condition"], "ok")
+        self.assertEqual(state["nodes"]["testnet/node-a"]["condition"], "ok")
+
 
 class SharedStallTests(unittest.TestCase):
     NOW = 2_000.0
@@ -897,6 +1037,35 @@ class SharedStallTests(unittest.TestCase):
         self.assertTrue(
             all(not entry["alerting"] for entry in self.state["nodes"].values())
         )
+
+    def test_non_finite_timers_are_not_stall_evidence(self):
+        for timer in (float("nan"), float("inf"), "-inf", True):
+            with self.subTest(timer=timer):
+                self.state = {
+                    "version": watchdog.STATE_VERSION,
+                    "nodes": {},
+                    "fleets": {},
+                    "shared_stalls": {},
+                }
+                self.posted.clear()
+                self.run_snapshot([self.row("node-a", 100, timer)])
+                self.assertEqual(self.posted, [])
+                self.assertEqual(
+                    self.state["nodes"]["testnet/node-a"]["condition"], "ok"
+                )
+
+    def test_non_finite_persisted_timer_does_not_crash_reconciliation(self):
+        self.state["nodes"]["testnet/node-a"] = {
+            "condition": "stalled",
+            "bad_since": float("inf"),
+            "alerting": False,
+            "event_height": 100,
+        }
+
+        self.run_snapshot([self.row("node-a", 100, 700.0)])
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
 
     def test_failed_shared_recovery_aborts_constituent_alerts(self):
         self.run_snapshot(

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT_PATH = Path(__file__).with_name("zakura-cluster-watchdog.py")
@@ -21,7 +23,12 @@ def make_args(**overrides):
     defaults = {
         "down_after": 600.0,
         "stalled_after": 600.0,
+        "shared_stalled_after": 1800.0,
         "starting_grace": 120.0,
+        "dashboard_down_after": 600.0,
+        "request_timeout": 20.0,
+        "slack_timeout": 20.0,
+        "suppression_file": Path("/nonexistent/zakura-watchdog-suppression"),
         "slack_webhook": None,
         "dry_run": True,
     }
@@ -69,6 +76,7 @@ class StallRecoveryTests(unittest.TestCase):
         self.assertEqual(self.posted, [], "posted a recovery at an unchanged height")
         self.assertTrue(bucket["fleet/node-a"]["alerting"], "alert should stay latched")
         self.assertEqual(bucket["fleet/node-a"]["alert_height"], 4129396)
+
 
     def test_repeated_timer_resets_never_clear_the_stall(self):
         bucket = {}
@@ -196,8 +204,931 @@ class StallRecoveryTests(unittest.TestCase):
         self.assertEqual(self.posted, [])
 
 
-if __name__ == "__main__":
-    unittest.main()
+class StallDiagnosticTests(unittest.TestCase):
+    def setUp(self):
+        self.fleet = watchdog.Fleet(
+            name="mainnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+
+    @staticmethod
+    def diagnostics(**metrics):
+        return {
+            "last_poll": 1_000.0,
+            "metrics_at": 999.0,
+            "metrics_available": True,
+            "metrics": metrics,
+        }
+
+    def test_node_alert_formats_atomic_pipeline_and_repair_metrics(self):
+        row = {
+            "name": "canada-0",
+            "health": "stale",
+            "height": 3_461_397,
+            "headers": 3_461_900,
+            "header_lag": 503,
+            "peer_count": 7,
+            "commit": "5c33befdfae0a9e047079c96b9254d9d894c3885",
+            "version": "1.3.0-rc2",
+            "detail": "height has not advanced within stale window",
+            "alert_diagnostics": self.diagnostics(
+                checkpoint_verified_height=3_461_397.0,
+                sync_estimated_network_tip_height=3_461_901.0,
+                sync_estimated_distance_to_tip=504.0,
+                sync_block_applying=0.0,
+                sync_block_best_header_tip_height=3_461_900.0,
+                sync_block_verified_tip_height=3_461_397.0,
+                sync_block_fill_stop=1.0,
+                sync_block_outstanding=0.0,
+                sync_block_missing_bodies=4_000.0,
+                state_vct_root_stalled_height=3_461_398.0,
+                sync_header_vct_repair_context_unavailable_total=5.0,
+                sync_header_vct_repair_timed_out_total=2.0,
+            ),
+        }
+        row["alert_diagnostics"].update({"health": "healthy", "height": 9_999_999})
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 617.0)
+
+        self.assertIn("health: stale - height: 3461397", text)
+        self.assertIn("headers 3461900 | header lag 503 | peers 7", text)
+        self.assertIn("checkpoint verified 3461397", text)
+        self.assertIn("block applying 0", text)
+        self.assertIn("block header tip 3461900", text)
+        self.assertIn("block verified tip 3461397", text)
+        self.assertIn("block fill stop 1", text)
+        self.assertIn("block outstanding 0 | missing bodies 4000", text)
+        self.assertIn("context unavailable 5 | timed out 2", text)
+        self.assertNotIn("no supplier", text)
+
+    def test_missing_diagnostics_do_not_hide_the_stall(self):
+        row = {
+            "name": "canada-0",
+            "health": "stale",
+            "height": 3_461_397,
+            "detail": "height has not advanced within stale window",
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 617.0)
+
+        self.assertIn("`canada-0` stalled", text)
+        self.assertIn("metrics: absent from fleet snapshot", text)
+
+    def test_due_alert_uses_one_fleet_request(self):
+        posted = []
+        instance = watchdog.Watchdog([self.fleet], make_args())
+        snapshot = {
+            "last_poll": 1_000.0,
+            "rows": [
+                {
+                    "name": "canada-0",
+                    "health": "stale",
+                    "height": 3_461_397,
+                    "block_hash": "aaaa",
+                    "seconds_since_advanced": 700.0,
+                    "alert_diagnostics": self.diagnostics(
+                        sync_block_missing_bodies=4_000.0
+                    ),
+                }
+            ],
+        }
+
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot) as fetch,
+            patch.object(watchdog.time, "time", return_value=1_000.0),
+            patch.object(
+                watchdog,
+                "post_slack",
+                side_effect=lambda text, _args: (posted.append(text), True)[1],
+            ),
+        ):
+            instance.run_once({"nodes": {}, "fleets": {}, "shared_stalls": {}})
+
+        fetch.assert_called_once_with(self.fleet.url, instance.args.request_timeout)
+        self.assertEqual(len(posted), 1)
+        self.assertIn("missing bodies 4000", posted[0])
+
+    def test_diagnostic_rendering_is_bounded(self):
+        fields = watchdog.STALL_PIPELINE_METRICS + watchdog.STALL_REPAIR_METRICS
+        metrics = {
+            name: float(index) for index, (_label, name) in enumerate(fields)
+        }
+        row = {
+            "name": "node-a",
+            "health": "stale",
+            "height": 1,
+            "detail": "stalled",
+            "version": "x" * 10_000,
+            "alert_diagnostics": self.diagnostics(**metrics),
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "stalled", 700.0)
+
+        self.assertLess(len(text), 2_000)
+        self.assertNotIn("x" * 65, text)
+
+    def test_node_detail_is_plain_text_and_bounded(self):
+        detail = (
+            "connection failed\n<!channel> *second_line* `command` "
+            + "x" * 10_000
+        )
+        row = {
+            "name": "node-a",
+            "health": "down",
+            "detail": detail,
+        }
+
+        text = watchdog.node_alert_text(self.fleet, row, "down", 700.0)
+        detail_line = next(
+            line for line in text.splitlines() if line.startswith("health:")
+        )
+
+        self.assertIn("connection failed", detail_line)
+        self.assertIn("second＿line", detail_line)
+        self.assertNotIn("<!channel>", detail_line)
+        self.assertNotIn("*second_line*", detail_line)
+        self.assertNotIn("`command`", detail_line)
+        self.assertLessEqual(
+            len(detail_line), watchdog.MAX_NODE_DETAIL_CHARS + 64
+        )
+
+
+class SlackPayloadTests(unittest.TestCase):
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return b"ok"
+
+    def posted_text(self, text, limit=watchdog.MAX_SLACK_MESSAGE_CHARS):
+        with (
+            patch.object(watchdog, "MAX_SLACK_MESSAGE_CHARS", limit),
+            patch.object(
+                watchdog.urllib.request,
+                "urlopen",
+                return_value=self.Response(),
+            ) as urlopen,
+        ):
+            posted = watchdog.post_slack_webhook(
+                "https://hooks.slack.invalid/test", text, make_args()
+            )
+
+        self.assertTrue(posted)
+        request = urlopen.call_args.args[0]
+        return json.loads(request.data.decode("utf-8"))["text"]
+
+    def test_webhook_payload_caps_the_final_message(self):
+        text = "useful prefix\n" + "x" * (watchdog.MAX_SLACK_MESSAGE_CHARS * 2)
+        posted_text = self.posted_text(text)
+
+        self.assertLessEqual(len(posted_text), watchdog.MAX_SLACK_MESSAGE_CHARS)
+        self.assertTrue(posted_text.startswith("useful prefix\n"))
+        self.assertIn(watchdog.SLACK_TRUNCATION_MARKER, posted_text)
+
+    def test_truncated_node_alert_keeps_incident_and_dashboard(self):
+        fields = watchdog.STALL_PIPELINE_METRICS + watchdog.STALL_REPAIR_METRICS
+        metrics = {name: 1e308 for _label, name in fields}
+        fleet = watchdog.Fleet(
+            name="mainnet",
+            url="http://source.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        row = {
+            "name": "node-" + "n" * 10_000,
+            "health": "stale",
+            "height": "9" * 10_000,
+            "detail": "probe failed " + "d" * 10_000,
+            "alert_diagnostics": StallDiagnosticTests.diagnostics(**metrics),
+        }
+
+        alert = watchdog.node_alert_text(fleet, row, "stalled", 700.0)
+        posted_text = self.posted_text(alert, limit=1_200)
+
+        self.assertLessEqual(len(posted_text), 1_200)
+        self.assertTrue(
+            posted_text.startswith(":rotating_light: *Zakura mainnet* - `node-")
+        )
+        self.assertIn("stalled for 11m 40s", posted_text.splitlines()[0])
+        self.assertIn(watchdog.SLACK_TRUNCATION_MARKER, posted_text)
+        self.assertTrue(posted_text.endswith("dashboard: http://dashboard.invalid/"))
+        self.assertNotIn("n" * (watchdog.MAX_ALERT_NAME_CHARS + 1), posted_text)
+
+    def test_truncated_shared_alert_keeps_full_incident_and_dashboard(self):
+        fields = watchdog.STALL_PIPELINE_METRICS + watchdog.STALL_REPAIR_METRICS
+        metrics = {name: 1e308 for _label, name in fields}
+        fleet = watchdog.Fleet(
+            name="mainnet",
+            url="http://source.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        rows = [
+            {
+                "name": f"node-{index}",
+                "height": 100,
+                "alert_diagnostics": StallDiagnosticTests.diagnostics(**metrics),
+            }
+            for index in range(watchdog.MAX_SHARED_DIAGNOSTIC_ROWS)
+        ]
+
+        alert = watchdog.shared_stall_alert_text(
+            fleet,
+            100,
+            "g" * 10_000,
+            len(rows),
+            1_900.0,
+            rows,
+        )
+        posted_text = self.posted_text(alert, limit=512)
+
+        self.assertLessEqual(len(posted_text), 512)
+        self.assertEqual(
+            posted_text.splitlines()[:3],
+            [
+                ":rotating_light: *Zakura mainnet* network height has not advanced for 31m 40s",
+                "8 nodes agree at height 100",
+                "tip hash: invalid (" + "g" * watchdog.MAX_BLOCK_HASH_CHARS + ")",
+            ],
+        )
+        self.assertIn(watchdog.SLACK_TRUNCATION_MARKER, posted_text)
+        self.assertTrue(posted_text.endswith("dashboard: http://dashboard.invalid/"))
+
+
+class SharedStallTests(unittest.TestCase):
+    NOW = 2_000.0
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self._real_post = watchdog.post_slack
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        self.fleet = watchdog.Fleet(
+            name="testnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        self.args = make_args()
+        self.instance = watchdog.Watchdog([self.fleet], self.args)
+        self.state = {
+            "version": watchdog.STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
+
+    def tearDown(self):
+        watchdog.post_slack = self._real_post
+
+    @staticmethod
+    def row(
+        name,
+        height,
+        seconds_since_advanced,
+        health="stale",
+        block_hash="00aa",
+    ):
+        return {
+            "name": name,
+            "height": height,
+            "block_hash": block_hash,
+            "health": health,
+            "detail": "height has not advanced within stale window",
+            "seconds_since_advanced": seconds_since_advanced,
+        }
+
+    def run_snapshot(self, rows, now=None):
+        snapshot = {"rows": rows}
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot),
+            patch.object(watchdog.time, "time", return_value=now or self.NOW),
+        ):
+            self.instance.run_once(self.state)
+
+    def test_matching_height_and_hash_posts_one_fleet_alert(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_817),
+                self.row("node-b", 4_302_737, 1_816),
+                self.row("node-c", 4_302_737, 1_803),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("3 nodes agree at height 4302737", self.posted[0])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_shared_alert_lists_only_participating_nodes(self):
+        node_a = self.row("node-a", 4_302_737, 1_817)
+        node_b = self.row("node-b", 4_302_737, 1_816)
+        for row in (node_a, node_b):
+            row["alert_diagnostics"] = StallDiagnosticTests.diagnostics(
+                checkpoint_verified_height=4_302_737.0
+            )
+        down = self.row("down-node", 7, 1_900, health="down", block_hash="bbbb")
+
+        self.run_snapshot([down, node_a, node_b])
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("- node-a:", self.posted[0])
+        self.assertIn("- node-b:", self.posted[0])
+        self.assertNotIn("- down-node:", self.posted[0])
+
+    def test_shared_alert_limits_rendered_participants(self):
+        rows = [
+            {
+                **self.row(f"node-{index:02}", 100, 1_900, block_hash="aaaa"),
+                "alert_diagnostics": StallDiagnosticTests.diagnostics(
+                    sync_block_missing_bodies=4_000.0,
+                    state_vct_root_stalled_height=101.0,
+                    state_vct_root_retry_count=3.0,
+                    state_vct_aux_sweep_frontier_height=99.0,
+                    sync_header_vct_repair_context_unavailable_total=2.0,
+                    sync_header_vct_repair_timed_out_total=1.0,
+                    sync_header_vct_repair_resource_stalled_total=0.0,
+                ),
+            }
+            for index in range(12)
+        ]
+
+        text = watchdog.shared_stall_alert_text(
+            self.fleet, 100, "aaaa", len(rows), 1_900.0, rows
+        )
+
+        self.assertEqual(
+            sum(line.startswith("- node-") for line in text.splitlines()),
+            watchdog.MAX_SHARED_DIAGNOSTIC_ROWS,
+        )
+        self.assertIn("- 4 more participating nodes not shown", text)
+        self.assertEqual(text.count("metrics ok"), watchdog.MAX_SHARED_DIAGNOSTIC_ROWS)
+        self.assertIn("vct stalled 101 | vct retries 3 | sweep 99", text)
+        self.assertIn("repair unavailable 2 | repair timed out 1", text)
+        self.assertLess(len(text), 3_000)
+
+    def test_shared_alert_marks_unavailable_and_absent_metrics(self):
+        unavailable = self.row("node-a", 100, 1_900, block_hash="aaaa")
+        unavailable["alert_diagnostics"] = {
+            "last_poll": 1_000.0,
+            "metrics_at": None,
+            "metrics_available": False,
+            "metrics": {},
+        }
+        absent = self.row("node-b", 100, 1_900, block_hash="aaaa")
+
+        text = watchdog.shared_stall_alert_text(
+            self.fleet, 100, "aaaa", 2, 1_900.0, [unavailable, absent]
+        )
+
+        self.assertIn("- node-a: height 100 | metrics unavailable", text)
+        self.assertIn("- node-b: height 100 | metrics absent", text)
+
+    def test_short_common_idle_does_not_alert(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 617),
+                self.row("node-b", 4_302_737, 616),
+                self.row("node-c", 4_302_737, 603),
+            ]
+        )
+
+        self.assertEqual(self.posted, [])
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_common_height_recovery_posts_once_after_progress(self):
+        stalled = [
+            self.row("node-a", 4_302_737, 1_817),
+            self.row("node-b", 4_302_737, 1_816),
+        ]
+        self.run_snapshot(stalled)
+        self.posted.clear()
+
+        advanced = [
+            self.row("node-a", 4_302_790, 5, "healthy"),
+            self.row("node-b", 4_302_790, 5, "healthy"),
+        ]
+        self.run_snapshot(advanced, now=self.NOW + 60)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("network height advanced", self.posted[0])
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_divergence_recovers_fleet_and_alerts_lagging_node(self):
+        stalled = [
+            self.row("node-a", 4_302_737, 1_817),
+            self.row("node-b", 4_302_737, 1_816),
+        ]
+        self.run_snapshot(stalled)
+        self.posted.clear()
+
+        diverged = [
+            self.row("node-a", 4_302_800, 5, "healthy"),
+            self.row("node-b", 4_302_737, 1_876),
+        ]
+        self.run_snapshot(diverged, now=self.NOW + 60)
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertIn("network height advanced", self.posted[0])
+        self.assertIn("`node-b` stalled", self.posted[1])
+
+    def test_matching_height_with_different_hashes_keeps_node_alerts(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 601, block_hash="aaaa"),
+                self.row("node-b", 4_302_737, 601, block_hash="bbbb"),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertTrue(all("stalled" in post for post in self.posted))
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_missing_hash_keeps_node_alerts(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 601),
+                self.row("node-b", 4_302_737, 601, block_hash=""),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_fork_closes_shared_alert_before_posting_node_alerts(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_801, block_hash="aaaa"),
+                self.row("node-b", 4_302_737, 1_801, block_hash="aaaa"),
+            ]
+        )
+        self.posted.clear()
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_861, block_hash="aaaa"),
+                self.row("node-b", 4_302_737, 1_861, block_hash="bbbb"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(len(self.posted), 3)
+        self.assertIn("shared stall cleared", self.posted[0])
+        self.assertTrue(all("stalled" in post for post in self.posted[1:]))
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+
+    def test_threshold_skew_never_posts_a_constituent_node_alert(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 601),
+                self.row("node-b", 4_302_737, 541),
+            ]
+        )
+        self.assertEqual(self.posted, [])
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_861),
+                self.row("node-b", 4_302_737, 1_801),
+            ],
+            now=self.NOW + 1_260,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("network height has not advanced", self.posted[0])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_new_tip_after_polling_gap_gets_a_new_timer(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_200, block_hash="aaaa"),
+                self.row("node-b", 100, 1_200, block_hash="aaaa"),
+            ]
+        )
+        self.run_snapshot(
+            [
+                self.row("node-a", 101, 660, block_hash="bbbb"),
+                self.row("node-b", 101, 660, block_hash="bbbb"),
+            ],
+            now=self.NOW + 660,
+        )
+
+        self.assertEqual(self.posted, [])
+        entry = self.state["shared_stalls"]["testnet"]
+        self.assertEqual(entry["event_height"], 101)
+        self.assertEqual(entry["event_hash"], "bbbb")
+        self.assertEqual(entry["bad_since"], self.NOW)
+
+    def test_alerted_old_tip_recovers_before_new_tip_timer_starts(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_801, block_hash="aaaa"),
+                self.row("node-b", 100, 1_801, block_hash="aaaa"),
+            ]
+        )
+        self.posted.clear()
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 101, 660, block_hash="bbbb"),
+                self.row("node-b", 101, 660, block_hash="bbbb"),
+            ],
+            now=self.NOW + 660,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("network height advanced", self.posted[0])
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertEqual(
+            self.state["shared_stalls"]["testnet"]["event_height"], 101
+        )
+
+    def test_preexisting_node_alert_represents_the_shared_incident(self):
+        self.state["nodes"]["testnet/node-a"] = {
+            "condition": "stalled",
+            "bad_since": self.NOW - 2_000,
+            "alerting": True,
+            "alert_height": 4_302_737,
+        }
+        self.run_snapshot(
+            [
+                self.row("node-a", 4_302_737, 1_900),
+                self.row("node-b", 4_302_737, 1_900),
+            ]
+        )
+
+        self.assertEqual(self.posted, [])
+        shared = self.state["shared_stalls"]["testnet"]
+        self.assertFalse(shared["alerting"])
+        self.assertEqual(shared["owner"], "node:node-a")
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
+
+    def test_timer_reset_does_not_replace_a_latched_node_owner(self):
+        self.state["nodes"]["testnet/node-a"] = {
+            "condition": "stalled",
+            "bad_since": 0,
+            "alerting": True,
+            "alert_height": 100,
+        }
+        self.state["shared_stalls"]["testnet"] = {
+            "condition": "stalled",
+            "event_height": 100,
+            "event_hash": "aaaa",
+            "node_names": ["node-a", "node-b"],
+            "bad_since": 0,
+            "alerting": False,
+        }
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 5, "healthy", block_hash="aaaa"),
+                self.row("node-b", 100, 5, "healthy", block_hash="aaaa"),
+            ]
+        )
+
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
+        self.assertEqual(
+            self.state["shared_stalls"]["testnet"]["owner"],
+            "node:node-a",
+        )
+
+    def test_missed_progress_closes_old_node_event_before_new_shared_event(self):
+        self.run_snapshot([self.row("node-a", 100, 601, block_hash="aaaa")])
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`node-a` stalled", self.posted[0])
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 101, 660, block_hash="bbbb"),
+                self.row("node-b", 101, 660, block_hash="bbbb"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertIn("`node-a` recovered from stalled", self.posted[1])
+        self.assertFalse(self.state["nodes"]["testnet/node-a"]["alerting"])
+        self.assertEqual(
+            self.state["nodes"]["testnet/node-a"]["event_height"], 101
+        )
+
+        self.posted.clear()
+        self.run_snapshot(
+            [
+                self.row("node-a", 101, 1_801, block_hash="bbbb"),
+                self.row("node-b", 101, 1_801, block_hash="bbbb"),
+            ],
+            now=self.NOW + 1_201,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("network height has not advanced", self.posted[0])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertFalse(self.state["nodes"]["testnet/node-a"]["alerting"])
+
+    def test_resync_to_lower_height_keeps_one_latched_node_event(self):
+        self.run_snapshot([self.row("node-a", 100, 601, block_hash="aaaa")])
+        self.posted.clear()
+
+        self.run_snapshot(
+            [self.row("node-a", 50, 5, "healthy", block_hash="bbbb")],
+            now=self.NOW + 60,
+        )
+        entry = self.state["nodes"]["testnet/node-a"]
+        self.assertEqual(self.posted, [])
+        self.assertTrue(entry["alerting"])
+        self.assertEqual(entry["alert_height"], 50)
+        self.assertEqual(entry["event_height"], 50)
+
+        self.run_snapshot(
+            [self.row("node-a", 50, 601, block_hash="bbbb")],
+            now=self.NOW + 660,
+        )
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
+
+    def test_retained_shared_owner_suppresses_the_remaining_node(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_801, block_hash="aaaa"),
+                self.row("node-b", 100, 1_801, block_hash="aaaa"),
+            ]
+        )
+        self.posted.clear()
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_861, block_hash="aaaa"),
+                self.row("node-b", 100, 1_861, "down", block_hash="aaaa"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertFalse(self.state["nodes"]["testnet/node-a"]["alerting"])
+
+    def test_malformed_rows_cannot_silently_clear_a_shared_owner(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_801, block_hash="aaaa"),
+                self.row("node-b", 100, 1_801, block_hash="aaaa"),
+            ]
+        )
+        self.posted.clear()
+
+        malformed = [
+            self.row("node-a", 100, None, block_hash="aaaa"),
+            self.row("node-b", 100, None, block_hash="aaaa"),
+        ]
+        self.run_snapshot(malformed, now=self.NOW + 60)
+
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_failed_shared_recovery_aborts_constituent_alerts(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_801, block_hash="aaaa"),
+                self.row("node-b", 100, 1_801, block_hash="aaaa"),
+            ]
+        )
+        self.posted.clear()
+
+        def fail_recovery(text, _args):
+            self.posted.append(text)
+            return "shared stall cleared" not in text
+
+        watchdog.post_slack = fail_recovery
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_861, block_hash="aaaa"),
+                self.row("node-b", 100, 1_861, block_hash="bbbb"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("shared stall cleared", self.posted[0])
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_failed_shared_alert_retries_without_constituent_alerts(self):
+        watchdog.post_slack = lambda text, _args: (self.posted.append(text), False)[1]
+        rows = [
+            self.row("node-a", 100, 1_801, block_hash="aaaa"),
+            self.row("node-b", 100, 1_801, block_hash="aaaa"),
+        ]
+
+        self.run_snapshot(rows)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+        watchdog.post_slack = lambda text, _args: (self.posted.append(text), True)[1]
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_861, block_hash="aaaa"),
+                self.row("node-b", 100, 1_861, block_hash="aaaa"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(len(self.posted), 2)
+        self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertTrue(
+            all(not entry["alerting"] for entry in self.state["nodes"].values())
+        )
+
+    def test_failed_node_recovery_aborts_new_shared_event(self):
+        self.run_snapshot([self.row("node-a", 100, 601, block_hash="aaaa")])
+        old_node = dict(self.state["nodes"]["testnet/node-a"])
+        self.posted.clear()
+        watchdog.post_slack = lambda text, _args: (self.posted.append(text), False)[1]
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 101, 660, block_hash="bbbb"),
+                self.row("node-b", 101, 660, block_hash="bbbb"),
+            ],
+            now=self.NOW + 60,
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`node-a` recovered from stalled", self.posted[0])
+        self.assertEqual(self.state["nodes"]["testnet/node-a"], old_node)
+        self.assertEqual(self.state["shared_stalls"]["testnet"]["condition"], "ok")
+
+    def test_failed_dashboard_recovery_aborts_stall_processing(self):
+        self.state["fleets"]["testnet"] = {
+            "condition": "unreachable",
+            "bad_since": self.NOW - 1_000,
+            "alerting": True,
+        }
+        watchdog.post_slack = lambda text, _args: (self.posted.append(text), False)[1]
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_900, block_hash="aaaa"),
+                self.row("node-b", 100, 1_900, block_hash="aaaa"),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("dashboard recovered", self.posted[0])
+        self.assertTrue(self.state["fleets"]["testnet"]["alerting"])
+        self.assertEqual(self.state["nodes"], {})
+        self.assertEqual(self.state["shared_stalls"], {})
+
+    def test_pr802_duplicate_owners_migrate_to_one_node_owner(self):
+        self.state["nodes"]["testnet/node-a"] = {
+            "condition": "stalled",
+            "bad_since": self.NOW - 2_000,
+            "alerting": True,
+            "alert_height": 100,
+        }
+        self.state["shared_stalls"]["testnet"] = {
+            "condition": "stalled",
+            "bad_since": self.NOW - 2_000,
+            "alerting": True,
+            "alert_height": 100,
+        }
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_900, block_hash="aaaa"),
+                self.row("node-b", 100, 1_900, block_hash="aaaa"),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("constituent node alert continues", self.posted[0])
+        shared = self.state["shared_stalls"]["testnet"]
+        self.assertFalse(shared["alerting"])
+        self.assertEqual(shared["owner"], "node:node-a")
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
+
+    def test_multiple_constituent_owners_reconcile_to_one_node(self):
+        for node_name in ("node-a", "node-b"):
+            self.state["nodes"][f"testnet/{node_name}"] = {
+                "condition": "stalled",
+                "bad_since": self.NOW - 2_000,
+                "alerting": True,
+                "alert_height": 100,
+            }
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_900, block_hash="aaaa"),
+                self.row("node-b", 100, 1_900, block_hash="aaaa"),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`node-b` duplicate stall alert cleared", self.posted[0])
+        self.assertTrue(self.state["nodes"]["testnet/node-a"]["alerting"])
+        self.assertFalse(self.state["nodes"]["testnet/node-b"]["alerting"])
+        self.assertEqual(
+            self.state["shared_stalls"]["testnet"]["owner"],
+            "node:node-a",
+        )
+
+    def test_failed_pr802_migration_recovery_preserves_both_states(self):
+        old_node = {
+            "condition": "stalled",
+            "bad_since": self.NOW - 2_000,
+            "alerting": True,
+            "alert_height": 100,
+        }
+        old_shared = {
+            "condition": "stalled",
+            "bad_since": self.NOW - 2_000,
+            "alerting": True,
+            "alert_height": 100,
+        }
+        self.state["nodes"]["testnet/node-a"] = dict(old_node)
+        self.state["shared_stalls"]["testnet"] = dict(old_shared)
+        watchdog.post_slack = lambda text, _args: (self.posted.append(text), False)[1]
+
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_900, block_hash="aaaa"),
+                self.row("node-b", 100, 1_900, block_hash="aaaa"),
+            ]
+        )
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertEqual(self.state["nodes"]["testnet/node-a"], old_node)
+        self.assertEqual(self.state["shared_stalls"]["testnet"], old_shared)
+
+    def test_membership_timer_boundary_persists_after_removal(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_000, block_hash="aaaa"),
+                self.row("node-b", 100, 1_000, block_hash="aaaa"),
+                self.row("node-c", 100, 2_000, block_hash="aaaa"),
+            ]
+        )
+
+        for now in (self.NOW + 60, self.NOW + 120):
+            self.run_snapshot(
+                [
+                    self.row("node-a", 100, now, block_hash="aaaa"),
+                    self.row("node-b", 100, now, block_hash="aaaa"),
+                ],
+                now=now,
+            )
+
+        shared = self.state["shared_stalls"]["testnet"]
+        self.assertEqual(self.posted, [])
+        self.assertEqual(shared["bad_since"], self.NOW - 1_000)
+        self.assertEqual(shared["timer_floor"], self.NOW - 1_000)
+
+    def test_membership_timer_boundary_persists_after_addition(self):
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_200, block_hash="aaaa"),
+                self.row("node-b", 100, 1_200, block_hash="aaaa"),
+            ]
+        )
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_260, block_hash="aaaa"),
+                self.row("node-b", 100, 1_260, block_hash="aaaa"),
+                self.row("node-c", 100, 60, block_hash="aaaa"),
+            ],
+            now=self.NOW + 60,
+        )
+        self.run_snapshot(
+            [
+                self.row("node-a", 100, 1_320, block_hash="aaaa"),
+                self.row("node-b", 100, 1_320, block_hash="aaaa"),
+                self.row("node-c", 100, 120, block_hash="aaaa"),
+            ],
+            now=self.NOW + 120,
+        )
+
+        shared = self.state["shared_stalls"]["testnet"]
+        self.assertEqual(self.posted, [])
+        self.assertEqual(shared["bad_since"], self.NOW)
+        self.assertEqual(shared["timer_floor"], self.NOW)
 
 
 def make_release_state(**overrides):
@@ -325,3 +1256,6 @@ class ReleaseStateConfigTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.load('[[release_state]]\nname = "m"\n')
 
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -16,6 +16,7 @@ import argparse
 import concurrent.futures
 import ipaddress
 import json
+import math
 import re
 import shlex
 import subprocess
@@ -84,6 +85,38 @@ NODE_DETAIL_KEYS = (
     "mempool_bytes",
     "node_errors",
     "node_errors_at",
+)
+# Fixed numeric fields copied into each fleet row for stall alerts. The
+# watchdog gets these fields from the same collector snapshot as the node
+# condition, so it never needs to fetch the larger per-node detail payload.
+ALERT_DIAGNOSTIC_METRICS = (
+    "sync_estimated_distance_to_tip",
+    "sync_estimated_network_tip_height",
+    "checkpoint_processing_next_height",
+    "checkpoint_verified_height",
+    "state_finalized_block_height",
+    "sync_header_chain_frontier_header_best_height",
+    "sync_header_chain_frontier_verified_best_height",
+    "sync_header_chain_frontier_finalized_height",
+    "sync_header_work_last_progress_age_seconds",
+    "sync_header_work_oldest_missing_height",
+    "sync_header_work_in_flight_count",
+    "sync_block_applying",
+    "sync_block_best_header_tip_height",
+    "sync_block_verified_tip_height",
+    "sync_block_fill_stop",
+    "sync_block_outstanding",
+    "sync_block_missing_bodies",
+    "state_vct_root_stalled_height",
+    "state_vct_root_repair_requested",
+    "state_vct_root_retry_count",
+    "state_vct_aux_sweep_frontier_height",
+    "sync_header_vct_repair_requested_total",
+    "sync_header_vct_repair_scheduled_total",
+    "sync_header_vct_repair_admitted_total",
+    "sync_header_vct_repair_context_unavailable_total",
+    "sync_header_vct_repair_timed_out_total",
+    "sync_header_vct_repair_resource_stalled_total",
 )
 RECENT_REORG_LIMIT = 40
 # Sampled best-chain ancestor offsets used to estimate fork depth between tips.
@@ -283,6 +316,13 @@ out = {
 WANTED_METRICS = frozenset((
     "sync_estimated_distance_to_tip",
     "sync_estimated_network_tip_height",
+    "checkpoint_processing_next_height",
+    "checkpoint_verified_height",
+    "state_finalized_block_height",
+    "state_vct_root_stalled_height",
+    "state_vct_root_repair_requested",
+    "state_vct_root_retry_count",
+    "state_vct_aux_sweep_frontier_height",
     "sync_downloads_in_flight",
     "sync_downloaded_block_count",
     "sync_verified_block_count",
@@ -307,6 +347,12 @@ WANTED_METRICS = frozenset((
     "sync_header_root_auth_work_pending_batches",
     "sync_header_peer_violation",
     "sync_header_fill_stop",
+    "sync_header_vct_repair_requested_total",
+    "sync_header_vct_repair_scheduled_total",
+    "sync_header_vct_repair_admitted_total",
+    "sync_header_vct_repair_context_unavailable_total",
+    "sync_header_vct_repair_timed_out_total",
+    "sync_header_vct_repair_resource_stalled_total",
     "sync_block_applying",
     "sync_block_outstanding",
     "sync_block_backlog_at_cap",
@@ -347,7 +393,6 @@ WANTED_METRICS = frozenset((
     "candidate_set_pending",
     "candidate_set_failed",
     "candidate_set_disconnected",
-    "state_finalized_block_height",
     "zakura_state_rocksdb_total_disk_size_bytes",
     "zcash_chain_verified_block_total",
     "zcash_mempool_size_transactions",
@@ -1270,15 +1315,16 @@ class ClusterCollector:
         if probe.get("metrics_skipped"):
             metrics_snapshot = self.last_metrics.get(node.name, {})
         else:
+            probe_error = probe.get("error")
             metrics_snapshot = {
                 "metrics": probe.get("metrics") or {},
-                "metrics_error": probe.get("metrics_error"),
+                "metrics_error": probe.get("metrics_error") or probe_error,
                 "metrics_version": probe.get("metrics_version") or "",
                 "metrics_bytes": coerce_int(probe.get("metrics_bytes")),
                 "metrics_series": coerce_int(probe.get("metrics_series")),
                 "metrics_scrape_seconds": probe.get("metrics_scrape_seconds"),
                 "peer_user_agents": probe.get("peer_user_agents") or [],
-                "metrics_at": now,
+                "metrics_at": None if probe_error else now,
             }
             self.last_metrics[node.name] = metrics_snapshot
 
@@ -1357,7 +1403,7 @@ class ClusterCollector:
         """
         with self.lock:
             rows = [
-                {key: value for key, value in row.items() if key not in NODE_DETAIL_KEYS}
+                fleet_row(row, self.last_poll)
                 for row in self.rows
             ]
             last_poll = self.last_poll
@@ -1517,6 +1563,43 @@ def coerce_int(value) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        return value if math.isfinite(value) else None
+    except OverflowError:
+        return None
+
+
+def alert_diagnostics(row: dict, last_poll: float | None) -> dict:
+    metrics = row.get("metrics")
+    metrics_at = finite_number(row.get("metrics_at"))
+    selected = {}
+    if isinstance(metrics, dict):
+        for name in ALERT_DIAGNOSTIC_METRICS:
+            value = finite_number(metrics.get(name))
+            if value is not None:
+                selected[name] = value
+
+    return {
+        "last_poll": finite_number(last_poll),
+        "metrics_at": metrics_at,
+        "metrics_available": isinstance(metrics, dict)
+        and metrics_at is not None
+        and not bool(row.get("metrics_error")),
+        "metrics": selected,
+    }
+
+
+def fleet_row(row: dict, last_poll: float | None) -> dict:
+    summary = {
+        key: value for key, value in row.items() if key not in NODE_DETAIL_KEYS
+    }
+    summary["alert_diagnostics"] = alert_diagnostics(row, last_poll)
+    return summary
 
 
 def empty_chain_summary() -> dict:

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import time
@@ -26,6 +27,67 @@ from typing import Any
 
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
+MAX_SHARED_DIAGNOSTIC_ROWS = 8
+MAX_NODE_DETAIL_CHARS = 512
+MAX_ALERT_NAME_CHARS = 128
+MAX_ALERT_STATUS_CHARS = 64
+MAX_BLOCK_HASH_CHARS = 64
+MAX_DASHBOARD_URL_CHARS = 2_048
+MAX_ALERT_ERROR_CHARS = 2_048
+MAX_SLACK_MESSAGE_CHARS = 35_000
+SLACK_ESSENTIAL_PREFIX_LINES = 3
+SLACK_TRUNCATION_MARKER = "[alert truncated]"
+SLACK_PLAIN_TEXT_TRANSLATION = str.maketrans(
+    {
+        "&": "＆",
+        "<": "‹",
+        ">": "›",
+        "*": "∗",
+        "_": "＿",
+        "~": "～",
+        "`": "ˋ",
+        "@": "＠",
+    }
+)
+STALL_PIPELINE_METRICS = (
+    ("network tip", "sync_estimated_network_tip_height"),
+    ("distance", "sync_estimated_distance_to_tip"),
+    ("checkpoint next", "checkpoint_processing_next_height"),
+    ("checkpoint verified", "checkpoint_verified_height"),
+    ("state finalized", "state_finalized_block_height"),
+    ("header best", "sync_header_chain_frontier_header_best_height"),
+    ("header verified", "sync_header_chain_frontier_verified_best_height"),
+    ("header finalized", "sync_header_chain_frontier_finalized_height"),
+    ("header progress age", "sync_header_work_last_progress_age_seconds"),
+    ("oldest missing", "sync_header_work_oldest_missing_height"),
+    ("header in flight", "sync_header_work_in_flight_count"),
+    ("block applying", "sync_block_applying"),
+    ("block header tip", "sync_block_best_header_tip_height"),
+    ("block verified tip", "sync_block_verified_tip_height"),
+    ("block fill stop", "sync_block_fill_stop"),
+    ("block outstanding", "sync_block_outstanding"),
+    ("missing bodies", "sync_block_missing_bodies"),
+)
+STALL_REPAIR_METRICS = (
+    ("stalled height", "state_vct_root_stalled_height"),
+    ("state requests", "state_vct_root_repair_requested"),
+    ("state retries", "state_vct_root_retry_count"),
+    ("sweep frontier", "state_vct_aux_sweep_frontier_height"),
+    ("requested", "sync_header_vct_repair_requested_total"),
+    ("scheduled", "sync_header_vct_repair_scheduled_total"),
+    ("admitted", "sync_header_vct_repair_admitted_total"),
+    ("context unavailable", "sync_header_vct_repair_context_unavailable_total"),
+    ("timed out", "sync_header_vct_repair_timed_out_total"),
+    ("resource stalled", "sync_header_vct_repair_resource_stalled_total"),
+)
+SHARED_REPAIR_METRICS = (
+    ("vct stalled", "state_vct_root_stalled_height"),
+    ("vct retries", "state_vct_root_retry_count"),
+    ("sweep", "state_vct_aux_sweep_frontier_height"),
+    ("repair unavailable", "sync_header_vct_repair_context_unavailable_total"),
+    ("repair timed out", "sync_header_vct_repair_timed_out_total"),
+    ("repair resource stalled", "sync_header_vct_repair_resource_stalled_total"),
+)
 
 
 @dataclass(frozen=True)
@@ -33,6 +95,25 @@ class Fleet:
     name: str
     url: str
     dashboard_url: str
+
+
+@dataclass(frozen=True)
+class SharedTip:
+    height: int
+    block_hash: str
+    bad_since: float
+    node_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NodeObservation:
+    name: str
+    row: dict[str, Any]
+    condition: str
+    bad_since: float
+    threshold: float
+    height: int | None
+    block_hash: str
 
 
 @dataclass(frozen=True)
@@ -123,16 +204,27 @@ def load_fleets(config_path: Path) -> list[Fleet]:
 
 def load_state(state_path: Path) -> dict[str, Any]:
     if not state_path.exists():
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {
+            "version": STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
 
     with state_path.open(encoding="utf-8") as state_file:
         state = json.load(state_file)
 
     if not isinstance(state, dict) or state.get("version") != STATE_VERSION:
-        return {"version": STATE_VERSION, "nodes": {}, "fleets": {}}
+        return {
+            "version": STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+        }
 
     state.setdefault("nodes", {})
     state.setdefault("fleets", {})
+    state.setdefault("shared_stalls", {})
     state.setdefault("release_state", {})
     return state
 
@@ -172,8 +264,15 @@ def coerce_float(value: object) -> float | None:
         return None
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
+
+
+def coerce_height(value: object) -> int | None:
+    height = coerce_float(value)
+    if height is None or height < 0 or not height.is_integer():
+        return None
+    return int(height)
 
 
 def format_duration(seconds: float) -> str:
@@ -187,6 +286,157 @@ def format_duration(seconds: float) -> str:
 
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h" if minutes == 0 else f"{hours}h {minutes}m"
+
+
+def format_metric(value: object) -> str | None:
+    number = coerce_float(value)
+    if number is None or not math.isfinite(number):
+        return None
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:.2f}".rstrip("0").rstrip(".")
+
+
+def named_metrics(
+    source: dict[str, Any], fields: tuple[tuple[str, str], ...]
+) -> str:
+    values = []
+    for label, key in fields:
+        value = format_metric(source.get(key))
+        if value is not None:
+            values.append(f"{label} {value}")
+    return " | ".join(values)
+
+
+def bounded_text(value: object, limit: int) -> str:
+    return " ".join(str(value or "").split())[:limit]
+
+
+def slack_plain_text(value: object, limit: int) -> str:
+    return bounded_text(value, limit).translate(SLACK_PLAIN_TEXT_TRANSLATION)
+
+
+def slack_identity(value: object, limit: int, fallback: str) -> str:
+    return slack_plain_text(value or fallback, limit) or fallback
+
+
+def slack_dashboard_url(value: object) -> str:
+    return bounded_text(value, MAX_DASHBOARD_URL_CHARS)
+
+
+def slack_block_hash(value: object) -> str:
+    block_hash = validated_block_hash(value)
+    if block_hash is not None:
+        return block_hash
+
+    preview = slack_plain_text(normalized_block_hash(value), MAX_BLOCK_HASH_CHARS)
+    return f"invalid ({preview or 'missing'})"
+
+
+def bounded_slack_message(text: str) -> str:
+    if len(text) <= MAX_SLACK_MESSAGE_CHARS:
+        return text
+
+    lines = text.splitlines()
+    if len(lines) < 2:
+        keep = MAX_SLACK_MESSAGE_CHARS - len(SLACK_TRUNCATION_MARKER)
+        return text[:keep] + SLACK_TRUNCATION_MARKER
+
+    prefix_count = min(SLACK_ESSENTIAL_PREFIX_LINES, len(lines) - 1)
+    prefix = lines[:prefix_count]
+    middle = lines[prefix_count:-1]
+    suffix = lines[-1]
+    protected = [*prefix, SLACK_TRUNCATION_MARKER, suffix]
+    protected_length = sum(map(len, protected)) + len(protected) - 1
+    if protected_length > MAX_SLACK_MESSAGE_CHARS:
+        # Alert formatters bound protected fields before they reach this fallback.
+        # Keep both ends for direct callers that do not use an alert formatter.
+        available = MAX_SLACK_MESSAGE_CHARS - len(SLACK_TRUNCATION_MARKER) - 2
+        prefix_budget = max(0, available // 2)
+        suffix_budget = max(0, available - prefix_budget)
+        return "\n".join(
+            (
+                "\n".join(prefix)[:prefix_budget],
+                SLACK_TRUNCATION_MARKER,
+                suffix[:suffix_budget],
+            )
+        )
+
+    remaining = MAX_SLACK_MESSAGE_CHARS - protected_length
+    kept_middle = []
+    for line in middle:
+        added = len(line) + 1
+        if added > remaining:
+            break
+        kept_middle.append(line)
+        remaining -= added
+
+    return "\n".join(
+        (*prefix, *kept_middle, SLACK_TRUNCATION_MARKER, suffix)
+    )
+
+
+def alert_metrics(row: dict[str, Any]) -> tuple[dict[str, Any], bool | None]:
+    diagnostics = row.get("alert_diagnostics")
+    if not isinstance(diagnostics, dict):
+        return {}, None
+    metrics = diagnostics.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+    available = diagnostics.get("metrics_available")
+    return metrics, available if isinstance(available, bool) else None
+
+
+def metrics_availability_marker(
+    metrics: dict[str, Any], available: bool | None
+) -> str:
+    if available is False:
+        return "metrics unavailable"
+    if available is None:
+        return "metrics absent"
+    if not metrics:
+        return "metrics empty"
+    return "metrics ok"
+
+
+def node_diagnostic_lines(row: dict[str, Any]) -> list[str]:
+    identity = named_metrics(
+        row,
+        (
+            ("headers", "headers"),
+            ("header lag", "header_lag"),
+            ("peers", "peer_count"),
+        ),
+    )
+    commit = slack_plain_text(row.get("commit"), 12)
+    version = slack_plain_text(row.get("version"), 64)
+    build = " | ".join(
+        value
+        for value in (
+            f"commit {commit}" if commit else "",
+            f"version {version}" if version else "",
+        )
+        if value
+    )
+    metrics, available = alert_metrics(row)
+    pipeline = named_metrics(metrics, STALL_PIPELINE_METRICS)
+    repair = named_metrics(metrics, STALL_REPAIR_METRICS)
+
+    lines = []
+    if identity or build:
+        lines.append("node: " + " | ".join(value for value in (identity, build) if value))
+    if pipeline:
+        lines.append(f"pipeline: {pipeline}")
+    if repair:
+        lines.append(f"repair: {repair}")
+    if not pipeline and not repair:
+        if available is False:
+            lines.append("metrics: unavailable")
+        elif available is None:
+            lines.append("metrics: absent from fleet snapshot")
+        else:
+            lines.append("metrics: no alert diagnostics emitted")
+    return lines
 
 
 def suppression_until(path: Path) -> float | None:
@@ -220,6 +470,7 @@ def slack_webhook_url() -> str:
 
 
 def post_slack(text: str, args: argparse.Namespace) -> bool:
+    text = bounded_slack_message(text)
     webhook = slack_webhook_url()
     if args.dry_run:
         print(f"dry-run Slack message:\n{text}\n")
@@ -237,6 +488,7 @@ def post_slack(text: str, args: argparse.Namespace) -> bool:
 
 
 def post_slack_webhook(webhook: str, text: str, args: argparse.Namespace) -> bool:
+    text = bounded_slack_message(text)
     payload = json.dumps({"text": text}).encode("utf-8")
     request = urllib.request.Request(
         webhook,
@@ -286,6 +538,96 @@ def node_condition(
     return ("ok", now, 0)
 
 
+def tip_is_observable(row: dict[str, Any]) -> bool:
+    health = str(row.get("health") or "unknown")
+    return health not in DOWN_HEALTH and health != "starting"
+
+
+def normalized_block_hash(value: object) -> str:
+    return str(value or "").strip().casefold()
+
+
+def validated_block_hash(value: object) -> str | None:
+    block_hash = normalized_block_hash(value)
+    if (
+        block_hash
+        and len(block_hash) <= MAX_BLOCK_HASH_CHARS
+        and all(character in "0123456789abcdef" for character in block_hash)
+    ):
+        return block_hash
+    return None
+
+
+def tip_is_verifiable(row: dict[str, Any]) -> bool:
+    return (
+        tip_is_observable(row)
+        and coerce_height(row.get("height")) is not None
+        and validated_block_hash(row.get("block_hash")) is not None
+        and coerce_float(row.get("seconds_since_advanced")) is not None
+    )
+
+
+def shared_stall_candidate(
+    rows: list[dict[str, Any]],
+    now: float,
+) -> SharedTip | None:
+    """Return a common verifiable tip before individual stall alerts become due."""
+    observed: list[tuple[int, str, float, str]] = []
+
+    for row in rows:
+        if not tip_is_observable(row):
+            continue
+
+        height = coerce_height(row.get("height"))
+        block_hash = validated_block_hash(row.get("block_hash"))
+        seconds_since_advanced = coerce_float(row.get("seconds_since_advanced"))
+        node_name = str(row.get("name") or "unknown")
+        if height is None or block_hash is None or seconds_since_advanced is None:
+            return None
+        observed.append((height, block_hash, now - seconds_since_advanced, node_name))
+
+    if len(observed) < 2 or len({item[3] for item in observed}) != len(observed):
+        return None
+
+    identities = {(height, block_hash) for height, block_hash, *_rest in observed}
+    if len(identities) != 1:
+        return None
+
+    height, block_hash = next(iter(identities))
+    return SharedTip(
+        height=height,
+        block_hash=block_hash,
+        # The shared interval starts when the last node reached this tip.
+        bad_since=max(bad_since for _height, _hash, bad_since, _name in observed),
+        node_names=tuple(name for _height, _hash, _bad_since, name in observed),
+    )
+
+
+def classify_node_observations(
+    rows: list[dict[str, Any]],
+    now: float,
+    grace_since: float,
+    args: argparse.Namespace,
+) -> tuple[NodeObservation, ...]:
+    observations = []
+    for row in rows:
+        condition, bad_since, threshold = node_condition(
+            row, now, grace_since, args
+        )
+        observations.append(
+            NodeObservation(
+                name=str(row.get("name") or "unknown"),
+                row=row,
+                condition=condition,
+                bad_since=bad_since,
+                threshold=threshold,
+                height=coerce_height(row.get("height")),
+                block_hash=validated_block_hash(row.get("block_hash")) or "",
+            )
+        )
+    return tuple(observations)
+
+
 def stall_cleared(entry: dict[str, Any], height: float | None) -> bool:
     """True when a stalled alert may be retired.
 
@@ -314,6 +656,7 @@ def update_alert_state(
     suppressed: bool,
     args: argparse.Namespace,
     height: float | None = None,
+    log_suppressed: bool = True,
 ) -> None:
     entry = state_bucket.get(key, {"condition": "ok", "alerting": False})
     was_alerting = bool(entry.get("alerting"))
@@ -329,6 +672,8 @@ def update_alert_state(
                     # only clear once it re-synced past it, so a node that was fixed
                     # by a resync would never post a recovery.
                     entry = {**entry, "alert_height": height}
+                    if "event_height" in entry:
+                        entry["event_height"] = height
                 state_bucket[key] = entry
                 return
             if post_slack(recovery_text, args):
@@ -364,7 +709,8 @@ def update_alert_state(
 
     if not alerting and age >= threshold:
         if suppressed:
-            print(f"suppressed alert for {key}: {condition} for {format_duration(age)}")
+            if log_suppressed:
+                print(f"suppressed alert for {key}: {condition} for {format_duration(age)}")
         elif post_slack(alert_text, args):
             next_entry["alerting"] = True
             next_entry["last_alert_at"] = now
@@ -376,49 +722,132 @@ def update_alert_state(
 
 
 def node_alert_text(fleet: Fleet, row: dict[str, Any], condition: str, age: float) -> str:
-    name = row.get("name") or "unknown"
-    health = row.get("health") or "unknown"
-    height = row.get("height")
-    detail = row.get("detail") or "no detail"
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    name = slack_identity(row.get("name"), MAX_ALERT_NAME_CHARS, "unknown")
+    health = slack_identity(row.get("health"), MAX_ALERT_STATUS_CHARS, "unknown")
+    height = coerce_height(row.get("height"))
+    detail = slack_plain_text(row.get("detail") or "no detail", MAX_NODE_DETAIL_CHARS)
     height_text = str(height) if height is not None else "-"
 
-    return (
-        f":rotating_light: *Zakura {fleet.name}* - `{name}` {condition} "
-        f"for {format_duration(age)}\n"
-        f"health: {health} - height: {height_text} - detail: {detail}\n"
-        f"dashboard: {fleet.dashboard_url}"
-    )
+    lines = [
+        f":rotating_light: *Zakura {fleet_name}* - `{name}` {condition} "
+        f"for {format_duration(age)}",
+        f"health: {health} - height: {height_text} - detail: {detail}",
+        *node_diagnostic_lines(row),
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}",
+    ]
+    return "\n".join(lines)
 
 
 def node_recovery_text(fleet: Fleet, row: dict[str, Any], previous: dict[str, Any]) -> str:
-    name = row.get("name") or "unknown"
-    condition = previous.get("condition") or "unhealthy"
-    height = row.get("height")
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    name = slack_identity(row.get("name"), MAX_ALERT_NAME_CHARS, "unknown")
+    condition = slack_identity(
+        previous.get("condition"), MAX_ALERT_STATUS_CHARS, "unhealthy"
+    )
+    health = slack_identity(row.get("health"), MAX_ALERT_STATUS_CHARS, "unknown")
+    height = coerce_height(row.get("height"))
     height_text = str(height) if height is not None else "-"
 
     return (
-        f":white_check_mark: *Zakura {fleet.name}* - `{name}` recovered "
+        f":white_check_mark: *Zakura {fleet_name}* - `{name}` recovered "
         f"from {condition}\n"
-        f"health: {row.get('health') or 'unknown'} - height: {height_text}\n"
-        f"dashboard: {fleet.dashboard_url}"
+        f"health: {health} - height: {height_text}\n"
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
     )
 
 
 def fleet_alert_text(fleet: Fleet, error: Exception, age: float) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
     return (
-        f":rotating_light: *Zakura {fleet.name}* dashboard unreachable "
+        f":rotating_light: *Zakura {fleet_name}* dashboard unreachable "
         f"for {format_duration(age)}\n"
-        f"endpoint: {fleet.url}\n"
-        f"error: {error}"
+        f"endpoint: {slack_dashboard_url(fleet.url)}\n"
+        f"error: {slack_plain_text(error, MAX_ALERT_ERROR_CHARS)}"
     )
 
 
 def fleet_recovery_text(fleet: Fleet, previous: dict[str, Any]) -> str:
-    condition = previous.get("condition") or "unreachable"
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    condition = slack_identity(
+        previous.get("condition"), MAX_ALERT_STATUS_CHARS, "unreachable"
+    )
     return (
-        f":white_check_mark: *Zakura {fleet.name}* dashboard recovered "
+        f":white_check_mark: *Zakura {fleet_name}* dashboard recovered "
         f"from {condition}\n"
-        f"endpoint: {fleet.url}"
+        f"endpoint: {slack_dashboard_url(fleet.url)}"
+    )
+
+
+def shared_stall_alert_text(
+    fleet: Fleet,
+    height: float,
+    block_hash: str,
+    node_count: int,
+    age: float,
+    rows: list[dict[str, Any]],
+) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    lines = [
+        f":rotating_light: *Zakura {fleet_name}* network height has not advanced "
+        f"for {format_duration(age)}",
+        f"{node_count} nodes agree at height {int(height)}",
+        f"tip hash: {slack_block_hash(block_hash)}",
+    ]
+    for row in rows[:MAX_SHARED_DIAGNOSTIC_ROWS]:
+        summary = named_metrics(
+            row,
+            (
+                ("height", "height"),
+                ("headers", "headers"),
+                ("header lag", "header_lag"),
+                ("peers", "peer_count"),
+            ),
+        )
+        metrics, available = alert_metrics(row)
+        pipeline = named_metrics(
+            metrics,
+            (
+                ("checkpoint", "checkpoint_verified_height"),
+                ("network tip", "sync_estimated_network_tip_height"),
+                ("distance", "sync_estimated_distance_to_tip"),
+                ("applying", "sync_block_applying"),
+                ("outstanding", "sync_block_outstanding"),
+                ("missing", "sync_block_missing_bodies"),
+            ),
+        )
+        repair = named_metrics(metrics, SHARED_REPAIR_METRICS)
+        commit = slack_plain_text(row.get("commit"), 12)
+        summary = " | ".join(
+            value
+            for value in (
+                summary,
+                metrics_availability_marker(metrics, available),
+                pipeline,
+                repair,
+                f"commit {commit}" if commit else "",
+            )
+            if value
+        )
+        name = slack_identity(row.get("name"), MAX_ALERT_NAME_CHARS, "unknown")
+        lines.append(f"- {name}: {summary or 'no diagnostics'}")
+    hidden = max(0, node_count - MAX_SHARED_DIAGNOSTIC_ROWS)
+    if hidden:
+        lines.append(f"- {hidden} more participating nodes not shown")
+    lines.append(f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}")
+    return "\n".join(lines)
+
+
+def shared_stall_recovery_text(
+    fleet: Fleet, height: float | None, detail: str = "network height advanced"
+) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    height_text = str(int(height)) if height is not None else "-"
+    return (
+        f":white_check_mark: *Zakura {fleet_name}* shared stall cleared\n"
+        f"detail: {detail}\n"
+        f"height: {height_text}\n"
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
     )
 
 
@@ -468,20 +897,28 @@ def pointer_age_seconds(generated_at: Any, now: float) -> float | None:
 def release_state_alert_text(
     target: ReleaseState, condition: str, detail: str, height: Any
 ) -> str:
+    target_name = slack_identity(target.name, MAX_ALERT_NAME_CHARS, "unknown")
+    condition_text = slack_identity(condition, MAX_ALERT_STATUS_CHARS, "unhealthy")
+    height_text = slack_plain_text(
+        height if height is not None else "-", MAX_ALERT_STATUS_CHARS
+    )
     return (
-        f":rotating_light: *Zakura {target.name} release state* {condition}\n"
-        f"{detail}\n"
-        f"pointer: {target.url}\n"
-        f"height: {height}"
+        f":rotating_light: *Zakura {target_name} release state* {condition_text}\n"
+        f"{slack_plain_text(detail, MAX_ALERT_ERROR_CHARS)}\n"
+        f"pointer: {slack_dashboard_url(target.url)}\n"
+        f"height: {height_text}"
     )
 
 
 def release_state_recovery_text(target: ReleaseState, previous: dict[str, Any]) -> str:
-    condition = previous.get("condition") or "unhealthy"
+    target_name = slack_identity(target.name, MAX_ALERT_NAME_CHARS, "unknown")
+    condition = slack_identity(
+        previous.get("condition"), MAX_ALERT_STATUS_CHARS, "unhealthy"
+    )
     return (
-        f":white_check_mark: *Zakura {target.name} release state* recovered "
+        f":white_check_mark: *Zakura {target_name} release state* recovered "
         f"from {condition}\n"
-        f"pointer: {target.url}"
+        f"pointer: {slack_dashboard_url(target.url)}"
     )
 
 
@@ -510,14 +947,50 @@ class Watchdog:
                 self.handle_fleet_error(state, fleet, error, now, suppressed)
                 continue
 
-            self.handle_fleet_recovered(state, fleet, now)
+            if not self.handle_fleet_recovered(state, fleet, now):
+                continue
             rows = snapshot.get("rows", [])
             if not isinstance(rows, list):
                 rows = []
 
-            for row in rows:
-                if isinstance(row, dict):
-                    self.handle_node(state, fleet, row, now, suppressed)
+            node_rows = [row for row in rows if isinstance(row, dict)]
+            grace_since = max(
+                self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
+            )
+            observations = classify_node_observations(
+                node_rows, now, grace_since, self.args
+            )
+            common_stall = shared_stall_candidate(node_rows, now)
+            if not self.reconcile_obsolete_node_alerts(
+                state, fleet, observations
+            ):
+                continue
+            if not self.reconcile_duplicate_owners(
+                state, fleet, observations, common_stall
+            ):
+                continue
+            reconciled, shared_nodes = self.reconcile_shared_stall(
+                state,
+                fleet,
+                node_rows,
+                observations,
+                common_stall,
+                now,
+                suppressed,
+            )
+            if not reconciled:
+                continue
+
+            for observation in observations:
+                self.handle_node_observation(
+                    state,
+                    fleet,
+                    observation,
+                    now,
+                    suppressed,
+                    observation.condition == "stalled"
+                    and observation.name in shared_nodes,
+                )
 
         for target in self.release_state:
             self.handle_release_state(state, target, now, suppressed)
@@ -603,7 +1076,7 @@ class Watchdog:
         state: dict[str, Any],
         fleet: Fleet,
         now: float,
-    ) -> None:
+    ) -> bool:
         key = fleet.name
         bucket = state.setdefault("fleets", {})
         previous = dict(bucket.get(key, {}))
@@ -622,38 +1095,400 @@ class Watchdog:
             False,
             self.args,
         )
+        return not (
+            previous.get("alerting")
+            and bucket.get(key, {}).get("alerting")
+        )
 
-    def handle_node(
+    @staticmethod
+    def node_event_height(entry: dict[str, Any]) -> int | None:
+        return coerce_height(entry.get("event_height", entry.get("alert_height")))
+
+    @classmethod
+    def node_alert_matches_observation(
+        cls, entry: dict[str, Any], observation: NodeObservation
+    ) -> bool:
+        previous_condition = entry.get("condition")
+        if previous_condition == observation.condition:
+            if observation.condition != "stalled":
+                return True
+            previous_height = cls.node_event_height(entry)
+            return (
+                previous_height is None
+                or observation.height is None
+                or previous_height == observation.height
+            )
+
+        if previous_condition == "stalled" and observation.condition == "ok":
+            return not stall_cleared(entry, observation.height)
+        return False
+
+    def reconcile_obsolete_node_alerts(
         self,
         state: dict[str, Any],
         fleet: Fleet,
-        row: dict[str, Any],
+        observations: tuple[NodeObservation, ...],
+    ) -> bool:
+        bucket = state.setdefault("nodes", {})
+        for observation in observations:
+            key = f"{fleet.name}/{observation.name}"
+            previous = dict(bucket.get(key, {}))
+            if not previous.get("alerting"):
+                continue
+            if self.node_alert_matches_observation(previous, observation):
+                continue
+            if not post_slack(
+                node_recovery_text(fleet, observation.row, previous), self.args
+            ):
+                return False
+            bucket[key] = {"condition": "ok", "alerting": False}
+        return True
+
+    @staticmethod
+    def shared_event_identity(entry: dict[str, Any]) -> tuple[int | None, str]:
+        height = coerce_height(entry.get("event_height", entry.get("alert_height")))
+        return height, normalized_block_hash(entry.get("event_hash"))
+
+    @classmethod
+    def shared_event_matches_tip(
+        cls, entry: dict[str, Any], common_stall: SharedTip
+    ) -> bool:
+        height, block_hash = cls.shared_event_identity(entry)
+        return (
+            entry.get("condition") == "stalled"
+            and height == common_stall.height
+            and (not block_hash or block_hash == common_stall.block_hash)
+        )
+
+    @staticmethod
+    def observation_matches_shared_event(
+        observation: NodeObservation,
+        height: int | None,
+        block_hash: str,
+    ) -> bool:
+        return (
+            observation.condition == "stalled"
+            and height is not None
+            and observation.height == height
+            and (not block_hash or observation.block_hash == block_hash)
+        )
+
+    @classmethod
+    def active_node_owners(
+        cls,
+        state: dict[str, Any],
+        fleet: Fleet,
+        observations: tuple[NodeObservation, ...],
+        height: int | None,
+        block_hash: str,
+    ) -> list[NodeObservation]:
+        bucket = state.setdefault("nodes", {})
+        owners = []
+        for observation in observations:
+            entry = bucket.get(f"{fleet.name}/{observation.name}", {})
+            alert_height = cls.node_event_height(entry)
+            if (
+                entry.get("condition") == "stalled"
+                and entry.get("alerting")
+                and (alert_height is None or alert_height == height)
+                and observation.height == height
+                and (not block_hash or observation.block_hash == block_hash)
+                and cls.node_alert_matches_observation(
+                    entry, observation
+                )
+            ):
+                owners.append(observation)
+        return sorted(owners, key=lambda observation: observation.name)
+
+    def reconcile_duplicate_owners(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        observations: tuple[NodeObservation, ...],
+        common_stall: SharedTip | None,
+    ) -> bool:
+        shared_bucket = state.setdefault("shared_stalls", {})
+        shared_entry = dict(shared_bucket.get(fleet.name, {}))
+        shared_height, shared_hash = self.shared_event_identity(shared_entry)
+
+        if shared_entry.get("alerting"):
+            node_owners = self.active_node_owners(
+                state,
+                fleet,
+                observations,
+                shared_height,
+                shared_hash,
+            )
+            if node_owners:
+                if not post_slack(
+                    shared_stall_recovery_text(
+                        fleet,
+                        shared_height,
+                        "constituent node alert continues to represent this incident",
+                    ),
+                    self.args,
+                ):
+                    return False
+                shared_bucket[fleet.name] = {
+                    "condition": "ok",
+                    "alerting": False,
+                }
+
+        if common_stall is None:
+            return True
+
+        node_owners = self.active_node_owners(
+            state,
+            fleet,
+            observations,
+            common_stall.height,
+            common_stall.block_hash,
+        )
+        if len(node_owners) < 2:
+            return True
+
+        owner = node_owners[0]
+        bucket = state.setdefault("nodes", {})
+        for duplicate in node_owners[1:]:
+            text = (
+                f":white_check_mark: *Zakura {fleet.name}* - `{duplicate.name}` "
+                "duplicate stall alert cleared\n"
+                f"detail: `{owner.name}` continues to represent the shared incident\n"
+                f"height: {common_stall.height}\n"
+                f"dashboard: {fleet.dashboard_url}"
+            )
+            if not post_slack(text, self.args):
+                return False
+            bucket[f"{fleet.name}/{duplicate.name}"] = {
+                "condition": "ok",
+                "alerting": False,
+            }
+        return True
+
+    def reconcile_shared_stall(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        rows: list[dict[str, Any]],
+        observations: tuple[NodeObservation, ...],
+        common_stall: SharedTip | None,
         now: float,
         suppressed: bool,
+    ) -> tuple[bool, set[str]]:
+        bucket = state.setdefault("shared_stalls", {})
+        previous = dict(bucket.get(fleet.name, {}))
+        heights = [
+            height
+            for row in rows
+            if tip_is_verifiable(row)
+            if (height := coerce_height(row.get("height"))) is not None
+        ]
+        current_height = max(heights, default=None)
+
+        if common_stall is None:
+            return self.clear_or_hold_shared_stall(
+                bucket,
+                fleet,
+                observations,
+                previous,
+                current_height,
+            )
+
+        previous_height, _previous_hash = self.shared_event_identity(previous)
+        same_event = self.shared_event_matches_tip(previous, common_stall)
+
+        if not same_event:
+            recovery_detail = (
+                "network height advanced"
+                if previous_height is not None
+                and common_stall.height > previous_height
+                else "shared tip changed"
+            )
+            if previous.get("alerting") and not post_slack(
+                shared_stall_recovery_text(
+                    fleet, common_stall.height, recovery_detail
+                ),
+                self.args,
+            ):
+                return False, set()
+            previous = {}
+
+        bad_since = common_stall.bad_since
+        timer_floor = bad_since
+        if same_event:
+            previous_bad_since = float(previous.get("bad_since", bad_since))
+            previous_nodes = set(previous.get("node_names") or ())
+            current_nodes = set(common_stall.node_names)
+            if previous_nodes == current_nodes:
+                timer_floor = float(
+                    previous.get("timer_floor", previous_bad_since)
+                )
+                bad_since = max(
+                    timer_floor,
+                    min(previous_bad_since, bad_since),
+                )
+            else:
+                # A changed constituent set starts a conservative timer boundary.
+                # Persist the boundary so the next poll cannot backdate it.
+                bad_since = max(previous_bad_since, bad_since)
+                timer_floor = bad_since
+        age = now - bad_since
+        alerting = bool(previous.get("alerting"))
+        node_owners = self.active_node_owners(
+            state,
+            fleet,
+            observations,
+            common_stall.height,
+            common_stall.block_hash,
+        )
+        node_owner = node_owners[0].name if node_owners else None
+        next_entry = {
+            "condition": "stalled",
+            "event_height": common_stall.height,
+            "event_hash": common_stall.block_hash,
+            "node_names": list(common_stall.node_names),
+            "bad_since": bad_since,
+            "timer_floor": timer_floor,
+            "alerting": alerting,
+            "owner": f"node:{node_owner}" if node_owner else "shared",
+            "last_seen": now,
+        }
+        if alerting:
+            next_entry["alert_height"] = common_stall.height
+            if "last_alert_at" in previous:
+                next_entry["last_alert_at"] = previous["last_alert_at"]
+
+        if not alerting and node_owner is None and age >= self.args.shared_stalled_after:
+            if suppressed:
+                if not previous.get("suppression_logged"):
+                    print(
+                        f"suppressed alert for {fleet.name}: shared stall for "
+                        f"{format_duration(age)}"
+                    )
+                next_entry["suppression_logged"] = True
+            else:
+                participant_names = set(common_stall.node_names)
+                participant_rows = [
+                    row
+                    for row in rows
+                    if str(row.get("name") or "unknown") in participant_names
+                ]
+                alert_text = shared_stall_alert_text(
+                    fleet,
+                    common_stall.height,
+                    common_stall.block_hash,
+                    len(common_stall.node_names),
+                    age,
+                    participant_rows,
+                )
+                if post_slack(alert_text, self.args):
+                    next_entry["alerting"] = True
+                    next_entry["last_alert_at"] = now
+                    next_entry["alert_height"] = common_stall.height
+
+        bucket[fleet.name] = next_entry
+        return True, set(common_stall.node_names)
+
+    def clear_or_hold_shared_stall(
+        self,
+        bucket: dict[str, Any],
+        fleet: Fleet,
+        observations: tuple[NodeObservation, ...],
+        previous: dict[str, Any],
+        current_height: int | None,
+    ) -> tuple[bool, set[str]]:
+        if not previous.get("alerting"):
+            bucket[fleet.name] = {"condition": "ok", "alerting": False}
+            return True, set()
+
+        previous_height = coerce_height(
+            previous.get("event_height", previous.get("alert_height"))
+        )
+        eligible_count = sum(
+            tip_is_verifiable(observation.row) for observation in observations
+        )
+        if current_height is not None and (
+            previous_height is None or current_height > previous_height
+        ):
+            detail = "network height advanced"
+        elif eligible_count >= 2:
+            detail = "nodes no longer share one verifiable tip"
+        else:
+            previous["owner"] = "shared"
+            bucket[fleet.name] = previous
+            previous_hash = normalized_block_hash(previous.get("event_hash"))
+            owned_nodes = {
+                observation.name
+                for observation in observations
+                if self.observation_matches_shared_event(
+                    observation, previous_height, previous_hash
+                )
+            }
+            return True, owned_nodes
+
+        if not post_slack(
+            shared_stall_recovery_text(fleet, current_height, detail), self.args
+        ):
+            return False, set()
+        bucket[fleet.name] = {"condition": "ok", "alerting": False}
+        return True, set()
+
+    def handle_node_observation(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        observation: NodeObservation,
+        now: float,
+        suppressed: bool,
+        coalesced: bool = False,
     ) -> None:
-        node_name = str(row.get("name") or "unknown")
-        key = f"{fleet.name}/{node_name}"
+        key = f"{fleet.name}/{observation.name}"
         bucket = state.setdefault("nodes", {})
         previous = dict(bucket.get(key, {}))
-        grace_since = max(self.started_at, self.fetch_recovered_at.get(fleet.name, 0))
-        condition, bad_since, threshold = node_condition(row, now, grace_since, self.args)
-        if condition != "ok" and previous.get("condition") == condition:
+        previous_height = self.node_event_height(previous)
+        same_stall_event = (
+            observation.condition == "stalled"
+            and previous.get("condition") == "stalled"
+            and (
+                previous_height is None
+                or observation.height is None
+                or previous_height == observation.height
+            )
+        )
+        if (
+            observation.condition == "stalled"
+            and previous.get("condition") == "stalled"
+            and not same_stall_event
+        ):
+            previous = {}
+            bucket[key] = {"condition": "ok", "alerting": False}
+
+        bad_since = observation.bad_since
+        if (
+            observation.condition != "ok"
+            and previous.get("condition") == observation.condition
+        ):
             bad_since = min(float(previous.get("bad_since", bad_since)), bad_since)
         age = now - bad_since
 
         update_alert_state(
             bucket,
             key,
-            condition,
+            observation.condition,
             bad_since,
-            threshold,
-            node_alert_text(fleet, row, condition, age),
-            node_recovery_text(fleet, row, previous),
+            observation.threshold,
+            node_alert_text(fleet, observation.row, observation.condition, age),
+            node_recovery_text(fleet, observation.row, previous),
             now,
-            suppressed,
+            suppressed or coalesced,
             self.args,
-            coerce_float(row.get("height")),
+            observation.height,
+            log_suppressed=not coalesced,
         )
+        if observation.condition == "stalled":
+            entry = bucket.get(key, {})
+            if entry.get("condition") == "stalled" and observation.height is not None:
+                entry["event_height"] = observation.height
 
 
 def parse_args() -> argparse.Namespace:
@@ -679,6 +1514,12 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=600.0,
         help="alert after no block progress for this many seconds",
+    )
+    parser.add_argument(
+        "--shared-stalled-after",
+        type=float,
+        default=1800.0,
+        help="alert after every observable node shares one stalled tip this long",
     )
     parser.add_argument(
         "--dashboard-down-after",

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -260,12 +260,13 @@ def fetch_json(url: str, timeout: float) -> dict[str, Any]:
 
 
 def coerce_float(value: object) -> float | None:
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     try:
-        return float(value)
+        number = float(value)
     except (OverflowError, TypeError, ValueError):
         return None
+    return number if math.isfinite(number) else None
 
 
 def coerce_height(value: object) -> int | None:
@@ -684,7 +685,9 @@ def update_alert_state(
         return
 
     if entry.get("condition") == condition:
-        bad_since = min(float(entry.get("bad_since", bad_since)), bad_since)
+        previous_bad_since = coerce_float(entry.get("bad_since"))
+        if previous_bad_since is not None:
+            bad_since = min(previous_bad_since, bad_since)
         alerting = was_alerting
     else:
         alerting = False
@@ -760,7 +763,7 @@ def node_recovery_text(fleet: Fleet, row: dict[str, Any], previous: dict[str, An
 def fleet_alert_text(fleet: Fleet, error: Exception, age: float) -> str:
     fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
     return (
-        f":rotating_light: *Zakura {fleet_name}* dashboard unreachable "
+        f":rotating_light: *Zakura {fleet_name}* dashboard unavailable "
         f"for {format_duration(age)}\n"
         f"endpoint: {slack_dashboard_url(fleet.url)}\n"
         f"error: {slack_plain_text(error, MAX_ALERT_ERROR_CHARS)}"
@@ -849,6 +852,54 @@ def shared_stall_recovery_text(
         f"height: {height_text}\n"
         f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
     )
+
+
+def duplicate_stall_recovery_text(
+    fleet: Fleet,
+    duplicate_name: object,
+    owner_name: object,
+    height: object,
+) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    duplicate = slack_identity(duplicate_name, MAX_ALERT_NAME_CHARS, "unknown")
+    owner = slack_identity(owner_name, MAX_ALERT_NAME_CHARS, "unknown")
+    height_value = coerce_height(height)
+    height_text = str(height_value) if height_value is not None else "-"
+    return (
+        f":white_check_mark: *Zakura {fleet_name}* - `{duplicate}` "
+        "duplicate stall alert cleared\n"
+        f"detail: `{owner}` continues to represent the shared incident\n"
+        f"height: {height_text}\n"
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
+    )
+
+
+def validated_fleet_rows(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = snapshot.get("rows")
+    if not isinstance(rows, list):
+        raise ValueError("dashboard snapshot rows is not a list")
+    if not rows:
+        raise ValueError("dashboard snapshot has no node rows")
+    if any(not isinstance(row, dict) for row in rows):
+        raise ValueError("dashboard snapshot contains a non-object node row")
+
+    names = [row.get("name") for row in rows]
+    if any(not isinstance(name, str) or not name.strip() for name in names):
+        raise ValueError("dashboard snapshot contains a node row without a name")
+    if len(set(names)) != len(names):
+        raise ValueError("dashboard snapshot contains duplicate node names")
+    return rows
+
+
+def snapshot_last_poll(snapshot: dict[str, Any]) -> float | None:
+    if "last_poll" not in snapshot:
+        # Dashboards deployed before the atomic diagnostic payload omitted this
+        # field. Accept them during a rolling upgrade.
+        return None
+    last_poll = coerce_float(snapshot.get("last_poll"))
+    if last_poll is None:
+        raise ValueError("dashboard snapshot has no valid last_poll timestamp")
+    return last_poll
 
 
 def release_state_condition(
@@ -943,17 +994,33 @@ class Watchdog:
         for fleet in self.fleets:
             try:
                 snapshot = fetch_json(fleet.url, self.args.request_timeout)
+                node_rows = validated_fleet_rows(snapshot)
+                last_poll = snapshot_last_poll(snapshot)
             except Exception as error:
                 self.handle_fleet_error(state, fleet, error, now, suppressed)
                 continue
 
+            if (
+                last_poll is not None
+                and now - last_poll >= self.args.dashboard_down_after
+            ):
+                age = now - last_poll
+                error = ValueError(
+                    "dashboard snapshot is stale: last poll was "
+                    f"{format_duration(age)} ago"
+                )
+                self.handle_fleet_error(
+                    state,
+                    fleet,
+                    error,
+                    now,
+                    suppressed,
+                    bad_since=last_poll,
+                )
+                continue
+
             if not self.handle_fleet_recovered(state, fleet, now):
                 continue
-            rows = snapshot.get("rows", [])
-            if not isinstance(rows, list):
-                rows = []
-
-            node_rows = [row for row in rows if isinstance(row, dict)]
             grace_since = max(
                 self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
             )
@@ -1018,9 +1085,12 @@ class Watchdog:
         except Exception as error:
             condition, detail = "unreachable", str(error)
 
+        previous_bad_since = coerce_float(entry.get("bad_since"))
         bad_since = (
-            float(entry.get("bad_since", now))
-            if entry.get("condition") == condition and condition != "ok"
+            previous_bad_since
+            if entry.get("condition") == condition
+            and condition != "ok"
+            and previous_bad_since is not None
             else now
         )
 
@@ -1048,15 +1118,17 @@ class Watchdog:
         error: Exception,
         now: float,
         suppressed: bool,
+        bad_since: float | None = None,
     ) -> None:
         key = fleet.name
         bucket = state.setdefault("fleets", {})
         entry = bucket.get(key, {})
-        bad_since = (
-            float(entry.get("bad_since", now))
-            if entry.get("condition") == "unreachable"
-            else now
-        )
+        previous_bad_since = coerce_float(entry.get("bad_since"))
+        detected_bad_since = now if bad_since is None else min(now, bad_since)
+        if entry.get("condition") == "unreachable" and previous_bad_since is not None:
+            bad_since = min(previous_bad_since, detected_bad_since)
+        else:
+            bad_since = detected_bad_since
         age = now - bad_since
         update_alert_state(
             bucket,
@@ -1250,12 +1322,11 @@ class Watchdog:
         owner = node_owners[0]
         bucket = state.setdefault("nodes", {})
         for duplicate in node_owners[1:]:
-            text = (
-                f":white_check_mark: *Zakura {fleet.name}* - `{duplicate.name}` "
-                "duplicate stall alert cleared\n"
-                f"detail: `{owner.name}` continues to represent the shared incident\n"
-                f"height: {common_stall.height}\n"
-                f"dashboard: {fleet.dashboard_url}"
+            text = duplicate_stall_recovery_text(
+                fleet,
+                duplicate.name,
+                owner.name,
+                common_stall.height,
             )
             if not post_slack(text, self.args):
                 return False
@@ -1316,13 +1387,15 @@ class Watchdog:
         bad_since = common_stall.bad_since
         timer_floor = bad_since
         if same_event:
-            previous_bad_since = float(previous.get("bad_since", bad_since))
+            previous_bad_since = coerce_float(previous.get("bad_since"))
+            if previous_bad_since is None:
+                previous_bad_since = bad_since
             previous_nodes = set(previous.get("node_names") or ())
             current_nodes = set(common_stall.node_names)
             if previous_nodes == current_nodes:
-                timer_floor = float(
-                    previous.get("timer_floor", previous_bad_since)
-                )
+                timer_floor = coerce_float(previous.get("timer_floor"))
+                if timer_floor is None:
+                    timer_floor = previous_bad_since
                 bad_since = max(
                     timer_floor,
                     min(previous_bad_since, bad_since),
@@ -1468,7 +1541,9 @@ class Watchdog:
             observation.condition != "ok"
             and previous.get("condition") == observation.condition
         ):
-            bad_since = min(float(previous.get("bad_since", bad_since)), bad_since)
+            previous_bad_since = coerce_float(previous.get("bad_since"))
+            if previous_bad_since is not None:
+                bad_since = min(previous_bad_since, bad_since)
         age = now - bad_since
 
         update_alert_state(

--- a/deploy/runner/zakura-fleet-watchdog.service
+++ b/deploy/runner/zakura-fleet-watchdog.service
@@ -9,7 +9,7 @@ WorkingDirectory=/opt/zakura-fleet-watchdog
 EnvironmentFile=-/etc/zakura-fleet-watchdog/env
 StateDirectory=zakura-fleet-watchdog
 RuntimeDirectory=zakura-fleet-watchdog
-ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zakura-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --dashboard-down-after 600
+ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zakura-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --shared-stalled-after 1800 --dashboard-down-after 600
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
## Motivation

Synchronized fleet stalls produced duplicate node alerts and lacked bounded, atomic diagnostics. Later ownership transitions could lose or duplicate alerts when node membership, tip identity, or Slack delivery changed. Whole-probe failures also reported metrics as available, and prefix-only payload truncation could remove the dashboard link.

This PR consolidates and replaces the effective changes from #802, #805, #809, #812, #814, and #816.

## Solution

- identify shared stalls by height and validated block hash
- maintain one alert owner across node, shared, dashboard, and Slack failure transitions
- preserve conservative membership timer boundaries and legacy state compatibility
- attach atomic, bounded sync and VCT diagnostics to fleet rows
- mark whole-probe and timestamp-free metric samples unavailable
- sanitize and bound dynamic alert fields
- truncate payloads on line boundaries while preserving the incident prefix and dashboard link
- keep a shared owner latched when malformed rows cannot prove recovery

## Testing

- `python3 deploy/runner/test_zakura_cluster_watchdog.py` (59 passed)
- `python3 -m unittest discover -s deploy/runner -p "test_zakura_cluster_watchdog.py"` (59 passed)
- `python3 deploy/runner/test_zakura_cluster_status.py` (57 passed)
- `python3 -m unittest discover -s deploy/runner -p "test_zakura_cluster_status.py"` (57 passed)
- `python3 -m py_compile deploy/runner/zakura-cluster-status.py deploy/runner/zakura-cluster-watchdog.py deploy/runner/test_zakura_cluster_status.py deploy/runner/test_zakura_cluster_watchdog.py`
- `systemd-analyze verify deploy/runner/zakura-fleet-watchdog.service`
- `actionlint .github/workflows/zakura-mainnet-deploy.yml`
- `git diff --check origin/main...HEAD`

The tests cover shared-tip identity, threshold skew, membership changes, state migration, failed Slack transitions, dashboard outages, whole-probe failures, malformed rows, bounded diagnostics, and oversized formatted payloads.

## Changelog

No Rust source file or Cargo manifest changed.

### Follow-up Work

A versioned fleet diagnostic contract could replace the duplicated metric-name maps in a later PR.