### PR TITLE
fix(sync): complete legacy fallback checkpoint handoff

### DIFF
--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -4943,18 +4943,17 @@ mod zakura_header_sync_driver_tests {
         reactor_task.abort();
     }
 
-    /// Drives the block-sync apply loop against the *real* checkpoint verifier and a *real*
-    /// ephemeral state, reproducing the checkpoint-range batch-commit that Regtest (genesis
-    /// checkpoint only) cannot exercise.
+    /// Drives the block-sync apply loop against the real checkpoint verifier and an ephemeral
+    /// state. This test reproduces the checkpoint-range batch commit that Regtest cannot exercise.
     ///
     /// A checkpoint is placed at height 10 so an 11-block range covers a full checkpoint gap
     /// without 400 real blocks. The whole range is submitted except one mid-range body, which
     /// the verifier holds the entire range for (it commits nothing until the range is
-    /// contiguous to the next checkpoint). Delivering the withheld body must let the whole
-    /// range commit — i.e. a transiently-missing body recovers instead of wedging the floor,
-    /// which is the production "drop-through" failure mode.
+    /// contiguous to the next checkpoint). The fallback handoff must transfer the held requests
+    /// to the shared verifier. The legacy driver can then deliver the withheld body and commit the
+    /// range.
     #[tokio::test]
-    async fn block_sync_driver_recovers_checkpoint_range_after_withheld_body() {
+    async fn legacy_fallback_completes_transferred_checkpoint_range() {
         const CHECKPOINT_HEIGHT: u32 = 10;
         const WITHHELD: u32 = 5;
 
@@ -4998,6 +4997,7 @@ mod zakura_header_sync_driver_tests {
         // `Service<zakura_consensus::Request, Response = block::Hash>` bound.
         let checkpoint_verifier =
             tower::buffer::Buffer::new(BoxService::new(checkpoint_verifier), 16);
+        let legacy_verifier = checkpoint_verifier.clone();
         let verifier = service_fn(move |request: zakura_consensus::Request| {
             let checkpoint_verifier = checkpoint_verifier.clone();
             async move {
@@ -5014,10 +5014,12 @@ mod zakura_header_sync_driver_tests {
         let startup = block_sync_startup_for_test();
         let (block_sync, _reactor_actions, reactor_task) =
             zakura_network::zakura::spawn_block_sync_reactor(startup);
+        let handoff = super::zakura::SyncCoordinator::new();
         let (driver, shutdown_tx) = DriverParams {
             // Every block 0..=10 is at or below the checkpoint, so all are Checkpoint-class
             // (indefinite-wait) commits — the path that wedges in production.
             max_checkpoint_height: block::Height(CHECKPOINT_HEIGHT),
+            handoff: handoff.clone(),
             ..DriverParams::default()
         }
         .spawn(
@@ -5070,20 +5072,27 @@ mod zakura_header_sync_driver_tests {
             "checkpoint range must not commit while a mid-range body is missing",
         );
 
-        // Deliver the withheld body; the verifier can now commit the whole range.
-        let (withheld_height, withheld_block) = chain
+        let fallback = tokio::spawn(async move {
+            handoff
+                .acquire_legacy_fallback(Duration::from_secs(1))
+                .await
+        });
+        let _fallback_lease = tokio::time::timeout(Duration::from_secs(1), fallback)
+            .await
+            .expect("fallback must not wait for an incomplete checkpoint range")
+            .expect("fallback acquisition task must finish")
+            .expect("fallback must acquire the transferred checkpoint range");
+
+        // The legacy driver uses the same verifier. Its missing body completes the transferred
+        // checkpoint range.
+        let (_withheld_height, withheld_block) = chain
             .iter()
             .find(|(height, _)| height.0 == WITHHELD)
             .expect("withheld block is part of the test chain");
-        action_tx
-            .send(BlockSyncAction::SubmitBlock {
-                owner: test_block_work_owner(),
-                source: test_block_source(),
-                token: u64::from(withheld_height.0),
-                block: withheld_block.clone(),
-            })
+        legacy_verifier
+            .oneshot(withheld_block.clone())
             .await
-            .expect("driver action channel stays open");
+            .expect("legacy verifier submission completes the checkpoint range");
 
         // Recovery: the entire range commits, so the finalized tip reaches the checkpoint.
         tokio::time::timeout(Duration::from_secs(10), async {
@@ -5095,7 +5104,7 @@ mod zakura_header_sync_driver_tests {
             }
         })
         .await
-        .expect("delivering the withheld body must let the checkpoint range commit to the tip");
+        .expect("legacy fallback must let the checkpoint range commit to the tip");
 
         let _ = shutdown_tx.send(());
         driver.await.expect("driver task exits cleanly");

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -4982,7 +4982,7 @@ mod zakura_header_sync_driver_tests {
             zakura_state::init_test_services(&network).await;
 
         // A low checkpoint at height 10 turns the 11-block range into one checkpoint batch.
-        let checkpoint_verifier = zakura_consensus::CheckpointVerifier::from_list(
+        let mut checkpoint_verifier = zakura_consensus::CheckpointVerifier::from_list(
             [
                 (block::Height(0), genesis_hash),
                 (block::Height(CHECKPOINT_HEIGHT), checkpoint_hash),
@@ -4992,6 +4992,13 @@ mod zakura_header_sync_driver_tests {
             write_state,
         )
         .expect("a checkpoint list with genesis and one mid-chain checkpoint is valid");
+
+        let submitted_count = Arc::new(AtomicUsize::new(0));
+        let verifier_submitted_count = submitted_count.clone();
+        let checkpoint_verifier = service_fn(move |block| {
+            verifier_submitted_count.fetch_add(1, Ordering::SeqCst);
+            checkpoint_verifier.call(block)
+        });
 
         // Adapt the checkpoint verifier (`Service<Arc<Block>>`) to the driver's
         // `Service<zakura_consensus::Request, Response = block::Hash>` bound.
@@ -5062,10 +5069,17 @@ mod zakura_header_sync_driver_tests {
                 .expect("driver action channel stays open");
         }
 
-        // While the body is missing the range cannot commit, and the driver must keep the
-        // checkpoint-class commits pending (not time them out): the tip never reaches the
-        // checkpoint.
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        let expected_submissions = chain.len().saturating_sub(1);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while submitted_count.load(Ordering::SeqCst) != expected_submissions {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the driver must submit every available checkpoint body before fallback starts");
+
+        // While the body is missing, the range cannot commit. The driver must keep the
+        // checkpoint-class commits pending instead of timing them out.
         assert_ne!(
             finalized_tip().await,
             Some(block::Height(CHECKPOINT_HEIGHT)),

--- a/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
@@ -662,7 +662,7 @@ fn abandon_block_apply(
     token: BlockApplyToken,
     block: &block::Block,
     trace: &ZakuraTrace,
-) {
+) -> BlockApplyResult {
     let Some((height, expected_hash, result, event)) =
         abandoned_block_apply_finished_event(owner, source, token, block)
     else {
@@ -670,11 +670,12 @@ fn abandon_block_apply(
             expected_hash = ?block.hash(),
             "dropping abandoned Zakura block-sync body without coinbase height"
         );
-        return;
+        return BlockApplyResult::Rejected;
     };
 
     let _ = block_sync.send_control(event);
     trace.trace_block_apply_finished(token, height, expected_hash, result, false);
+    result
 }
 
 pub(crate) fn abandoned_block_apply_finished_event(
@@ -1101,6 +1102,13 @@ fn drain_pending_block_applies<ReadState, BlockVerifier>(
             continue;
         };
         debug!(operation_id = ?accepted.id(), token = pending.token, "accepted native block apply operation");
+        let transfer_handoff = handoff.clone();
+        let transfer_block = pending.block.clone();
+        let transfer_owner = pending.owner;
+        let transfer_source = pending.source;
+        let transfer_token = pending.token;
+        let transfer_block_sync = block_sync.clone();
+        let transfer_trace = trace.clone();
         let apply = apply_block_sync_body(
             block_verifier.clone(),
             latest_chain_tip.clone(),
@@ -1117,17 +1125,52 @@ fn drain_pending_block_applies<ReadState, BlockVerifier>(
         );
         in_flight_applies.push(
             async move {
-                let completed = apply.await;
-                let terminal = match completed.result {
-                    BlockApplyResult::Committed | BlockApplyResult::Duplicate => {
-                        super::BlockApplyTerminal::Committed
+                tokio::pin!(apply);
+                let mut accepted = Some(accepted);
+                tokio::select! {
+                    biased;
+                    completed = &mut apply => {
+                        let terminal = match completed.result {
+                            BlockApplyResult::Committed | BlockApplyResult::Duplicate => {
+                                super::BlockApplyTerminal::Committed
+                            }
+                            BlockApplyResult::Rejected
+                            | BlockApplyResult::Unavailable
+                            | BlockApplyResult::TimedOut => super::BlockApplyTerminal::Rejected,
+                        };
+                        accepted
+                            .take()
+                            .expect("accepted operation has one terminal result")
+                            .complete(terminal);
+                        completed
                     }
-                    BlockApplyResult::Rejected
-                    | BlockApplyResult::Unavailable
-                    | BlockApplyResult::TimedOut => super::BlockApplyTerminal::Rejected,
-                };
-                accepted.complete(terminal);
-                completed
+                    _ = transfer_handoff.wait_for_legacy_yield(),
+                        if class == BlockApplyClass::Checkpoint =>
+                    {
+                        // The checkpoint verifier owns transactional range commits after it
+                        // accepts a request. A partial range cannot commit until another request
+                        // supplies every missing body. Legacy fallback uses the same verifier, so
+                        // it can complete the range after this driver transfers completion
+                        // responsibility.
+                        let result = abandon_block_apply(
+                            &transfer_block_sync,
+                            transfer_owner,
+                            transfer_source,
+                            transfer_token,
+                            transfer_block.as_ref(),
+                            &transfer_trace,
+                        );
+                        accepted
+                            .take()
+                            .expect("accepted operation has one terminal result")
+                            .complete(super::BlockApplyTerminal::TransferredToLegacy);
+                        metrics::counter!(
+                            "sync.zakura.apply.checkpoint_transferred_to_legacy"
+                        )
+                        .increment(1);
+                        BlockApplyCompletion { class, result }
+                    }
+                }
             }
             .boxed(),
         );

--- a/crates/zakurad/src/commands/start/zakura/coordinator.rs
+++ b/crates/zakurad/src/commands/start/zakura/coordinator.rs
@@ -40,6 +40,7 @@ pub(crate) enum BlockApplyOperationState {
     Accepted,
     TooLate,
     Cancelled,
+    TransferredToLegacy,
     Committed,
     Rejected,
     Failed,
@@ -73,9 +74,13 @@ pub(crate) struct AcceptedBlockApplyOperation {
 pub(crate) enum BlockApplyTerminal {
     Committed,
     Rejected,
+    TransferredToLegacy,
 }
 
-/// Exclusive authorization for one fully drained legacy fallback round.
+/// Authorization for one legacy fallback round after native admission stops.
+///
+/// Full semantic commits drain before this lease activates. The block driver transfers incomplete
+/// checkpoint ranges to the shared checkpoint verifier so fallback can supply their missing bodies.
 #[derive(Debug)]
 pub(crate) struct LegacyFallbackLease {
     coordinator: Arc<SyncCoordinator>,
@@ -192,6 +197,19 @@ impl SyncCoordinator {
         }
     }
 
+    /// Wait until fallback starts draining native applies.
+    pub(crate) async fn wait_for_legacy_yield(&self) {
+        loop {
+            let changed = self.phase_changed.notified();
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            if self.is_yielded_to_legacy() {
+                return;
+            }
+            changed.await;
+        }
+    }
+
     /// Reserve one apply in the exact current native epoch.
     #[cfg(test)]
     pub(crate) fn begin_apply(self: &Arc<Self>) -> Option<BlockApplyPermit> {
@@ -264,7 +282,7 @@ impl SyncCoordinator {
         }
     }
 
-    /// Stop native admission, drain the exact epoch, then authorize one legacy round.
+    /// Stop native admission, quiesce the exact epoch, then authorize one legacy round.
     pub(crate) async fn acquire_legacy_fallback(
         self: &Arc<Self>,
         diagnostic_interval: Duration,
@@ -417,6 +435,9 @@ impl SyncCoordinator {
             let state = match terminal {
                 BlockApplyTerminal::Committed => BlockApplyOperationState::Committed,
                 BlockApplyTerminal::Rejected => BlockApplyOperationState::Rejected,
+                BlockApplyTerminal::TransferredToLegacy => {
+                    BlockApplyOperationState::TransferredToLegacy
+                }
             };
             record.state = state;
             record.state_tx.send_replace(state);

--- a/docs/changelog/unreleased/823.md
+++ b/docs/changelog/unreleased/823.md
@@ -1,0 +1,6 @@
+## Fixed
+
+- Fixed dual-stack nodes waiting forever to start legacy fallback when native block sync holds an
+  incomplete checkpoint range. Legacy fallback can now supply the missing bodies and resume block
+  verification
+  ([#823](https://github.com/zakura-core/zakura/pull/823)).


### PR DESCRIPTION
## Motivation

The legacy fallback handoff can wait forever on an incomplete checkpoint range. Native block sync submits checkpoint bodies to the shared checkpoint verifier. The verifier holds each response until every body in the checkpoint range arrives. When fallback starts, the coordinator stops new native admission but treats every accepted checkpoint response as too late to cancel. The coordinator then waits for those responses before it authorizes legacy sync. Legacy sync cannot supply the missing body until it receives that authorization.

This circular wait left five Mainnet fleet nodes without block verification progress. The affected nodes retained 18–401 native applies after the VCT repair restored state progress.

## Solution

- transfer incomplete checkpoint-range responses when fallback starts draining native applies
- keep the shared checkpoint verifier responsible for transactional checkpoint commits
- let legacy sync supply the missing bodies through that same verifier
- notify the native block-sync reactor that transferred submissions were abandoned
- record transferred operations with an explicit lifecycle state and metric
- keep full semantic commits behind the existing strict drain barrier

The completion branch has priority when a checkpoint response and the transfer signal become ready together. A completed response therefore retains its committed or rejected result.

## Testing

- `cargo test -p zakura --lib legacy_fallback_completes_transferred_checkpoint_range`
- `cargo test -p zakura --lib fallback_yield_releases_queued_submit_blocks`
- `cargo test -p zakura --lib buffered_native_commit_blocks_legacy_fallback_past_every_diagnostic_interval`
- `cargo test -p zakura --lib commands::start::zakura::coordinator::tests`
- `cargo clippy -p zakura --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`

The regression test uses a real checkpoint verifier and an ephemeral state. It submits every block in a checkpoint range except one body. It proves that fallback acquires the handoff while the range remains incomplete. It then submits the missing body through the shared legacy verifier and verifies that the finalized tip reaches the checkpoint.

The full `cargo test -p zakura --lib` run passed 410 tests. `components::inbound::tests::real_peer_set::inbound_pruned_block_is_not_advertised_and_getdata_logs_error` failed its pruning-log assertion. PR #821 reports the same failure at its unmodified base, and this PR does not change inbound pruning or logging.

## Changelog

`docs/changelog/unreleased/823.md` records the operator-visible fix.

### Specifications & References

This bug is separate from the VCT root-repair livelock fixed by #821. The fleet validation branch `validate/sync-fixes-complete-20260826` combined #818, #819, #820, and #821. That validation cleared the VCT repair backlog and exposed the checkpoint handoff residue.

- #818 keeps block-sync retry-filter work nonempty.
- #819 retries transient legacy block failures in place. It does not break this handoff cycle because legacy sync cannot start.
- #820 reports the resulting fleet stalls. The alerts predate the validation deployment and remain accurate.
- #821 fixes VCT repair liveness. It does not cause or fix this checkpoint handoff cycle.

### Follow-up Work

Validate the fix on the five affected fleet nodes and confirm that `zcash_chain_verified_block_height` resumes.
