### PR TITLE
ci: use direct attestation action

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -475,7 +475,10 @@ jobs:
       # the canonical public repository; private rehearsal repos skip it.
       - name: Attest build provenance
         if: ${{ github.repository == 'zakura-core/zakura' }}
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 #v4.2.2
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d #v4.2.1
+        env:
+          # Preserve the response-header limit set by the former wrapper.
+          NODE_OPTIONS: --max-http-header-size=32768
         with:
           subject-path: |
             ./publish/final/zakurad-*.tar.gz


### PR DESCRIPTION
## Motivation

`actions/attest-build-provenance` v4 is now a wrapper around `actions/attest`, and GitHub recommends using the consolidated action directly for new implementations.

## Solution

Call the exact `actions/attest` v4.2.1 commit used by the current v4.2.2 wrapper. Preserve the wrapper’s `NODE_OPTIONS=--max-http-header-size=32768` setting explicitly, so the release attestation inputs, runtime behavior, and permissions remain unchanged.

## Testing

- `git diff --check`
- Prettier successfully parsed and rendered the workflow. Its repository check remains nonzero only for two pre-existing long `needs` arrays elsewhere in this file (lines 711 and 823).
- Draft CI will run the repository workflow-policy and security checks.

## Changelog

Not required: this is an internal GitHub Actions workflow change with no Rust or `Cargo.toml` changes.

### Specifications & References

- https://github.com/actions/attest-build-provenance/releases/tag/v4.2.2
- https://github.com/actions/attest/commit/508db95dd578ae2727ebd6217d5ba78e4fbda05d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal GitHub Actions change only; attestation inputs and runtime tuning are preserved intentionally.
> 
> **Overview**
> The **release-binaries** workflow’s build provenance step now calls **`actions/attest`** (pinned v4.2.1) instead of the **`actions/attest-build-provenance`** wrapper (v4.2.2), matching GitHub’s recommendation to use the consolidated action.
> 
> **`NODE_OPTIONS=--max-http-header-size=32768`** is set explicitly on that step so attestation behavior matches what the wrapper used to provide. The repo guard, **`subject-path`** globs, and job permissions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc13e050db0d0d62fa40ea47e211aa0cbc317ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->