### PR TITLE
chore(release): consume the pending #826 changelog fragment for v1.3.0-rc3

### DIFF
--- a/docs/changelog/unreleased/826.md
+++ b/docs/changelog/unreleased/826.md
@@ -1,3 +1,0 @@
-<!-- changelog: none -->
-
-This PR only adds regression tests and has no operator-visible effect.


### PR DESCRIPTION
## Motivation

The `Create release` run for v1.3.0-rc3 failed its changelog gate: PR #826 (test-only, explicit no-changelog fragment) merged minutes before release PR #825, so the release preparation — branched from an older main — never consumed `docs/changelog/unreleased/826.md`.

## Solution

Run `make prepare-release-changelog RELEASE_TAG=v1.3.0-rc3` on current main, exactly as a post-#826 preparation would have. The fragment is a no-changelog fragment, so consuming it deletes the file and changes no changelog text (`updated 0 changelog(s) and consumed 1 fragment(s)`).

## Testing

- `make pre-release-changelog RELEASE_TAG=v1.3.0-rc3` (the exact gate that failed) now reports "release changelogs are assembled".

After merge, re-dispatch `Create release` with the same tag v1.3.0-rc3 — no tag was created by the failed run.

### AI Disclosure

Prepared by Claude Code using the repository's release tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)