### PR TITLE
ci: check cross-platform builds after merge

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,53 @@
+name: Cross-platform build
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Pull requests and merge groups deliberately do not trigger this workflow.
+# The post-merge signal must not block either path.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check workspace on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          cache-key: cross-platform-${{ matrix.os }}
+          cache-on-failure: true
+          cache-save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: ./.github/actions/setup-zakura-build
+
+      - name: Install LLVM on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install llvm -y --no-progress
+          "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Check all workspace targets
+        run: cargo check --workspace --all-targets --locked

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ on:
       - deny.toml
       - rust-toolchain.toml
       - .github/workflows/lint.yml
+      - .github/workflows/cross-platform.yml
       - docs/specs/fork-aware-header-chain-engine.md
       - qa/supply-chain/**
       - "scripts/**.sh"
@@ -37,6 +38,7 @@ on:
       - deny.toml
       - rust-toolchain.toml
       - .github/workflows/lint.yml
+      - .github/workflows/cross-platform.yml
       - docs/specs/fork-aware-header-chain-engine.md
       - qa/supply-chain/**
       - "scripts/**.sh"


### PR DESCRIPTION
## Motivation

The pull request gates run on Linux, so a Windows-incompatible source path reached release packaging. PR #829 fixes the current reserved filename and adds a fast packaging gate before merge. The repository also needs a recurring signal for platform-specific compile failures without adding latency or a required check to pull requests.

## Solution

Add a post-merge build workflow with macOS and Windows jobs. Existing pull-request and main-branch workflows already cover Ubuntu. Each new job checks all workspace targets with stable Rust. The workflow runs only after pushes to main or through manual dispatch; it has no pull_request or merge_group trigger.

The Windows job installs LLVM for RocksDB bindgen. The existing build setup installs each platform’s other native dependencies. The lint workflow watches this workflow file so pull requests run the existing workflow security audit.

## Testing

- actionlint .github/workflows/cross-platform.yml .github/workflows/lint.yml
- cargo check --workspace --all-targets --locked

The Linux workspace check validated the shared command successfully. GitHub-hosted macOS and Windows runners will exercise their platform-specific jobs after merge or manual dispatch.

## Changelog

No changelog fragment is required because this PR changes CI only.

### Follow-up Work

Merge #829 before this PR. Otherwise, the first post-merge Windows job cannot check out the reserved aux.rs path.