### PR TITLE
fix(deploy): suppress watchdog alerts during planned restarts

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -325,6 +325,68 @@ jobs:
           printf '%s\n' "$(( $(date +%s) + 1200 ))" \
             | sudo tee /run/zakura-fleet-watchdog/deploy-suppressed-until >/dev/null
 
+      - name: Suppress node watchdog alerts during deploy
+        # Keep this in workflow-owned code because the requested rollback ref
+        # can contain a deploy.py that predates node-local suppression.
+        if: ${{ !inputs.no_restart }}
+        working-directory: deploy/deployer
+        env:
+          NODE: ${{ inputs.node }}
+        run: |
+          set -euo pipefail
+
+          ssh_targets="$(
+            python3 - <<'PY'
+          import os
+          import sys
+          import tomllib
+
+          with open("nodes.ci.toml", "rb") as config_file:
+              config = tomllib.load(config_file)
+
+          selected = os.environ.get("NODE", "")
+          targets = [
+              node["ssh_string"]
+              for node in config["nodes"]
+              if not selected or node["name"] == selected
+          ]
+          if selected and not targets:
+              print(f"unknown deployer node: {selected}", file=sys.stderr)
+              raise SystemExit(1)
+          print("\n".join(targets))
+          PY
+          )"
+
+          if [ -z "$ssh_targets" ]; then
+            echo "deployer config contains no node SSH targets" >&2
+            exit 1
+          fi
+
+          while IFS= read -r ssh_target; do
+            timeout --signal=TERM --kill-after=5s 60s \
+              ssh \
+                -o BatchMode=yes \
+                -o ConnectTimeout=20 \
+                -o ServerAliveInterval=10 \
+                -o ServerAliveCountMax=3 \
+                -o StrictHostKeyChecking=yes \
+                -- "$ssh_target" bash -s <<'REMOTE'
+          set -euo pipefail
+
+          marker=/run/zakura-watchdog/deployment-suppressed-until
+          mkdir -p -m 755 "$(dirname "$marker")"
+          marker_tmp="$(mktemp "${marker}.tmp.XXXXXX")"
+          cleanup() {
+            rm -f "$marker_tmp"
+          }
+          trap cleanup EXIT
+          printf '%s\n' "$(( $(date +%s) + 1200 ))" > "$marker_tmp"
+          chmod 644 "$marker_tmp"
+          mv -f "$marker_tmp" "$marker"
+          trap - EXIT
+          REMOTE
+          done <<< "$ssh_targets"
+
       - name: Deploy fleet
         working-directory: deploy/deployer
         env:

--- a/deploy/deployer/README.md
+++ b/deploy/deployer/README.md
@@ -321,6 +321,23 @@ The mainnet workflow writes it locally on `us-east-0`; the testnet workflow
 refreshes it on `us-east-0` over SSH on a best-effort basis. While the marker is
 in the future, new failure alerts are logged but not posted to Slack.
 
+Before restarting a systemd node, the deployer also writes the configured
+node-local watchdog marker. The defaults match
+`/run/zakura-watchdog/deployment-suppressed-until` and the watchdog's 20-minute
+maximum. If `/etc/zakura-watchdog/env` overrides
+`WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE` or
+`WATCHDOG_MAX_DEPLOYMENT_SUPPRESSION`, set the matching
+`watchdog_deployment_suppression_file` and
+`watchdog_max_deployment_suppression` values in the deployer's `[defaults]` or
+`[[nodes]]` table. This keeps the local watchdog checks running while
+suppressing expected Sentry failure and recovery transitions during the
+restart. A `--no-restart` deploy does not write either suppression marker, and
+failures that outlast the configured window alert normally.
+
+The mainnet workflow also writes the default node-local marker before invoking
+the deployer from the requested ref. This keeps rollback deployments suppressed
+when the requested older ref predates deployer-managed node-local markers.
+
 Manual dry run from `us-east-0`:
 
 ```bash

--- a/deploy/deployer/deploy.py
+++ b/deploy/deployer/deploy.py
@@ -31,6 +31,11 @@ BUILD_CACHE_DIR_ENV = "ZAKURA_DEPLOYER_BUILD_CACHE_DIR"
 BUILD_CACHE_RETAIN_ENV = "ZAKURA_DEPLOYER_BUILD_CACHE_RETAIN"
 DEFAULT_BUILD_CACHE_RETAIN = 12
 DATA_MOUNT = Path("/mnt/data")
+WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE = Path(
+    "/run/zakura-watchdog/deployment-suppressed-until"
+)
+WATCHDOG_MAX_DEPLOYMENT_SUPPRESSION = 1200
+SHELL_SIGNED_INTEGER_MAX = (1 << 63) - 1
 
 # ssh/scp options shared by every remote call. BatchMode avoids interactive
 # password prompts hanging a parallel deploy; accept-new pins unknown host keys
@@ -83,6 +88,9 @@ DEFAULTS = {
     # Docker deploys replace the binary in an existing container without
     # recreating it, preserving its mounts, networking, and image configuration.
     "container_name": "",
+    # These must match any overrides in the node's zakura-watchdog service.
+    "watchdog_deployment_suppression_file": str(WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE),
+    "watchdog_max_deployment_suppression": WATCHDOG_MAX_DEPLOYMENT_SUPPRESSION,
 }
 
 
@@ -120,6 +128,8 @@ class Node:
     start_command: str
     process_pattern: str
     container_name: str
+    watchdog_deployment_suppression_file: str
+    watchdog_max_deployment_suppression: int
     port: object = None
     # resolved at runtime
     sha: str = ""
@@ -169,6 +179,33 @@ def normalize_p2p_stack(value: object, *, where: str) -> str:
             f"expected one of: default, legacy, zakura, dual"
         )
     return stack
+
+
+def normalize_watchdog_suppression_file(value: object, *, where: str) -> str:
+    """Validate the marker path that must match the watchdog configuration."""
+    if not isinstance(value, str) or not value.strip():
+        raise DeployError(
+            f"{where}: watchdog_deployment_suppression_file must be a non-empty string"
+        )
+    if not Path(value).is_absolute():
+        raise DeployError(
+            f"{where}: watchdog_deployment_suppression_file must be an absolute path"
+        )
+    return value
+
+
+def normalize_watchdog_max_suppression(value: object, *, where: str) -> int:
+    """Validate the watchdog's non-negative maximum suppression window."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= SHELL_SIGNED_INTEGER_MAX
+    ):
+        raise DeployError(
+            f"{where}: watchdog_max_deployment_suppression must be an integer "
+            f"between 0 and {SHELL_SIGNED_INTEGER_MAX}"
+        )
+    return value
 
 
 def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
@@ -247,6 +284,14 @@ def load_nodes(config_path: Path, only: list[str] | None) -> list[Node]:
             start_command=merged["start_command"],
             process_pattern=merged["process_pattern"],
             container_name=merged["container_name"],
+            watchdog_deployment_suppression_file=normalize_watchdog_suppression_file(
+                merged["watchdog_deployment_suppression_file"],
+                where=f"[[nodes]] {name}",
+            ),
+            watchdog_max_deployment_suppression=normalize_watchdog_max_suppression(
+                merged["watchdog_max_deployment_suppression"],
+                where=f"[[nodes]] {name}",
+            ),
             port=merged["port"],
         ))
 
@@ -283,6 +328,35 @@ def run(cmd: list[str], *, cwd: Path | None = None, capture: bool = False,
 def repo_root() -> Path:
     result = run(["git", "rev-parse", "--show-toplevel"], cwd=SCRIPT_DIR, capture=True)
     return Path(result.stdout.strip())
+
+
+def watchdog_deployment_suppression_script(node: Node) -> str:
+    """Render the node-local alert suppression marker for a planned restart."""
+    marker_arg = shlex.quote(node.watchdog_deployment_suppression_file)
+    return f"""
+WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE={marker_arg}
+WATCHDOG_DEPLOYMENT_SUPPRESSION_SECONDS={node.watchdog_max_deployment_suppression}
+WATCHDOG_DEPLOYMENT_SUPPRESSION_NOW=$(date +%s)
+WATCHDOG_DEPLOYMENT_SUPPRESSION_MAX_EPOCH={SHELL_SIGNED_INTEGER_MAX}
+if (( WATCHDOG_DEPLOYMENT_SUPPRESSION_SECONDS >
+      WATCHDOG_DEPLOYMENT_SUPPRESSION_MAX_EPOCH -
+      WATCHDOG_DEPLOYMENT_SUPPRESSION_NOW )); then
+    echo "watchdog suppression window exceeds shell arithmetic range" >&2
+    exit 1
+fi
+mkdir -p -m 755 "$(dirname "$WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE")"
+WATCHDOG_DEPLOYMENT_SUPPRESSION_UNTIL=$((
+    WATCHDOG_DEPLOYMENT_SUPPRESSION_NOW +
+    WATCHDOG_DEPLOYMENT_SUPPRESSION_SECONDS
+))
+WATCHDOG_DEPLOYMENT_SUPPRESSION_TMP=$(mktemp \
+    "${{WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE}}.tmp.XXXXXX")
+printf '%s\n' "$WATCHDOG_DEPLOYMENT_SUPPRESSION_UNTIL" \\
+    > "$WATCHDOG_DEPLOYMENT_SUPPRESSION_TMP"
+chmod 644 "$WATCHDOG_DEPLOYMENT_SUPPRESSION_TMP"
+mv -f "$WATCHDOG_DEPLOYMENT_SUPPRESSION_TMP" \\
+    "$WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE"
+"""
 
 
 # --------------------------------------------------------------------------- #
@@ -543,6 +617,10 @@ require_data_mount_for() {{
 require_data_mount_for "$STATE_DIR"
 require_data_mount_for "$(dirname "$LOG_FILE")"
 
+if [ "$NO_RESTART" != "1" ]; then
+{watchdog_suppression}
+fi
+
 mkdir -p "$(dirname "$BIN_PATH")" "$(dirname "$CONFIG_PATH")" "$(dirname "$LOG_FILE")"
 
 # Stage uploaded artifacts (uploaded to /tmp by the deploy step).
@@ -709,6 +787,10 @@ BIN_PATH={bin_path}
 SERVICE={service}
 NO_RESTART={no_restart}
 
+if [ "$NO_RESTART" != "1" ]; then
+{watchdog_suppression}
+fi
+
 mkdir -p "$(dirname "$BIN_PATH")"
 
 if [ -x "$BIN_PATH" ]; then
@@ -856,6 +938,7 @@ def cmd_deploy(args) -> int:
                         bin_path=shlex.quote(node.bin_path),
                         service=shlex.quote(node.service_name),
                         no_restart="1" if args.no_restart else "0",
+                        watchdog_suppression=watchdog_deployment_suppression_script(node),
                     )
                 proc = ssh_with_stdin(node, script)
                 if proc.returncode != 0:
@@ -887,6 +970,7 @@ def cmd_deploy(args) -> int:
                     log_file=shlex.quote(node.log_file),
                     state_dir=shlex.quote(node.state_cache_dir),
                     no_restart="1" if args.no_restart else "0",
+                    watchdog_suppression=watchdog_deployment_suppression_script(node),
                 )
             else:
                 script = PROCESS_INSTALL_SCRIPT.format(

--- a/deploy/deployer/nodes.example.toml
+++ b/deploy/deployer/nodes.example.toml
@@ -22,6 +22,10 @@ p2p_stack       = "dual"                     # legacy | zakura | dual | default
 # zakurad panics if either address is already bound, so check the port first.
 # metrics_endpoint   = "127.0.0.1:9999"     # Prometheus /metrics
 # health_listen_addr = "127.0.0.1:8080"     # /healthy and /ready
+# Match any overrides in /etc/zakura-watchdog/env so planned systemd restarts
+# write the marker where the watchdog reads it and within its accepted window.
+# watchdog_deployment_suppression_file = "/run/zakura-watchdog/deployment-suppressed-until"
+# watchdog_max_deployment_suppression = 1200
 # port          = 22                        # optional non-default ssh port
 
 # Optional fleet-wide Zakura settings, rendered into [network.zakura] on every

--- a/deploy/deployer/test_deploy.py
+++ b/deploy/deployer/test_deploy.py
@@ -1,7 +1,9 @@
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
+import time
 import tomllib
 import unittest
 from pathlib import Path
@@ -118,6 +120,153 @@ class BuildCacheTests(unittest.TestCase):
             })
 
 
+class DeploymentSuppressionTests(unittest.TestCase):
+    def test_suppression_script_uses_node_watchdog_configuration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "watchdog" / "deployment-suppressed-until"
+            duration = 30
+            node = mock.Mock(
+                watchdog_deployment_suppression_file=str(marker),
+                watchdog_max_deployment_suppression=duration,
+            )
+            before = int(time.time())
+
+            subprocess.run(
+                ["bash", "-c", deploy.watchdog_deployment_suppression_script(node)],
+                check=True,
+            )
+
+            after = int(time.time())
+            suppression_until = int(marker.read_text().strip())
+            self.assertGreaterEqual(
+                suppression_until,
+                before + duration,
+            )
+            self.assertLessEqual(
+                suppression_until,
+                after + duration,
+            )
+            self.assertEqual(marker.stat().st_mode & 0o777, 0o644)
+
+    def test_suppression_script_preserves_existing_directory_permissions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker_dir = Path(tmp) / "private-watchdog"
+            marker_dir.mkdir(mode=0o700)
+            marker = marker_dir / "deployment-suppressed-until"
+            node = mock.Mock(
+                watchdog_deployment_suppression_file=str(marker),
+                watchdog_max_deployment_suppression=30,
+            )
+
+            subprocess.run(
+                ["bash", "-c", deploy.watchdog_deployment_suppression_script(node)],
+                check=True,
+            )
+
+            self.assertEqual(marker_dir.stat().st_mode & 0o777, 0o700)
+
+    def test_suppression_script_rejects_timestamp_overflow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "watchdog" / "deployment-suppressed-until"
+            node = mock.Mock(
+                watchdog_deployment_suppression_file=str(marker),
+                watchdog_max_deployment_suppression=deploy.SHELL_SIGNED_INTEGER_MAX,
+            )
+
+            result = subprocess.run(
+                ["bash", "-c", deploy.watchdog_deployment_suppression_script(node)],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("exceeds shell arithmetic range", result.stderr)
+            self.assertFalse(marker.exists())
+
+    def test_suppression_script_publishes_marker_atomically(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = Path(tmp) / "watchdog" / "deployment-suppressed-until"
+            marker.parent.mkdir()
+            marker.write_text("old\n")
+            node = mock.Mock(
+                watchdog_deployment_suppression_file=str(marker),
+                watchdog_max_deployment_suppression=30,
+            )
+            assert_old_marker_during_write = """
+set -e
+printf() {
+    [ "$(<\"$WATCHDOG_TEST_MARKER\")" = "old" ] || return 90
+    command printf "$@"
+}
+"""
+
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    assert_old_marker_during_write
+                    + deploy.watchdog_deployment_suppression_script(node),
+                ],
+                check=True,
+                env={**os.environ, "WATCHDOG_TEST_MARKER": str(marker)},
+            )
+
+            self.assertGreater(int(marker.read_text().strip()), int(time.time()))
+            self.assertEqual(list(marker.parent.glob(f"{marker.name}.tmp.*")), [])
+
+    def test_systemd_restarts_activate_suppression_before_replacing_artifacts(self):
+        marker_command = "ACTIVATE_WATCHDOG_SUPPRESSION"
+        scripts = {
+            "managed": (
+                deploy.INSTALL_SCRIPT.format(
+                    bin_path="/usr/local/bin/zakurad",
+                    config_path="/etc/zakura/zakura.toml",
+                    service="zakurad",
+                    log_file="/var/log/zakura/zakura.log",
+                    state_dir="/var/lib/zakura",
+                    no_restart="0",
+                    watchdog_suppression=marker_command,
+                ),
+                "install -m 644 /tmp/zakurad-deploy.service",
+            ),
+            "binary-only": (
+                deploy.BINARY_ONLY_INSTALL_SCRIPT.format(
+                    bin_path="/usr/local/bin/zakurad",
+                    service="zakurad",
+                    no_restart="0",
+                    watchdog_suppression=marker_command,
+                ),
+                "install -m 755 /tmp/zakurad-deploy.new",
+            ),
+        }
+
+        for name, (script, first_artifact_install) in scripts.items():
+            with self.subTest(name=name):
+                subprocess.run(["bash", "-n"], input=script, text=True, check=True)
+                restart_guard = script.index('if [ "$NO_RESTART" != "1" ]')
+                suppression = script.index(marker_command)
+                restart_guard_end = script.index("\nfi", suppression)
+                artifact_install = script.index(first_artifact_install)
+                self.assertLess(restart_guard, suppression)
+                self.assertLess(suppression, restart_guard_end)
+                self.assertLess(restart_guard_end, artifact_install)
+
+    def test_mainnet_workflow_bounds_suppression_ssh_sessions(self):
+        workflow = (
+            SCRIPT_DIR.parent.parent
+            / ".github/workflows/zakura-mainnet-deploy.yml"
+        ).read_text()
+        suppression_step = workflow.split(
+            "      - name: Suppress node watchdog alerts during deploy\n", 1
+        )[1].split("      - name: Deploy fleet\n", 1)[0]
+
+        self.assertIn(
+            "timeout --signal=TERM --kill-after=5s 60s \\", suppression_step
+        )
+        self.assertIn("-o ServerAliveInterval=10 \\", suppression_step)
+        self.assertIn("-o ServerAliveCountMax=3 \\", suppression_step)
+
+
 class NodeBuilder:
     """Shared minimal node fixture for the rendering tests."""
 
@@ -151,6 +300,12 @@ class NodeBuilder:
             "start_command": "",
             "process_pattern": "",
             "container_name": "",
+            "watchdog_deployment_suppression_file": str(
+                deploy.WATCHDOG_DEPLOYMENT_SUPPRESSION_FILE
+            ),
+            "watchdog_max_deployment_suppression": (
+                deploy.WATCHDOG_MAX_DEPLOYMENT_SUPPRESSION
+            ),
         }
         data.update(overrides)
         return deploy.Node(**data)
@@ -221,6 +376,44 @@ class ConfigKeyTests(unittest.TestCase):
             nodes = deploy.load_nodes(path, None)
 
             self.assertEqual(nodes[0].health_listen_addr, "127.0.0.1:8080")
+
+    def test_watchdog_suppression_settings_are_per_node(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, """
+                [defaults]
+                watchdog_deployment_suppression_file = "/run/custom-watchdog/default"
+                watchdog_max_deployment_suppression = 45
+
+                [[nodes]]
+                name = "node-a"
+                ssh_string = "root@example"
+                commit = "main"
+                watchdog_deployment_suppression_file = "/run/custom-watchdog/node-a"
+                watchdog_max_deployment_suppression = 30
+            """.replace("                ", ""))
+
+            node = deploy.load_nodes(path, None)[0]
+
+            self.assertEqual(
+                node.watchdog_deployment_suppression_file,
+                "/run/custom-watchdog/node-a",
+            )
+            self.assertEqual(node.watchdog_max_deployment_suppression, 30)
+
+    def test_watchdog_suppression_file_must_be_absolute(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self.write_config(tmp, """
+                [defaults]
+                watchdog_deployment_suppression_file = "relative/marker"
+
+                [[nodes]]
+                name = "node-a"
+                ssh_string = "root@example"
+                commit = "main"
+            """.replace("                ", ""))
+
+            with self.assertRaisesRegex(deploy.DeployError, "must be an absolute path"):
+                deploy.load_nodes(path, None)
 
     def test_unknown_key_still_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/deploy/zakura-watchdog/src/reporting.rs
+++ b/deploy/zakura-watchdog/src/reporting.rs
@@ -60,6 +60,11 @@ impl Reporter {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn last_status_for_test(&self, check_name: &'static str) -> Option<CheckStatus> {
+        self.last_status.get(check_name).copied()
+    }
+
     /// Logs the outcome of one check cycle and captures a Sentry event when
     /// the check transitioned between passing and failing.
     ///

--- a/deploy/zakura-watchdog/src/runner.rs
+++ b/deploy/zakura-watchdog/src/runner.rs
@@ -17,13 +17,16 @@ use crate::{
 fn run_cycle(
     checks: &[Box<dyn Check>],
     reporter: &mut Reporter,
-    suppression: Option<&AlertSuppression>,
+    suppression_config: Option<&Config>,
 ) -> bool {
     let mut all_passed = true;
 
     for check in checks {
         let outcome = check.run_once();
-        reporter.report(check.name(), &outcome, suppression);
+        // Re-read after the check so a marker written while an RPC was in
+        // flight still suppresses the resulting deployment failure.
+        let suppression = suppression_config.and_then(deployment_alert_suppression);
+        reporter.report(check.name(), &outcome, suppression.as_ref());
 
         if outcome.status == CheckStatus::Fail {
             all_passed = false;
@@ -80,8 +83,7 @@ pub fn run_forever(config: &Config, checks: &[Box<dyn Check>], reporter: &mut Re
     );
 
     loop {
-        let suppression = deployment_alert_suppression(config);
-        run_cycle(checks, reporter, suppression.as_ref());
+        run_cycle(checks, reporter, Some(config));
         thread::sleep(Duration::from_secs(config.watchdog_interval));
     }
 }
@@ -147,6 +149,22 @@ mod tests {
             } else {
                 CheckOutcome::pass("scripted pass", BTreeMap::new())
             }
+        }
+    }
+
+    struct MarkerWritingCheck {
+        marker: PathBuf,
+    }
+
+    impl Check for MarkerWritingCheck {
+        fn name(&self) -> &'static str {
+            "marker_writing"
+        }
+
+        fn run_once(&self) -> CheckOutcome {
+            fs::write(&self.marker, (now_epoch_seconds() + 60).to_string())
+                .expect("test can write suppression marker");
+            CheckOutcome::fail("deployment restart", BTreeMap::new())
         }
     }
 
@@ -219,6 +237,22 @@ mod tests {
         let _ = fs::remove_file(&config.deployment_suppression_file);
 
         assert_eq!(deployment_alert_suppression(&config), None);
+    }
+
+    #[test]
+    fn marker_written_during_check_suppresses_its_failure() {
+        let mut config = test_config(5, 1);
+        config.deployment_suppression_file = test_suppression_path("in-flight");
+        let _ = fs::remove_file(&config.deployment_suppression_file);
+        let checks: Vec<Box<dyn Check>> = vec![Box::new(MarkerWritingCheck {
+            marker: config.deployment_suppression_file.clone(),
+        })];
+        let mut reporter = Reporter::new(false);
+
+        assert!(!run_cycle(&checks, &mut reporter, Some(&config)));
+        assert_eq!(reporter.last_status_for_test("marker_writing"), None);
+
+        let _ = fs::remove_file(&config.deployment_suppression_file);
     }
 
     #[test]

--- a/docs/changelog/unreleased/832.md
+++ b/docs/changelog/unreleased/832.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Suppressed planned restart alerts when a watchdog check was already in
+  progress as deployment began
+  ([#832](https://github.com/zakura-core/zakura/pull/832)).


### PR DESCRIPTION
## Motivation

Planned mainnet restarts refreshed only the central fleet-watchdog marker. The node-local Zakura watchdog therefore emitted Sentry failure and recovery transitions while the compatibility node restarted cleanly.

## Solution

Systemd deploys now publish a bounded node-local suppression marker atomically before replacing artifacts or restarting services. The path and window are configurable per node, unsafe paths and timestamp overflow are rejected, existing directory permissions are preserved, and the watchdog re-checks suppression after each health check. The mainnet workflow also publishes the marker before rollback deploys whose selected revision may predate this deployer behavior, with each SSH session bounded so the fleet marker window cannot be consumed by a stalled host.

## Testing

All 20 deployer tests and 19 watchdog tests pass. Targeted Clippy with warnings denied, Rust formatting, Python compilation, workflow YAML and shell validation, ShellCheck, diff checks, and changelog validation also pass.

## Changelog

Added the required operator-visible fragment for the watchdog behavior change.
