### PR TITLE
fix(zcashd-compat): allow non-Unix executable no-op

### DIFF
--- a/crates/zakurad/src/components/zcashd_compat/managed.rs
+++ b/crates/zakurad/src/components/zcashd_compat/managed.rs
@@ -354,14 +354,14 @@ fn sha256_hex_file(path: &Path) -> Result<String, Report> {
 /// Makes `path` executable on Unix targets.
 ///
 /// Non-Unix targets currently no-op because managed release targets are Linux.
-fn make_executable(path: &Path) -> Result<(), Report> {
+fn make_executable(_path: &Path) -> Result<(), Report> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
 
-        let mut permissions = fs::metadata(path)?.permissions();
+        let mut permissions = fs::metadata(_path)?.permissions();
         permissions.set_mode(0o755);
-        fs::set_permissions(path, permissions)?;
+        fs::set_permissions(_path, permissions)?;
     }
 
     Ok(())

--- a/docs/changelog/unreleased/834.md
+++ b/docs/changelog/unreleased/834.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only fixes the Windows workspace build and does not change runtime behavior.


### PR DESCRIPTION
## Motivation

The post-merge Windows workspace check fails because make_executable excludes its Unix-only body and leaves path unused. The workspace denies warnings.

## Solution

Prefix the parameter with an underscore and use that binding in the Unix block. Rust then accepts the intentional non-Unix no-op while Unix behavior stays unchanged.

## Testing

- cargo fmt --all -- --check
- cargo check --locked -p zakura --lib --all-features
- ./scripts/changelog.py check
- git diff --check

The cross-platform workflow will verify the Windows target on this branch.

## Changelog

- docs/changelog/unreleased/834.md records this internal-only build fix.

### Specifications & References

- Windows failure: https://github.com/zakura-core/zakura/actions/runs/33107995430/job/98642947646