### PR TITLE
chore(release): consume the pending #835 changelog fragment for v1.3.0-rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ independently.
 - Fixed native sync stalls caused by header retention evicting a full-state fork. The node now
   completes affected descendant operations and exits if legacy fallback waits 30 minutes for
   native applies to drain ([#831](https://github.com/zakura-core/zakura/pull/831)).
+- Suppressed node-local watchdog alerts during planned `zakura-compat` restarts
+  ([#835](https://github.com/zakura-core/zakura/pull/835)).
 
 ## [1.3.0-rc3] - 2026-08-27
 

--- a/docs/changelog/unreleased/835.md
+++ b/docs/changelog/unreleased/835.md
@@ -1,4 +1,0 @@
-## Fixed
-
-- Suppressed node-local watchdog alerts during planned `zakura-compat` restarts
-  ([#835](https://github.com/zakura-core/zakura/pull/835)).


### PR DESCRIPTION
## Motivation

The `Create release` run for v1.3.0-rc4 ([run 33190503162](https://github.com/zakura-core/zakura/actions/runs/33190503162)) failed at the `Validate release` changelog gate:

> release 1.3.0-rc4 already exists but Unreleased entries remain; bump the release version first

Root cause: PR #835 merged just before release PR #837, after #837's changelog had been assembled, so its `docs/changelog/unreleased/835.md` fragment was never consumed. Merged `main` has a `1.3.0-rc4` changelog section plus a pending fragment, which `make pre-release` rejects.

## Solution

Fold the #835 `Fixed` entry into the existing `1.3.0-rc4` section (in PR-number order, matching what the assembler would have produced) and delete the consumed fragment. The v1.3.0-rc4 tag was never created — the run failed before tag/asset creation — so no published changelog is being rewritten, and the release can be re-dispatched for the same tag. Same approach as #828, which consumed the pending #826 fragment for v1.3.0-rc3.

`make prepare-release-changelog` cannot generate this merge itself: `changelog.py` intentionally refuses to amend an existing release section when non-empty entries remain, so the fold is done by hand.

## Testing

- `./scripts/changelog.py check` — validated 0 fragments
- `./scripts/changelog.py release v1.3.0-rc4 --check` / `make pre-release-changelog RELEASE_TAG=v1.3.0-rc4` — the exact gate that failed in CI now passes
- `./scripts/check-release-version.sh v1.3.0-rc4` and `./scripts/check-release-requirements.sh v1.3.0-rc4` — pass
- `python3 -m unittest scripts.tests.test_changelog` — 22 tests OK
- `markdownlint --config .github/.markdownlint.yaml CHANGELOG.md` — clean

## Changelog

Markdown-only change (no Rust or Cargo.toml files touched), so no new fragment is required; the shared changelog edit is release preparation, not an ordinary-PR changelog edit.

### Specifications & References

- Failed run: https://github.com/zakura-core/zakura/actions/runs/33190503162
- Precedent: #828

### Follow-up Work

Re-dispatch `create-release.yml` for `v1.3.0-rc4` from `main` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)