### PR TITLE
build(deps): bump Zakura Common crates to 1.0.1 and replace yanked chacha20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ independently.
   protocol or user configuration
   ([#707](https://github.com/zakura-core/zakura/pull/707)).
 - Changed the published dependency graph to use the coordinated Zakura
-  cryptography forks, so crate consumers resolve the Zakura implementations
+  Common forks, so crate consumers resolve the Zakura implementations
   instead of their upstream equivalents
   ([#749](https://github.com/zakura-core/zakura/pull/749)).
 - The Mainnet release-state bundle now carries the historical frontier grid alongside the
@@ -164,14 +164,15 @@ independently.
 - A commitment-root repair that no connected peer can supply now reports why each peer was
   excluded and escalates after 60 seconds
   ([#821](https://github.com/zakura-core/zakura/pull/821)).
-- Updated the `zakura-core/libraries` crates to their final `1.0.0` release,
+- Updated the `zakura-core/common` crates to their final `1.0.0` release,
   picking up Orchard/halo2 proving and verification performance improvements
   ([#824](https://github.com/zakura-core/zakura/pull/824),
   [#839](https://github.com/zakura-core/zakura/pull/839),
   [#842](https://github.com/zakura-core/zakura/pull/842)).
 - Sped up Orchard note commitment tree updates during sync by about 2x by
-  evaluating `MerkleCRH^Orchard` with the libraries' new weighted fixed-length
-  Sinsemilla evaluator, for a one-time 3.75 MiB in-memory table
+  evaluating `MerkleCRH^Orchard` with the Zakura Common libraries' new
+  weighted fixed-length Sinsemilla evaluator, for a one-time 3.75 MiB
+  in-memory table
   ([#824](https://github.com/zakura-core/zakura/pull/824)).
 - Shortened this release's end-of-support window from 40 to 31 days, so
   Mainnet `zakurad` nodes running it halt at block 3,501,339, estimated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,9 +7696,9 @@ checksum = "1518d74211e0ae2422cab4560acdc67f72ae8fcdb871294eb03476a5a4586a74"
 
 [[package]]
 name = "zakura-bellman"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57a0ef43d09d41602ee6f313f371b7a4b779eae067aa6d2fcb9218be2eede37"
+checksum = "82c72c84165959b2578cbf8800ff491e74d819397b53658bbf1b2b170b3ee9fc"
 dependencies = [
  "bitvec",
  "blake2s_simd",
@@ -7713,9 +7713,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-bls12-381"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70821a2d2c88a38585d239651d620e78092e404cdfcc9c75a13118239481da"
+checksum = "2d9c833a85b5ba3303a5f14ed760d613bee8a9769923da5a1e7f51851849e7f5"
 dependencies = [
  "ff",
  "group",
@@ -7844,9 +7844,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-gadgets"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2743e20797b1d79d353371cebc78a06573186af0f0eb17c20211fa3e97c122d"
+checksum = "c601160505e513507664516f16a38b8e875a31b48155a93964b6e97c1e07d315"
 dependencies = [
  "arrayvec",
  "ff",
@@ -7860,15 +7860,15 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-legacy-pdqsort"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3324d3eaae64e48717cf18df2f84461385025ad0e05bc77ecf12d9150d07571d"
+checksum = "f7e2ecc4b9f643499164caceb5fe3339d1cdd9088dac084dd14314d6f6a75b0e"
 
 [[package]]
 name = "zakura-halo2-poseidon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f196e3c9b62f963d8bc39901f711f3b76230404613c2fba9d051897d62a9e3"
+checksum = "531ec02070913e40067ae2df9aab21139a55b239f289140d116af5d5e25e5240"
 dependencies = [
  "bitvec",
  "ff",
@@ -7878,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-proofs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1386cce49a4d9e4a1b1e32fbbb3ba34d23e53dcefd700ee976d736d72f302a"
+checksum = "2c39132f1dae675ef4105321da11dee1d70c2b07bbc7d78a31c4044ed381fd74"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7922,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-jubjub"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494ad340524224ea1e4b8e9f242825cf2a4e1e4421e6ef39af65a562347c2e15"
+checksum = "4b10077e35b311a780366567771c4730245a4df7bd23b1f3414444b0e5c3a9cd"
 dependencies = [
  "bitvec",
  "ff",
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-keys"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9821f05289f696c0a6ae8586facd324da5b0297ff6705a16d6f50ddcfd8de73f"
+checksum = "ac02340ce2b8eecc13047a936efe6545cc6de3761e2eda11eb5ab30cde8a6bed"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -8021,9 +8021,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-orchard"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5ef84c9e8dfa576e80f7be5aff3449741b57900d78fcbf4f536b42ce909fd6"
+checksum = "79f40234883ea702da695f1cbf470a0ba3b9fe0ac51d24af588a058afc383d68"
 dependencies = [
  "aes",
  "bitvec",
@@ -8057,18 +8057,18 @@ dependencies = [
 
 [[package]]
 name = "zakura-pairing"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4070556df188aa068ff09235a43c367cb171de10f74902923da8c84ce0aaeb"
+checksum = "93d3f4e77bb286c0f1770c90e721edcd99bd493acce6199734fa1eaeb4037f12"
 dependencies = [
  "group",
 ]
 
 [[package]]
 name = "zakura-pasta-curves"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b11ea111779520b119485fdb0fd69c3ec96b6eaab0e1bfbfb3f9cb67c55815a"
+checksum = "6c906d3541e9e6b71aaa77af25c229a0c1ed38df58930fa75f2fd569632989dd"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -8083,9 +8083,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-primitives"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5c71f57ec127e0429928795354ec3971fc58151603657a4a6f1ffd9f4e0d67"
+checksum = "268f6d451f4870f763b5ba51e5f84fd2843d86b103cc01b8fbf9cae84115c36c"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8114,9 +8114,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-proofs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83174f4acaf7e5eebd3438628a92f0c59e24f856de37ea4a18b2cfbb3ac5c9fb"
+checksum = "fce73755c38fa3d0de97d420d547855b0111083b0f1270ab7d4e53896cb16a7c"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8134,9 +8134,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-reddsa"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6341ee8bb195dbfb00be64d2e8121d7cc8e7ae14878b4b6724c674b3abb95d7"
+checksum = "8ecd8e46ef79bd3675733cee6741c432ccd259b9e060e4838d2cc311a654744f"
 dependencies = [
  "blake2b_simd",
  "frost-rerandomized",
@@ -8152,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-redjubjub"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de3e8fc50ba4a6e608c71ae636a120b9e6427e3151252ab855e526040146893"
+checksum = "37aa0ca5f5747caad4527ee92ad538271e7124949bc799cdc30b09c631b447fe"
 dependencies = [
  "rand_core 0.10.1",
  "serde",
@@ -8233,9 +8233,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sapling-crypto"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a0158acd9219ba07630d53cf2463b73d222f55a270fadc5b3ccf2ec2a1b277"
+checksum = "6fcd5a8073598e33ffaa2694ca59d7c522a60dd349a3d74d239e6eb929733107"
 dependencies = [
  "aes",
  "bitvec",
@@ -8285,9 +8285,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sinsemilla"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef987ae2e927d3e53711e93b44c3030df0f430ff44865a06195573eaca5d10a"
+checksum = "043da1b236d2b976b2046112811dc1be3f734c566a6edb1a0a52b5379231e212"
 dependencies = [
  "group",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -4743,7 +4743,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,26 +49,26 @@ edition = "2021"
 # gate refers to `zakura-assets` and nothing else.
 zakura-assets = { version = "=0.3462171.0" }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = { version = "1.0.0", package = "zakura-orchard" }
-sapling-crypto = { version = "1.0.0", package = "zakura-sapling-crypto" }
+orchard = { version = "1.0.1", package = "zakura-orchard" }
+sapling-crypto = { version = "1.0.1", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
 zcash_history = "0.5.0"
-zcash_keys = { version = "1.0.0", package = "zakura-keys" }
-zcash_primitives = { version = "1.0.0", package = "zakura-primitives" }
-zcash_proofs = { version = "1.0.0", package = "zakura-proofs" }
+zcash_keys = { version = "1.0.1", package = "zakura-keys" }
+zcash_primitives = { version = "1.0.1", package = "zakura-primitives" }
+zcash_proofs = { version = "1.0.1", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
 abscissa_core = { version = "0.7", default-features = false }
 base64 = "0.22.1"
 bech32 = "0.11.0"
-bellman = { version = "1.0.0", package = "zakura-bellman" }
+bellman = { version = "1.0.1", package = "zakura-bellman" }
 bincode = "1.3"
 bitflags = "2.9"
 bitflags-serde-legacy = "0.1.1"
 bitvec = "1.0"
 blake2b_simd = "1.0"
 blake2s_simd = "1.0"
-bls12_381 = { version = "1.0.0", package = "zakura-bls12-381" }
+bls12_381 = { version = "1.0.1", package = "zakura-bls12-381" }
 bs58 = "0.5"
 byteorder = "1.5"
 bytes = "1.10"
@@ -87,7 +87,7 @@ futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 group = "0.14"
-halo2 = { version = "1.0.0", package = "zakura-halo2-proofs" }
+halo2 = { version = "1.0.1", package = "zakura-halo2-proofs" }
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -106,7 +106,7 @@ itertools = "0.14"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
-jubjub = { version = "1.0.0", package = "zakura-jubjub" }
+jubjub = { version = "1.0.1", package = "zakura-jubjub" }
 lazy_static = "1.4"
 libzcash_script = "0.1"
 log = "0.4.27"
@@ -129,8 +129,8 @@ rand_10 = { package = "rand", version = "0.10" }
 rand_chacha_10 = { package = "rand_chacha", version = "0.10" }
 rand_core_10 = { package = "rand_core", version = "0.10" }
 rayon = "1.10"
-reddsa = { version = "1.0.0", package = "zakura-reddsa" }
-redjubjub = { version = "1.0.0", package = "zakura-redjubjub" }
+reddsa = { version = "1.0.1", package = "zakura-reddsa" }
+redjubjub = { version = "1.0.1", package = "zakura-redjubjub" }
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false }
 ripemd = "0.1"
@@ -145,7 +145,7 @@ serde_json = "1.0.140"
 serde_with = "3.12"
 sha2 = "0.10"
 schemars = "1"
-sinsemilla = { version = "1.0.0", package = "zakura-sinsemilla" }
+sinsemilla = { version = "1.0.1", package = "zakura-sinsemilla" }
 spandoc = "0.2"
 anyhow = "1.0"
 strum = "0.27"

--- a/deny.toml
+++ b/deny.toml
@@ -89,7 +89,7 @@ deny = [
 #
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    # Zakura's cryptography forks use Rand 0.10, while the remaining ecosystem
+    # The Zakura Common libraries use Rand 0.10, while the remaining ecosystem
     # still resolves Rand 0.9. Remove these when the workspace converges.
     { name = "chacha20", version = "=0.9.1" },
     { name = "rand", version = "=0.9.4" },

--- a/docs/changelog/unreleased/844.md
+++ b/docs/changelog/unreleased/844.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Updated the Zakura Common (`zakura-core/common`) crates from `1.0.0` to
+  `1.0.1`
+  ([#844](https://github.com/zakura-core/zakura/pull/844)).

--- a/docs/changelog/unreleased/844.md
+++ b/docs/changelog/unreleased/844.md
@@ -3,3 +3,10 @@
 - Updated the Zakura Common (`zakura-core/common`) crates from `1.0.0` to
   `1.0.1`
   ([#844](https://github.com/zakura-core/zakura/pull/844)).
+
+## Security
+
+- Replaced the yanked transitive `chacha20 0.10.1` dependency with `0.10.2`,
+  whose SSE2 backend no longer emits an SSE4.1 instruction that crashes
+  `zakurad` on x86 CPUs without SSE4.1 support
+  ([#844](https://github.com/zakura-core/zakura/pull/844)).

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -392,87 +392,87 @@ version = "0.52.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zakura-bellman]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-bls12-381]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-gadgets]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-legacy-pdqsort]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-poseidon]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-proofs]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-jubjub]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-keys]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-orchard]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pairing]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pasta-curves]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-primitives]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-proofs]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-reddsa]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-redjubjub]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sapling-crypto]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sinsemilla]]
-version = "1.0.0"
+version = "1.0.1"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -73,7 +73,7 @@ audit-as-crates-io = false
 [[exemptions.addchain]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
-notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+notes = "Introduced by the Zakura Common fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.addr2line]]
 version = "0.21.0"
@@ -130,12 +130,12 @@ notes = "Audit deferred: the safe single-sink wrappers preserve the documented e
 [[exemptions.ff]]
 version = "0.14.0"
 criteria = "safe-to-deploy"
-notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+notes = "Introduced by the Zakura Common fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.ff_derive]]
 version = "0.14.0"
 criteria = "safe-to-deploy"
-notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+notes = "Introduced by the Zakura Common fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.fixedbitset]]
 version = "0.5.7"
@@ -151,7 +151,7 @@ notes = "Audit hold: recursive directory enumeration follows directory symlinks,
 [[exemptions.group]]
 version = "0.14.0"
 criteria = "safe-to-deploy"
-notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+notes = "Introduced by the Zakura Common fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.h2]]
 version = "0.4.16"
@@ -269,7 +269,7 @@ notes = "Audit hold: the UEFI protocol tables expose firmware operations that ac
 [[exemptions.rand_chacha]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
-notes = "Introduced by the Zakura cryptography fork migration; retain this exact-version exemption pending dedicated review."
+notes = "Introduced by the Zakura Common fork migration; retain this exact-version exemption pending dedicated review."
 
 [[exemptions.redox_users]]
 version = "0.4.5"

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -95,9 +95,9 @@ criteria = "safe-to-deploy"
 notes = "Audit held: safe set_file_name and set_extension methods mutate the wrapped path without re-canonicalizing it, breaking the advertised canonical-path invariant; is_dir also delegates to is_file. A version-wide safe-to-deploy certification is deferred pending an upstream fix."
 
 [[exemptions.chacha20]]
-version = "0.10.1"
+version = "0.10.2"
 criteria = "safe-to-deploy"
-notes = "Audit hold: the public RNG get_block_pos method subtracts the four-block buffer width without wrapping. After set_block_pos(u64::MAX) followed by one generated word, the internal counter wraps to 3 and get_block_pos panics on 3 - 4 in debug builds. Reproduced with ChaCha20Rng; retain the exemption pending wrapping arithmetic or an upstream fix."
+notes = "Audit hold: the public RNG get_block_pos method subtracts the four-block buffer width without wrapping. After set_block_pos(u64::MAX) followed by one generated word, the internal counter wraps to 3 and get_block_pos panics on 3 - 4 in debug builds. Reproduced with ChaCha20Rng; retain the exemption pending wrapping arithmetic or an upstream fix. 0.10.2 replaces the yanked 0.10.1 (its SSE2 backend emitted an SSE4.1 instruction, crashing x86 CPUs without SSE4.1) and does not resolve this hold."
 
 [[exemptions.console]]
 version = "0.15.11"


### PR DESCRIPTION
## Motivation

Three related maintenance items:

- The Zakura Common libraries (`zakura-core/common`, formerly
  `zakura-core/libraries`) published their `1.0.1` release.
- Our lockfile carried `chacha20 0.10.1`, which upstream yanked on 2026-08-27:
  its SSE2 backend emitted an SSE4.1 instruction, crashing x86 CPUs without
  SSE4.1 support. The yank fails `cargo deny check advisories` (`yanked = "deny"`).
- A handful of comments and changelog entries still used the retired
  "Zakura cryptography forks" / `zakura-core/libraries` naming.

## Solution

One commit per item:

1. **Bump the Zakura Common crates from 1.0.0 to 1.0.1** — the 12 direct
   `zakura-*` workspace dependencies in `Cargo.toml`, all 17 locked `zakura-*`
   crates (12 direct + 5 transitive), and the 17 matching exact-version
   cargo-vet exemptions in `qa/supply-chain/config.toml`.
2. **Replace yanked `chacha20 0.10.1` with `0.10.2`** — the crate is purely
   transitive via `rand` 0.10, so only `Cargo.lock` moves. The cargo-vet
   exemption follows the version; its pre-existing `get_block_pos` audit-hold
   note is retained since 0.10.2 only fixes the yank reason. `cargo deny`
   confirms this was the only yanked or advisory-flagged crate not already
   deliberately ignored in `deny.toml`.
3. **Adopt the Zakura Common naming** in the remaining prose: the `deny.toml`
   rand-duplicate skip comment, five cargo-vet exemption notes, and the 1.3.0
   `CHANGELOG.md` entries that named the old repository and suite. A repo-wide
   sweep finds no other old-name references. This commit edits released
   changelog prose (naming only, no entry changes) and is isolated so it can be
   dropped if preferred.

## Testing

- `cargo deny check`: advisories, bans, licenses, and sources all pass (the
  chacha20 yank failure is cleared).
- `cargo vet check --store-path ./qa/supply-chain/`: Vetting Succeeded
  (676 fully audited, 16 partially audited, 66 exempted).
- `cargo check -p zakura-chain -p zakura-consensus -p zakura-rpc --locked`
  compiles cleanly against the 1.0.1 crates.
- `./scripts/changelog.py check` validates the fragment.
- `markdownlint` (CI config) passes on the changed Markdown files.
- Full workspace build/tests are left to draft CI.

## Changelog

`docs/changelog/unreleased/844.md` with a `Changed` entry for the Zakura
Common bump and a `Security` entry for the chacha20 replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)