### PR TITLE
fix(header-chain): preserve auxiliary capacity and diversity

### DIFF
--- a/crates/xtask/src/header_conformance.rs
+++ b/crates/xtask/src/header_conformance.rs
@@ -10,7 +10,7 @@ use std::{
 use serde::Deserialize;
 
 const SUPPORTED_SPEC_VERSION: &str = "1.4";
-const EXPECTED_RULE_COUNT: usize = 116;
+const EXPECTED_RULE_COUNT: usize = 117;
 const SPEC_PATH: &str = "docs/specs/fork-aware-header-chain-engine.md";
 const MANIFEST_PATH: &str = "crates/zakura-header-chain/conformance.toml";
 const MAX_DOCUMENT_BYTES: u64 = 2 * 1024 * 1024;

--- a/crates/zakura-header-chain/conformance.toml
+++ b/crates/zakura-header-chain/conformance.toml
@@ -730,6 +730,14 @@ tests = ["IN-06::vct_boundary_failure_attribution_never_weakens_authenticated_ev
 networks = ["mainnet", "testnet", "custom"]
 
 [[rule]]
+id = "LC-AUX-06"
+name = "Semantic auxiliary capacity"
+status = "implemented"
+owner = "zakura_header_chain::HeaderChainEngine::plan_transition"
+tests = ["IN-06::auxiliary_admission_preserves_semantic_diversity_under_duplicate_delivery_pressure", "DG-06::projected_auxiliary_rows_cannot_duplicate_a_semantic_payload", "DG-06::projected_per_header_auxiliary_count_must_stay_within_the_plan_limit"]
+networks = ["mainnet", "testnet", "custom"]
+
+[[rule]]
 id = "LC-WIRE-01"
 name = "Bounded decoding"
 status = "implemented"

--- a/crates/zakura-header-chain/src/config.rs
+++ b/crates/zakura-header-chain/src/config.rs
@@ -42,8 +42,8 @@ pub const MAX_NON_FINALIZED_NODES_V1: usize = 65_536;
 pub const MAX_STAGED_TARGETS_V1: usize = 16;
 /// Exact v1 maximum prepared headers admitted by one transition.
 pub const MAX_HEADERS_PER_TRANSITION_V1: usize = 4_000;
-/// Exact v1 maximum auxiliary deliveries retained for one header.
-pub const MAX_AUX_DELIVERIES_PER_HEADER_V1: usize = 16;
+/// Exact v1 maximum distinct auxiliary payloads retained for one header.
+pub const MAX_AUX_DELIVERIES_PER_HEADER_V1: usize = 32;
 /// Exact v1 maximum auxiliary deliveries retained across the graph.
 pub const MAX_AUX_DELIVERIES_TOTAL_V1: usize = MAX_NON_FINALIZED_NODES_V1;
 /// Full-state fork policy plus one independent selected header tip set the candidate-tip cap.
@@ -456,7 +456,7 @@ pub struct EngineLimits {
     pub max_non_finalized_nodes: NonZeroUsize,
     /// Maximum prepared headers accepted before any batch-proportional work.
     pub max_headers_per_transition: NonZeroUsize,
-    /// Maximum fixed-size auxiliary records retained for one header.
+    /// Maximum distinct auxiliary payloads retained for one header.
     pub max_aux_deliveries_per_header: NonZeroUsize,
     /// Maximum fixed-size auxiliary records retained across the graph.
     pub max_aux_deliveries_total: NonZeroUsize,
@@ -497,7 +497,7 @@ const _: () = assert!(MAX_CANDIDATE_TIPS_V1 == 11);
 const _: () = assert!(MAX_NON_FINALIZED_NODES_V1 == 65_536);
 const _: () = assert!(MAX_STAGED_TARGETS_V1 == 16);
 const _: () = assert!(MAX_HEADERS_PER_TRANSITION_V1 == 4_000);
-const _: () = assert!(MAX_AUX_DELIVERIES_PER_HEADER_V1 == 16);
+const _: () = assert!(MAX_AUX_DELIVERIES_PER_HEADER_V1 == 32);
 const _: () = assert!(MAX_AUX_DELIVERIES_TOTAL_V1 == 65_536);
 const _: () = assert!(MAX_RETENTION_REFERENCES_V1 == 27);
 
@@ -519,6 +519,8 @@ mod tests {
         assert_eq!(limits.local_finality_depth.get(), 1_000);
         assert_eq!(limits.max_candidate_tips.get(), 11);
         assert_eq!(limits.max_non_finalized_nodes.get(), 65_536);
+        assert_eq!(limits.max_aux_deliveries_per_header.get(), 32);
+        assert_eq!(limits.max_aux_deliveries_total.get(), 65_536);
         assert_eq!(
             limits.max_retention_references.get(),
             MAX_STAGED_TARGETS_V1 + limits.max_candidate_tips.get(),

--- a/crates/zakura-header-chain/src/transition/invariants/checks/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/invariants/checks/auxiliary.rs
@@ -118,6 +118,22 @@ pub(crate) fn verify_aux<G: HeaderGraphView>(
                 return Err(InvariantViolation::Auxiliary(node.hash));
             }
         }
+        for delivery in puts.values().filter(|delivery| {
+            delivery.header_hash == node.hash
+                && engine_before_commit
+                    .aux_delivery(delivery.delivery_id)
+                    .is_none()
+        }) {
+            if deliveries.iter().any(|other| {
+                other.delivery_id != delivery.delivery_id
+                    && (other.semantic_fingerprint() == delivery.semantic_fingerprint()
+                        || (delivery.tree_aux.is_some()
+                            && other.tree_aux.is_some()
+                            && other.source == delivery.source))
+            }) {
+                return Err(InvariantViolation::Auxiliary(node.hash));
+            }
+        }
         if node.aux_delivery_ids.iter().any(|delivery_id| {
             !deliveries
                 .iter()
@@ -263,6 +279,81 @@ mod tests {
             [
                 Err(InvariantViolation::Limits),
                 Err(InvariantViolation::Limits),
+            ]
+        );
+    }
+
+    #[test]
+    fn projected_auxiliary_rows_cannot_duplicate_a_semantic_payload() {
+        let fixture = fixture(EngineMode::HeadersOnly);
+        let ids = [
+            EvidenceId::from_digest([0x77; 32]),
+            EvidenceId::from_digest([0x78; 32]),
+        ];
+        let mut overlay = GraphOverlay::new(fixture.engine.graph());
+        for id in ids {
+            overlay
+                .record_auxiliary_evidence_delivery(fixture.child.hash, id)
+                .expect("the fixture child accepts the delivery identity");
+        }
+        let mut plan = candidate_with_delta(&fixture.engine, overlay.delta());
+        plan.change_set.aux_changes = ids
+            .into_iter()
+            .map(|id| AuxDelta::Put(Box::new(delivery(&fixture.engine, fixture.child.hash, id))))
+            .collect();
+        plan.limits.max_aux_deliveries_per_header = NonZeroUsize::new(2).expect("two is nonzero");
+        plan.limits.max_aux_deliveries_total = NonZeroUsize::new(2).expect("two is nonzero");
+
+        assert_eq!(
+            verify_in_both_modes(&fixture, &plan),
+            [
+                Err(InvariantViolation::Auxiliary(fixture.child.hash)),
+                Err(InvariantViolation::Auxiliary(fixture.child.hash)),
+            ]
+        );
+    }
+
+    #[test]
+    fn projected_auxiliary_rows_allow_one_rooted_payload_per_supplier() {
+        let fixture = fixture(EngineMode::HeadersOnly);
+        let ids = [
+            EvidenceId::from_digest([0x79; 32]),
+            EvidenceId::from_digest([0x7a; 32]),
+        ];
+        let mut overlay = GraphOverlay::new(fixture.engine.graph());
+        for id in ids {
+            overlay
+                .record_auxiliary_evidence_delivery(fixture.child.hash, id)
+                .expect("the fixture child accepts the delivery identity");
+        }
+        let mut deliveries = ids.map(|id| delivery(&fixture.engine, fixture.child.hash, id));
+        for (index, delivery) in deliveries.iter_mut().enumerate() {
+            delivery.tree_aux = Some(crate::TreeAuxRecordV1 {
+                height: fixture.child.height,
+                sapling_root: zakura_chain::sapling::tree::Root::default(),
+                orchard_root: zakura_chain::orchard::tree::Root::default(),
+                ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+                sapling_tx_count: 1,
+                orchard_tx_count: 2,
+                ironwood_tx_count: 3,
+                auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from(
+                    [u8::try_from(index).expect("the fixture index fits in u8"); 32],
+                ),
+            });
+        }
+        let mut plan = candidate_with_delta(&fixture.engine, overlay.delta());
+        plan.change_set.aux_changes = deliveries
+            .into_iter()
+            .map(|delivery| AuxDelta::Put(Box::new(delivery)))
+            .collect();
+        plan.limits.max_aux_deliveries_per_header = NonZeroUsize::new(2).expect("two is nonzero");
+        plan.limits.max_aux_deliveries_total = NonZeroUsize::new(2).expect("two is nonzero");
+
+        assert_eq!(
+            verify_in_both_modes(&fixture, &plan),
+            [
+                Err(InvariantViolation::Auxiliary(fixture.child.hash)),
+                Err(InvariantViolation::Auxiliary(fixture.child.hash)),
             ]
         );
     }

--- a/crates/zakura-header-chain/src/transition/invariants/checks/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/invariants/checks/auxiliary.rs
@@ -60,6 +60,17 @@ pub(crate) fn verify_aux<G: HeaderGraphView>(
             AuxDelta::Delete { .. } => None,
         })
         .collect();
+    let projected_aux_count = engine_before_commit
+        .aux_delivery_count()
+        .saturating_sub(deleted_ids.len())
+        .saturating_add(
+            puts.keys()
+                .filter(|delivery_id| engine_before_commit.aux_delivery(**delivery_id).is_none())
+                .count(),
+        );
+    if projected_aux_count > plan.limits.max_aux_deliveries_total.get() {
+        return Err(InvariantViolation::Limits);
+    }
     let mut nodes: Vec<&HeaderNode> = match mode {
         #[cfg(any(test, feature = "fuzz-impl"))]
         VerificationMode::Exhaustive => graph.view_header_nodes(),
@@ -88,6 +99,9 @@ pub(crate) fn verify_aux<G: HeaderGraphView>(
     };
     nodes.sort_unstable_by_key(|node| node.hash.0);
     for node in nodes {
+        if node.aux_delivery_ids.len() > plan.limits.max_aux_deliveries_per_header.get() {
+            return Err(InvariantViolation::Limits);
+        }
         let mut deliveries = engine_before_commit.aux_deliveries(node.hash).to_vec();
         deliveries.retain(|delivery| !deleted_ids.contains(&delivery.delivery_id));
         for delivery in puts
@@ -132,6 +146,8 @@ pub(crate) fn verify_aux<G: HeaderGraphView>(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::super::super::test_support::{
         candidate_with_delta, delivery, fixture, no_change_candidate, projected_graph,
     };
@@ -187,6 +203,66 @@ mod tests {
             [
                 Err(InvariantViolation::Auxiliary(fixture.child.hash)),
                 Err(InvariantViolation::Auxiliary(fixture.child.hash)),
+            ]
+        );
+    }
+
+    #[test]
+    fn projected_auxiliary_total_must_stay_within_the_plan_limit() {
+        let fixture = fixture(EngineMode::HeadersOnly);
+        let ids = [
+            EvidenceId::from_digest([0x73; 32]),
+            EvidenceId::from_digest([0x74; 32]),
+        ];
+        let mut overlay = GraphOverlay::new(fixture.engine.graph());
+        for id in ids {
+            overlay
+                .record_auxiliary_evidence_delivery(fixture.child.hash, id)
+                .expect("the fixture child accepts the delivery identity");
+        }
+        let mut plan = candidate_with_delta(&fixture.engine, overlay.delta());
+        plan.change_set.aux_changes = ids
+            .into_iter()
+            .map(|id| AuxDelta::Put(Box::new(delivery(&fixture.engine, fixture.child.hash, id))))
+            .collect();
+        plan.limits.max_aux_deliveries_per_header = NonZeroUsize::new(2).expect("two is nonzero");
+        plan.limits.max_aux_deliveries_total = NonZeroUsize::new(1).expect("one is nonzero");
+
+        assert_eq!(
+            verify_in_both_modes(&fixture, &plan),
+            [
+                Err(InvariantViolation::Limits),
+                Err(InvariantViolation::Limits),
+            ]
+        );
+    }
+
+    #[test]
+    fn projected_per_header_auxiliary_count_must_stay_within_the_plan_limit() {
+        let fixture = fixture(EngineMode::HeadersOnly);
+        let ids = [
+            EvidenceId::from_digest([0x75; 32]),
+            EvidenceId::from_digest([0x76; 32]),
+        ];
+        let mut overlay = GraphOverlay::new(fixture.engine.graph());
+        for id in ids {
+            overlay
+                .record_auxiliary_evidence_delivery(fixture.child.hash, id)
+                .expect("the fixture child accepts the delivery identity");
+        }
+        let mut plan = candidate_with_delta(&fixture.engine, overlay.delta());
+        plan.change_set.aux_changes = ids
+            .into_iter()
+            .map(|id| AuxDelta::Put(Box::new(delivery(&fixture.engine, fixture.child.hash, id))))
+            .collect();
+        plan.limits.max_aux_deliveries_per_header = NonZeroUsize::new(1).expect("one is nonzero");
+        plan.limits.max_aux_deliveries_total = NonZeroUsize::new(2).expect("two is nonzero");
+
+        assert_eq!(
+            verify_in_both_modes(&fixture, &plan),
+            [
+                Err(InvariantViolation::Limits),
+                Err(InvariantViolation::Limits),
             ]
         );
     }

--- a/crates/zakura-header-chain/src/transition/planner/admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/admission.rs
@@ -1,6 +1,6 @@
 //! Bounded admission, authentication, and header-insertion rebasing.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use zakura_chain::block;
 
@@ -155,6 +155,16 @@ fn validate_event_resource_bounds(
     }
     if insert.aux.len() > limits.max_aux_deliveries_total.get() {
         return Err(TransitionFailure::AuxiliaryLimitExceeded);
+    }
+    let mut deliveries_by_header = HashMap::<block::Hash, HashSet<crate::EvidenceId>>::new();
+    for delivery in &insert.aux {
+        let delivery_ids = deliveries_by_header
+            .entry(delivery.header_hash)
+            .or_default();
+        delivery_ids.insert(delivery.delivery_id);
+        if delivery_ids.len() > limits.max_aux_deliveries_per_header.get() {
+            return Err(TransitionFailure::AuxiliaryLimitExceeded);
+        }
     }
     Ok(())
 }

--- a/crates/zakura-header-chain/src/transition/planner/admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/admission.rs
@@ -1,13 +1,13 @@
 //! Bounded admission, authentication, and header-insertion rebasing.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use zakura_chain::block;
 
 use super::{InvalidTransitionEvidence, LimitViolation, TransitionFailure};
 use crate::{
     BodyWorkOwner, EngineLimits, EngineMetadata, EngineMode, EngineSnapshot, EventAdmission,
-    EvidenceId, FinalityRecord, Frontier, HeaderChainEngine, HeaderSyncWorkOwner, MemHeaderStore,
+    FinalityRecord, Frontier, HeaderChainEngine, HeaderSyncWorkOwner, MemHeaderStore,
     TargetCompletion, TransitionContext, TransitionEvent, TransitionInput,
 };
 
@@ -73,7 +73,7 @@ pub(super) fn authenticate_and_admit(
     }
     validate_retention_references(input, context)?;
     let event = input.event();
-    validate_event_resource_bounds(engine, &event, context.config.limits)?;
+    validate_event_resource_bounds(&event, context.config.limits)?;
     validate_authority(&event, context)?;
     let full_state_authorization_version = context
         .full_state_authority
@@ -138,7 +138,6 @@ pub(super) fn validate_snapshot(
 }
 
 fn validate_event_resource_bounds(
-    engine: &HeaderChainEngine,
     event: &TransitionEvent,
     limits: EngineLimits,
 ) -> Result<(), TransitionFailure> {
@@ -155,28 +154,6 @@ fn validate_event_resource_bounds(
         );
     }
     if insert.aux.len() > limits.max_aux_deliveries_total.get() {
-        return Err(TransitionFailure::AuxiliaryLimitExceeded);
-    }
-    let mut additions = HashMap::<block::Hash, HashSet<EvidenceId>>::new();
-    for delivery in &insert.aux {
-        additions
-            .entry(delivery.header_hash)
-            .or_default()
-            .insert(delivery.delivery_id);
-    }
-    let mut new_total = engine.aux_delivery_count();
-    for (hash, delivery_ids) in additions {
-        let existing = engine.aux_deliveries(hash);
-        let new_count = delivery_ids
-            .iter()
-            .filter(|id| !existing.iter().any(|row| row.delivery_id == **id))
-            .count();
-        if existing.len().saturating_add(new_count) > limits.max_aux_deliveries_per_header.get() {
-            return Err(TransitionFailure::AuxiliaryLimitExceeded);
-        }
-        new_total = new_total.saturating_add(new_count);
-    }
-    if new_total > limits.max_aux_deliveries_total.get() {
         return Err(TransitionFailure::AuxiliaryLimitExceeded);
     }
     Ok(())

--- a/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
+++ b/crates/zakura-header-chain/src/transition/planner/event_effects/header_admission.rs
@@ -210,6 +210,8 @@ pub(super) fn admit_prepared_headers(
         .map(|header| (header.hash, header.height))
         .collect();
     let mut delivery_ids = HashSet::new();
+    let mut admitted_semantic_payloads = HashSet::new();
+    let mut admitted_root_sources = HashSet::new();
     for delivery in &event.aux {
         let expected_height = batch_headers.get(&delivery.header_hash).copied();
         if !delivery_ids.insert(delivery.delivery_id)
@@ -245,7 +247,29 @@ pub(super) fn admit_prepared_headers(
                 .into());
             }
         }
+        let semantic_fingerprint = delivery.semantic_fingerprint();
+        let semantic_payload_exists = admitted_semantic_payloads
+            .contains(&(delivery.header_hash, semantic_fingerprint))
+            || engine
+                .aux_deliveries(delivery.header_hash)
+                .iter()
+                .any(|existing| existing.semantic_fingerprint() == semantic_fingerprint);
+        let rooted_source_exists = delivery.tree_aux.is_some()
+            && (admitted_root_sources.contains(&(delivery.header_hash, delivery.source))
+                || engine
+                    .aux_deliveries(delivery.header_hash)
+                    .iter()
+                    .any(|existing| {
+                        existing.tree_aux.is_some() && existing.source == delivery.source
+                    }));
+        if semantic_payload_exists || rooted_source_exists {
+            continue;
+        }
         projected.record_aux_delivery(*delivery)?;
+        admitted_semantic_payloads.insert((delivery.header_hash, semantic_fingerprint));
+        if delivery.tree_aux.is_some() {
+            admitted_root_sources.insert((delivery.header_hash, delivery.source));
+        }
     }
     Ok(())
 }

--- a/crates/zakura-header-chain/src/transition/planner/projected_state.rs
+++ b/crates/zakura-header-chain/src/transition/planner/projected_state.rs
@@ -246,6 +246,48 @@ pub(super) struct SettledProjectedState<'a> {
 }
 
 impl<'a> SettledProjectedState<'a> {
+    /// Validate auxiliary bounds against the exact post-retention projection.
+    pub(super) fn validate_auxiliary_limits(
+        &self,
+        engine: &HeaderChainEngine,
+        limits: EngineLimits,
+    ) -> Result<(), TransitionFailure> {
+        let deleted = self
+            .aux_changes
+            .iter()
+            .filter(|change| matches!(change, AuxDelta::Delete { .. }))
+            .count();
+        let inserted = self
+            .aux_changes
+            .iter()
+            .filter_map(|change| match change {
+                AuxDelta::Put(delivery) => Some(delivery),
+                AuxDelta::Delete { .. } => None,
+            })
+            .filter(|delivery| engine.aux_delivery(delivery.delivery_id).is_none())
+            .count();
+        let projected_total = engine
+            .aux_delivery_count()
+            .saturating_sub(deleted)
+            .saturating_add(inserted);
+        if projected_total > limits.max_aux_deliveries_total.get() {
+            return Err(TransitionFailure::AuxiliaryLimitExceeded);
+        }
+        for delivery in self.aux_changes.iter().filter_map(|change| match change {
+            AuxDelta::Put(delivery) => Some(delivery),
+            AuxDelta::Delete { .. } => None,
+        }) {
+            let count = self
+                .graph
+                .view_header_node(delivery.header_hash)
+                .map_or(0, |node| node.aux_delivery_ids.len());
+            if count > limits.max_aux_deliveries_per_header.get() {
+                return Err(TransitionFailure::AuxiliaryLimitExceeded);
+            }
+        }
+        Ok(())
+    }
+
     /// Atomically expose the graph and its matching final delta to write derivation.
     pub(super) fn into_write_parts(
         self,

--- a/crates/zakura-header-chain/src/transition/planner/settlement.rs
+++ b/crates/zakura-header-chain/src/transition/planner/settlement.rs
@@ -271,6 +271,7 @@ pub(super) fn derive_finality_and_retention<'engine, 'ctx>(
     };
 
     let projected = projected.finish_after_retention(engine)?;
+    projected.validate_auxiliary_limits(engine, context.config.limits)?;
     Ok(FinalityRetentionOutcome::Settled(Box::new(
         SettledTransition {
             projected,

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -188,6 +188,54 @@ fn auxiliary_limit_uses_the_post_retention_delivery_set() {
 }
 
 #[test]
+fn aggregate_auxiliary_saturation_without_eviction_is_rejected() {
+    let (mut store, mut config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized_frontier();
+    let difficulty = store
+        .graph
+        .header_node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let target = insert_verified_branch(&mut store.graph, anchor, 1, difficulty, 0xa6);
+    synchronize_fixture(&mut store, target);
+    config.limits.max_aux_deliveries_per_header =
+        std::num::NonZeroUsize::new(1).expect("one is nonzero");
+    config.limits.max_aux_deliveries_total =
+        std::num::NonZeroUsize::new(1).expect("one is nonzero");
+
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([0xa7; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        unreachable!("the fixture constructs a header insertion")
+    };
+    let retained = crate::AuxDelivery::new(
+        EvidenceId::from_digest([0xa8; 32]),
+        target.hash,
+        insert.source,
+        insert.owner,
+        crate::BodySizeHint::Unknown,
+        None,
+    );
+    store
+        .graph
+        .record_auxiliary_evidence_delivery(retained.header_hash, retained.delivery_id)
+        .expect("the selected header accepts the retained delivery identity");
+    store.aux.push(retained);
+    insert.aux.push(unauthenticated_delivery(
+        insert,
+        EvidenceId::from_digest([0xa9; 32]),
+    ));
+
+    assert!(matches!(
+        apply_transition(&store, request, &context(&config, &clock, None)),
+        Err(TransitionFailure::AuxiliaryLimitExceeded)
+    ));
+    assert!(!store.metadata.alarms.resource_stalled);
+    assert_eq!(store.aux, vec![retained]);
+}
+
+#[test]
 fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
     use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
 

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -470,6 +470,123 @@ fn selected_auxiliary_repair_adds_only_one_exact_provenance_record() {
 }
 
 #[test]
+fn auxiliary_admission_preserves_semantic_diversity_under_duplicate_delivery_pressure() {
+    let (mut store, config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.metadata.frontiers.finalized;
+    let initial = insertion(&store, 2, EvidenceId::from_digest([0x40; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &initial.event else {
+        panic!("the fixture constructs a header insertion");
+    };
+    let repaired = insert.batch.headers()[0].clone();
+    let selected_target = Frontier::new(repaired.height, repaired.hash);
+    let inserted = apply_transition(&store, initial, &context(&config, &clock, None))
+        .expect("the selected fixture branch inserts");
+    store.commit(&inserted);
+
+    let make_repair = |store: &TestStore,
+                       source_marker: u8,
+                       request_id: u64,
+                       delivery_marker: u8,
+                       payload_marker: u8| {
+        let owner = body_owner(&store.snapshot(), u64::from(source_marker), request_id);
+        let source = SourceId::from_digest([source_marker; 32]);
+        let delivery = crate::AuxDelivery::new(
+            EvidenceId::from_digest([delivery_marker; 32]),
+            repaired.hash,
+            source,
+            owner.into(),
+            crate::BodySizeHint::Unknown,
+            Some(crate::TreeAuxRecordV1 {
+                height: repaired.height,
+                sapling_root: zakura_chain::sapling::tree::Root::default(),
+                orchard_root: zakura_chain::orchard::tree::Root::default(),
+                ironwood_root: zakura_chain::ironwood::tree::Root::default(),
+                sapling_tx_count: 1,
+                orchard_tx_count: 2,
+                ironwood_tx_count: 3,
+                auth_data_root: zakura_chain::block::merkle::AuthDataRoot::from(
+                    [payload_marker; 32],
+                ),
+            }),
+        );
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::InsertHeaders(Box::new(crate::InsertHeaders {
+                owner: owner.into(),
+                source,
+                parent_hash: anchor.hash,
+                target_tip_hash: repaired.hash,
+                completion: TargetCompletion::SelectedAuxiliaryRepair {
+                    common_ancestor: anchor,
+                    selected_target,
+                },
+                batch: PreparedHeaderBatch::new(
+                    vec![repaired.clone()],
+                    anchor,
+                    store.lease.network().clone(),
+                    store.lease.trust_anchor_digest,
+                    EvidenceId::from_digest([delivery_marker.wrapping_add(1); 32]),
+                )
+                .expect("the repair batch is nonempty"),
+                aux: vec![delivery],
+            })),
+        }
+    };
+
+    store.lease.parent = anchor;
+    let first = apply_transition(
+        &store,
+        make_repair(&store, 0x41, 1, 0x42, 0x43),
+        &context(&config, &clock, None),
+    )
+    .expect("the first semantic payload is admitted");
+    store.commit(&first);
+
+    store.lease.parent = anchor;
+    let duplicate = apply_transition(
+        &store,
+        make_repair(&store, 0x44, 2, 0x45, 0x43),
+        &context(&config, &clock, None),
+    )
+    .expect("another supplier's duplicate payload is an idempotent success");
+    assert!(duplicate.is_no_change());
+    assert!(duplicate.change_set.aux_changes.is_empty());
+
+    store.lease.parent = anchor;
+    let distinct = apply_transition(
+        &store,
+        make_repair(&store, 0x46, 3, 0x47, 0x48),
+        &context(&config, &clock, None),
+    )
+    .expect("a different supplier's distinct payload is admitted");
+    store.commit(&distinct);
+
+    store.lease.parent = anchor;
+    let same_supplier = apply_transition(
+        &store,
+        make_repair(&store, 0x46, 4, 0x49, 0x4a),
+        &context(&config, &clock, None),
+    )
+    .expect("one supplier cannot consume another rooted payload slot");
+    assert!(same_supplier.is_no_change());
+    assert_eq!(store.aux.len(), 2);
+    assert_eq!(
+        store
+            .graph
+            .header_node(repaired.hash)
+            .expect("the repaired header remains retained")
+            .aux_delivery_ids
+            .len(),
+        2
+    );
+    assert!(store
+        .aux
+        .iter()
+        .all(|delivery| delivery.source != SourceId::from_digest([0x44; 32])));
+}
+
+#[test]
 fn auxiliary_delivery_is_batch_hash_scoped_and_selection_neutral() {
     let (store, config) = TestStore::new(EngineMode::Integrated);
     let clock = ManualClock(Utc::now());
@@ -636,12 +753,8 @@ fn auxiliary_outcomes_derive_from_exact_owned_observations() {
         crate::BodySizeHint::Unknown,
         Some(tree_aux(2, 0xc2)),
     );
-    let mut third_delivery = delivery;
-    third_delivery.delivery_id = EvidenceId::from_digest([0xc3; 32]);
     insert_event.source = delivery.source;
-    insert_event
-        .aux
-        .extend([delivery, second_delivery, third_delivery]);
+    insert_event.aux.extend([delivery, second_delivery]);
     let inserted = apply_transition(&store, insert, &context(&config, &clock, None))
         .expect("the target and unauthenticated delivery insert atomically");
     store.commit(&inserted);
@@ -695,7 +808,7 @@ fn auxiliary_outcomes_derive_from_exact_owned_observations() {
         TransitionRequest {
             expected_version: store.metadata.state_version,
             event: observed(
-                vec![third_delivery, second_delivery],
+                vec![delivery, second_delivery],
                 crate::AuxVerificationFactV1::ambiguous_deliveries_failed(2),
                 Some([0xb7; 32].into()),
             ),

--- a/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/auxiliary.rs
@@ -128,6 +128,66 @@ fn same_transition_auxiliary_eviction_has_no_generation_effect() {
 }
 
 #[test]
+fn auxiliary_limit_uses_the_post_retention_delivery_set() {
+    use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
+
+    let (mut store, mut config) = TestStore::new(EngineMode::Integrated);
+    let clock = ManualClock(Utc::now());
+    let anchor = store.graph.finalized_frontier();
+    let easy = store
+        .graph
+        .header_node(anchor.hash)
+        .expect("the anchor exists")
+        .header
+        .difficulty_threshold;
+    let easy_target: U256 = easy.to_expanded().expect("the target expands").into();
+    let hard = ExpandedDifficulty::from(easy_target >> 3).into();
+    let selected = insert_verified_branch(&mut store.graph, anchor, 1, hard, 0xa1);
+    let evicted = insert_verified_branch(&mut store.graph, anchor, 1, easy, 0xa2);
+    synchronize_fixture(&mut store, selected);
+    assert_eq!(store.metadata.frontiers.header_best, selected);
+
+    config.limits.max_non_finalized_nodes = std::num::NonZeroUsize::new(2).expect("two is nonzero");
+    config.limits.max_aux_deliveries_per_header =
+        std::num::NonZeroUsize::new(1).expect("one is nonzero");
+    config.limits.max_aux_deliveries_total =
+        std::num::NonZeroUsize::new(1).expect("one is nonzero");
+
+    let mut request = insertion(&store, 1, EvidenceId::from_digest([0xa3; 32]));
+    let TransitionEvent::InsertHeaders(insert) = &mut request.event else {
+        unreachable!("the fixture constructs a header insertion")
+    };
+    let incoming = unauthenticated_delivery(insert, EvidenceId::from_digest([0xa4; 32]));
+    let retained = crate::AuxDelivery::new(
+        EvidenceId::from_digest([0xa5; 32]),
+        evicted.hash,
+        insert.source,
+        insert.owner,
+        crate::BodySizeHint::Unknown,
+        None,
+    );
+    store
+        .graph
+        .record_auxiliary_evidence_delivery(retained.header_hash, retained.delivery_id)
+        .expect("the losing branch remains retained before projection");
+    store.aux.push(retained);
+    insert.aux.push(incoming);
+
+    let plan = apply_transition(&store, request, &context(&config, &clock, None))
+        .expect("retention frees aggregate auxiliary capacity for the incoming delivery");
+
+    assert!(plan.change_set.delete_nodes.contains(&evicted.hash));
+    assert!(plan.change_set.aux_changes.contains(&AuxDelta::Delete {
+        header_hash: evicted.hash,
+        delivery_id: retained.delivery_id,
+    }));
+    assert!(plan
+        .change_set
+        .aux_changes
+        .contains(&AuxDelta::Put(Box::new(incoming))));
+}
+
+#[test]
 fn auxiliary_deletes_for_evicted_headers_are_sorted_by_hash_and_delivery_id() {
     use zakura_chain::work::difficulty::{ExpandedDifficulty, U256};
 

--- a/crates/zakura-header-chain/src/transition/types/auxiliary.rs
+++ b/crates/zakura-header-chain/src/transition/types/auxiliary.rs
@@ -2,6 +2,7 @@
 
 use std::num::NonZeroU32;
 
+use sha2::{Digest, Sha256};
 use zakura_chain::{
     block::{self, merkle::AuthDataRoot},
     ironwood, orchard, sapling,
@@ -201,6 +202,27 @@ impl AuxDelivery {
             tree_aux,
             outcome: AuxOutcome::unauthenticated(),
         }
+    }
+
+    /// Return the semantic payload identity without transport ownership or body-size metadata.
+    pub fn semantic_fingerprint(self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"zakura-header-aux-semantic-v1");
+        hasher.update(self.header_hash.0);
+        let Some(aux) = self.tree_aux else {
+            hasher.update([0]);
+            return hasher.finalize().into();
+        };
+        hasher.update([1]);
+        hasher.update(aux.height.0.to_le_bytes());
+        hasher.update(<[u8; 32]>::from(aux.sapling_root));
+        hasher.update(<[u8; 32]>::from(aux.orchard_root));
+        hasher.update(<[u8; 32]>::from(aux.ironwood_root));
+        hasher.update(aux.sapling_tx_count.to_le_bytes());
+        hasher.update(aux.orchard_tx_count.to_le_bytes());
+        hasher.update(aux.ironwood_tx_count.to_le_bytes());
+        hasher.update(<[u8; 32]>::from(aux.auth_data_root));
+        hasher.finalize().into()
     }
 
     /// Return the engine-derived outcome.

--- a/crates/zakura-header-chain/src/transition/types/outcome.rs
+++ b/crates/zakura-header-chain/src/transition/types/outcome.rs
@@ -223,7 +223,9 @@ pub struct CommittedStallReceipt {
 /// These must not be collapsed:
 ///
 /// 1. **[`crate::TransitionFailure::AuxiliaryLimitExceeded`]** — planner refuses
-///    before any durable mutation; no resource-stall alarm.
+///    event-local bounds or post-retention retained bounds before any durable
+///    mutation; no resource-stall alarm. A graph-retention resource stall can
+///    take precedence because no settled projection exists in that case.
 /// 2. **Verified `resource_stalled` → [`Self::ResourceStalled`]** — retention could
 ///    not enforce limits without breaking protected paths; the durable
 ///    resource-stall alarm may be recorded or retained.

--- a/crates/zakura-header-chain/src/transition/types/tests.rs
+++ b/crates/zakura-header-chain/src/transition/types/tests.rs
@@ -1,6 +1,9 @@
 //! Semantic coverage for the typed transition surface.
 
-use std::{num::NonZeroU64, sync::Arc};
+use std::{
+    num::{NonZeroU32, NonZeroU64},
+    sync::Arc,
+};
 
 use zakura_chain::{
     block::{self, genesis::regtest_genesis_block},
@@ -449,6 +452,35 @@ fn body_size_hints_enforce_zero_sentinel_and_canonical_limit() {
         BodySizeHint::new(maximum + 1),
         Err(TransitionTypeError::InvalidBodySize(maximum + 1))
     );
+}
+
+#[test]
+fn auxiliary_semantic_fingerprint_excludes_transport_metadata() {
+    let header_hash = block::Hash([0x81; 32]);
+    let first = delivery(
+        EvidenceId::from_digest([0x82; 32]),
+        header_hash,
+        header_owner(),
+    );
+    let mut second = first;
+    second.delivery_id = EvidenceId::from_digest([0x83; 32]);
+    second.source = SourceId::from_digest([0x84; 32]);
+    second.owner = HeaderWorkAuthority {
+        header_generation: HeaderGeneration::new(9),
+        branch: BranchId::new(block::Hash([0x85; 32]), block::Hash([0x86; 32])),
+    }
+    .bind(
+        10,
+        NonZeroU64::new(11).expect("the fixture request ID is nonzero"),
+    )
+    .into();
+    second.body_size =
+        BodySizeHint::Known(NonZeroU32::new(12).expect("the fixture body size is nonzero"));
+
+    assert_eq!(first.semantic_fingerprint(), second.semantic_fingerprint());
+
+    second.header_hash = block::Hash([0x87; 32]);
+    assert_ne!(first.semantic_fingerprint(), second.semantic_fingerprint());
 }
 
 #[test]

--- a/crates/zakura-state/src/service/write/vct_authentication_sweep/tests.rs
+++ b/crates/zakura-state/src/service/write/vct_authentication_sweep/tests.rs
@@ -869,7 +869,6 @@ fn a_replacement_successor_preserves_and_authenticates_the_honest_predecessor() 
     fixture.sweep(&mut sweeper);
 
     fixture.redeliver(bad, None, 0x71);
-    fixture.redeliver(bad, None, 0x72);
     fixture.sweep(&mut sweeper);
 
     assert!(matches!(

--- a/docs/changelog/unreleased/845.md
+++ b/docs/changelog/unreleased/845.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed header-chain auxiliary admission so retention can free capacity before
+  the planner enforces retained delivery limits
+  ([#845](https://github.com/zakura-core/zakura/pull/845)).

--- a/docs/changelog/unreleased/845.md
+++ b/docs/changelog/unreleased/845.md
@@ -1,5 +1,6 @@
 ## Fixed
 
-- Fixed header-chain auxiliary admission so retention can free capacity before
-  the planner enforces retained delivery limits
+- Fixed header-chain auxiliary admission so retention can free aggregate
+  capacity before the planner enforces retained delivery limits. Event-local
+  bounds still protect projection work
   ([#845](https://github.com/zakura-core/zakura/pull/845)).

--- a/docs/changelog/unreleased/845.md
+++ b/docs/changelog/unreleased/845.md
@@ -1,6 +1,8 @@
 ## Fixed
 
 - Fixed header-chain auxiliary admission so retention can free aggregate
-  capacity before the planner enforces retained delivery limits. Event-local
+  capacity before the planner enforces retained delivery limits. The engine
+  retains one copy of each semantic payload and one rooted payload per supplier.
+  The per-header semantic-payload limit increases from 16 to 32. Event-local
   bounds still protect projection work
   ([#845](https://github.com/zakura-core/zakura/pull/845)).

--- a/docs/specs/fork-aware-header-chain-engine.md
+++ b/docs/specs/fork-aware-header-chain-engine.md
@@ -402,6 +402,8 @@ VCT/tree-aux records are execution assistance. They can help reconstruct and aut
 
 **LC-AUX-04 [ZW] — Cryptographic metadata authentication.** Auxiliary roots MAY be marked authenticated only after the existing integrated verifier reconstructs the relevant ZIP 221 history-tree inputs and checks them against the appropriate checkpoint/header commitment, including the one-header-later authentication boundary. Proven bad metadata MAY score its supplier but MUST NOT invalidate the header.
 
+**LC-AUX-06 [LS] — Semantic auxiliary capacity.** The engine MUST retain no more than 32 distinct auxiliary payloads for one header. The semantic payload identity MUST include the header hash and every tree-aux field. It MUST exclude the delivery ID, supplier, session, request, work owner, and body-size hint. A duplicate semantic payload MUST NOT consume another slot or replace a distinct retained payload. One supplier MUST NOT consume more than one rooted semantic-payload slot for one header. Independent plan verification MUST enforce the same rules.
+
 ## 5. Native fork-discovery protocol
 
 ### 5.1 Stream version and codec
@@ -700,7 +702,7 @@ Every normative rule is mapped here. A range such as `LC-SCOPE-01..03` includes 
 | LC-AVAIL-01..03 | IN-03 |
 | LC-WORK-01..03 | IN-05, IN-07, AUD-04..09, AUD-INCIDENT |
 | LC-ERR-01..02 | IN-02, IN-05, IN-07, PW-04 |
-| LC-AUX-01..05 | IN-06 |
+| LC-AUX-01..06 | IN-06 |
 | LC-WIRE-01 | PW-01 |
 | LC-WIRE-02 | PW-01, PW-05, HV-07 |
 | LC-WIRE-03..04 | PW-02, PW-05 |
@@ -771,8 +773,8 @@ Non-normative provenance: the production failure evidence that motivated the aud
 | Protocol sections 7.7.3–7.7.4; ZIP 205; ZIP 208 | 17-block averaging, 11-block medians, compact-target conversion, Testnet minimum difficulty, and Blossom spacing | LC-VAL-06; HV-04, DF-01 |
 | Protocol section 7.7.5; ZIP 221 work metadata | exact per-block work and ecosystem 256-bit cumulative-work bound | LC-VAL-10, LC-WORKCALC-01, LC-SELECT-02, LC-WIRE-02; HV-07, PW-01, DF-01 |
 | ZIP 204 | bounded framing and contiguous-response discipline, adopted as design ancestry only; no `getheaders`/`headers` message path is implemented or served | LC-VAL-01, LC-SCOPE-09; HV-01, PW-08 |
-| ZIP 221 | Heartwood activation zero, history-tree commitment semantics, and one-header-later authentication boundary | LC-COMMIT-01, LC-AUX-01..05; HV-08, IN-06 |
-| ZIP 244 | NU5 `hashBlockCommitments` and `hashAuthDataRoot` semantics | LC-COMMIT-01, LC-AUX-01..05; HV-08, IN-02, IN-06 |
+| ZIP 221 | Heartwood activation zero, history-tree commitment semantics, and one-header-later authentication boundary | LC-COMMIT-01, LC-AUX-01..06; HV-08, IN-06 |
+| ZIP 244 | NU5 `hashBlockCommitments` and `hashAuthDataRoot` semantics | LC-COMMIT-01, LC-AUX-01..06; HV-08, IN-02, IN-06 |
 | ZIP 307 | wallet scanning and payment detection, explicitly outside this engine | LC-SCOPE-04; architecture dependency check |
 
 This table covers every part of the cited Zcash sources that this engine implements, strengthens, or explicitly excludes. Transaction, proof, script, note, nullifier, and state-transition rules remain full-state responsibilities under LC-SCOPE-03 and are not re-specified here.


### PR DESCRIPTION
## Motivation

The dual-stack continuous-sync canary repeatedly received
`AuxiliaryLimitExceeded` while VCT repair was pending. Header-chain admission
evaluated new deliveries against the pre-retention engine state. It could reject
a transition whose retention pass would evict an old delivery and keep the
settled state within the aggregate limit.

The retained run does not expose auxiliary-delivery or retained-node counts. It
therefore cannot show whether the failed transition would have evicted a
delivery. The shared error also does not identify whether the event-local
per-header limit, the event-local aggregate limit, the retained per-header
limit, or the retained aggregate limit caused the refusal.

Version 1.3 allows 16 retained auxiliary deliveries per header and 65,536
retained auxiliary deliveries across the graph. Transport retries can store the
same payload under new delivery IDs. An attacker can also send several distinct
payloads from one peer. Both cases can consume capacity without adding an
independent repair candidate.

This change raises the per-header limit to 32 distinct semantic payloads. It
keeps the 65,536-row aggregate limit. It also removes the pre-retention
false-rejection case. It does not bound the VCT repair episode or claim to fix
every cause of that livelock.

## Solution

- Keep aggregate and per-header event bounds before projection.
- Enforce retained per-header and aggregate auxiliary limits after finality and
  retention produce the settled projection.
- Enforce the same limits during independent plan verification.
- Identify a semantic payload by its header hash and tree-aux fields.
- Exclude transport ownership, supplier, body-size hint, and delivery ID from
  the semantic identity.
- Retain one row for each semantic payload.
- Retain at most one rooted semantic payload from one supplier for one header.
- Raise the retained per-header semantic-payload limit from 16 to 32.

The event-local per-header bound prevents one aggregate-sized event from forcing
quadratic vector insertion work for one header. The post-retention bound allows
retention to replace old deliveries without a false capacity rejection.

The first retained row preserves provenance for a semantic payload. Header sync
continues to track which peers announced the header. A repeated delivery from a
new peer does not need another durable payload row.

The planner may represent a transition above the aggregate limit while it
calculates retention. The engine never commits that intermediate projection.
The final atomic transition must remain within both retained limits.

## Alternatives

- Raise both limits without deduplication. This option delays saturation but
  lets transport retries and supplier-controlled duplicates consume the new
  capacity.
- Retain one delivery per peer. This option protects peer diversity but lets
  Sybil identities consume the per-header limit with identical payloads.
- Retain only unique payloads. This option protects semantic diversity but lets
  one supplier consume every slot with distinct payloads.
- Replace an existing payload when a new delivery arrives. This option lets an
  attacker displace useful retained input. The engine instead keeps the first
  retained row for each semantic payload.
- Run retention as a separate transition before admission. This option adds a
  durable transition and creates a race between retention and later admission.
- Refuse the delivery, run retention, and retry. This option requires reliable
  retry coordination and can repeat the same failure.
- Predict retention during admission. This option duplicates retention policy
  and can disagree with the settlement calculation.
- Reserve replacement capacity. This option requires explicit slot ownership
  and a larger protocol change.
- Keep a fixed-size replacement structure for each target. This option provides
  stronger containment but belongs with the state-owned repair protocol.

The selected policy combines semantic deduplication, one rooted slot per
supplier, and a 32-payload per-header limit. The policy preserves useful
payload diversity without adding a new durable supplier-set schema.

## Testing

- `cargo test -p zakura-header-chain --lib`
- `cargo test -p zakura-state --lib`
- `cargo clippy -p zakura-header-chain --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check-pr --base origin/main --head HEAD --pr 845`

The replacement regression starts at a one-row aggregate auxiliary cap. The
transition adds one delivery while retention evicts the losing branch delivery.
The test verifies that the planner admits the transition and that the final
delta replaces the old delivery without exceeding the cap.

The saturation regression starts at the same cap without an eviction. It
verifies that the planner still returns `AuxiliaryLimitExceeded`. The
event-local test covers the per-header work bound. The invariant tests corrupt
candidates above the aggregate and per-header retained limits. Production and
exhaustive verification reject those candidates.

The semantic-diversity regression admits payload A and ignores the same payload
from another supplier. It then admits payload B and ignores another rooted
payload from B's supplier. The fingerprint regression proves that transport
metadata cannot make a duplicate payload distinct. Independent verification
rejects duplicate semantic payloads and multiple rooted payloads from one
supplier.

### Follow-up Work

- Redesign continuous-sync stall detection in #846.
- Add the state-owned repair episode and rejected-input protocol in #847. A
  completed local failure can still repeat until that protocol lands.
- Add separate capacity metrics for each auxiliary limit before using another
  production run to attribute a refusal to a specific saturation mode.
