### PR TITLE
fix(block-sync): preserve refill control capacity

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -42,7 +42,7 @@ use super::{
         ThroughputMeter,
     },
     work_queue::{WorkItem, WorkQueue, WorkReturnOutcome},
-    BlockSyncAction, BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
+    BlockSyncMessage, BlockSyncMisbehavior, BlockSyncPeerSession, BlockSyncStatus,
     ZakuraBlockSyncConfig, ZakuraPeerId, ZakuraTrace, MSG_BS_BLOCK,
 };
 use crate::zakura::{
@@ -317,7 +317,6 @@ pub(super) struct PeerRoutine {
     sequencer_input: mpsc::Sender<SequencedBody>,
     sequencer_input_bytes: Arc<std::sync::atomic::AtomicU64>,
     sequencer_input_decoded_attributed_memory_bytes: Arc<std::sync::atomic::AtomicU64>,
-    actions: mpsc::Sender<BlockSyncAction>,
     /// Shared routine-to-reactor channel for serving, status, re-query, and misbehavior events.
     /// Bounded `try_send` prevents a busy reactor from stalling the transport decode loop.
     routine_to_reactor: mpsc::Sender<RoutineToReactor>,
@@ -357,7 +356,6 @@ impl PeerRoutine {
         sequencer_input: mpsc::Sender<SequencedBody>,
         sequencer_input_bytes: Arc<std::sync::atomic::AtomicU64>,
         sequencer_input_decoded_attributed_memory_bytes: Arc<std::sync::atomic::AtomicU64>,
-        actions: mpsc::Sender<BlockSyncAction>,
         routine_to_reactor: mpsc::Sender<RoutineToReactor>,
         sequencer_view: watch::Receiver<SequencerView>,
         cancel: CancellationToken,
@@ -402,7 +400,6 @@ impl PeerRoutine {
             sequencer_input,
             sequencer_input_bytes,
             sequencer_input_decoded_attributed_memory_bytes,
-            actions,
             routine_to_reactor,
             sequencer_view,
             last_reset_epoch,
@@ -2155,11 +2152,15 @@ impl PeerRoutine {
         // Misbehavior is record-only: observe and forward it, but never cancel the
         // session. Peer scoring no longer drives disconnects.
         metrics::counter!("sync.block.peer.violation").increment(1);
-        // `Misbehavior` is best-effort: never block the routine.
-        let _ = self.actions.try_send(BlockSyncAction::Misbehavior {
-            peer: self.peer.clone(),
-            reason,
-        });
+        // `Misbehavior` is best-effort: never block the routine. The reactor owns
+        // action dispatch so attacker-triggered reports cannot bypass its reserved
+        // control capacity.
+        let _ = self
+            .routine_to_reactor
+            .try_send(RoutineToReactor::Misbehavior {
+                peer: self.peer.clone(),
+                reason,
+            });
     }
 
     // ===================== view reads ======================================
@@ -2368,7 +2369,6 @@ mod tests {
         );
 
         let (sequencer_input_tx, _sequencer_input_rx) = mpsc::channel(16);
-        let (actions_tx, _actions_rx) = mpsc::channel(16);
         let (routine_to_reactor_tx, _routine_to_reactor_rx) = mpsc::channel(16);
         let (_view_tx, view_rx) = watch::channel(initial_view(BlockSyncFrontiers {
             finalized_height: block::Height(0),
@@ -2390,7 +2390,6 @@ mod tests {
             sequencer_input_tx,
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-            actions_tx,
             routine_to_reactor_tx,
             view_rx,
             cancel,
@@ -2459,7 +2458,6 @@ mod tests {
         let session = BlockSyncPeerSession::for_test(peer.clone(), out_send, cancel.clone());
 
         let (sequencer_input_tx, _sequencer_input_rx) = mpsc::channel(16);
-        let (actions_tx, _actions_rx) = mpsc::channel(16);
         let (routine_to_reactor_tx, _routine_to_reactor_rx) = mpsc::channel(16);
         let (_view_tx, view_rx) = watch::channel(initial_view(BlockSyncFrontiers {
             finalized_height: block::Height(0),
@@ -2482,7 +2480,6 @@ mod tests {
             sequencer_input_tx,
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-            actions_tx,
             routine_to_reactor_tx,
             view_rx,
             cancel,
@@ -2555,7 +2552,6 @@ mod tests {
         let session = BlockSyncPeerSession::for_test(peer.clone(), out_send, cancel.clone());
 
         let (sequencer_input_tx, _sequencer_input_rx) = mpsc::channel(16);
-        let (actions_tx, _actions_rx) = mpsc::channel(16);
         let (routine_to_reactor_tx, _routine_to_reactor_rx) = mpsc::channel(16);
         let (_view_tx, view_rx) = watch::channel(initial_view(BlockSyncFrontiers {
             finalized_height: block::Height(0),
@@ -2578,7 +2574,6 @@ mod tests {
             sequencer_input_tx,
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-            actions_tx,
             routine_to_reactor_tx,
             view_rx,
             cancel,

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -20,12 +20,12 @@ const ACTION_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 /// misbehavior actions.
 const BS_ACTION_SPARE_POOL: usize = 128;
 
-/// Action slots that peer serving cannot consume.
+/// Action slots that expendable peer traffic cannot consume.
 ///
 /// The Sequencer's submission bound accounts for its data-plane actions. This
-/// reservation protects a reactor-local needed-body refill from an untrusted
-/// `GetBlocks` flood that occupies the spare pool.
-const BS_ACTION_CONTROL_RESERVE: usize = 1;
+/// reservation protects a reactor-local needed-body refill from untrusted
+/// serving and misbehavior-report floods that occupy the spare pool.
+pub(super) const BS_ACTION_CONTROL_RESERVE: usize = 1;
 
 /// Bound on the shared routine→reactor channel (status-advertise / serve /
 /// re-query / serving-misbehavior). Sized generously so a transient burst of
@@ -2288,8 +2288,10 @@ impl BlockSyncReactor {
     /// accepted.
     fn dispatch_action(&self, action: BlockSyncAction) -> bool {
         let action_label = action.metric_label();
-        if matches!(action, BlockSyncAction::QueryBlocksByHeightRange { .. })
-            && self.actions.capacity() <= BS_ACTION_CONTROL_RESERVE
+        if matches!(
+            action,
+            BlockSyncAction::QueryBlocksByHeightRange { .. } | BlockSyncAction::Misbehavior { .. }
+        ) && self.actions.capacity() <= BS_ACTION_CONTROL_RESERVE
         {
             metrics::counter!(
                 "sync.block.action.control_capacity_reserved",

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -2289,22 +2289,32 @@ impl BlockSyncReactor {
     /// accepted.
     fn dispatch_action(&self, action: BlockSyncAction) -> bool {
         let action_label = action.metric_label();
-        if matches!(
-            action,
-            BlockSyncAction::QueryBlocksByHeightRange { .. } | BlockSyncAction::Misbehavior { .. }
-        ) && self.actions.capacity() <= BS_ACTION_CONTROL_RESERVE
-        {
-            metrics::counter!(
-                "sync.block.action.control_capacity_reserved",
-                "action" => action_label
-            )
-            .increment(1);
-            return false;
-        }
         let queue_depth = self
             .actions
             .max_capacity()
             .saturating_sub(self.actions.capacity());
+        let peer_action_permits = if matches!(
+            action,
+            BlockSyncAction::QueryBlocksByHeightRange { .. } | BlockSyncAction::Misbehavior { .. }
+        ) {
+            // Acquire the peer-action slot and protected control capacity in one
+            // semaphore operation. The Sequencer sends concurrently, so a
+            // separate capacity check followed by `try_send` has a race.
+            match self.actions.try_reserve_many(BS_ACTION_CONTROL_RESERVE + 1) {
+                Ok(permits) => Some(permits),
+                Err(mpsc::error::TrySendError::Full(())) => {
+                    metrics::counter!(
+                        "sync.block.action.control_capacity_reserved",
+                        "action" => action_label
+                    )
+                    .increment(1);
+                    return false;
+                }
+                Err(mpsc::error::TrySendError::Closed(())) => return false,
+            }
+        } else {
+            None
+        };
         // Metrics accepts f64 samples; this lossy conversion is observability-only.
         metrics::histogram!(
             "sync.block.action.queue.depth",
@@ -2314,6 +2324,13 @@ impl BlockSyncReactor {
         self.startup
             .trace
             .emit_event(|| BlockActionDispatched::new(&action));
+        if let Some(mut permits) = peer_action_permits {
+            permits
+                .next()
+                .expect("the atomic reservation includes one peer-action permit")
+                .send(action);
+            return true;
+        }
         match self.actions.try_send(action) {
             Ok(()) => true,
             Err(mpsc::error::TrySendError::Full(_)) => {

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -235,6 +235,7 @@ pub fn spawn_block_sync_reactor(
         sequencer_input_bytes: sequencer_input_bytes.clone(),
         sequencer_input_decoded_attributed_memory_bytes:
             sequencer_input_decoded_attributed_memory_bytes.clone(),
+        #[cfg(test)]
         actions: actions_tx.clone(),
         routine_to_reactor: routine_to_reactor_tx,
         view: sequencer_view_rx.clone(),

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -20,6 +20,13 @@ const ACTION_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 /// misbehavior actions.
 const BS_ACTION_SPARE_POOL: usize = 128;
 
+/// Action slots that peer serving cannot consume.
+///
+/// The Sequencer's submission bound accounts for its data-plane actions. This
+/// reservation protects a reactor-local needed-body refill from an untrusted
+/// `GetBlocks` flood that occupies the spare pool.
+const BS_ACTION_CONTROL_RESERVE: usize = 1;
+
 /// Bound on the shared routine→reactor channel (status-advertise / serve /
 /// re-query / serving-misbehavior). Sized generously so a transient burst of
 /// per-peer events never makes a routine's `try_send` drop a serving/status
@@ -378,10 +385,9 @@ impl BlockSyncReactor {
         let mut header_tip_open = header_tip.is_some();
         let mut committed_views = self.startup.committed_views.clone();
         set_block_reactor_active_connection_gauge(self.state.peers.len());
-        // Metrics/trace snapshot cadence only. Per-peer request timeouts are owned
-        // by the routines (each sleeps to its own earliest deadline), so this timer
-        // no longer drives any timeout; it reuses `request_timeout` purely as a
-        // reasonable periodic refresh interval.
+        // Per-peer request timeouts are owned by the routines. This local tick
+        // also retries the level-triggered needed-body query, so a lost routine
+        // notification or a full action queue cannot consume the refill need.
         let mut metrics_ticks = time::interval(self.startup.config.request_timeout);
         let mut status_ticks = time::interval(
             self.startup
@@ -479,6 +485,7 @@ impl BlockSyncReactor {
                     }
                 }
                 _ = metrics_ticks.tick() => {
+                    self.query_needed_blocks().await;
                     self.publish_metrics();
                     self.refresh_throughput();
                     self.trace_sync_state(true);
@@ -2281,6 +2288,16 @@ impl BlockSyncReactor {
     /// accepted.
     fn dispatch_action(&self, action: BlockSyncAction) -> bool {
         let action_label = action.metric_label();
+        if matches!(action, BlockSyncAction::QueryBlocksByHeightRange { .. })
+            && self.actions.capacity() <= BS_ACTION_CONTROL_RESERVE
+        {
+            metrics::counter!(
+                "sync.block.action.control_capacity_reserved",
+                "action" => action_label
+            )
+            .increment(1);
+            return false;
+        }
         let queue_depth = self
             .actions
             .max_capacity()

--- a/crates/zakura-network/src/zakura/block_sync/service.rs
+++ b/crates/zakura-network/src/zakura/block_sync/service.rs
@@ -706,7 +706,6 @@ impl Service for BlockSyncService {
                             wiring.sequencer_input,
                             wiring.sequencer_input_bytes,
                             wiring.sequencer_input_decoded_attributed_memory_bytes,
-                            wiring.actions,
                             wiring.routine_to_reactor,
                             wiring.view,
                             run_cancel,

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -137,6 +137,7 @@ pub(super) struct RoutineWiring {
     pub(super) sequencer_input: mpsc::Sender<super::sequencer_task::SequencedBody>,
     pub(super) sequencer_input_bytes: Arc<std::sync::atomic::AtomicU64>,
     pub(super) sequencer_input_decoded_attributed_memory_bytes: Arc<std::sync::atomic::AtomicU64>,
+    #[cfg(test)]
     pub(super) actions: mpsc::Sender<BlockSyncAction>,
     pub(super) routine_to_reactor: mpsc::Sender<super::events::RoutineToReactor>,
     pub(super) view: watch::Receiver<super::sequencer_task::SequencerView>,

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -16,7 +16,6 @@ use super::{
         DEFAULT_BS_REQUEST_TIMEOUT, MAX_BS_INFLIGHT_REQUESTS, MAX_BS_RESPONSE_BYTES,
         MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES,
     },
-    events::RoutineToReactor,
     peer_registry::{OutstandingMeta, PeerRegistry},
     reactor::{
         node_id_from_block_peer_id, BS_ACTION_CONTROL_RESERVE, EMPTY_STATE_HEADER_QUIET_MIN_LAG,
@@ -14020,7 +14019,7 @@ async fn misbehavior_flood_cannot_consume_needed_query_capacity() {
     );
     let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
     let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
-    let (peer_id, _inbound_tx, mut outbound_rx) = connect_peer_with_status(
+    let (peer_id, inbound_tx, mut outbound_rx) = connect_peer_with_status(
         &service,
         &mut actions,
         63,
@@ -14054,23 +14053,32 @@ async fn misbehavior_flood_cannot_consume_needed_query_capacity() {
             .expect("the test fills one unreserved action slot");
     }
 
-    wiring
-        .routine_to_reactor
-        .send(RoutineToReactor::Misbehavior {
-            peer: peer_id.clone(),
-            reason: BlockSyncMisbehavior::InvalidBlock,
-        })
-        .await
-        .expect("the attacker-controlled misbehavior report queues");
-    wiring
-        .routine_to_reactor
-        .send(RoutineToReactor::StatusReceived {
-            peer: peer_id,
-            send_reply: true,
-        })
-        .await
-        .expect("the routine-channel barrier queues");
-    wait_for_outbound_status(&mut outbound_rx).await;
+    send_inbound(&inbound_tx, BlockSyncMessage::Block(blocks[1].clone())).await;
+    send_inbound(
+        &inbound_tx,
+        BlockSyncMessage::Status(BlockSyncStatus {
+            servable_low: block::Height(1),
+            servable_high: block::Height(2),
+            tip_hash: blocks[1].hash(),
+            max_blocks_per_response: 16,
+            max_inflight_requests: 1,
+            max_response_bytes: MAX_BS_RESPONSE_BYTES,
+        }),
+    )
+    .await;
+    await_until(
+        "the download routine handles the unsolicited body before its status barrier",
+        Duration::from_secs(1),
+        || {
+            wiring.registry.candidate_snapshot().iter().any(
+                |(peer, received_status, _, servable_high)| {
+                    peer == &peer_id && *received_status && *servable_high == block::Height(2)
+                },
+            )
+        },
+    )
+    .await
+    .expect("the download routine reports the attacker-controlled body");
     assert_eq!(
         wiring.actions.capacity(),
         BS_ACTION_CONTROL_RESERVE,

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -16,9 +16,10 @@ use super::{
         DEFAULT_BS_REQUEST_TIMEOUT, MAX_BS_INFLIGHT_REQUESTS, MAX_BS_RESPONSE_BYTES,
         MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES,
     },
+    events::RoutineToReactor,
     peer_registry::{OutstandingMeta, PeerRegistry},
     reactor::{
-        node_id_from_block_peer_id, EMPTY_STATE_HEADER_QUIET_MIN_LAG,
+        node_id_from_block_peer_id, BS_ACTION_CONTROL_RESERVE, EMPTY_STATE_HEADER_QUIET_MIN_LAG,
         EMPTY_STATE_HEADER_QUIET_PERIOD,
     },
     reorder::*,
@@ -13994,6 +13995,111 @@ async fn serving_flood_cannot_consume_needed_query_retry() {
     })
     .await
     .expect("the local tick retries the needed-body query");
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
+async fn misbehavior_flood_cannot_consume_needed_query_capacity() {
+    let blocks = mainnet_blocks_1_to_3();
+    let mut config = ZakuraBlockSyncConfig {
+        request_timeout: Duration::from_secs(2),
+        ..ZakuraBlockSyncConfig::default()
+    };
+    config.peer_limits.outbound_queue_depth = 16;
+    let (_tip_tx, tip_rx) = watch::channel((block::Height(1), blocks[0].hash()));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(1),
+            verified_block_hash: blocks[0].hash(),
+        },
+        (block::Height(1), blocks[0].hash()),
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (peer_id, _inbound_tx, mut outbound_rx) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        63,
+        block::Height(1),
+        blocks[0].hash(),
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+
+    let wiring = handle
+        .routine_wiring
+        .as_ref()
+        .expect("the spawned reactor exposes its shared test wiring");
+    await_until(
+        "the peer status reaches the registry",
+        Duration::from_secs(1),
+        || wiring.registry.has_received_status(&peer_id),
+    )
+    .await
+    .expect("the peer becomes ready");
+    wait_for_outbound_status(&mut outbound_rx).await;
+
+    while wiring.actions.capacity() > BS_ACTION_CONTROL_RESERVE {
+        wiring
+            .actions
+            .try_send(BlockSyncAction::Misbehavior {
+                peer: peer(0xfe),
+                reason: BlockSyncMisbehavior::InvalidBlock,
+            })
+            .expect("the test fills one unreserved action slot");
+    }
+
+    wiring
+        .routine_to_reactor
+        .send(RoutineToReactor::Misbehavior {
+            peer: peer_id.clone(),
+            reason: BlockSyncMisbehavior::InvalidBlock,
+        })
+        .await
+        .expect("the attacker-controlled misbehavior report queues");
+    wiring
+        .routine_to_reactor
+        .send(RoutineToReactor::StatusReceived {
+            peer: peer_id,
+            send_reply: true,
+        })
+        .await
+        .expect("the routine-channel barrier queues");
+    wait_for_outbound_status(&mut outbound_rx).await;
+    assert_eq!(
+        wiring.actions.capacity(),
+        BS_ACTION_CONTROL_RESERVE,
+        "peer-triggered misbehavior retained the refill control reservation",
+    );
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(2),
+            hash: blocks[1].hash(),
+        })
+        .await
+        .expect("the higher header tip queues");
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            match actions.recv().await {
+                Some(BlockSyncAction::QueryNeededBlocks {
+                    from: block::Height(2),
+                    best_header_tip: block::Height(2),
+                    ..
+                }) => break,
+                Some(_) => {}
+                None => panic!("the action stream closed before the needed-body query"),
+            }
+        }
+    })
+    .await
+    .expect("the needed-body query uses the reserved capacity");
 
     reactor_task.abort();
 }

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -13884,6 +13884,120 @@ async fn reactor_backpressures_serving_slots_without_scoring_peer() {
     reactor_task.abort();
 }
 
+#[tokio::test]
+async fn serving_flood_cannot_consume_needed_query_retry() {
+    let blocks = mainnet_blocks_1_to_3();
+    let mut config = ZakuraBlockSyncConfig {
+        request_timeout: Duration::from_secs(2),
+        ..ZakuraBlockSyncConfig::default()
+    };
+    config.peer_limits.outbound_queue_depth = 16;
+    let (_tip_tx, tip_rx) = watch::channel((block::Height(1), blocks[0].hash()));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(1),
+            verified_block_hash: blocks[0].hash(),
+        },
+        (block::Height(1), blocks[0].hash()),
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (peer_id, inbound_tx, _outbound_rx) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        62,
+        block::Height(1),
+        blocks[0].hash(),
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+
+    let wiring = handle
+        .routine_wiring
+        .as_ref()
+        .expect("the spawned reactor exposes its shared test wiring");
+    await_until(
+        "the peer status reaches the registry",
+        Duration::from_secs(1),
+        || wiring.registry.has_received_status(&peer_id),
+    )
+    .await
+    .expect("the valid serving peer becomes ready");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    while wiring.actions.capacity() > 0 {
+        wiring
+            .actions
+            .try_send(BlockSyncAction::Misbehavior {
+                peer: peer(0xfe),
+                reason: BlockSyncMisbehavior::InvalidBlock,
+            })
+            .expect("the test fills one available action slot");
+    }
+
+    handle
+        .send(BlockSyncEvent::HeaderTipChanged {
+            height: block::Height(2),
+            hash: blocks[1].hash(),
+        })
+        .await
+        .expect("the higher header tip queues");
+    let (barrier_send, _barrier_recv) = framed_channel(1);
+    handle
+        .send(BlockSyncEvent::PeerConnected(
+            BlockSyncPeerSession::for_test(peer(0xfd), barrier_send, CancellationToken::new()),
+        ))
+        .await
+        .expect("the event-order barrier queues");
+    await_until(
+        "the reactor handles the full-queue refill attempt",
+        Duration::from_secs(1),
+        || handle.peer_snapshot().outbound_peers == 2,
+    )
+    .await
+    .expect("the peer event follows the header-tip event");
+    assert_eq!(
+        wiring.actions.capacity(),
+        0,
+        "the first needed-body query loses to the full action queue",
+    );
+
+    let _ = actions.recv().await.expect("one flooded action drains");
+    send_inbound(
+        &inbound_tx,
+        BlockSyncMessage::GetBlocks {
+            start_height: block::Height(1),
+            count: 1,
+        },
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match actions.recv().await {
+                Some(BlockSyncAction::QueryNeededBlocks {
+                    from: block::Height(2),
+                    best_header_tip: block::Height(2),
+                    ..
+                }) => break,
+                Some(BlockSyncAction::QueryBlocksByHeightRange { .. }) => {
+                    panic!("peer serving consumed the refill control reservation")
+                }
+                Some(_) => {}
+                None => panic!("the action stream closed before the refill retry"),
+            }
+        }
+    })
+    .await
+    .expect("the local tick retries the needed-body query");
+
+    reactor_task.abort();
+}
+
 /// A full per-peer serving queue must drop the serving send, never disconnect
 /// the peer.
 ///

--- a/docs/changelog/unreleased/849.md
+++ b/docs/changelog/unreleased/849.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Prevented peer block-serving traffic from consuming the block-sync action
+  capacity reserved for needed-body refill recovery
+  ([#849](https://github.com/zakura-core/zakura/pull/849)).

--- a/docs/changelog/unreleased/849.md
+++ b/docs/changelog/unreleased/849.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Prevented peer block-serving traffic from consuming the block-sync action
-  capacity reserved for needed-body refill recovery
+- Prevented peer serving and misbehavior-report traffic from consuming the
+  block-sync action capacity reserved for needed-body refill recovery
   ([#849](https://github.com/zakura-core/zakura/pull/849)).


### PR DESCRIPTION
## Motivation

Peer `GetBlocks` requests, peer-triggered misbehavior reports, and needed-body refill actions share one bounded block-sync action queue. Peer traffic can consume a newly available slot after a full queue drops the refill attempt. The node can then stop producing body work until an unrelated event wakes the reactor.

## Solution

Reserve one action slot from peer-serving reads and peer-triggered misbehavior reports. Acquire each expendable peer-action permit and the protected control capacity atomically, so the concurrent Sequencer sender cannot interleave between admission and enqueue. Retry the level-triggered needed-body query from the reactor's existing periodic tick.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-network --all-targets -- -D warnings`
- `cargo test -p zakura-network --lib zakura::block_sync -- --test-threads=1` (284 passed)
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/849.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `git diff --check origin/main...HEAD`

The serving regression fills the action queue, drops a refill attempt, and sends a valid serving request after one slot opens. It verifies that the refill retry receives the reserved slot first. The misbehavior regression drives an attacker-controlled report through the routine channel and verifies that it cannot consume the reserved slot.

## Changelog

Added `docs/changelog/unreleased/849.md`.

### Specifications & References

- Useful-item-loss audit finding F009
- Builds on #847

### Follow-up Work

Related composition hardening: #850, #852, and #853.
