### PR TITLE
fix(block-sync): retain invalid-body evidence handoff

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -758,7 +758,7 @@ impl SequencerTask {
         if let zakura_header_chain::BodyVerificationOutcome::Retryable(failure) =
             outcome.verification()
         {
-            self.send_action(BlockSyncAction::RecordBodyUnavailable {
+            self.send_required_action(BlockSyncAction::RecordBodyUnavailable {
                 expected_version: semantic_state_version,
                 failure: *failure,
             })
@@ -1068,13 +1068,14 @@ impl SequencerTask {
         }
     }
 
-    /// Retain a consensus-critical action until the driver accepts it.
+    /// Retain a durability-relevant action until the driver accepts it.
     ///
     /// A bounded timeout is correct for replaceable submissions and telemetry.
-    /// It is not correct for deterministic invalidity. Waiting on the bounded
-    /// channel gives this sender FIFO capacity ahead of later peer-serving
-    /// `try_send` calls. A closed receiver leaves this future fail-closed with
-    /// the exact action retained until subsystem supervision cancels the task.
+    /// It is not correct for deterministic invalidity or the latest retry state.
+    /// Waiting on the bounded channel gives this sender FIFO capacity ahead of
+    /// later peer-serving `try_send` calls. A closed receiver leaves this future
+    /// fail-closed with the exact action retained until subsystem supervision
+    /// cancels the task.
     async fn send_required_action(&self, action: BlockSyncAction) {
         let action_label = action.metric_label();
         if let Err(error) = self.actions.send(action).await {
@@ -1087,8 +1088,9 @@ impl SequencerTask {
                 action = action_label,
                 "required block-sync action receiver closed"
             );
-            let _retained_action = error.0;
+            let retained_action = error.0;
             std::future::pending::<()>().await;
+            drop(retained_action);
         }
     }
 
@@ -1771,6 +1773,119 @@ mod tests {
                 ..
             }) if actual == invalid
         ));
+    }
+
+    #[tokio::test]
+    async fn retryable_evidence_waits_for_action_capacity() {
+        let frontiers = BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        };
+        let input_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let input_decoded_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (_body_tx, body_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::unbounded_channel();
+        let (actions, mut actions_rx) = mpsc::channel(1);
+        let action_sender = actions.clone();
+        let (view_tx, _view_rx) = watch::channel(initial_view(frontiers));
+        let mut task = SequencerTask::new(
+            Sequencer::new(block::Height(0), 1),
+            ByteBudget::new(123),
+            Arc::new(WorkQueue::new(block::Height(0))),
+            Arc::new(PeerRegistry::new()),
+            actions,
+            ThroughputMeter::new(Instant::now()),
+            frontiers,
+            Some(super::test_work_scope()),
+            crate::zakura::header_sync::SeededRetryJitter::new([0; 32]),
+            body_rx,
+            control_rx,
+            input_bytes.clone(),
+            input_decoded_bytes.clone(),
+            view_tx,
+            Duration::from_millis(20),
+            ZakuraTrace::noop(),
+        );
+
+        let mut body = queued_test_body(input_bytes, input_decoded_bytes);
+        body.leave_queue();
+        task.handle_accept_body(body);
+        task.submit_pending_blocks().await;
+        let BlockSyncAction::SubmitBlock {
+            owner,
+            source,
+            token,
+            block,
+        } = actions_rx.recv().await.expect("body is submitted")
+        else {
+            panic!("expected a body submission");
+        };
+        let height = block.coinbase_height().expect("test block has height");
+        let hash = block.hash();
+        let mut outcome = BlockApplyOutcome::retryable(zakura_header_chain::TransientBodyFailure {
+            hash,
+            evidence: zakura_header_chain::EvidenceId::from_digest([0xa2; 32]),
+            kind: zakura_header_chain::TransientBodyFailureKind::VerifierUnavailable,
+            availability: zakura_header_chain::BodyUnavailableSummary::default(),
+        });
+
+        action_sender
+            .send(BlockSyncAction::Misbehavior {
+                peer: ZakuraPeerId::new(vec![0xee; 32])
+                    .expect("the filler peer ID has the required length"),
+                reason: BlockSyncMisbehavior::InvalidBlock,
+            })
+            .await
+            .expect("the filler occupies the action channel");
+        let completion = tokio::spawn(async move {
+            let result = task
+                .handle_apply_finished(
+                    owner,
+                    source,
+                    token,
+                    height,
+                    hash,
+                    &mut outcome,
+                    BTreeSet::new(),
+                    None,
+                    Some((owner, zakura_header_chain::StateVersion::new(8))),
+                )
+                .await;
+            (task, result)
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !completion.is_finished(),
+            "retry state must remain pending after the ordinary action timeout",
+        );
+        assert!(matches!(
+            actions_rx.recv().await,
+            Some(BlockSyncAction::Misbehavior {
+                reason: BlockSyncMisbehavior::InvalidBlock,
+                ..
+            })
+        ));
+        assert!(matches!(
+            actions_rx.recv().await,
+            Some(BlockSyncAction::RecordBodyUnavailable {
+                expected_version,
+                failure,
+            }) if expected_version == zakura_header_chain::StateVersion::new(8)
+                && failure.hash == hash
+                && failure.evidence
+                    == zakura_header_chain::EvidenceId::from_digest([0xa2; 32])
+                && failure.kind
+                    == zakura_header_chain::TransientBodyFailureKind::VerifierUnavailable
+        ));
+
+        let (task, result) = completion.await.expect("the sequencer task does not panic");
+        assert_eq!(result, (true, true));
+        assert!(
+            !task.sequencer.applying_contains(height),
+            "the sequencer retires the body only after it hands off retry state",
+        );
     }
 
     #[tokio::test]

--- a/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -740,7 +740,7 @@ impl SequencerTask {
             if let zakura_header_chain::BodyVerificationOutcome::ConsensusInvalid(invalid) =
                 outcome.verification()
             {
-                self.send_action(BlockSyncAction::RecordBodyInvalid {
+                self.send_required_action(BlockSyncAction::RecordBodyInvalid {
                     expected_version: semantic_state_version,
                     invalid: invalid.clone(),
                 })
@@ -1065,6 +1065,30 @@ impl SequencerTask {
                 .increment(1);
                 false
             }
+        }
+    }
+
+    /// Retain a consensus-critical action until the driver accepts it.
+    ///
+    /// A bounded timeout is correct for replaceable submissions and telemetry.
+    /// It is not correct for deterministic invalidity. Waiting on the bounded
+    /// channel gives this sender FIFO capacity ahead of later peer-serving
+    /// `try_send` calls. A closed receiver leaves this future fail-closed with
+    /// the exact action retained until subsystem supervision cancels the task.
+    async fn send_required_action(&self, action: BlockSyncAction) {
+        let action_label = action.metric_label();
+        if let Err(error) = self.actions.send(action).await {
+            metrics::counter!(
+                "sync.block.action.required_receiver_closed",
+                "action" => action_label
+            )
+            .increment(1);
+            tracing::error!(
+                action = action_label,
+                "required block-sync action receiver closed"
+            );
+            let _retained_action = error.0;
+            std::future::pending::<()>().await;
         }
     }
 
@@ -1630,6 +1654,123 @@ mod tests {
         task.handle_accept_body(old_body);
         assert_eq!(task.sequencer.reorder_len(), 0);
         assert_eq!(task.sequencer.applying_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn consensus_invalid_evidence_waits_for_action_capacity() {
+        let frontiers = BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        };
+        let input_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let input_decoded_bytes = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (_body_tx, body_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::unbounded_channel();
+        let (actions, mut actions_rx) = mpsc::channel(1);
+        let action_sender = actions.clone();
+        let (view_tx, _view_rx) = watch::channel(initial_view(frontiers));
+        let mut task = SequencerTask::new(
+            Sequencer::new(block::Height(0), 1),
+            ByteBudget::new(123),
+            Arc::new(WorkQueue::new(block::Height(0))),
+            Arc::new(PeerRegistry::new()),
+            actions,
+            ThroughputMeter::new(Instant::now()),
+            frontiers,
+            Some(super::test_work_scope()),
+            crate::zakura::header_sync::SeededRetryJitter::new([0; 32]),
+            body_rx,
+            control_rx,
+            input_bytes.clone(),
+            input_decoded_bytes.clone(),
+            view_tx,
+            Duration::from_millis(20),
+            ZakuraTrace::noop(),
+        );
+
+        let mut body = queued_test_body(input_bytes, input_decoded_bytes);
+        body.leave_queue();
+        task.handle_accept_body(body);
+        task.submit_pending_blocks().await;
+        let BlockSyncAction::SubmitBlock {
+            owner,
+            source,
+            token,
+            block,
+        } = actions_rx.recv().await.expect("body is submitted")
+        else {
+            panic!("expected a body submission");
+        };
+        let height = block.coinbase_height().expect("test block has height");
+        let hash = block.hash();
+        let invalid = zakura_header_chain::ConsensusBodyInvalid {
+            hash,
+            evidence: zakura_header_chain::EvidenceId::from_digest([0xa1; 32]),
+            rule: zakura_header_chain::BodyRuleId::new("test.consensus_invalid"),
+            source,
+        };
+        let mut outcome = BlockApplyOutcome::consensus_invalid(invalid.clone());
+
+        action_sender
+            .send(BlockSyncAction::Misbehavior {
+                peer: ZakuraPeerId::new(vec![0xee; 32])
+                    .expect("the filler peer ID has the required length"),
+                reason: BlockSyncMisbehavior::InvalidBlock,
+            })
+            .await
+            .expect("the filler occupies the action channel");
+        let completion = tokio::spawn(async move {
+            let result = task
+                .handle_apply_finished(
+                    owner,
+                    source,
+                    token,
+                    height,
+                    hash,
+                    &mut outcome,
+                    BTreeSet::new(),
+                    None,
+                    Some((owner, zakura_header_chain::StateVersion::new(7))),
+                )
+                .await;
+            (task, result)
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !completion.is_finished(),
+            "invalidity must remain pending after the ordinary action timeout",
+        );
+        assert!(matches!(
+            actions_rx.recv().await,
+            Some(BlockSyncAction::Misbehavior {
+                reason: BlockSyncMisbehavior::InvalidBlock,
+                ..
+            })
+        ));
+        assert!(matches!(
+            actions_rx.recv().await,
+            Some(BlockSyncAction::RecordBodyInvalid {
+                expected_version,
+                invalid: actual,
+            }) if expected_version == zakura_header_chain::StateVersion::new(7)
+                && actual == invalid
+        ));
+
+        let (task, result) = completion.await.expect("the sequencer task does not panic");
+        assert_eq!(result, (true, true));
+        assert!(
+            !task.sequencer.applying_contains(height),
+            "the sequencer retires the body only after it hands off invalidity",
+        );
+        assert!(matches!(
+            actions_rx.recv().await,
+            Some(BlockSyncAction::Misbehavior {
+                reason: BlockSyncMisbehavior::ConsensusBodyInvalid(actual),
+                ..
+            }) if actual == invalid
+        ));
     }
 
     #[tokio::test]

--- a/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
+++ b/crates/zakura-network/src/zakura/block_sync/sequencer_task.rs
@@ -1889,6 +1889,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closed_action_receiver_retains_exact_required_evidence() {
+        let frontiers = BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        };
+        let (_body_tx, body_rx) = mpsc::channel(1);
+        let (_control_tx, control_rx) = mpsc::unbounded_channel();
+        let (actions, actions_rx) = mpsc::channel(1);
+        drop(actions_rx);
+        let (view_tx, _view_rx) = watch::channel(initial_view(frontiers));
+        let task = SequencerTask::new(
+            Sequencer::new(block::Height(0), 1),
+            ByteBudget::new(123),
+            Arc::new(WorkQueue::new(block::Height(0))),
+            Arc::new(PeerRegistry::new()),
+            actions,
+            ThroughputMeter::new(Instant::now()),
+            frontiers,
+            Some(super::test_work_scope()),
+            crate::zakura::header_sync::SeededRetryJitter::new([0; 32]),
+            body_rx,
+            control_rx,
+            Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            view_tx,
+            Duration::from_millis(20),
+            ZakuraTrace::noop(),
+        );
+
+        let rule: Arc<str> = Arc::from("test.retained_consensus_invalid");
+        let retained_rule = Arc::downgrade(&rule);
+        let action = BlockSyncAction::RecordBodyInvalid {
+            expected_version: zakura_header_chain::StateVersion::new(9),
+            invalid: zakura_header_chain::ConsensusBodyInvalid {
+                hash: block::Hash([0xa3; 32]),
+                evidence: zakura_header_chain::EvidenceId::from_digest([0xa4; 32]),
+                rule: zakura_header_chain::BodyRuleId::new(rule),
+                source: zakura_header_chain::SourceId::from_digest([0xa5; 32]),
+            },
+        };
+        let mut handoff = tokio::spawn(async move {
+            task.send_required_action(action).await;
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut handoff)
+                .await
+                .is_err(),
+            "a closed receiver must leave the required handoff fail-closed",
+        );
+        assert!(
+            retained_rule.upgrade().is_some(),
+            "the fail-closed handoff must retain the exact invalidity evidence",
+        );
+
+        handoff.abort();
+        let _ = handoff.await;
+        assert!(
+            retained_rule.upgrade().is_none(),
+            "supervision cancellation releases the retained evidence",
+        );
+    }
+
+    #[tokio::test]
     // IN-02: enumerate every commitment mismatch so each proves body-only
     // attribution while preserving the independently valid header.
     async fn each_commitment_mismatch_scores_only_body_delivery() {

--- a/docs/changelog/unreleased/850.md
+++ b/docs/changelog/unreleased/850.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Preserved deterministic invalid-body evidence until the block-sync driver
-  accepts its persistence action
+- Preserved deterministic invalid-body evidence and retry state until the
+  block-sync driver accepts each persistence action
   ([#850](https://github.com/zakura-core/zakura/pull/850)).

--- a/docs/changelog/unreleased/850.md
+++ b/docs/changelog/unreleased/850.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Preserved deterministic invalid-body evidence until the block-sync driver
+  accepts its persistence action
+  ([#850](https://github.com/zakura-core/zakura/pull/850)).


### PR DESCRIPTION
## Motivation

The sequencer used the ordinary five-second action timeout when it handed deterministic invalid-body evidence and retry state to the driver. Queue contention could expire that timeout. The sequencer then retired the body without preserving the persistence action.

A lost invalid-body action can leave the invalid branch selected and cause repeated downloads. A lost retry-state action can discard the latest durable retry history.

## Solution

Use a required FIFO send for deterministic invalid-body evidence and retry state. Keep the exact action pending until the driver accepts it.

If the receiver closes, retain the exact action while the node fails closed. PR #853 makes the driver exit visible to the node root and starts node shutdown.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p zakura-network --lib zakura::block_sync -- --test-threads=1` (282 passed)
- `./scripts/changelog.py check`
- `git diff --check`

The regressions hold the only queue slot beyond the ordinary action timeout. They verify that the sequencer retains each action until capacity returns. A closed-receiver regression verifies that the pending future owns the exact invalidity evidence until supervision cancels it.

## Changelog

Added `docs/changelog/unreleased/850.md`.

### Specifications & References

- Useful-item-loss audit finding F010

### Follow-up Work

Merge PR #853 first so a closed driver receiver stops the node.