### PR TITLE
perf(rpc): cache getblockchaininfo disk size

### DIFF
--- a/crates/zakura-state/src/request.rs
+++ b/crates/zakura-state/src/request.rs
@@ -1440,7 +1440,10 @@ impl Request {
 /// [`ReadStateService`](crate::service::ReadStateService).
 pub enum ReadRequest {
     /// Returns [`ReadResponse::UsageInfo(num_bytes: u64)`](ReadResponse::UsageInfo)
-    /// with the current disk space usage in bytes.
+    /// with a recent estimate of the disk space usage in bytes.
+    ///
+    /// The state service refreshes this estimate with its RocksDB metrics, normally every 30
+    /// seconds.
     UsageInfo,
 
     /// Returns [`ReadResponse::PruningInfo`] with

--- a/crates/zakura-state/src/response.rs
+++ b/crates/zakura-state/src/response.rs
@@ -387,7 +387,7 @@ pub struct BlockSyncBodyMetadata {
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s [`ReadRequest`].
 pub enum ReadResponse {
-    /// Response to [`ReadRequest::UsageInfo`] with the current best chain tip.
+    /// Response to [`ReadRequest::UsageInfo`] with a recent disk space usage estimate.
     UsageInfo(u64),
 
     /// Response to [`ReadRequest::PruningInfo`] with this node's pruning status.

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -2470,7 +2470,7 @@ impl Service<ReadRequest> for ReadStateService {
 
         let request_handler = move || match req {
             // Used by the `getblockchaininfo` RPC.
-            ReadRequest::UsageInfo => Ok(ReadResponse::UsageInfo(state.db.size())),
+            ReadRequest::UsageInfo => Ok(ReadResponse::UsageInfo(state.db.cached_size())),
 
             // Used by the `getblockchaininfo` RPC.
             ReadRequest::PruningInfo => Ok(ReadResponse::PruningInfo {

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -17,7 +17,7 @@ use std::{
     ops::RangeBounds,
     path::Path,
     sync::{
-        atomic::{self, AtomicBool},
+        atomic::{self, AtomicBool, AtomicU64},
         Arc,
     },
 };
@@ -136,6 +136,9 @@ pub struct DiskDb {
     //
     // Everything contained in this state must be shared by all clones, or read-only.
     //
+    /// Database startup and each metrics export update this cached disk size.
+    cached_size: Arc<AtomicU64>,
+
     /// The shared inner RocksDB database.
     ///
     /// RocksDB allows reads and writes via a shared reference.
@@ -737,6 +740,8 @@ impl DiskDb {
         }
 
         metrics::gauge!("zakura.state.rocksdb.total_disk_size_bytes").set(total_disk as f64);
+        self.cached_size
+            .store(total_disk, atomic::Ordering::Relaxed);
         metrics::gauge!("zakura.state.rocksdb.live_data_size_bytes").set(total_live as f64);
         metrics::gauge!("zakura.state.rocksdb.total_memory_size_bytes").set(total_mem as f64);
 
@@ -765,6 +770,11 @@ impl DiskDb {
 
     /// Returns the estimated total disk space usage of the database.
     pub fn size(&self) -> u64 {
+        self.cached_size.load(atomic::Ordering::Relaxed)
+    }
+
+    /// Refreshes the cached estimate of the database's disk usage.
+    fn refresh_cached_size(&self) {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
         let mut total_size_on_disk = 0;
@@ -781,7 +791,8 @@ impl DiskDb {
                 .unwrap_or(0);
         }
 
-        total_size_on_disk
+        self.cached_size
+            .store(total_size_on_disk, atomic::Ordering::Relaxed);
     }
 
     /// Sets `finished_format_upgrades` to true to indicate that Zebra has
@@ -1177,9 +1188,11 @@ impl DiskDb {
                     db: Arc::new(db),
                     _secondary_dir: secondary_dir,
                     finished_format_upgrades: Arc::new(AtomicBool::new(false)),
+                    cached_size: Arc::new(AtomicU64::new(0)),
                 };
 
                 db.assert_default_cf_is_empty();
+                db.refresh_cached_size();
 
                 Ok(db)
             }

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -708,15 +708,21 @@ impl DiskDb {
         let mut total_disk: u64 = 0;
         let mut total_live: u64 = 0;
         let mut total_mem: u64 = 0;
+        let mut measured_column_family = false;
+        let mut complete_disk_measurement = true;
 
         for cf_descriptor in column_families {
             let cf_name = cf_descriptor.name().to_string();
             if let Some(cf_handle) = db.cf_handle(&cf_name) {
-                let disk = db
-                    .property_int_value_cf(cf_handle, "rocksdb.total-sst-files-size")
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0);
+                measured_column_family = true;
+                let disk = match db.property_int_value_cf(cf_handle, "rocksdb.total-sst-files-size")
+                {
+                    Ok(Some(disk)) => disk,
+                    _ => {
+                        complete_disk_measurement = false;
+                        0
+                    }
+                };
                 let live = db
                     .property_int_value_cf(cf_handle, "rocksdb.estimate-live-data-size")
                     .ok()
@@ -736,12 +742,16 @@ impl DiskDb {
                     .set(disk as f64);
                 metrics::gauge!("zakura.state.rocksdb.cf_memory_size_bytes", "cf" => cf_name)
                     .set(mem as f64);
+            } else {
+                complete_disk_measurement = false;
             }
         }
 
         metrics::gauge!("zakura.state.rocksdb.total_disk_size_bytes").set(total_disk as f64);
-        self.cached_size
-            .store(total_disk, atomic::Ordering::Relaxed);
+        if measured_column_family && complete_disk_measurement {
+            self.cached_size
+                .store(total_disk, atomic::Ordering::Relaxed);
+        }
         metrics::gauge!("zakura.state.rocksdb.live_data_size_bytes").set(total_live as f64);
         metrics::gauge!("zakura.state.rocksdb.total_memory_size_bytes").set(total_mem as f64);
 
@@ -770,29 +780,43 @@ impl DiskDb {
 
     /// Returns the estimated total disk space usage of the database.
     pub fn size(&self) -> u64 {
+        self.measure_size().0
+    }
+
+    /// Returns the most recently cached disk space estimate.
+    pub(crate) fn cached_size(&self) -> u64 {
         self.cached_size.load(atomic::Ordering::Relaxed)
     }
 
     /// Refreshes the cached estimate of the database's disk usage.
     fn refresh_cached_size(&self) {
+        let (size, complete) = self.measure_size();
+        if complete {
+            self.cached_size.store(size, atomic::Ordering::Relaxed);
+        }
+    }
+
+    /// Measures the estimated disk usage and reports whether every property was available.
+    fn measure_size(&self) -> (u64, bool) {
         let db: &Arc<DB> = &self.db;
         let db_options = DiskDb::options();
         let mut total_size_on_disk = 0;
+        let mut measured_column_family = false;
+        let mut complete = true;
         for cf_descriptor in DiskDb::construct_column_families(db_options, db.path(), [], false) {
             let cf_name = &cf_descriptor.name();
             let cf_handle = db
                 .cf_handle(cf_name)
-                .expect("Column family handle must exist");
+                .expect("column family handle exists because RocksDB opened every descriptor");
+            measured_column_family = true;
 
-            total_size_on_disk += db
-                .property_int_value_cf(cf_handle, "rocksdb.total-sst-files-size")
-                .ok()
-                .flatten()
-                .unwrap_or(0);
+            match db.property_int_value_cf(cf_handle, "rocksdb.total-sst-files-size") {
+                Ok(Some(size)) => total_size_on_disk += size,
+                _ => complete = false,
+            }
         }
 
-        self.cached_size
-            .store(total_size_on_disk, atomic::Ordering::Relaxed);
+        (total_size_on_disk, measured_column_family && complete)
     }
 
     /// Sets `finished_format_upgrades` to true to indicate that Zebra has

--- a/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
@@ -73,10 +73,20 @@ fn exporting_metrics_refreshes_cached_disk_size() {
         "the flushed SST file should use disk space"
     );
     db.cached_size.store(u64::MAX, Ordering::Relaxed);
+    assert_eq!(
+        db.size(),
+        expected_size,
+        "the on-demand size must not return the cached estimate"
+    );
+    assert_eq!(
+        db.cached_size(),
+        u64::MAX,
+        "the test must replace the cached estimate"
+    );
     db.export_metrics();
 
     assert_eq!(
-        db.size(),
+        db.cached_size(),
         expected_size,
         "the metrics export should refresh the cached disk size"
     );

--- a/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db/tests.rs
@@ -3,9 +3,15 @@
 #![allow(clippy::unwrap_in_result)]
 #![allow(dead_code)]
 
-use std::ops::Deref;
+use std::{ops::Deref, sync::atomic::Ordering};
 
-use crate::service::finalized_state::disk_db::{format_bytes, DiskDb, DB};
+use semver::Version;
+use zakura_chain::parameters::Network;
+
+use crate::{
+    service::finalized_state::disk_db::{format_bytes, DiskDb, DB},
+    Config,
+};
 
 // Enable older test code to automatically access the inner database via Deref coercion.
 impl Deref for DiskDb {
@@ -37,6 +43,43 @@ fn format_bytes_preserves_decimal_unit_boundaries() {
     assert_eq!(format_bytes(999_950), "1000 KB");
     assert_eq!(format_bytes(1_000_000), "1 MB");
     assert_eq!(format_bytes(u64::MAX), "18.4 EB");
+}
+
+#[test]
+fn exporting_metrics_refreshes_cached_disk_size() {
+    let _init_guard = zakura_test::init();
+    let db = DiskDb::new(
+        &Config::ephemeral(),
+        "cached-size-test",
+        &Version::new(1, 0, 0),
+        &Network::Mainnet,
+        ["cached_size".to_owned()],
+        false,
+    )
+    .expect("the ephemeral database configuration is valid");
+
+    let cf = db
+        .cf_handle("cached_size")
+        .expect("the test column family was configured");
+    db.put_cf(cf, b"key", [0xa5; 4096])
+        .expect("writing the test value should succeed");
+    db.flush_cf(cf)
+        .expect("flushing the test column family should succeed");
+    db.refresh_cached_size();
+
+    let expected_size = db.size();
+    assert!(
+        expected_size > 0,
+        "the flushed SST file should use disk space"
+    );
+    db.cached_size.store(u64::MAX, Ordering::Relaxed);
+    db.export_metrics();
+
+    assert_eq!(
+        db.size(),
+        expected_size,
+        "the metrics export should refresh the cached disk size"
+    );
 }
 
 /// Check that zs_iter_opts returns an upper bound one greater than provided inclusive end bounds.

--- a/crates/zakura-state/src/service/finalized_state/zakura_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db.rs
@@ -474,6 +474,11 @@ impl ZakuraDb {
     pub fn size(&self) -> u64 {
         self.db.size()
     }
+
+    /// Returns the most recently cached disk space estimate.
+    pub(crate) fn cached_size(&self) -> u64 {
+        self.db.cached_size()
+    }
 }
 
 /// The first database format version whose Mainnet VCT databases are guaranteed to hold the

--- a/docs/changelog/unreleased/854.md
+++ b/docs/changelog/unreleased/854.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Reduced `getblockchaininfo` latency by reusing the periodic database disk-size measurement
+  ([#854](https://github.com/zakura-core/zakura/pull/854)).

--- a/scripts/rpc-bench.py
+++ b/scripts/rpc-bench.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Measure one JSON-RPC method over persistent HTTP connections."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import math
+import threading
+import time
+from array import array
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer argument."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def percentile(sorted_values: array, fraction: float) -> int:
+    """Return the nearest-rank percentile from sorted nanosecond values."""
+    if not sorted_values:
+        return 0
+    rank = max(0, math.ceil(fraction * len(sorted_values)) - 1)
+    return sorted_values[rank]
+
+
+def worker(
+    host: str,
+    port: int,
+    body: bytes,
+    deadline: float,
+    latencies: array,
+    errors: list[str],
+) -> None:
+    """Send requests on one persistent connection until the deadline."""
+    connection = http.client.HTTPConnection(host, port, timeout=10)
+    headers = {"Content-Type": "application/json"}
+    try:
+        while time.monotonic() < deadline:
+            started = time.perf_counter_ns()
+            try:
+                connection.request("POST", "/", body=body, headers=headers)
+                response = connection.getresponse()
+                payload = response.read()
+                if response.status != 200:
+                    raise RuntimeError(f"HTTP {response.status}")
+                decoded = json.loads(payload)
+                if decoded.get("error") is not None:
+                    raise RuntimeError(str(decoded["error"]))
+                latencies.append(time.perf_counter_ns() - started)
+            except Exception as error:  # noqa: BLE001 - count every request failure.
+                errors.append(str(error))
+                connection.close()
+                connection = http.client.HTTPConnection(host, port, timeout=10)
+    finally:
+        connection.close()
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    """Run one warmup and one measured concurrency level."""
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": "rpc-bench", "method": args.method, "params": []},
+        separators=(",", ":"),
+    ).encode()
+
+    if args.warmup_seconds:
+        warmup_deadline = time.monotonic() + args.warmup_seconds
+        warmup_threads = []
+        for _ in range(args.concurrency):
+            thread = threading.Thread(
+                target=worker,
+                args=(args.host, args.port, body, warmup_deadline, array("Q"), []),
+            )
+            thread.start()
+            warmup_threads.append(thread)
+        for thread in warmup_threads:
+            thread.join()
+
+    deadline = time.monotonic() + args.duration_seconds
+    samples = [array("Q") for _ in range(args.concurrency)]
+    thread_errors = [[] for _ in range(args.concurrency)]
+    threads = []
+    started = time.monotonic()
+    for index in range(args.concurrency):
+        thread = threading.Thread(
+            target=worker,
+            args=(args.host, args.port, body, deadline, samples[index], thread_errors[index]),
+        )
+        thread.start()
+        threads.append(thread)
+    for thread in threads:
+        thread.join()
+    elapsed = time.monotonic() - started
+
+    latencies = array("Q")
+    for sample in samples:
+        latencies.extend(sample)
+    latencies = array("Q", sorted(latencies))
+    errors = [error for group in thread_errors for error in group]
+    count = len(latencies)
+    return {
+        "method": args.method,
+        "concurrency": args.concurrency,
+        "duration_seconds": elapsed,
+        "requests": count,
+        "requests_per_second": count / elapsed if elapsed else 0,
+        "errors": len(errors),
+        "first_error": errors[0] if errors else None,
+        "latency_ms": {
+            "p50": percentile(latencies, 0.50) / 1_000_000,
+            "p95": percentile(latencies, 0.95) / 1_000_000,
+            "p99": percentile(latencies, 0.99) / 1_000_000,
+            "max": (latencies[-1] / 1_000_000) if latencies else 0,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=positive_int, default=8232)
+    parser.add_argument("--method", default="getblockchaininfo")
+    parser.add_argument("--concurrency", type=positive_int, required=True)
+    parser.add_argument("--duration-seconds", type=positive_int, default=30)
+    parser.add_argument("--warmup-seconds", type=int, default=5)
+    args = parser.parse_args()
+    if args.warmup_seconds < 0:
+        parser.error("--warmup-seconds must be non-negative")
+    print(json.dumps(run(args), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

Lightwalletd calls `getblockchaininfo` for each `GetLatestBlock` request. A CPU profile on a synchronized full-state node showed that the `UsageInfo` state read dominated this RPC. Each request called `DB::ListColumnFamilies`. RocksDB then replayed the manifest and summed SST metadata for every column family.

## Solution

Cache the database disk-size estimate in `DiskDb`. Database startup computes the initial value. The existing RocksDB metrics task normally refreshes it every 30 seconds. The `UsageInfo` state read now performs one atomic load.

Keep the public `DiskDb::size()` and `ZakuraDb::size()` methods as on-demand measurements. This preserves their behavior for direct database users and offline tools. An incomplete RocksDB property scan also retains the last complete cached value.

Add `scripts/rpc-bench.py` to measure JSON-RPC latency and throughput over persistent HTTP connections.

## Freshness rationale

The RPC defines `size_on_disk` as an estimated size. The underlying RocksDB property only counts SST file bytes, so the prior on-demand value was already not an exact filesystem measurement. The 30-second cache interval adds bounded operational staleness without changing consensus or chain-tip data.

The mainnet target block interval is 75 seconds. Lightwalletd does not deserialize or use `size_on_disk`. It uses the block height and best block hash for `GetLatestBlock`. Operators that need exact free-space information must use filesystem monitoring rather than this RPC estimate.

## Benchmark

I reran an isolated A/B benchmark after the audit fixes. The baseline used unpatched `main` at `0f435507338a19fe0b8aff51875c6dac784e39c2`. The candidate used the same commit plus this PR at `d2339c5f575793504807864228edac9df7859c8f`. Both binaries used the same synchronized full-state database, configuration, hardware, and localhost RPC path.

| Concurrency | Metric | Unpatched `main` | Patched `main` | Improvement |
| ---: | --- | ---: | ---: | ---: |
| 1 | p50 | 22.56 ms | 0.84 ms | 27.0x |
| 1 | p95 | 26.81 ms | 1.29 ms | 20.8x |
| 1 | p99 | 36.05 ms | 1.80 ms | 20.0x |
| 1 | requests/s | 43.48 | 1,102.34 | 25.3x |
| 4 | p50 | 41.68 ms | 1.90 ms | 22.0x |
| 4 | p95 | 55.65 ms | 3.48 ms | 16.0x |
| 4 | p99 | 64.22 ms | 4.73 ms | 13.6x |
| 4 | requests/s | 96.69 | 1,932.11 | 20.0x |

Every benchmark request succeeded. The candidate's `size_on_disk` value of 277,008,746,976 bytes exactly matched `zakura_state_rocksdb_total_disk_size_bytes`. I restored the node's exact original binary and verified RPC health afterward.

## Testing

The state test writes and flushes an SST file. It verifies that direct size measurements do not use the cache. It also verifies that the metrics export refreshes the cached nonzero disk size.

The following checks passed:

- `cargo test -p zakura-state --lib` (541 passed, 3 ignored)
- `cargo test -p zakura-state exporting_metrics_refreshes_cached_disk_size --lib`
- `cargo test -p zakura-rpc get_blockchain_info --lib`
- `cargo clippy -p zakura-state --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo build --release --bin zakurad`
- `python3 -B scripts/rpc-bench.py --help`

## Changelog

Added `docs/changelog/unreleased/854.md` under `Fixed`.
