### PR TITLE
feat(consensus): implement ZIP 233 behind a build feature

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -336,6 +336,33 @@ jobs:
       - name: Check generated zakurad config compatibility
         run: cargo nextest run --profile zakura-config --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst" --no-fail-fast
 
+  zip218:
+    name: ZIP 218 feature tests
+    needs: changes
+    # Compiles its own binaries, because the shared nextest archive is built
+    # without this feature.
+    if: needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Test the crates that ZIP 218 changes
+        run: |
+          cargo test --locked --features zakura-chain/zip218 \
+            -p zakura-chain -p zakura-header-chain --lib
+          cargo test --locked --features zip218 \
+            -p zakura-consensus -p zakura-rpc --lib
+
   network-dependent:
     name: network-dependent acceptance tests
     needs: changes
@@ -464,6 +491,7 @@ jobs:
       - build-tests
       - unit-tests
       - zakura-config
+      - zip218
       - network-dependent
       - pruned-storage
       - check-no-git-dependencies
@@ -481,7 +509,7 @@ jobs:
           # check-no-git-dependencies is A-release-label only, publish-graph
           # skips on PRs that do not touch Cargo manifests or this check.
           # Failed, non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, publish-graph
+          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, zip218, publish-graph
 
   report-nightly-result:
     name: report nightly release test result

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -363,6 +363,36 @@ jobs:
           cargo test --locked --features zip218 \
             -p zakura-consensus -p zakura-rpc --lib
 
+  zip233:
+    name: ZIP 233 feature tests
+    needs: changes
+    # Compiles its own binaries, because the shared nextest archive is built
+    # without this feature, and because the feature needs its own RUSTFLAGS.
+    if: needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # ZIP 233 changes the v6 transaction format on both sides of the
+      # `zakura-primitives` boundary, and that crate gates its half on this cfg.
+      RUSTFLAGS: --cfg zcash_unstable="nu7"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Test the crates that ZIP 233 changes
+        run: |
+          cargo test --locked --features zakura-chain/zip233 -p zakura-chain --lib
+          cargo test --locked --features zip233 \
+            -p zakura-consensus -p zakura-rpc --lib
+
   network-dependent:
     name: network-dependent acceptance tests
     needs: changes
@@ -492,6 +522,7 @@ jobs:
       - unit-tests
       - zakura-config
       - zip218
+      - zip233
       - network-dependent
       - pruned-storage
       - check-no-git-dependencies
@@ -509,7 +540,7 @@ jobs:
           # check-no-git-dependencies is A-release-label only, publish-graph
           # skips on PRs that do not touch Cargo manifests or this check.
           # Failed, non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, zip218, publish-graph
+          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, zip218, zip233, publish-graph
 
   report-nightly-result:
     name: report nightly release test result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,7 +7607,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "abscissa_core",
  "bytes",
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "bech32",
  "bitflags",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-header-chain"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bitflags",
  "blake2b_simd",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "jsonrpsee-types",
  "reqwest 0.12.28",
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8267,7 +8267,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "hex",
  "lazy_static",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -8408,7 +8408,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "blake2b_simd",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "bech32",
  "bitflags",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-header-chain"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -8297,7 +8297,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "6.1.0"
+version = "7.0.0"
 dependencies = [
  "bech32",
  "bitflags",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "blake2b_simd",
  "chrono",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "6.0.0"
+version = "6.1.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "6.1.0"
+version = "7.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -32,9 +32,11 @@ zip218 = []
 # ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
 # `zip233Amount` field on v6 transactions, which removes value from circulation.
 #
-# The field changes the v6 transaction format and the ZIP 244 header digest, so this
-# feature also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'` to reach the matching code
-# in `zakura-primitives`. A build without that flag fails to compile.
+# The field changes the v6 transaction format and the ZIP 244 header digest, and the
+# matching `zakura-primitives` code is gated on the `zcash_unstable = "nu7"` cfg as well
+# as on its own feature. `ZIP233_ENABLED` requires that cfg too, so a build without
+# `RUSTFLAGS='--cfg zcash_unstable="nu7"'` follows today's consensus rather than half of
+# ZIP 233.
 zip233 = ["zcash_primitives/zip-233"]
 
 # Consensus-critical conversion from JSON to Zcash types

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "6.1.0"
+version = "6.2.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -29,6 +29,14 @@ default = []
 # one.
 zip218 = []
 
+# ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
+# `zip233Amount` field on v6 transactions, which removes value from circulation.
+#
+# The field changes the v6 transaction format and the ZIP 244 header digest, so this
+# feature also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'` to reach the matching code
+# in `zakura-primitives`. A build without that flag fails to compile.
+zip233 = ["zcash_primitives/zip-233"]
+
 # Consensus-critical conversion from JSON to Zcash types
 json-conversion = [
     "serde_json",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -20,6 +20,15 @@ default = []
 
 # Production features that activate extra functionality
 
+# ZIP 218 "25-second Block Target Spacing": 25 second block target spacing, a
+# 102-block difficulty averaging window, a block subsidy divided by the spacing
+# ratio, and per-block shielded action limits, all from NU7 activation onwards.
+#
+# The rules stay dormant until NU7 has an activation height on the configured
+# network, so this feature only changes consensus on a network that configures
+# one.
+zip218 = []
+
 # Consensus-critical conversion from JSON to Zcash types
 json-conversion = [
     "serde_json",

--- a/crates/zakura-chain/benches/transaction.rs
+++ b/crates/zakura-chain/benches/transaction.rs
@@ -67,6 +67,7 @@ fn v6_ironwood_only_tx(orchard_tx: &Transaction) -> Arc<Transaction> {
         .expect("Orchard-only tx has Orchard shielded data");
 
     Arc::new(Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),

--- a/crates/zakura-chain/src/block/tests/vectors.rs
+++ b/crates/zakura-chain/src/block/tests/vectors.rs
@@ -216,6 +216,7 @@ fn ironwood_block_accessors_preserve_pool_and_wire_order() {
         |orchard_shielded_data: orchard::ShieldedData,
          ironwood_shielded_data: ironwood::ShieldedData| {
             Arc::new(Transaction::V6 {
+                zip233_amount: Default::default(),
                 network_upgrade: Nu6_3,
                 lock_time: LockTime::unlocked(),
                 expiry_height: Height(1),
@@ -308,6 +309,7 @@ fn ironwood_transaction_count_is_pool_specific_and_counts_bundles() {
         |orchard_shielded_data: Option<orchard::ShieldedData>,
          ironwood_shielded_data: Option<ironwood::ShieldedData>| {
             Arc::new(Transaction::V6 {
+                zip233_amount: Default::default(),
                 network_upgrade: Nu6_3,
                 lock_time: LockTime::unlocked(),
                 expiry_height: Height(1),

--- a/crates/zakura-chain/src/parallel/tree.rs
+++ b/crates/zakura-chain/src/parallel/tree.rs
@@ -359,6 +359,7 @@ mod tests {
             |orchard_shielded_data: orchard::ShieldedData,
              ironwood_shielded_data: ironwood::ShieldedData| {
                 Arc::new(Transaction::V6 {
+                    zip233_amount: Default::default(),
                     network_upgrade: Nu6_3,
                     lock_time: LockTime::unlocked(),
                     expiry_height: Height(1),
@@ -372,6 +373,7 @@ mod tests {
 
         let height = Height(123);
         let coinbase = Arc::new(Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: height,

--- a/crates/zakura-chain/src/parameters.rs
+++ b/crates/zakura-chain/src/parameters.rs
@@ -23,7 +23,7 @@ mod transaction;
 pub mod arbitrary;
 
 pub use genesis::*;
-pub use network::{magic::Magic, subsidy, testnet, Network, NetworkKind};
+pub use network::{magic::Magic, subsidy, testnet, Network, NetworkKind, V4Deprecation};
 pub use network_upgrade::*;
 pub use transaction::*;
 

--- a/crates/zakura-chain/src/parameters/network.rs
+++ b/crates/zakura-chain/src/parameters/network.rs
@@ -30,6 +30,33 @@ const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_36
 // lands 3_500 blocks later.
 const TESTNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(4_048_500);
 
+/// When a network stops accepting version 4 transactions.
+///
+/// [ZIP 2003] disallows version 4 transactions from NU7 onwards. The Zcash
+/// community polls that decide NU7's scope also offer a deprecation date later
+/// than NU7 activation, and the option of setting no date at all, so a network
+/// chooses between the three rather than inheriting the NU7 activation height.
+///
+/// [ZIP 2003]: https://zips.z.cash/zip-2003
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum V4Deprecation {
+    /// Version 4 transactions are invalid from the NU7 activation height onwards,
+    /// which is what ZIP 2003 proposes.
+    ///
+    /// A network that does not activate NU7 keeps accepting version 4 transactions.
+    #[default]
+    AtNu7,
+
+    /// Version 4 transactions are invalid from this height onwards.
+    ///
+    /// The height is independent of the NU7 activation height, so a network can
+    /// activate NU7 and deprecate version 4 transactions later.
+    AtHeight(Height),
+
+    /// Version 4 transactions stay valid at every height.
+    Never,
+}
+
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization
 //       of history trees in the db format.
@@ -340,6 +367,37 @@ impl Network {
                 )
             })
             .collect()
+    }
+
+    /// Returns when this network stops accepting version 4 transactions.
+    ///
+    /// See [`V4Deprecation`] and [ZIP 2003].
+    ///
+    /// [ZIP 2003]: https://zips.z.cash/zip-2003
+    pub fn v4_deprecation(&self) -> V4Deprecation {
+        match self {
+            Network::Mainnet => V4Deprecation::AtNu7,
+            Network::Testnet(parameters) => parameters.v4_deprecation(),
+        }
+    }
+
+    /// Returns the first height at which version 4 transactions are invalid on this
+    /// network, or `None` if they stay valid at every height.
+    ///
+    /// [`V4Deprecation::AtNu7`] resolves to the NU7 activation height, so a network
+    /// that does not activate NU7 keeps accepting version 4 transactions.
+    pub fn v4_deprecation_height(&self) -> Option<Height> {
+        match self.v4_deprecation() {
+            V4Deprecation::AtNu7 => NetworkUpgrade::Nu7.activation_height(self),
+            V4Deprecation::AtHeight(height) => Some(height),
+            V4Deprecation::Never => None,
+        }
+    }
+
+    /// Returns whether version 4 transactions are invalid at `height` on this network.
+    pub fn is_v4_deprecated(&self, height: Height) -> bool {
+        self.v4_deprecation_height()
+            .is_some_and(|deprecation_height| height >= deprecation_height)
     }
 
     /// Returns the height at which the soft fork that temporarily disables Orchard

--- a/crates/zakura-chain/src/parameters/network/subsidy.rs
+++ b/crates/zakura-chain/src/parameters/network/subsidy.rs
@@ -417,28 +417,38 @@ pub fn halving_divisor(height: Height, network: &Network) -> Option<u64> {
 /// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn halving(height: Height, network: &Network) -> u32 {
     let slow_start_shift = network.slow_start_shift();
-    let blossom_height = NetworkUpgrade::Blossom
-        .activation_height(network)
-        .expect("blossom activation height should be available");
+    if height < slow_start_shift {
+        return 0;
+    }
 
-    let halving_index = if height < slow_start_shift {
-        0
-    } else if height < blossom_height {
-        let pre_blossom_height = height - slow_start_shift;
-        pre_blossom_height / network.pre_blossom_halving_interval()
-    } else {
-        let pre_blossom_height = blossom_height - slow_start_shift;
-        let scaled_pre_blossom_height =
-            pre_blossom_height * HeightDiff::from(BLOSSOM_POW_TARGET_SPACING_RATIO);
+    // Each target spacing era contributes (blocks in the era * era spacing) to a
+    // running total of block seconds, which the pre-Blossom halving interval
+    // measured in seconds then divides. This is the spec's segmented sum of
+    // fractions with the common denominator factored out, so it stays in integer
+    // arithmetic no matter how many spacing eras a network has. ZIP 218 adds a
+    // third era at NU7.
+    let pre_blossom_spacing_seconds = NetworkUpgrade::Genesis.target_spacing().num_seconds();
+    let mut total_block_seconds: HeightDiff = 0;
 
-        let post_blossom_height = height - blossom_height;
+    let mut eras = NetworkUpgrade::target_spacings(network)
+        .filter(|(era_start, _)| *era_start <= height)
+        .peekable();
 
-        (scaled_pre_blossom_height + post_blossom_height) / network.post_blossom_halving_interval()
-    };
+    while let Some((era_start, era_spacing)) = eras.next() {
+        let era_end = eras
+            .peek()
+            .map(|(next_start, _)| *next_start)
+            .unwrap_or(height);
+        let era_blocks = (era_end - era_start.max(slow_start_shift)).max(0);
+        total_block_seconds += era_blocks * era_spacing.num_seconds();
+    }
 
-    halving_index
+    let pre_blossom_denominator =
+        network.pre_blossom_halving_interval() * pre_blossom_spacing_seconds;
+
+    (total_block_seconds / pre_blossom_denominator)
         .try_into()
-        .expect("already checked for negatives")
+        .expect("halving index is non-negative and fits in u32")
 }
 
 /// `BlockSubsidy(height)` as described in [protocol specification §7.8][7.8]
@@ -462,13 +472,17 @@ pub fn block_subsidy(height: Height, net: &Network) -> Result<Amount<NonNegative
             slow_start_rate * (u64::from(height) + 1)
         }
     } else {
-        let base_subsidy = if NetworkUpgrade::current(net, height) < NetworkUpgrade::Blossom {
-            MAX_BLOCK_SUBSIDY
-        } else {
-            MAX_BLOCK_SUBSIDY / u64::from(BLOSSOM_POW_TARGET_SPACING_RATIO)
-        };
+        // Each spacing era scales the per-block subsidy by
+        // `current_spacing / pre_blossom_spacing`, which keeps issuance per unit of
+        // wall-clock time constant across spacing changes. Blossom divides the
+        // subsidy by 2, and ZIP 218 divides it by a further 3 at NU7. The casts are
+        // safe because target spacings are small positive constants.
+        let current_spacing_seconds =
+            NetworkUpgrade::target_spacing_for_height(net, height).num_seconds() as u64;
+        let pre_blossom_spacing_seconds =
+            NetworkUpgrade::Genesis.target_spacing().num_seconds() as u64;
 
-        base_subsidy / halving_div
+        MAX_BLOCK_SUBSIDY * current_spacing_seconds / pre_blossom_spacing_seconds / halving_div
     };
 
     Ok(Amount::try_from(amount)?)

--- a/crates/zakura-chain/src/parameters/network/testnet.rs
+++ b/crates/zakura-chain/src/parameters/network/testnet.rs
@@ -31,7 +31,7 @@ use crate::{
     work::difficulty::{ExpandedDifficulty, U256},
 };
 
-use super::magic::Magic;
+use super::{magic::Magic, V4Deprecation};
 
 /// Reserved network names that should not be allowed for configured Testnets.
 pub const RESERVED_NETWORK_NAMES: [&str; 6] = [
@@ -634,6 +634,8 @@ pub struct ParametersBuilder {
     checkpoints: Arc<CheckpointList>,
     /// Height at which the soft-fork to temporarily disable Orchard in transactions activates
     temporary_orchard_disabling_soft_fork_height: Option<Height>,
+    /// When this network stops accepting version 4 transactions, see ZIP 2003
+    v4_deprecation: V4Deprecation,
 }
 
 impl Default for ParametersBuilder {
@@ -674,6 +676,7 @@ impl Default for ParametersBuilder {
             temporary_orchard_disabling_soft_fork_height: Some(
                 super::TESTNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT,
             ),
+            v4_deprecation: V4Deprecation::AtNu7,
         }
     }
 }
@@ -994,6 +997,12 @@ impl ParametersBuilder {
         self
     }
 
+    /// Sets when this network stops accepting version 4 transactions, see ZIP 2003.
+    pub fn with_v4_deprecation(mut self, v4_deprecation: V4Deprecation) -> Self {
+        self.v4_deprecation = v4_deprecation;
+        self
+    }
+
     /// Converts the builder to a [`Parameters`] struct
     fn finish(self) -> Parameters {
         // The builder defaults to public Testnet consensus parameters, so an unset
@@ -1019,6 +1028,7 @@ impl ParametersBuilder {
             lockbox_disbursements,
             checkpoints,
             temporary_orchard_disabling_soft_fork_height,
+            v4_deprecation,
         } = self;
         Parameters {
             network_name,
@@ -1037,6 +1047,7 @@ impl ParametersBuilder {
             lockbox_disbursements,
             checkpoints,
             temporary_orchard_disabling_soft_fork_height,
+            v4_deprecation,
         }
     }
 
@@ -1092,6 +1103,7 @@ impl ParametersBuilder {
             lockbox_disbursements,
             checkpoints: _,
             temporary_orchard_disabling_soft_fork_height: _,
+            v4_deprecation,
         } = Self::default();
 
         self.activation_heights == activation_heights
@@ -1107,6 +1119,9 @@ impl ParametersBuilder {
             && self.pre_blossom_halving_interval == pre_blossom_halving_interval
             && self.post_blossom_halving_interval == post_blossom_halving_interval
             && self.lockbox_disbursements == lockbox_disbursements
+            // A network that keeps accepting version 4 transactions past the height where
+            // the default Testnet rejects them is on a different consensus rule.
+            && self.v4_deprecation == v4_deprecation
     }
 }
 
@@ -1172,6 +1187,8 @@ pub struct Parameters {
     checkpoints: Arc<CheckpointList>,
     /// Height at which the soft-fork to temporarily disable Orchard in transactions activates
     temporary_orchard_disabling_soft_fork_height: Option<Height>,
+    /// When this network stops accepting version 4 transactions, see ZIP 2003
+    v4_deprecation: V4Deprecation,
 }
 
 impl Default for Parameters {
@@ -1277,6 +1294,9 @@ impl Parameters {
             lockbox_disbursements: _,
             checkpoints: _,
             temporary_orchard_disabling_soft_fork_height: _,
+            // Version 4 deprecation follows the configurable Regtest activation heights,
+            // so it is not part of Regtest's identity.
+            v4_deprecation: _,
         } = Self::new_regtest(Default::default()).expect("default regtest parameters are valid");
 
         self.network_name == network_name
@@ -1388,6 +1408,11 @@ impl Parameters {
     /// transactions activates.
     pub fn temporary_orchard_disabling_soft_fork_height(&self) -> Option<Height> {
         self.temporary_orchard_disabling_soft_fork_height
+    }
+
+    /// Returns when this network stops accepting version 4 transactions, see ZIP 2003.
+    pub fn v4_deprecation(&self) -> V4Deprecation {
+        self.v4_deprecation
     }
 }
 

--- a/crates/zakura-chain/src/parameters/network/tests.rs
+++ b/crates/zakura-chain/src/parameters/network/tests.rs
@@ -318,3 +318,123 @@ fn check_height_for_num_halvings() {
         }
     }
 }
+
+/// Tests the ZIP 218 target spacing, halving, and block subsidy across the NU7
+/// activation boundary on a configured Testnet.
+#[test]
+#[cfg(feature = "zip218")]
+fn post_nu7_spacing_halving_and_subsidy() -> Result<(), Report> {
+    use crate::parameters::{
+        testnet::{self, ConfiguredActivationHeights},
+        NU7_POW_TARGET_SPACING_RATIO, POST_BLOSSOM_POW_TARGET_SPACING, POST_NU7_POW_TARGET_SPACING,
+    };
+
+    let _init_guard = zakura_test::init();
+
+    // Choose parameters where slow_start_shift == blossom_height, so the
+    // pre-Blossom term of the spec's halving sum is exactly zero and the halving
+    // boundaries land on multiples of the post-Blossom halving interval.
+    let blossom = 1u32;
+    let canopy = blossom + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL).unwrap();
+    let nu7 = canopy + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL * 2).unwrap();
+
+    let network = testnet::Parameters::build()
+        // slow_start_shift = slow_start_interval / 2 = 1, the Blossom height.
+        .with_slow_start_interval(Height(2))
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(blossom),
+            canopy: Some(canopy),
+            nu7: Some(nu7),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid");
+
+    let nu7_height = Height(nu7);
+
+    // The target spacing shortens exactly at the NU7 activation height.
+    assert_eq!(
+        i64::from(POST_BLOSSOM_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, (nu7_height - 1).unwrap())
+            .num_seconds()
+    );
+    assert_eq!(
+        i64::from(POST_NU7_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, nu7_height).num_seconds()
+    );
+
+    // Three post-Blossom halvings have elapsed at NU7 activation:
+    //   Halving = floor(0/PreBlossom + 1 + 2) = 3
+    assert_eq!(3, halving(nu7_height, &network));
+    assert_eq!(8, halving_divisor(nu7_height, &network).unwrap());
+
+    // BlockSubsidy(NU7) = floor(MAX / (BlossomRatio * NU7Ratio * 2^Halving))
+    //                   = floor(1_250_000_000 / (2 * 3 * 8)) = 26_041_666 zatoshi
+    assert_eq!(
+        Amount::<NonNegative>::try_from(26_041_666)?,
+        block_subsidy(nu7_height, &network)?,
+    );
+
+    // The third halving boundary lands exactly at NU7 here, so the block before
+    // NU7 is still in halving era 2: floor(1_250_000_000 / (2 * 4)) zatoshi.
+    assert_eq!(2, halving((nu7_height - 1).unwrap(), &network));
+    assert_eq!(
+        Amount::<NonNegative>::try_from(156_250_000)?,
+        block_subsidy((nu7_height - 1).unwrap(), &network)?,
+    );
+
+    // The halving counter does not reset at NU7. The next boundary arrives after
+    // one PostNU7HalvingInterval (= PostBlossomHalvingInterval * 3) of blocks.
+    let post_nu7_halving_interval =
+        POST_BLOSSOM_HALVING_INTERVAL * i64::from(NU7_POW_TARGET_SPACING_RATIO);
+    let next_halving = (nu7_height + post_nu7_halving_interval).unwrap();
+    assert_eq!(4, halving(next_halving, &network));
+    assert_eq!(16, halving_divisor(next_halving, &network).unwrap());
+    assert_eq!(
+        Amount::<NonNegative>::try_from(13_020_833)?,
+        block_subsidy(next_halving, &network)?,
+    );
+
+    Ok(())
+}
+
+/// Tests that the ZIP 218 difficulty averaging window widens at the NU7
+/// activation height.
+#[test]
+#[cfg(feature = "zip218")]
+fn averaging_window_changes_at_nu7_activation_height() -> Result<(), Report> {
+    use crate::parameters::{
+        testnet::{self, ConfiguredActivationHeights},
+        POST_NU7_POW_AVERAGING_WINDOW, PRE_NU7_POW_AVERAGING_WINDOW,
+    };
+
+    let _init_guard = zakura_test::init();
+
+    let network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(1),
+            nu7: Some(10),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid");
+
+    assert_eq!(
+        PRE_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(9))
+    );
+    assert_eq!(
+        POST_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(10))
+    );
+    assert_eq!(
+        POST_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(11))
+    );
+
+    Ok(())
+}

--- a/crates/zakura-chain/src/parameters/network_upgrade.rs
+++ b/crates/zakura-chain/src/parameters/network_upgrade.rs
@@ -273,23 +273,19 @@ pub const ZIP218_ENABLED: bool = cfg!(feature = "zip218");
 ///
 /// ZIP 233 adds the `zip233Amount` field to the v6 transaction format, which removes
 /// value from circulation. The field changes the v6 wire format and the ZIP 244 header
-/// digest, so a build with this feature disabled parses, serializes, and hashes v6
+/// digest, so a build with this constant false parses, serializes, and hashes v6
 /// transactions exactly as before, and every transaction has a `zip233_amount` of zero.
 ///
-/// The rules are still dormant until NU7 activates on the configured network.
+/// The matching `zakura-primitives` code, which parses and hashes the field on the
+/// `librustzcash` side, is gated on its own `zip-233` feature *and* on the
+/// `zcash_unstable = "nu7"` cfg, which no cargo feature can set on a dependency. This
+/// constant requires the same cfg, so the two sides are on and off together and cannot
+/// disagree about the v6 wire format. A `zip233` build without
+/// `RUSTFLAGS='--cfg zcash_unstable="nu7"'` therefore follows today's consensus rather
+/// than half of ZIP 233.
 ///
-/// Enabled by the `zip233` feature.
-pub const ZIP233_ENABLED: bool = cfg!(feature = "zip233");
-
-// The `zip233` feature only reaches the matching `zakura-primitives` code, which parses
-// and hashes the field on the `librustzcash` side, when the build also sets the
-// `zcash_unstable = "nu7"` cfg. Without it the two sides disagree on the v6 wire format,
-// which would be a consensus split rather than a compile error, so fail the build here.
-#[cfg(all(feature = "zip233", not(zcash_unstable = "nu7")))]
-compile_error!(
-    "the `zip233` feature needs RUSTFLAGS='--cfg zcash_unstable=\"nu7\"' so that \
-     `zakura-primitives` compiles its matching ZIP 233 code"
-);
+/// The rules are still dormant until NU7 activates on the configured network.
+pub const ZIP233_ENABLED: bool = cfg!(feature = "zip233") && cfg!(zcash_unstable = "nu7");
 
 /// The target block spacing after NU7 activation, in seconds.
 ///

--- a/crates/zakura-chain/src/parameters/network_upgrade.rs
+++ b/crates/zakura-chain/src/parameters/network_upgrade.rs
@@ -239,8 +239,14 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu6_2, ConsensusBranchId(0x5437f330)),
     (Nu6_3, ConsensusBranchId(0x37a5165b)),
     // TODO: set below to (Nu7, ConsensusBranchId(0x77190ad8)), once the same value is set in librustzcash
-    #[cfg(any(test, feature = "zakura-test"))]
+    //
+    // A `zcash_unstable = "nu7"` build must use the value `zcash_protocol` maps to NU7,
+    // because `Transaction::to_librustzcash` round-trips the branch ID through it. Such a
+    // build also gives NU7 a branch ID outside tests, because it is a NU7 build.
+    #[cfg(all(any(test, feature = "zakura-test"), not(zcash_unstable = "nu7")))]
     (Nu7, ConsensusBranchId(0xfffffffe)),
+    #[cfg(zcash_unstable = "nu7")]
+    (Nu7, ConsensusBranchId(0xffffffff)),
     #[cfg(zcash_unstable = "zfuture")]
     (ZFuture, ConsensusBranchId(0xfffffffd)),
 ];
@@ -262,6 +268,28 @@ pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 ///
 /// Enabled by the `zip218` feature.
 pub const ZIP218_ENABLED: bool = cfg!(feature = "zip218");
+
+/// Whether the ZIP 233 rules are compiled into this build.
+///
+/// ZIP 233 adds the `zip233Amount` field to the v6 transaction format, which removes
+/// value from circulation. The field changes the v6 wire format and the ZIP 244 header
+/// digest, so a build with this feature disabled parses, serializes, and hashes v6
+/// transactions exactly as before, and every transaction has a `zip233_amount` of zero.
+///
+/// The rules are still dormant until NU7 activates on the configured network.
+///
+/// Enabled by the `zip233` feature.
+pub const ZIP233_ENABLED: bool = cfg!(feature = "zip233");
+
+// The `zip233` feature only reaches the matching `zakura-primitives` code, which parses
+// and hashes the field on the `librustzcash` side, when the build also sets the
+// `zcash_unstable = "nu7"` cfg. Without it the two sides disagree on the v6 wire format,
+// which would be a consensus split rather than a compile error, so fail the build here.
+#[cfg(all(feature = "zip233", not(zcash_unstable = "nu7")))]
+compile_error!(
+    "the `zip233` feature needs RUSTFLAGS='--cfg zcash_unstable=\"nu7\"' so that \
+     `zakura-primitives` compiles its matching ZIP 233 code"
+);
 
 /// The target block spacing after NU7 activation, in seconds.
 ///
@@ -622,6 +650,14 @@ impl NetworkUpgrade {
             .values()
             .any(|upgrade| *upgrade == NetworkUpgrade::Nu7)
             && NetworkUpgrade::current(network, height) >= NetworkUpgrade::Nu7
+    }
+
+    /// Returns `true` if the ZIP 233 rules are compiled in and active for
+    /// `network` at `height`.
+    ///
+    /// See [`ZIP233_ENABLED`] and [`NetworkUpgrade::is_nu7_active`].
+    pub fn is_zip233_active(network: &Network, height: block::Height) -> bool {
+        ZIP233_ENABLED && Self::is_nu7_active(network, height)
     }
 
     /// Returns `true` if the ZIP 218 rules are compiled in and active for

--- a/crates/zakura-chain/src/parameters/network_upgrade.rs
+++ b/crates/zakura-chain/src/parameters/network_upgrade.rs
@@ -251,10 +251,84 @@ const PRE_BLOSSOM_POW_TARGET_SPACING: i64 = 150;
 /// The target block spacing after Blossom activation.
 pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 
+/// Whether the ZIP 218 consensus rules are compiled into this build.
+///
+/// ZIP 218 lowers the block target spacing from 75 to 25 seconds at NU7, widens
+/// the difficulty averaging window to match, divides the block subsidy by the
+/// spacing ratio, and adds per-block shielded action limits. The rules are still
+/// dormant until NU7 activates on the configured network, so a build with this
+/// feature enabled follows today's consensus on any network without an NU7
+/// activation height.
+///
+/// Enabled by the `zip218` feature.
+pub const ZIP218_ENABLED: bool = cfg!(feature = "zip218");
+
+/// The target block spacing after NU7 activation, in seconds.
+///
+/// `PostNU7PoWTargetSpacing` in ZIP 218.
+pub const POST_NU7_POW_TARGET_SPACING: u32 = 25;
+
+/// The ratio between the post-Blossom and post-NU7 block target spacings.
+///
+/// `NU7PoWTargetSpacingRatio` in ZIP 218:
+/// `PostBlossomPoWTargetSpacing / PostNU7PoWTargetSpacing = 75 / 25 = 3`.
+pub const NU7_POW_TARGET_SPACING_RATIO: u32 =
+    POST_BLOSSOM_POW_TARGET_SPACING / POST_NU7_POW_TARGET_SPACING;
+
 /// The averaging window for difficulty threshold arithmetic mean calculations.
 ///
+/// `PoWAveragingWindow` in the Zcash specification. ZIP 218 makes this window
+/// height-dependent, so prefer [`NetworkUpgrade::averaging_window`] or
+/// [`NetworkUpgrade::averaging_window_for_height`] over this constant.
+pub const POW_AVERAGING_WINDOW: usize = PRE_NU7_POW_AVERAGING_WINDOW;
+
+/// The averaging window for difficulty threshold arithmetic mean calculations
+/// before NU7.
+///
 /// `PoWAveragingWindow` in the Zcash specification.
-pub const POW_AVERAGING_WINDOW: usize = 17;
+pub const PRE_NU7_POW_AVERAGING_WINDOW: usize = 17;
+
+/// The averaging window for difficulty threshold arithmetic mean calculations
+/// from NU7 onwards.
+///
+/// `PostNU7PoWAveragingWindow` in ZIP 218. The window covers the same wall-clock
+/// timespan at 25 second spacing that 17 blocks covered at the launch 150 second
+/// spacing: `17 * (150 / 25) = 102` blocks.
+pub const POST_NU7_POW_AVERAGING_WINDOW: usize = 102;
+
+/// Per-block limit on the total number of Orchard actions, applied from NU7
+/// activation onwards.
+///
+/// `OrchardBlockActionLimit` in ZIP 218.
+pub const ORCHARD_BLOCK_ACTION_LIMIT: u32 = 330;
+
+/// Per-block limit on the total number of Sapling spends plus outputs, applied
+/// from NU7 activation onwards.
+///
+/// `SaplingBlockIOLimit` in ZIP 218.
+pub const SAPLING_BLOCK_IO_LIMIT: u32 = 300;
+
+/// Per-block limit on the total number of Sprout JoinSplits, applied from NU7
+/// activation onwards.
+///
+/// `SproutBlockJoinSplitLimit` in ZIP 218.
+pub const SPROUT_BLOCK_JOINSPLIT_LIMIT: u32 = 25;
+
+/// Per-block budget for the total shielded cost across all pools, applied from
+/// NU7 activation onwards.
+///
+/// `GlobalShieldedBudget` in ZIP 218. It bounds the worst-case shielded sync
+/// bandwidth per block whichever combination of pools a block uses. Sprout
+/// JoinSplits count twice because each produces two shielded outputs.
+pub const GLOBAL_SHIELDED_BUDGET: u32 = 330;
+
+/// The largest averaging window this build can use, which bounds the number of
+/// relevant blocks a difficulty adjustment reads.
+pub const MAX_POW_AVERAGING_WINDOW: usize = if ZIP218_ENABLED {
+    POST_NU7_POW_AVERAGING_WINDOW
+} else {
+    PRE_NU7_POW_AVERAGING_WINDOW
+};
 
 /// The multiplier used to derive the testnet minimum difficulty block time gap
 /// threshold.
@@ -402,12 +476,13 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu6_3 | Nu7 => {
+            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu6_3 => {
                 POST_BLOSSOM_POW_TARGET_SPACING.into()
             }
+            Nu7 => Self::post_nu7_target_spacing_seconds(),
 
             #[cfg(zcash_unstable = "zfuture")]
-            ZFuture => POST_BLOSSOM_POW_TARGET_SPACING.into(),
+            ZFuture => Self::post_nu7_target_spacing_seconds(),
         };
 
         Duration::seconds(spacing_seconds)
@@ -429,6 +504,10 @@ impl NetworkUpgrade {
             (
                 NetworkUpgrade::Blossom,
                 POST_BLOSSOM_POW_TARGET_SPACING.into(),
+            ),
+            (
+                NetworkUpgrade::Nu7,
+                NetworkUpgrade::post_nu7_target_spacing_seconds(),
             ),
         ]
         .into_iter()
@@ -497,7 +576,60 @@ impl NetworkUpgrade {
     ///
     /// `AveragingWindowTimespan` from the Zcash specification.
     pub fn averaging_window_timespan(&self) -> Duration {
-        self.target_spacing() * POW_AVERAGING_WINDOW.try_into().expect("fits in i32")
+        self.target_spacing() * self.averaging_window().try_into().expect("fits in i32")
+    }
+
+    /// Returns the post-NU7 target spacing in seconds for this build.
+    ///
+    /// Without the `zip218` feature, NU7 keeps the post-Blossom spacing.
+    fn post_nu7_target_spacing_seconds() -> i64 {
+        if ZIP218_ENABLED {
+            POST_NU7_POW_TARGET_SPACING.into()
+        } else {
+            POST_BLOSSOM_POW_TARGET_SPACING.into()
+        }
+    }
+
+    /// Returns the averaging window for difficulty threshold arithmetic mean
+    /// calculations.
+    ///
+    /// `PoWAveragingWindow` in ZIP 218, which widens the window at NU7.
+    pub fn averaging_window(&self) -> usize {
+        match self {
+            Genesis | BeforeOverwinter | Overwinter | Sapling | Blossom | Heartwood | Canopy
+            | Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu6_3 => PRE_NU7_POW_AVERAGING_WINDOW,
+            Nu7 => MAX_POW_AVERAGING_WINDOW,
+
+            #[cfg(zcash_unstable = "zfuture")]
+            ZFuture => MAX_POW_AVERAGING_WINDOW,
+        }
+    }
+
+    /// Returns the averaging window for `network` and `height`.
+    ///
+    /// See [`NetworkUpgrade::averaging_window`] for details.
+    pub fn averaging_window_for_height(network: &Network, height: block::Height) -> usize {
+        NetworkUpgrade::current(network, height).averaging_window()
+    }
+
+    /// Returns `true` if NU7 is configured on `network` and active at `height`.
+    ///
+    /// NU7 has no default Mainnet or Testnet activation height, so this also
+    /// checks that `network` configures one before treating it as active.
+    pub fn is_nu7_active(network: &Network, height: block::Height) -> bool {
+        network
+            .activation_list()
+            .values()
+            .any(|upgrade| *upgrade == NetworkUpgrade::Nu7)
+            && NetworkUpgrade::current(network, height) >= NetworkUpgrade::Nu7
+    }
+
+    /// Returns `true` if the ZIP 218 rules are compiled in and active for
+    /// `network` at `height`.
+    ///
+    /// See [`ZIP218_ENABLED`] and [`NetworkUpgrade::is_nu7_active`].
+    pub fn is_zip218_active(network: &Network, height: block::Height) -> bool {
+        ZIP218_ENABLED && Self::is_nu7_active(network, height)
     }
 
     /// Returns the averaging window timespan for `network` and `height`.

--- a/crates/zakura-chain/src/primitives/zcash_note_encryption.rs
+++ b/crates/zakura-chain/src/primitives/zcash_note_encryption.rs
@@ -256,6 +256,7 @@ mod tests {
         ironwood_shielded_data: Option<chain_orchard::ShieldedData>,
     ) -> Transaction {
         Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: height,

--- a/crates/zakura-chain/src/transaction.rs
+++ b/crates/zakura-chain/src/transaction.rs
@@ -307,6 +307,43 @@ impl fmt::Display for Transaction {
     }
 }
 
+/// The shielded action counts of a transaction or block, used to enforce the
+/// per-block shielded limits from ZIP 218.
+///
+/// Each count saturates at [`u32::MAX`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ShieldedActionCounts {
+    /// The number of Orchard actions.
+    pub orchard_actions: u32,
+    /// The number of Sapling spends plus outputs.
+    pub sapling_ios: u32,
+    /// The number of Sprout JoinSplits.
+    pub sprout_joinsplits: u32,
+}
+
+impl ShieldedActionCounts {
+    /// Returns the total shielded cost:
+    /// `orchard_actions + sapling_ios + 2 * sprout_joinsplits`.
+    ///
+    /// Sprout JoinSplits count twice because each produces two shielded outputs.
+    pub fn cost(&self) -> u32 {
+        self.orchard_actions
+            .saturating_add(self.sapling_ios)
+            .saturating_add(self.sprout_joinsplits.saturating_mul(2))
+    }
+
+    /// Returns the field-wise saturating sum of `self` and `other`.
+    pub fn saturating_add(self, other: Self) -> Self {
+        Self {
+            orchard_actions: self.orchard_actions.saturating_add(other.orchard_actions),
+            sapling_ios: self.sapling_ios.saturating_add(other.sapling_ios),
+            sprout_joinsplits: self
+                .sprout_joinsplits
+                .saturating_add(other.sprout_joinsplits),
+        }
+    }
+}
+
 impl Transaction {
     // identifiers and hashes
 
@@ -1253,6 +1290,19 @@ impl Transaction {
         self.orchard_shielded_data()
             .into_iter()
             .flat_map(orchard::ShieldedData::actions)
+    }
+
+    /// Returns this transaction's [`ShieldedActionCounts`], used to enforce the
+    /// ZIP 218 per-block shielded limits.
+    pub fn shielded_action_counts(&self) -> ShieldedActionCounts {
+        let count = |n: usize| u32::try_from(n).unwrap_or(u32::MAX);
+
+        ShieldedActionCounts {
+            orchard_actions: count(self.orchard_actions().count()),
+            sapling_ios: count(self.sapling_spends_per_anchor().count())
+                .saturating_add(count(self.sapling_outputs().count())),
+            sprout_joinsplits: count(self.joinsplit_count()),
+        }
     }
 
     /// Access the [`orchard::Nullifier`]s in this transaction, if there are any,

--- a/crates/zakura-chain/src/transaction.rs
+++ b/crates/zakura-chain/src/transaction.rs
@@ -158,6 +158,17 @@ pub enum Transaction {
         lock_time: LockTime,
         /// The latest block height that this transaction can be added to the chain.
         expiry_height: block::Height,
+        /// The value this transaction removes from circulation, in zatoshis.
+        ///
+        /// [ZIP 233] calls this `zip233Amount`. It produces no output in any chain value
+        /// pool, and is subtracted from the issued supply.
+        ///
+        /// The field is only serialized, and only committed to by the ZIP 244 header
+        /// digest, in a `zip233` build. In any other build it is always zero, so the v6
+        /// wire format is unchanged.
+        ///
+        /// [ZIP 233]: https://zips.z.cash/zip-0233
+        zip233_amount: Amount<NonNegative>,
         /// The transparent inputs to the transaction.
         inputs: Vec<transparent::Input>,
         /// The transparent outputs from the transaction.
@@ -1880,6 +1891,30 @@ impl Transaction {
             Transaction::V5 { .. } => Some(TX_V5_VERSION_GROUP_ID),
             Transaction::V6 { .. } => Some(TX_V6_VERSION_GROUP_ID),
         }
+    }
+
+    /// Returns the value this transaction removes from circulation, in zatoshis.
+    ///
+    /// [ZIP 233] calls this `zip233Amount`. Only v6 transactions carry the field, and
+    /// only in a `zip233` build, so this returns zero for every other transaction.
+    ///
+    /// [ZIP 233]: https://zips.z.cash/zip-0233
+    pub fn zip233_amount(&self) -> Amount<NonNegative> {
+        match self {
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. }
+            | Transaction::V5 { .. } => Amount::zero(),
+            Transaction::V6 { zip233_amount, .. } => *zip233_amount,
+        }
+    }
+
+    /// Returns whether this transaction removes value from circulation under [ZIP 233].
+    ///
+    /// [ZIP 233]: https://zips.z.cash/zip-0233
+    pub fn has_zip233_amount(&self) -> bool {
+        self.zip233_amount() > Amount::<NonNegative>::zero()
     }
 }
 

--- a/crates/zakura-chain/src/transaction/arbitrary.rs
+++ b/crates/zakura-chain/src/transaction/arbitrary.rs
@@ -1112,3 +1112,55 @@ pub fn insert_fake_orchard_shielded_data(
         _ => panic!("Fake V5 transaction is not V5"),
     }
 }
+
+/// Returns an empty V5 transaction with no shielded data, for use as a base in
+/// shielded-action test fixtures.
+pub fn empty_v5_transaction() -> Transaction {
+    Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        lock_time: LockTime::unlocked(),
+        expiry_height: block::Height(100),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    }
+}
+
+/// Returns a V5 transaction containing `count` Orchard actions.
+pub fn fake_v5_with_orchard_actions(count: usize) -> Arc<Transaction> {
+    let mut tx = empty_v5_transaction();
+    let shielded_data = insert_fake_orchard_shielded_data(&mut tx);
+    let action = shielded_data.actions.first().clone();
+    shielded_data.actions = at_least_one![action; count];
+
+    Arc::new(tx)
+}
+
+/// Returns a V5 transaction containing `count` Sapling outputs.
+pub fn fake_v5_with_sapling_outputs(count: usize) -> Arc<Transaction> {
+    let mut runner = TestRunner::default();
+    let mut shielded_data = any::<sapling::ShieldedData<sapling::SharedAnchor>>()
+        .new_tree(&mut runner)
+        .expect("sapling shielded data strategy is valid")
+        .current();
+    let output = any::<sapling::Output>()
+        .new_tree(&mut runner)
+        .expect("sapling output strategy is valid")
+        .current();
+
+    shielded_data.transfers = sapling::TransferData::JustOutputs {
+        outputs: at_least_one![output; count],
+    };
+
+    let mut tx = empty_v5_transaction();
+    match &mut tx {
+        Transaction::V5 {
+            sapling_shielded_data,
+            ..
+        } => *sapling_shielded_data = Some(shielded_data),
+        _ => unreachable!("empty_v5_transaction returns a V5 transaction"),
+    }
+
+    Arc::new(tx)
+}

--- a/crates/zakura-chain/src/transaction/serialize.rs
+++ b/crates/zakura-chain/src/transaction/serialize.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-use crate::parameters::TX_V6_VERSION_GROUP_ID;
+use crate::parameters::{TX_V6_VERSION_GROUP_ID, ZIP233_ENABLED};
 
 use super::*;
 use crate::sapling;
@@ -810,6 +810,7 @@ impl ZcashSerialize for Transaction {
                 network_upgrade,
                 lock_time,
                 expiry_height,
+                zip233_amount,
                 inputs,
                 outputs,
                 sapling_shielded_data,
@@ -841,6 +842,16 @@ impl ZcashSerialize for Transaction {
 
                 // Denoted as `nExpiryHeight` in the spec.
                 writer.write_u32::<LittleEndian>(expiry_height.0)?;
+
+                // Denoted as `zip233Amount` in ZIP 233, an 8-byte little-endian amount.
+                // Only a `zip233` build carries the field, so the v6 wire format is
+                // unchanged in any other build.
+                if ZIP233_ENABLED {
+                    writer.write_u64::<LittleEndian>(
+                        u64::try_from(i64::from(*zip233_amount))
+                            .expect("Amount<NonNegative> is never negative"),
+                    )?;
+                }
 
                 // Denoted as `tx_in_count` and `tx_in` in the spec.
                 inputs.zcash_serialize(&mut writer)?;
@@ -1189,6 +1200,18 @@ impl ZcashDeserialize for Transaction {
                 // Denoted as `nExpiryHeight` in the spec.
                 let expiry_height = block::Height(limited_reader.read_u32::<LittleEndian>()?);
 
+                // Denoted as `zip233Amount` in ZIP 233, an 8-byte little-endian amount.
+                // Only a `zip233` build carries the field, so the v6 wire format is
+                // unchanged in any other build.
+                //
+                // > The zip233_amount MUST be in the range {0 .. MAX_MONEY}.
+                let zip233_amount = if ZIP233_ENABLED {
+                    Amount::try_from(limited_reader.read_u64::<LittleEndian>()?)
+                        .map_err(|_| SerializationError::Parse("zip233Amount out of range"))?
+                } else {
+                    Amount::zero()
+                };
+
                 // Denoted as `tx_in_count` and `tx_in` in the spec.
                 let inputs: Vec<transparent::Input> = Vec::zcash_deserialize(&mut limited_reader)?;
 
@@ -1228,6 +1251,7 @@ impl ZcashDeserialize for Transaction {
                     network_upgrade,
                     lock_time,
                     expiry_height,
+                    zip233_amount,
                     inputs,
                     outputs,
                     sapling_shielded_data,

--- a/crates/zakura-chain/src/transaction/tests/prop.rs
+++ b/crates/zakura-chain/src/transaction/tests/prop.rs
@@ -117,6 +117,18 @@ fn v5_tx_strategy(
         .boxed()
 }
 
+/// A strategy for the ZIP 233 `zip233Amount` of a v6 transaction.
+///
+/// Only a `zip233` build serializes the field, so any other build must generate zero:
+/// a non-zero amount would not survive a serialization round-trip there.
+fn zip233_amount_strategy() -> BoxedStrategy<Amount<NonNegative>> {
+    if crate::parameters::ZIP233_ENABLED {
+        any::<Amount<NonNegative>>().boxed()
+    } else {
+        Just(Amount::zero()).boxed()
+    }
+}
+
 fn v6_tx_strategy(
     sapling_shielded_data: BoxedStrategy<Option<sapling::ShieldedData<sapling::SharedAnchor>>>,
     orchard_shielded_data: BoxedStrategy<Option<orchard::ShieldedData>>,
@@ -125,6 +137,7 @@ fn v6_tx_strategy(
     (
         any::<LockTime>(),
         any::<Height>(),
+        zip233_amount_strategy(),
         vec(any_with::<transparent::Input>(None), 0..MAX_ARBITRARY_ITEMS),
         vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
         sapling_shielded_data,
@@ -135,12 +148,14 @@ fn v6_tx_strategy(
             |(
                 lock_time,
                 expiry_height,
+                zip233_amount,
                 inputs,
                 outputs,
                 sapling_shielded_data,
                 orchard_shielded_data,
                 ironwood_shielded_data,
             )| Transaction::V6 {
+                zip233_amount,
                 network_upgrade: NetworkUpgrade::Nu6_3,
                 lock_time,
                 expiry_height,

--- a/crates/zakura-chain/src/transaction/tests/vectors.rs
+++ b/crates/zakura-chain/src/transaction/tests/vectors.rs
@@ -297,6 +297,7 @@ fn v6_orchard_cross_address_flag_fails_serialization_and_deserialization() {
         .expect("test vectors include an Orchard transaction");
 
     let make_tx = |shielded_data: crate::orchard::ShieldedData| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -359,6 +360,7 @@ fn v6_ironwood_cross_address_flag_round_trips_and_rejects_reserved_bits() {
         .insert(crate::orchard::Flags::ENABLE_CROSS_ADDRESS);
 
     let make_tx = |shielded_data: crate::ironwood::ShieldedData| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -804,7 +806,10 @@ fn native_zip244_matches_test_vectors() -> Result<()> {
             .to_le_bytes(),
         );
 
-        assert_native_zip244_matches_librustzcash_for_test_vector(&tx_bytes, test.scenario)?;
+        assert_native_zip244_matches_librustzcash_for_test_vector(
+            &with_zip233_amount(&tx_bytes),
+            test.scenario,
+        )?;
     }
 
     Ok(())
@@ -1369,6 +1374,79 @@ fn zip244_rejects_the_raw_pre_v5_sighash_path() {
     let _ = sighasher.sighash_v4_raw(0x41, None);
 }
 
+/// Checks that ZIP 233's `zip233Amount` is committed to by the txid and the auth digest,
+/// and that a `zip233` build agrees with `librustzcash` on both.
+///
+/// Without this commitment the amount would be malleable: a relaying node could change
+/// how much value a transaction removes from circulation without changing its txid.
+#[test]
+fn zip233_amount_is_committed_to_by_the_txid() -> Result<()> {
+    let _init_guard = zakura_test::init();
+
+    let (transaction, _, _) = v6_transparent_sighash_test_data()?;
+    let Transaction::V6 { zip233_amount, .. } = &transaction else {
+        panic!("the transparent sighash vector is a V6 transaction");
+    };
+    assert_eq!(
+        *zip233_amount,
+        Amount::<NonNegative>::zero(),
+        "the V6 test vectors remove nothing from circulation",
+    );
+
+    let mut burning = transaction.clone();
+    let Transaction::V6 { zip233_amount, .. } = &mut burning else {
+        unreachable!("cloned a V6 transaction");
+    };
+    *zip233_amount = Amount::try_from(100_000)?;
+
+    if !crate::parameters::ZIP233_ENABLED {
+        // A build without the feature does not serialize the field, so it cannot commit
+        // to it either. `zip233_amount` is always zero on such a build, and this
+        // transaction only exists because the test constructed it in memory.
+        assert_eq!(transaction.hash(), burning.hash());
+        return Ok(());
+    }
+
+    assert_ne!(
+        transaction.hash(),
+        burning.hash(),
+        "the txid must commit to zip233Amount",
+    );
+
+    // Both transactions must round-trip, and the native digests must match librustzcash.
+    for (tx, name) in [(&transaction, "zero zip233Amount"), (&burning, "burn")] {
+        let tx_bytes = tx.zcash_serialize_to_vec()?;
+        assert_eq!(
+            &tx_bytes.zcash_deserialize_into::<Transaction>()?,
+            tx,
+            "{name} must round-trip",
+        );
+        assert_native_zip244_matches_librustzcash_for_test_vector(&tx_bytes, name)?;
+    }
+
+    Ok(())
+}
+
+/// Returns `tx_bytes` with a zero `zip233Amount` spliced in, if this build reads one.
+///
+/// The V6 test vectors were generated before ZIP 233 added `zip233Amount` after
+/// `nExpiryHeight`, so a `zip233` build needs the field to parse them. Zero is the
+/// amount those vectors imply: they remove nothing from circulation.
+fn with_zip233_amount(tx_bytes: &[u8]) -> Vec<u8> {
+    if !crate::parameters::ZIP233_ENABLED {
+        return tx_bytes.to_vec();
+    }
+
+    // nVersion, nVersionGroupId, nConsensusBranchId, lock_time, and nExpiryHeight are
+    // four bytes each, and `zip233Amount` follows them.
+    const ZIP233_AMOUNT_OFFSET: usize = 20;
+
+    let mut padded = tx_bytes[..ZIP233_AMOUNT_OFFSET].to_vec();
+    padded.extend_from_slice(&0u64.to_le_bytes());
+    padded.extend_from_slice(&tx_bytes[ZIP233_AMOUNT_OFFSET..]);
+    padded
+}
+
 fn v6_transparent_sighash_test_data() -> Result<(Transaction, Arc<Vec<transparent::Output>>, usize)>
 {
     let test = ironwood_v6_tx_hash::TEST_VECTORS
@@ -1386,7 +1464,7 @@ fn v6_transparent_sighash_test_data() -> Result<(Transaction, Arc<Vec<transparen
         .to_le_bytes(),
     );
 
-    let transaction = tx_bytes.zcash_deserialize_into::<Transaction>()?;
+    let transaction = with_zip233_amount(&tx_bytes).zcash_deserialize_into::<Transaction>()?;
     let previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(
         test.amounts
             .iter()
@@ -1796,6 +1874,7 @@ fn v6_version_group_id_matches_librustzcash_and_wire_format() {
     );
 
     let tx = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(0),
@@ -1838,11 +1917,15 @@ fn v6_transactions_accept_nu6_3_and_later_branch_ids() {
         tx_bytes.extend_from_slice(&u32::from(branch_id).to_le_bytes());
         tx_bytes.extend_from_slice(&0u32.to_le_bytes());
         tx_bytes.extend_from_slice(&0u32.to_le_bytes());
+        if crate::parameters::ZIP233_ENABLED {
+            tx_bytes.extend_from_slice(&0u64.to_le_bytes());
+        }
         tx_bytes.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
         tx_bytes
     };
 
     let empty_v6_transaction = |network_upgrade| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(0),
@@ -1925,6 +2008,7 @@ fn v6_sighasher_preserves_distinct_orchard_and_ironwood_bundle_slots() {
         .expect("the test bundle has at least one action");
 
     let tx = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -1983,6 +2067,7 @@ fn v6_txid_commits_to_ironwood_digest() {
     let _init_guard = zakura_test::init();
 
     let tx_without_ironwood = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -2070,6 +2155,7 @@ fn v6_ironwood_anchor_changes_auth_digest_not_txid() {
     };
 
     let tx_a = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -2210,6 +2296,7 @@ fn v6_noncanonical_orchard_proof_is_rejected_during_deserialization() {
         .expect("test vectors include an Orchard transaction");
 
     let make_tx = |orchard_shielded_data| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -2261,6 +2348,7 @@ fn v6_noncanonical_ironwood_proof_is_rejected_during_deserialization() {
         .expect("test vectors include an Orchard-shaped bundle");
 
     let make_tx = |ironwood_shielded_data| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -2406,6 +2494,7 @@ fn orchard_rk_identity_point_rejected_during_deserialization() {
         };
 
         let v6_tx = Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: Height(0),
@@ -2762,6 +2851,7 @@ fn native_zip244_hashes_invalid_lazy_sapling_points_before_semantic_rejection() 
                 orchard_shielded_data: None,
             },
             Transaction::V6 {
+                zip233_amount: Default::default(),
                 network_upgrade: NetworkUpgrade::Nu6_3,
                 lock_time: LockTime::unlocked(),
                 expiry_height: Height(0),
@@ -2998,6 +3088,7 @@ fn sapling_point_encodings_check_rejects_bad_points() {
 
     let make_v6 = |cv: [u8; 32], epk: [u8; 32]| -> Transaction {
         Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: Height(0),

--- a/crates/zakura-chain/src/transaction/unmined/zip317/tests.rs
+++ b/crates/zakura-chain/src/transaction/unmined/zip317/tests.rs
@@ -75,6 +75,7 @@ fn zip317_counts_ironwood_actions() {
         binding_sig: [0u8; 64].into(),
     };
     let transaction = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: crate::block::Height(1),

--- a/crates/zakura-chain/src/transaction/zip244.rs
+++ b/crates/zakura-chain/src/transaction/zip244.rs
@@ -33,7 +33,7 @@ use blake2b_simd::{Hash as Blake2bHash, Params, State};
 
 use crate::{
     orchard,
-    parameters::{NetworkUpgrade, TX_V5_VERSION_GROUP_ID, TX_V6_VERSION_GROUP_ID},
+    parameters::{NetworkUpgrade, TX_V5_VERSION_GROUP_ID, TX_V6_VERSION_GROUP_ID, ZIP233_ENABLED},
     sapling,
     serialization::ZcashSerialize,
     transaction::{sighash::CanonicalHashType, AuthDigest, Hash, SigHash, Transaction},
@@ -345,6 +345,7 @@ struct Zip244Parts<'a> {
     network_upgrade: NetworkUpgrade,
     lock_time: u32,
     expiry_height: crate::block::Height,
+    zip233_amount: u64,
     inputs: &'a [transparent::Input],
     outputs: &'a [transparent::Output],
     sapling: Option<&'a sapling::ShieldedData<sapling::SharedAnchor>>,
@@ -364,6 +365,8 @@ fn zip244_parts(tx: &Transaction) -> Option<Zip244Parts<'_>> {
         network_upgrade: tx.network_upgrade()?,
         lock_time: tx.raw_lock_time(),
         expiry_height: tx.expiry_height().unwrap_or(crate::block::Height(0)),
+        zip233_amount: u64::try_from(i64::from(tx.zip233_amount()))
+            .expect("Amount<NonNegative> is never negative"),
         inputs: tx.inputs(),
         outputs: tx.outputs(),
         sapling: tx.sapling_shielded_data(),
@@ -397,6 +400,14 @@ fn hash_header(parts: &Zip244Parts) -> Blake2bHash {
     // lock_time and expiry_height are each a single LE u32.
     h.update(&parts.lock_time.to_le_bytes());
     h.update(&parts.expiry_height.0.to_le_bytes());
+
+    // ZIP 233 §T.1f: an 8-byte little-endian `zip233_amount`, committed to by v6
+    // transactions only. Without the `zip233` feature the field is absent from the
+    // digest, so a default build reproduces the pre-ZIP 233 txid and sighash.
+    if ZIP233_ENABLED && parts.version == Zip244Version::V6 {
+        h.update(&parts.zip233_amount.to_le_bytes());
+    }
+
     h.finalize()
 }
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -74,11 +74,11 @@ zcash_primitives = { workspace = true }
 tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.2.0" }
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.3.0" }
 
-zakura-script = { path = "../zakura-script", version = "3.2.1" }
-zakura-state = { path = "../zakura-state", version = "7.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1" }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
+zakura-state = { path = "../zakura-state", version = "7.1.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 
 zcash_protocol.workspace = true
 
@@ -100,8 +100,8 @@ toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -29,6 +29,15 @@ zip218 = [
     "zakura-header-chain/zip218",
 ]
 
+# ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
+# `zip233Amount` field on v6 transactions, which removes value from circulation.
+#
+# Also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`; see `zakura-chain`.
+zip233 = [
+    "zakura-chain/zip233",
+    "zakura-state/zip233",
+]
+
 # Production features that activate extra dependencies, or extra features in dependencies
 
 progress-bar = [

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "9.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -86,7 +86,7 @@ tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower
 zakura-script = { path = "../zakura-script", version = "3.2.2" }
 zakura-state = { path = "../zakura-state", version = "7.1.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 
 zcash_protocol.workspace = true
@@ -110,7 +110,7 @@ toml = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
 zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "7.0.0"
+version = "8.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -75,10 +75,10 @@ tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.3.0" }
 
 zakura-script = { path = "../zakura-script", version = "3.2.2" }
-zakura-state = { path = "../zakura-state", version = "7.1.0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0" }
 
 zcash_protocol.workspace = true
 
@@ -100,8 +100,8 @@ toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -22,6 +22,13 @@ categories = ["asynchronous", "cryptography::cryptocurrencies"]
 [features]
 default = []
 
+# ZIP 218 "25-second Block Target Spacing" consensus rules, dormant until NU7 activates.
+zip218 = [
+    "zakura-chain/zip218",
+    "zakura-state/zip218",
+    "zakura-header-chain/zip218",
+]
+
 # Production features that activate extra dependencies, or extra features in dependencies
 
 progress-bar = [

--- a/crates/zakura-consensus/src/block.rs
+++ b/crates/zakura-consensus/src/block.rs
@@ -326,6 +326,8 @@ where
                 .map_err(VerifyBlockError::Time)?;
             let coinbase_tx = check::coinbase_is_first(&block)?;
 
+            check::shielded_action_limits_are_valid(&block.transactions, height, &network)?;
+
             let expected_block_subsidy =
                 zakura_chain::parameters::subsidy::block_subsidy(height, &network)?;
 

--- a/crates/zakura-consensus/src/block/check.rs
+++ b/crates/zakura-consensus/src/block/check.rs
@@ -14,9 +14,10 @@ use zakura_chain::{
             founders_reward, founders_reward_address, funding_stream_values, FundingStreamReceiver,
             ParameterSubsidy, SubsidyError,
         },
-        Network, NetworkUpgrade,
+        Network, NetworkUpgrade, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT,
+        SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
     },
-    transaction::{self, Transaction},
+    transaction::{self, ShieldedActionCounts, Transaction},
     transparent::{Address, Output},
     work::{difficulty::ExpandedDifficulty, equihash},
 };
@@ -402,6 +403,83 @@ pub fn time_is_valid_at(
     hash: &Hash,
 ) -> Result<(), zakura_chain::block::BlockTimeError> {
     zakura_header_chain::validate_future_time(header, now, *height, *hash)
+}
+
+/// Returns `Ok(())` if the ZIP 218 per-block shielded limits hold for the sum of
+/// `transactions` on `network` at `height`.
+///
+/// The block verifier passes every transaction in the block. The transaction
+/// verifier passes a single transaction, because a transaction whose own counts
+/// exceed a per-block limit can never be mined, so the mempool rejects it on
+/// submission.
+///
+/// The limits apply only once ZIP 218 is compiled in and NU7 is active, so this
+/// is a no-op in a default build and on any network without an NU7 activation
+/// height.
+///
+/// # Consensus
+///
+/// > For each block at height `height` where `IsNU7Activated(height)`, the
+/// > following limits MUST be satisfied:
+/// >
+/// > - The total number of Orchard actions across all transactions in the block
+/// >   MUST NOT exceed `OrchardBlockActionLimit`.
+/// > - The total number of Sapling inputs and outputs across all transactions in
+/// >   the block MUST NOT exceed `SaplingBlockIOLimit`.
+/// > - The total number of Sprout JoinSplits across all transactions in the
+/// >   block MUST NOT exceed `SproutBlockJoinSplitLimit`.
+/// > - The total shielded cost across all pools MUST NOT exceed
+/// >   `GlobalShieldedBudget`, where that cost is
+/// >   `Σ orchard_actions + Σ (sapling_spends + sapling_outputs) + 2 * Σ joinsplits`.
+///
+/// <https://zips.z.cash/zip-0218#shielded-pool-action-limits>
+pub fn shielded_action_limits_are_valid<'a>(
+    transactions: impl IntoIterator<Item = &'a Arc<Transaction>>,
+    height: Height,
+    network: &Network,
+) -> Result<(), TransactionError> {
+    if !NetworkUpgrade::is_zip218_active(network, height) {
+        return Ok(());
+    }
+
+    let totals = transactions
+        .into_iter()
+        .map(|tx| tx.shielded_action_counts())
+        .fold(
+            ShieldedActionCounts::default(),
+            ShieldedActionCounts::saturating_add,
+        );
+
+    if totals.orchard_actions > ORCHARD_BLOCK_ACTION_LIMIT {
+        return Err(TransactionError::OrchardActionsExceedBlockLimit {
+            actions: totals.orchard_actions,
+            limit: ORCHARD_BLOCK_ACTION_LIMIT,
+        });
+    }
+
+    if totals.sapling_ios > SAPLING_BLOCK_IO_LIMIT {
+        return Err(TransactionError::SaplingIOsExceedBlockLimit {
+            ios: totals.sapling_ios,
+            limit: SAPLING_BLOCK_IO_LIMIT,
+        });
+    }
+
+    if totals.sprout_joinsplits > SPROUT_BLOCK_JOINSPLIT_LIMIT {
+        return Err(TransactionError::SproutJoinSplitsExceedBlockLimit {
+            joinsplits: totals.sprout_joinsplits,
+            limit: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        });
+    }
+
+    let cost = totals.cost();
+    if cost > GLOBAL_SHIELDED_BUDGET {
+        return Err(TransactionError::ShieldedCostExceedsBlockBudget {
+            cost,
+            limit: GLOBAL_SHIELDED_BUDGET,
+        });
+    }
+
+    Ok(())
 }
 
 /// Check Merkle root validity.

--- a/crates/zakura-consensus/src/block/tests.rs
+++ b/crates/zakura-consensus/src/block/tests.rs
@@ -1233,3 +1233,289 @@ fn state_commit_context_errors_keep_misbehavior_scores() {
     let router_error = crate::router::RouterError::from(err);
     assert_eq!(router_error.misbehavior_score(), 100);
 }
+
+/// Tests for the ZIP 218 per-block shielded action limits.
+///
+/// The limits only apply once the `zip218` feature is compiled in and NU7 is
+/// active, so the rejection cases only exist in a `zip218` build.
+mod zip218_shielded_action_limits {
+    use zakura_chain::{
+        block::{Block, Height},
+        parameters::{
+            testnet::{ConfiguredActivationHeights, Parameters},
+            Network, ORCHARD_BLOCK_ACTION_LIMIT,
+        },
+        serialization::{ZcashDeserialize, ZcashDeserializeInto},
+        transaction::arbitrary::fake_v5_with_orchard_actions,
+    };
+
+    use crate::block::check;
+
+    #[cfg(feature = "zip218")]
+    use std::sync::Arc;
+
+    #[cfg(feature = "zip218")]
+    use proptest::{
+        arbitrary::any,
+        strategy::{Strategy, ValueTree},
+        test_runner::TestRunner,
+    };
+
+    #[cfg(feature = "zip218")]
+    use zakura_chain::{
+        parameters::{
+            GLOBAL_SHIELDED_BUDGET, SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        },
+        primitives::Groth16Proof,
+        transaction::{
+            arbitrary::fake_v5_with_sapling_outputs, JoinSplitData, LockTime, Transaction,
+        },
+    };
+
+    #[cfg(feature = "zip218")]
+    use crate::error::TransactionError;
+
+    /// Every historical block satisfies the limits, because NU7 is not active on
+    /// Mainnet. A block with no shielded data also satisfies them once NU7 is
+    /// active.
+    #[test]
+    fn historical_blocks_satisfy_the_limits() {
+        let _init_guard = zakura_test::init();
+
+        for block in zakura_test::vectors::BLOCKS.iter() {
+            let block = block
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid");
+
+            check::shielded_action_limits_are_valid(
+                &block.transactions,
+                block
+                    .coinbase_height()
+                    .expect("block has a coinbase height"),
+                &Network::Mainnet,
+            )
+            .expect("a historical Mainnet block satisfies the shielded action limits");
+        }
+
+        let genesis =
+            Block::zcash_deserialize(&zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
+                .expect("mainnet genesis deserializes");
+
+        check::shielded_action_limits_are_valid(
+            &genesis.transactions,
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect("a block with no shielded data satisfies the post-NU7 limits");
+    }
+
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn limits_activate_at_the_nu7_height() {
+        let network = nu7_activation_testnet(2);
+        let over_limit_tx =
+            fake_v5_with_orchard_actions(limit_plus_one(ORCHARD_BLOCK_ACTION_LIMIT));
+
+        check::shielded_action_limits_are_valid(
+            [over_limit_tx.clone()].iter(),
+            Height(1),
+            &network,
+        )
+        .expect("the limits are inactive below the NU7 activation height");
+
+        let err =
+            check::shielded_action_limits_are_valid([over_limit_tx].iter(), Height(2), &network)
+                .expect_err("the limits are enforced at the NU7 activation height");
+
+        assert_eq!(
+            err,
+            TransactionError::OrchardActionsExceedBlockLimit {
+                actions: ORCHARD_BLOCK_ACTION_LIMIT + 1,
+                limit: ORCHARD_BLOCK_ACTION_LIMIT,
+            }
+        );
+    }
+
+    /// Without the `zip218` feature, the limits stay inactive even at an NU7
+    /// height.
+    #[test]
+    #[cfg(not(feature = "zip218"))]
+    fn limits_are_inactive_without_the_feature() {
+        let over_limit_tx =
+            fake_v5_with_orchard_actions(limit_plus_one(ORCHARD_BLOCK_ACTION_LIMIT));
+
+        check::shielded_action_limits_are_valid(
+            [over_limit_tx].iter(),
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect("the limits are inactive in a build without the zip218 feature");
+    }
+
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn counts_at_the_per_pool_limits_are_accepted() {
+        let cases: [(&str, Arc<Transaction>); 3] = [
+            (
+                "Orchard actions",
+                fake_v5_with_orchard_actions(limit_as_usize(ORCHARD_BLOCK_ACTION_LIMIT)),
+            ),
+            (
+                "Sapling spends and outputs",
+                fake_v5_with_sapling_outputs(limit_as_usize(SAPLING_BLOCK_IO_LIMIT)),
+            ),
+            (
+                "Sprout JoinSplits",
+                fake_v4_with_sprout_joinsplits(limit_as_usize(SPROUT_BLOCK_JOINSPLIT_LIMIT)),
+            ),
+        ];
+
+        for (pool, tx) in cases {
+            check::shielded_action_limits_are_valid([tx].iter(), Height(1), &nu7_active_testnet())
+                .unwrap_or_else(|error| {
+                    panic!("{pool} exactly at the per-block limit must pass, got {error}")
+                });
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn a_cost_at_the_global_budget_is_accepted() {
+        // One JoinSplit costs 2, so the rest of the budget can hold that many
+        // fewer Orchard actions.
+        let orchard_actions = limit_as_usize(
+            GLOBAL_SHIELDED_BUDGET
+                .checked_sub(2)
+                .expect("the global shielded budget covers at least one JoinSplit"),
+        );
+
+        check::shielded_action_limits_are_valid(
+            [
+                fake_v5_with_orchard_actions(orchard_actions),
+                fake_v4_with_sprout_joinsplits(1),
+            ]
+            .iter(),
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect("a combined shielded cost exactly at the global budget must pass");
+    }
+
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn sapling_ios_above_the_limit_are_rejected() {
+        let err = check::shielded_action_limits_are_valid(
+            [fake_v5_with_sapling_outputs(limit_plus_one(
+                SAPLING_BLOCK_IO_LIMIT,
+            ))]
+            .iter(),
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect_err("Sapling spends and outputs above the per-block limit must fail");
+
+        assert_eq!(
+            err,
+            TransactionError::SaplingIOsExceedBlockLimit {
+                ios: SAPLING_BLOCK_IO_LIMIT + 1,
+                limit: SAPLING_BLOCK_IO_LIMIT,
+            }
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn sprout_joinsplits_above_the_limit_are_rejected() {
+        let err = check::shielded_action_limits_are_valid(
+            [fake_v4_with_sprout_joinsplits(limit_plus_one(
+                SPROUT_BLOCK_JOINSPLIT_LIMIT,
+            ))]
+            .iter(),
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect_err("Sprout JoinSplits above the per-block limit must fail");
+
+        assert_eq!(
+            err,
+            TransactionError::SproutJoinSplitsExceedBlockLimit {
+                joinsplits: SPROUT_BLOCK_JOINSPLIT_LIMIT + 1,
+                limit: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+            }
+        );
+    }
+
+    /// A block can satisfy every per-pool limit and still exceed the global
+    /// budget.
+    #[test]
+    #[cfg(feature = "zip218")]
+    fn a_cost_above_the_global_budget_is_rejected() {
+        let err = check::shielded_action_limits_are_valid(
+            [
+                fake_v5_with_orchard_actions(limit_as_usize(ORCHARD_BLOCK_ACTION_LIMIT)),
+                fake_v5_with_sapling_outputs(1),
+            ]
+            .iter(),
+            Height(1),
+            &nu7_active_testnet(),
+        )
+        .expect_err("a combined shielded cost above the global budget must fail");
+
+        assert_eq!(
+            err,
+            TransactionError::ShieldedCostExceedsBlockBudget {
+                cost: GLOBAL_SHIELDED_BUDGET + 1,
+                limit: GLOBAL_SHIELDED_BUDGET,
+            }
+        );
+    }
+
+    fn nu7_active_testnet() -> Network {
+        nu7_activation_testnet(1)
+    }
+
+    fn nu7_activation_testnet(nu7_activation_height: u32) -> Network {
+        Parameters::build()
+            .with_slow_start_interval(Height(0))
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu7: Some(nu7_activation_height),
+                ..Default::default()
+            })
+            .expect("activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid")
+    }
+
+    #[cfg(feature = "zip218")]
+    fn limit_as_usize(limit: u32) -> usize {
+        usize::try_from(limit).expect("a shielded action limit fits in usize")
+    }
+
+    fn limit_plus_one(limit: u32) -> usize {
+        usize::try_from(limit + 1).expect("a shielded action limit fits in usize")
+    }
+
+    /// Returns a V4 transaction containing `count` Sprout JoinSplits.
+    #[cfg(feature = "zip218")]
+    fn fake_v4_with_sprout_joinsplits(count: usize) -> Arc<Transaction> {
+        let mut runner = TestRunner::default();
+        let mut joinsplit_data = any::<JoinSplitData<Groth16Proof>>()
+            .new_tree(&mut runner)
+            .expect("sprout JoinSplit data strategy is valid")
+            .current();
+        let rest_len = count
+            .checked_sub(1)
+            .expect("a Sprout JoinSplit test count is at least one");
+        joinsplit_data.rest = vec![joinsplit_data.first.clone(); rest_len];
+
+        Arc::new(Transaction::V4 {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            lock_time: LockTime::unlocked(),
+            expiry_height: Height(100),
+            joinsplit_data: Some(joinsplit_data),
+            sapling_shielded_data: None,
+        })
+    }
+}

--- a/crates/zakura-consensus/src/block/tests.rs
+++ b/crates/zakura-consensus/src/block/tests.rs
@@ -853,6 +853,7 @@ fn miner_fees_validation_includes_ironwood_balance() {
     let height = Height(1);
     let output_value = Amount::try_from(10).expect("valid test amount");
     let coinbase_tx = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::Height(Height(0)),
         expiry_height: height,

--- a/crates/zakura-consensus/src/block/tests.rs
+++ b/crates/zakura-consensus/src/block/tests.rs
@@ -661,6 +661,10 @@ async fn block_rejects_transactions_failing_librustzcash_conversion() {
     let _init_guard = zakura_test::init();
 
     let cases = [
+        // A `zcash_unstable = "nu7"` build gives NU7 the branch ID `zcash_protocol`
+        // recognises, so this case has no unrecognized branch ID to offer there. The
+        // remaining cases still cover a failed conversion.
+        #[cfg(not(zcash_unstable = "nu7"))]
         LibrustzcashConversionFailure {
             name: "unrecognized consensus branch ID",
             network_upgrade: NetworkUpgrade::Nu7,

--- a/crates/zakura-consensus/src/error.rs
+++ b/crates/zakura-consensus/src/error.rs
@@ -272,6 +272,22 @@ pub enum TransactionError {
     #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]
     MissingConsensusBranchId,
 
+    #[error("Orchard action count {actions} exceeds the per-block limit of {limit}")]
+    OrchardActionsExceedBlockLimit { actions: u32, limit: u32 },
+
+    #[error("Sapling spends + outputs count {ios} exceeds the per-block limit of {limit}")]
+    SaplingIOsExceedBlockLimit { ios: u32, limit: u32 },
+
+    #[error("Sprout JoinSplit count {joinsplits} exceeds the per-block limit of {limit}")]
+    SproutJoinSplitsExceedBlockLimit { joinsplits: u32, limit: u32 },
+
+    #[error(
+        "shielded cost {cost} \
+         (Orchard actions + Sapling spends + Sapling outputs + 2 * Sprout JoinSplits) \
+         exceeds the per-block global shielded budget of {limit}"
+    )]
+    ShieldedCostExceedsBlockBudget { cost: u32, limit: u32 },
+
     #[error("input/output error")]
     Io(String),
 
@@ -485,6 +501,18 @@ impl TransactionError {
             }
             Self::WrongConsensusBranchId => consensus("transaction.wrong_consensus_branch_id"),
             Self::MissingConsensusBranchId => consensus("transaction.missing_consensus_branch_id"),
+            Self::OrchardActionsExceedBlockLimit { .. } => {
+                consensus("transaction.orchard_actions_exceed_block_limit")
+            }
+            Self::SaplingIOsExceedBlockLimit { .. } => {
+                consensus("transaction.sapling_ios_exceed_block_limit")
+            }
+            Self::SproutJoinSplitsExceedBlockLimit { .. } => {
+                consensus("transaction.sprout_joinsplits_exceed_block_limit")
+            }
+            Self::ShieldedCostExceedsBlockBudget { .. } => {
+                consensus("transaction.shielded_cost_exceeds_block_budget")
+            }
             Self::Io(_) | Self::TryFromSlice(_) | Self::Other(_) => {
                 BodyVerificationClass::Retryable(TransientBodyFailureKind::VerifierUnavailable)
             }
@@ -547,6 +575,10 @@ impl TransactionError {
             | IronwoodProofSize
             | WrongConsensusBranchId
             | MissingConsensusBranchId
+            | OrchardActionsExceedBlockLimit { .. }
+            | SaplingIOsExceedBlockLimit { .. }
+            | SproutJoinSplitsExceedBlockLimit { .. }
+            | ShieldedCostExceedsBlockBudget { .. }
             | LockedUntilAfterBlockHeight(_)
             | LockedUntilAfterBlockTime(_) => 100,
 

--- a/crates/zakura-consensus/src/error.rs
+++ b/crates/zakura-consensus/src/error.rs
@@ -116,6 +116,9 @@ pub enum TransactionError {
     #[error("transaction version number MUST be >= 4")]
     WrongVersion,
 
+    #[error("transaction removes value from circulation before ZIP 233 activates at NU7")]
+    Zip233AmountBeforeNu7,
+
     #[error("transaction version {0} not supported by the network upgrade {1:?}")]
     UnsupportedByNetworkUpgrade(u32, zakura_chain::parameters::NetworkUpgrade),
 
@@ -445,6 +448,7 @@ impl TransactionError {
             Self::ExpiredTransaction { .. } => consensus("transaction.expired"),
             Self::Subsidy(_) => consensus("transaction.subsidy"),
             Self::WrongVersion => consensus("transaction.wrong_version"),
+            Self::Zip233AmountBeforeNu7 => consensus("transaction.zip233_amount_before_nu7"),
             Self::UnsupportedByNetworkUpgrade(_, _) => {
                 consensus("transaction.unsupported_by_network_upgrade")
             }
@@ -553,6 +557,7 @@ impl TransactionError {
             | IncorrectFee
             | Subsidy(_)
             | WrongVersion
+            | Zip233AmountBeforeNu7
             | NoInputs
             | NoOutputs
             | BadBalance

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -464,6 +464,14 @@ where
             }
             check::sapling_point_encodings_are_valid(&tx)?;
 
+            // A transaction whose own shielded counts exceed a per-block ZIP 218
+            // limit can never be mined, so reject it on submission.
+            crate::block::check::shielded_action_limits_are_valid(
+                std::iter::once(&tx),
+                req.height(),
+                &network,
+            )?;
+
             // Soft fork: temporarily require transactions to not contain Orchard actions.
             //
             // This soft fork was added while NU 6.1 was the active epoch on the Zcash

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -464,6 +464,10 @@ where
             }
             check::sapling_point_encodings_are_valid(&tx)?;
 
+            // ZIP 233 activates with NU7: a transaction cannot remove value from
+            // circulation before then.
+            check::zip233_amount_is_valid(&tx, req.height(), &network)?;
+
             // A transaction whose own shielded counts exceed a per-block ZIP 218
             // limit can never be mined, so reject it on submission.
             crate::block::check::shielded_action_limits_are_valid(
@@ -754,14 +758,25 @@ where
     }
 
     /// Calculate the miner fee from the transaction's value balance.
+    ///
+    /// The [ZIP 233] `zip233Amount` is part of the transaction's remaining value but is
+    /// not a fee: it leaves circulation instead of paying the miner, so the coinbase
+    /// cannot claim it. Subtracting it here is what makes the burn permanent, because
+    /// the block's coinbase output is checked against the block subsidy plus these fees.
+    ///
+    /// [ZIP 233]: https://zips.z.cash/zip-0233
     fn miner_fee(
         tx: &Transaction,
         spent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
     ) -> Result<Amount<NonNegative>, TransactionError> {
         match tx.value_balance(spent_utxos) {
-            Ok(value_balance) => value_balance
-                .remaining_transaction_value()
-                .map_err(|_| TransactionError::IncorrectFee),
+            Ok(value_balance) => {
+                let remaining_value = value_balance
+                    .remaining_transaction_value()
+                    .map_err(|_| TransactionError::IncorrectFee)?;
+
+                (remaining_value - tx.zip233_amount()).map_err(|_| TransactionError::IncorrectFee)
+            }
             Err(_) => Err(TransactionError::IncorrectFee),
         }
     }

--- a/crates/zakura-consensus/src/transaction.rs
+++ b/crates/zakura-consensus/src/transaction.rs
@@ -947,7 +947,7 @@ where
         let tx = request.transaction();
         let nu = request.upgrade(network);
 
-        Self::verify_v4_transaction_network_upgrade(&tx, nu)?;
+        Self::verify_v4_transaction_network_upgrade(&tx, network, request.height(), nu)?;
 
         let sapling_bundle = cached_ffi_transaction.sighasher().sapling_bundle();
 
@@ -964,11 +964,31 @@ where
         .and(Self::verify_sapling_bundle(sapling_bundle, &sighash, tx_id)))
     }
 
-    /// Verifies if a V4 `transaction` is supported by `network_upgrade`.
+    /// Verifies if a V4 `transaction` is supported by `network_upgrade` at `height` on
+    /// `network`.
     fn verify_v4_transaction_network_upgrade(
         transaction: &Transaction,
+        network: &Network,
+        height: block::Height,
         network_upgrade: NetworkUpgrade,
     ) -> Result<(), TransactionError> {
+        // # Consensus
+        //
+        // > [NU7 onward] The transaction version number MUST be 5 or 6.
+        //
+        // https://zips.z.cash/zip-2003
+        //
+        // ZIP 2003 deprecates V4 transactions at NU7, which is what
+        // `V4Deprecation::AtNu7` does. A network can instead name a later height, or keep
+        // accepting V4 transactions, so the deprecation date is chosen independently of
+        // the NU7 activation height.
+        if network.is_v4_deprecated(height) {
+            return Err(TransactionError::UnsupportedByNetworkUpgrade(
+                transaction.version(),
+                network_upgrade,
+            ));
+        }
+
         match network_upgrade {
             // Supports V4 transactions
             //
@@ -993,7 +1013,8 @@ where
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
             | NetworkUpgrade::Nu6_2
-            | NetworkUpgrade::Nu6_3 => Ok(()),
+            | NetworkUpgrade::Nu6_3
+            | NetworkUpgrade::Nu7 => Ok(()),
 
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => Ok(()),
@@ -1001,8 +1022,7 @@ where
             // Does not support V4 transactions
             NetworkUpgrade::Genesis
             | NetworkUpgrade::BeforeOverwinter
-            | NetworkUpgrade::Overwinter
-            | NetworkUpgrade::Nu7 => Err(TransactionError::UnsupportedByNetworkUpgrade(
+            | NetworkUpgrade::Overwinter => Err(TransactionError::UnsupportedByNetworkUpgrade(
                 transaction.version(),
                 network_upgrade,
             )),

--- a/crates/zakura-consensus/src/transaction/check.rs
+++ b/crates/zakura-consensus/src/transaction/check.rs
@@ -131,11 +131,37 @@ pub fn lock_time_has_passed(
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
     if !tx.has_transparent_or_shielded_inputs() {
         Err(TransactionError::NoInputs)
-    } else if !tx.has_transparent_or_shielded_outputs() {
+    } else if !tx.has_transparent_or_shielded_outputs() && !tx.has_zip233_amount() {
+        // A ZIP 233 burn is the transaction's effect on circulation, so a transaction
+        // whose only effect is a burn has somewhere for its value to go.
         Err(TransactionError::NoOutputs)
     } else {
         Ok(())
     }
+}
+
+/// Checks that a transaction's [ZIP 233] `zip233Amount` is allowed at `height` on
+/// `network`.
+///
+/// # Consensus
+///
+/// > The zip233_amount MUST be in the range {0 .. MAX_MONEY}.
+///
+/// ZIP 233 activates with NU7, so a transaction before NU7 must not remove value from
+/// circulation. `Amount<NonNegative>` already bounds the amount to `{0 .. MAX_MONEY}`,
+/// so only the activation height is checked here.
+///
+/// [ZIP 233]: https://zips.z.cash/zip-0233
+pub fn zip233_amount_is_valid(
+    tx: &Transaction,
+    height: Height,
+    network: &Network,
+) -> Result<(), TransactionError> {
+    if tx.has_zip233_amount() && !NetworkUpgrade::is_zip233_active(network, height) {
+        return Err(TransactionError::Zip233AmountBeforeNu7);
+    }
+
+    Ok(())
 }
 
 /// Checks that the transaction has enough orchard flags.

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -25,7 +25,7 @@ use zakura_chain::{
     orchard::{Action, AuthorizedAction, Flags},
     parameters::{
         testnet::{ConfiguredActivationHeights, Parameters},
-        Network, NetworkUpgrade,
+        Network, NetworkUpgrade, V4Deprecation,
     },
     primitives::{ed25519, x25519, Groth16Proof},
     sapling,
@@ -46,7 +46,7 @@ use zakura_chain::{ironwood, orchard};
 
 use zakura_node_services::mempool;
 use zakura_state::ValidateContextError;
-use zakura_test::mock_service::MockService;
+use zakura_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{error::TransactionError, primitives, transaction::POLL_MEMPOOL_DELAY, BoxError};
 
@@ -3932,6 +3932,123 @@ async fn v5_with_duplicate_orchard_action() {
 }
 
 /// Checks the activation boundary of the temporary Orchard-disabling soft fork:
+/// Checks the ZIP 2003 version 4 deprecation boundary: a V4 transaction is valid below
+/// the deprecation height and invalid at and above it, the default deprecation is the NU7
+/// activation height, a network can name a later height, and a network can keep accepting
+/// V4 transactions.
+#[test]
+fn v4_deprecation_boundary() {
+    let _init_guard = zakura_test::init();
+
+    let nu7 = Height(2_000_000);
+    let later = Height(2_500_000);
+
+    let tx = test_transactions(&Network::Mainnet)
+        .map(|(_, tx)| tx)
+        .find(|tx| matches!(**tx, Transaction::V4 { .. }))
+        .expect("V4 tx");
+
+    let activation_heights = ConfiguredActivationHeights {
+        before_overwinter: Some(1),
+        overwinter: Some(2),
+        sapling: Some(3),
+        blossom: Some(4),
+        heartwood: Some(5),
+        canopy: Some(6),
+        nu5: Some(7),
+        nu6: Some(8),
+        nu6_1: Some(9),
+        nu6_2: Some(10),
+        nu6_3: Some(11),
+        nu7: Some(nu7.0),
+    };
+
+    // A network on the ZIP 2003 default rejects V4 transactions from NU7 onwards.
+    let at_nu7 = Parameters::build()
+        .with_activation_heights(activation_heights)
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(at_nu7.v4_deprecation_height(), Some(nu7));
+    assert!(
+        verify_v4_at(&at_nu7, &tx, nu7.previous().expect("height")).is_ok(),
+        "a V4 transaction must be valid below the deprecation height",
+    );
+    assert_eq!(
+        verify_v4_at(&at_nu7, &tx, nu7),
+        Err(TransactionError::UnsupportedByNetworkUpgrade(
+            4,
+            NetworkUpgrade::Nu7
+        )),
+        "a V4 transaction must be invalid at the deprecation height",
+    );
+
+    // A network can deprecate V4 transactions after NU7 activates.
+    let at_height = Parameters::build()
+        .with_activation_heights(activation_heights)
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .with_v4_deprecation(V4Deprecation::AtHeight(later))
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(at_height.v4_deprecation_height(), Some(later));
+    assert!(
+        verify_v4_at(&at_height, &tx, nu7).is_ok(),
+        "a V4 transaction must stay valid at NU7 when deprecation is configured later",
+    );
+    assert!(
+        verify_v4_at(&at_height, &tx, later).is_err(),
+        "a V4 transaction must be invalid at the configured deprecation height",
+    );
+
+    // A network can keep accepting V4 transactions at every height.
+    let never = Parameters::build()
+        .with_activation_heights(activation_heights)
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .with_v4_deprecation(V4Deprecation::Never)
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(never.v4_deprecation_height(), None);
+    assert!(
+        verify_v4_at(&never, &tx, later).is_ok(),
+        "a V4 transaction must stay valid on a network that never deprecates it",
+    );
+
+    // A network without NU7 keeps accepting V4 transactions on the ZIP 2003 default.
+    let no_nu7 = Parameters::build()
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(no_nu7.v4_deprecation_height(), None);
+    assert!(!no_nu7.is_v4_deprecated(Height::MAX));
+}
+
+/// A [`Verifier`] with concrete service types, so a test can name its associated
+/// functions without the compiler inferring the services from a call.
+type TestVerifier = Verifier<
+    MockService<zakura_state::Request, zakura_state::Response, PanicAssertion>,
+    MockService<mempool::Request, mempool::Response, PanicAssertion>,
+>;
+
+/// Runs the V4 network upgrade check for `tx` at `height` on `network`.
+fn verify_v4_at(
+    network: &Network,
+    tx: &Transaction,
+    height: Height,
+) -> Result<(), TransactionError> {
+    TestVerifier::verify_v4_transaction_network_upgrade(
+        tx,
+        network,
+        height,
+        NetworkUpgrade::current(network, height),
+    )
+}
+
 /// it is inactive below the configured height and active at and above it, can be
 /// disabled entirely, and Mainnet uses its fixed activation height.
 #[test]

--- a/crates/zakura-consensus/src/transaction/tests.rs
+++ b/crates/zakura-consensus/src/transaction/tests.rs
@@ -106,6 +106,7 @@ fn shielded_proof_sizes_are_enforced_for_in_memory_transactions() {
         orchard_shielded_data: Some(orchard_shielded_data),
     };
     let make_v6 = |ironwood_shielded_data| Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -160,6 +161,7 @@ fn matching_orchard_and_ironwood_nullifiers_are_not_conflicts() {
         .find_map(|transaction| transaction.orchard_shielded_data().cloned())
         .expect("test vectors include an Orchard transaction");
     let transaction = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height: Height(1),
@@ -269,6 +271,7 @@ fn v6_pool_flow_transaction(
     transparent_outputs: Vec<transparent::Output>,
 ) -> Transaction {
     Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::Height(block::Height(0)),
         expiry_height: Height(1),
@@ -356,6 +359,7 @@ fn coinbase_rejects_orchard_shielded_data_after_nu6_3() {
     // zero value balance, so `disabled_add_to_orchard_pool` does NOT catch it — this
     // structural rule is what rejects it (the two rules are not redundant).
     let coinbase_with_orchard = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::Height(Height(0)),
         expiry_height: height,
@@ -377,6 +381,7 @@ fn coinbase_rejects_orchard_shielded_data_after_nu6_3() {
 
     // A V6 coinbase paying shielded output through Ironwood (no Orchard bundle) is allowed.
     let coinbase_with_ironwood = Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::Height(Height(0)),
         expiry_height: height,
@@ -3932,6 +3937,109 @@ async fn v5_with_duplicate_orchard_action() {
 }
 
 /// Checks the activation boundary of the temporary Orchard-disabling soft fork:
+/// Checks that a ZIP 233 burn is only valid once NU7 activates, and that the miner fee
+/// excludes it.
+#[test]
+fn zip233_amount_activates_at_nu7_and_is_not_a_fee() {
+    let _init_guard = zakura_test::init();
+
+    let nu7 = Height(2_000_000);
+    let network = Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(2),
+            sapling: Some(3),
+            blossom: Some(4),
+            heartwood: Some(5),
+            canopy: Some(6),
+            nu5: Some(7),
+            nu6: Some(8),
+            nu6_1: Some(9),
+            nu6_2: Some(10),
+            nu6_3: Some(11),
+            nu7: Some(nu7.0),
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("failed to build configured network");
+
+    let input_value = Amount::<NonNegative>::try_from(1_000_000).expect("valid amount");
+    let output_value = Amount::<NonNegative>::try_from(400_000).expect("valid amount");
+    let burn = Amount::<NonNegative>::try_from(250_000).expect("valid amount");
+
+    let outpoint = transparent::OutPoint::from_usize(Hash([0u8; 32]), 0);
+    let utxo = transparent::Utxo {
+        output: transparent::Output {
+            value: input_value,
+            lock_script: transparent::Script::new(&[]),
+        },
+        height: Height(1),
+        from_coinbase: false,
+    };
+    let spent_utxos = HashMap::from([(outpoint, utxo)]);
+
+    let make_tx = |zip233_amount| Transaction::V6 {
+        network_upgrade: NetworkUpgrade::Nu7,
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        zip233_amount,
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint,
+            unlock_script: transparent::Script::new(&[]),
+            sequence: 0,
+        }],
+        outputs: vec![transparent::Output {
+            value: output_value,
+            lock_script: transparent::Script::new(&[]),
+        }],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        ironwood_shielded_data: None,
+    };
+
+    let plain = make_tx(Amount::zero());
+    let burning = make_tx(burn);
+
+    // A transaction that removes nothing from circulation is valid at any height.
+    assert_eq!(
+        check::zip233_amount_is_valid(&plain, Height(12), &network),
+        Ok(())
+    );
+    assert_eq!(check::zip233_amount_is_valid(&plain, nu7, &network), Ok(()));
+
+    // A burn is invalid before NU7.
+    assert_eq!(
+        check::zip233_amount_is_valid(&burning, Height(12), &network),
+        Err(TransactionError::Zip233AmountBeforeNu7),
+    );
+
+    if zakura_chain::parameters::ZIP233_ENABLED {
+        assert_eq!(
+            check::zip233_amount_is_valid(&burning, nu7, &network),
+            Ok(())
+        );
+    } else {
+        // A build without the feature never reads the field from the wire, so a burn is
+        // invalid at every height. This transaction only exists because the test built
+        // it in memory.
+        assert_eq!(
+            check::zip233_amount_is_valid(&burning, nu7, &network),
+            Err(TransactionError::Zip233AmountBeforeNu7),
+        );
+    }
+
+    // The burn leaves circulation instead of paying the miner, so the fee excludes it.
+    let plain_fee = TestVerifier::miner_fee(&plain, &spent_utxos).expect("valid fee");
+    let burning_fee = TestVerifier::miner_fee(&burning, &spent_utxos).expect("valid fee");
+
+    assert_eq!(
+        plain_fee,
+        (input_value - output_value).expect("valid amount")
+    );
+    assert_eq!(burning_fee, (plain_fee - burn).expect("valid amount"));
+}
+
 /// Checks the ZIP 2003 version 4 deprecation boundary: a V4 transaction is valid below
 /// the deprecation height and invalid at and above it, the default deprecation is the NU7
 /// activation height, a network can name a later height, and a network can keep accepting

--- a/crates/zakura-consensus/src/transaction/tests/prop.rs
+++ b/crates/zakura-consensus/src/transaction/tests/prop.rs
@@ -322,6 +322,7 @@ fn mock_transparent_transaction(
             network_upgrade,
         },
         6 => Transaction::V6 {
+            zip233_amount: Default::default(),
             inputs,
             outputs,
             lock_time,

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -12,6 +12,12 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+
+# ZIP 218 "25-second Block Target Spacing" consensus rules, dormant until NU7 activates.
+zip218 = [
+    "zakura-chain/zip218",
+]
+
 fuzz-impl = []
 test-support = []
 

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-header-chain"
-version = "1.0.0"
+version = "1.1.0"
 authors.workspace = true
 description = "Fork-aware header-chain domain types and transition engine for Zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -26,7 +26,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-header-chain"
-version = "1.1.0"
+version = "1.2.0"
 authors.workspace = true
 description = "Fork-aware header-chain domain types and transition engine for Zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/zakura-header-chain/conformance.toml
+++ b/crates/zakura-header-chain/conformance.toml
@@ -382,7 +382,7 @@ id = "LC-ANCHOR-03"
 name = "Post-anchor validation context"
 status = "implemented"
 owner = "zakura_state::HeaderChainStore::validation_context"
-tests = ["HV-06::later_anchor_predecessor_context_has_exact_one_to_twenty_eight_boundary", "HV-06::later_anchor_predecessor_context_rejects_gap_hash_and_link_corruption", "HV-06::clean_store_initializes_only_from_finalized_full_state", "HV-06::atomic_finality_context_can_use_a_newly_staged_anchor_path", "AUD-14::every_crash_boundary_reopens_to_complete_transition"]
+tests = ["HV-06::later_anchor_predecessor_context_has_the_exact_span_boundary", "HV-06::later_anchor_predecessor_context_rejects_gap_hash_and_link_corruption", "HV-06::clean_store_initializes_only_from_finalized_full_state", "HV-06::atomic_finality_context_can_use_a_newly_staged_anchor_path", "AUD-14::every_crash_boundary_reopens_to_complete_transition"]
 networks = ["mainnet", "testnet", "custom"]
 
 [[rule]]

--- a/crates/zakura-header-chain/src/transition/types/preparation.rs
+++ b/crates/zakura-header-chain/src/transition/types/preparation.rs
@@ -372,7 +372,16 @@ mod tests {
     #[test]
     fn validation_lease_coherence_enforces_context_boundaries() {
         let network = Network::new_regtest(RegtestParameters::default());
-        for (height, expected_len) in [(0, 1), (27, 28), (28, 28), (40, 28)] {
+        // A lease retains every predecessor below the difficulty adjustment
+        // span, and caps at the span above it.
+        let span = crate::POW_ADJUSTMENT_BLOCK_SPAN;
+        let span_height = u32::try_from(span).expect("the difficulty adjustment span fits in u32");
+        for (height, expected_len) in [
+            (0, 1),
+            (span_height - 1, span),
+            (span_height, span),
+            (span_height + 12, span),
+        ] {
             let lease = lease_at(height);
             assert_eq!(lease.predecessors.len(), expected_len, "height {height}");
             assert!(

--- a/crates/zakura-header-chain/src/validation/contextual/adjusted_difficulty.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/adjusted_difficulty.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 use thiserror::Error;
 use zakura_chain::{
     block::{self, Block},
-    parameters::{Network, NetworkUpgrade, POW_AVERAGING_WINDOW},
+    parameters::{Network, NetworkUpgrade},
     work::difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty as _, U256},
     BoundedVec,
 };
@@ -161,6 +161,14 @@ impl AdjustedDifficulty {
         self.network.clone()
     }
 
+    /// Returns the averaging window in force at the candidate height.
+    ///
+    /// `PoWAveragingWindow` in the Zcash specification, which ZIP 218 widens at
+    /// NU7.
+    fn averaging_window(&self) -> usize {
+        NetworkUpgrade::averaging_window_for_height(&self.network, self.candidate_height)
+    }
+
     /// Calculate the expected `difficulty_threshold` from the candidate block's time and height,
     /// the network, and the
     /// `difficulty_threshold`s and `time`s from the previous
@@ -192,7 +200,7 @@ impl AdjustedDifficulty {
     /// The difficulty calculation implements `ThresholdBits` from the Zcash specification.
     /// `ThresholdBits` excludes the Testnet minimum difficulty adjustment.
     fn threshold_bits(&self) -> CompactDifficulty {
-        let averaging_window_height = u32::try_from(POW_AVERAGING_WINDOW)
+        let averaging_window_height = u32::try_from(self.averaging_window())
             .expect("averaging window is much smaller than u32::MAX");
 
         if self.candidate_height.0 <= averaging_window_height {
@@ -230,10 +238,11 @@ impl AdjustedDifficulty {
         // `threshold_bits` returns `PoWLimit` before it calls this function at early-chain heights.
         // A valid relevant chain contains at least 17 blocks at later heights.
 
+        let averaging_window = self.averaging_window();
         let averaging_window_thresholds =
-            &self.relevant_difficulty_thresholds.as_slice()[0..POW_AVERAGING_WINDOW];
+            &self.relevant_difficulty_thresholds.as_slice()[0..averaging_window];
 
-        let divisor: U256 = POW_AVERAGING_WINDOW.into();
+        let divisor: U256 = averaging_window.into();
         let mut quotient_total = U256::zero();
         let mut remainder_total = U256::zero();
         for compact in averaging_window_thresholds {
@@ -246,7 +255,7 @@ impl AdjustedDifficulty {
                 .expect("the sum of divided targets is at most U256::MAX");
             remainder_total = remainder_total
                 .checked_add(target % divisor)
-                .expect("17 remainders smaller than 17 fit in U256");
+                .expect("a window of remainders smaller than the window fits in U256");
         }
         ExpandedDifficulty::from(
             quotient_total
@@ -308,11 +317,12 @@ impl AdjustedDifficulty {
         let newer_median = self.median_time_past();
 
         // MedianTime(height : N) := median([ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to max(0, height − 1) ])
-        let older_median = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
+        let averaging_window = self.averaging_window();
+        let older_median = if self.relevant_times.len() > averaging_window {
             let older_times: Vec<_> = self
                 .relevant_times
                 .iter()
-                .skip(POW_AVERAGING_WINDOW)
+                .skip(averaging_window)
                 .cloned()
                 .take(POW_MEDIAN_BLOCK_SPAN)
                 .collect();

--- a/crates/zakura-header-chain/src/validation/contextual/constants.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/constants.rs
@@ -1,4 +1,4 @@
-use zakura_chain::parameters::POW_AVERAGING_WINDOW;
+use zakura_chain::parameters::MAX_POW_AVERAGING_WINDOW;
 
 /// The median block span for time median calculations.
 ///
@@ -9,7 +9,12 @@ pub const POW_MEDIAN_BLOCK_SPAN: usize = 11;
 ///
 /// `PoWAveragingWindow + PoWMedianBlockSpan` in the Zcash specification based on
 /// > ActualTimespan(height : N) := MedianTime(height) − MedianTime(height − PoWAveragingWindow)
-pub const POW_ADJUSTMENT_BLOCK_SPAN: usize = POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
+///
+/// ZIP 218 widens `PoWAveragingWindow` at NU7, so this span covers the largest
+/// window the build can use at any height. A `zip218` build therefore carries
+/// this wider context from genesis onwards and ignores the entries beyond the
+/// window in force at the candidate height.
+pub const POW_ADJUSTMENT_BLOCK_SPAN: usize = MAX_POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
 
 /// Durable predecessors needed below a separately retained parent frontier.
 pub const POW_PREDECESSOR_CONTEXT_SPAN: usize = POW_ADJUSTMENT_BLOCK_SPAN - 1;

--- a/crates/zakura-header-chain/src/validation/contextual/tests/arithmetic.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/tests/arithmetic.rs
@@ -23,8 +23,7 @@ fn custom_target_scaling_clamps_before_overflowing_u256() {
     // The context always spans `POW_ADJUSTMENT_BLOCK_SPAN` blocks, which can be
     // wider than the averaging window in force at this height.
     let candidate_height = block::Height(700_000);
-    let averaging_window =
-        NetworkUpgrade::averaging_window_for_height(&network, candidate_height);
+    let averaging_window = NetworkUpgrade::averaging_window_for_height(&network, candidate_height);
     let mut context = vec![(compact, candidate_time - Duration::seconds(1)); averaging_window];
     context.extend(vec![
         (compact, candidate_time - Duration::seconds(100_000));

--- a/crates/zakura-header-chain/src/validation/contextual/tests/arithmetic.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/tests/arithmetic.rs
@@ -5,7 +5,8 @@ use zakura_chain::{
     work::difficulty::{ExpandedDifficulty, ParameterDifficulty as _, U256},
 };
 
-use super::super::AdjustedDifficulty;
+use super::super::{AdjustedDifficulty, POW_ADJUSTMENT_BLOCK_SPAN};
+use zakura_chain::parameters::NetworkUpgrade;
 
 #[test]
 fn custom_target_scaling_clamps_before_overflowing_u256() {
@@ -17,10 +18,17 @@ fn custom_target_scaling_clamps_before_overflowing_u256() {
         .expect("the maximum compact-representable target is valid")
         .to_network()
         .expect("the custom network parameters are valid");
-    let mut context = vec![(compact, candidate_time - Duration::seconds(1)); 17];
+    // The recent averaging window is tightly spaced and everything older is far
+    // apart, so the actual timespan is large enough to clamp the scaled mean.
+    // The context always spans `POW_ADJUSTMENT_BLOCK_SPAN` blocks, which can be
+    // wider than the averaging window in force at this height.
+    let candidate_height = block::Height(700_000);
+    let averaging_window =
+        NetworkUpgrade::averaging_window_for_height(&network, candidate_height);
+    let mut context = vec![(compact, candidate_time - Duration::seconds(1)); averaging_window];
     context.extend(vec![
         (compact, candidate_time - Duration::seconds(100_000));
-        11
+        POW_ADJUSTMENT_BLOCK_SPAN - averaging_window
     ]);
     let adjustment = AdjustedDifficulty::new_from_header_time(
         candidate_time,

--- a/crates/zakura-header-chain/src/validation/contextual/tests/validation.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/tests/validation.rs
@@ -277,10 +277,12 @@ fn median_and_production_max_time_boundaries_are_exact() {
     ] {
         let context = vec![
             (network.target_difficulty_limit().to_compact(), base);
-            usize::try_from(height.0.min(
-                u32::try_from(POW_ADJUSTMENT_BLOCK_SPAN)
-                    .expect("the difficulty adjustment span fits in u32"),
-            ))
+            usize::try_from(
+                height.0.min(
+                    u32::try_from(POW_ADJUSTMENT_BLOCK_SPAN)
+                        .expect("the difficulty adjustment span fits in u32"),
+                )
+            )
             .expect("bounded height fits in usize")
         ];
         assert!(matches!(

--- a/crates/zakura-header-chain/src/validation/contextual/tests/validation.rs
+++ b/crates/zakura-header-chain/src/validation/contextual/tests/validation.rs
@@ -119,7 +119,9 @@ fn difficulty_windows_upgrades_testnet_minimum_and_partitions_match() {
                 continue;
             }
             let spacing = NetworkUpgrade::target_spacing_for_height(&network, height);
-            let context_len = usize::try_from(height.0.min(28))
+            let span = u32::try_from(POW_ADJUSTMENT_BLOCK_SPAN)
+                .expect("the difficulty adjustment span fits in u32");
+            let context_len = usize::try_from(height.0.min(span))
                 .expect("bounded test context length fits in usize");
             let context = context(&network, candidate_time, spacing, context_len);
             validate_with_expected_target(&network, height, candidate_time, &context)
@@ -131,7 +133,7 @@ fn difficulty_windows_upgrades_testnet_minimum_and_partitions_match() {
     let activation_height = block::Height(299_188);
     let spacing = NetworkUpgrade::target_spacing_for_height(&testnet, activation_height);
     let previous_time = candidate_time - spacing * 6;
-    let mut exact_gap = context(&testnet, candidate_time, spacing, 28);
+    let mut exact_gap = context(&testnet, candidate_time, spacing, POW_ADJUSTMENT_BLOCK_SPAN);
     exact_gap[0].1 = previous_time;
     let previous_height = (activation_height - 1).expect("height is positive");
     let exact_gap_target = AdjustedDifficulty::new_from_header_time(
@@ -148,7 +150,7 @@ fn difficulty_windows_upgrades_testnet_minimum_and_partitions_match() {
     );
 
     let minimum_time = candidate_time + Duration::seconds(1);
-    let minimum_context = context(&testnet, minimum_time, spacing, 28)
+    let minimum_context = context(&testnet, minimum_time, spacing, POW_ADJUSTMENT_BLOCK_SPAN)
         .into_iter()
         .enumerate()
         .map(|(index, (difficulty, time))| {
@@ -275,7 +277,11 @@ fn median_and_production_max_time_boundaries_are_exact() {
     ] {
         let context = vec![
             (network.target_difficulty_limit().to_compact(), base);
-            usize::try_from(height.0.min(28)).expect("bounded height fits in usize")
+            usize::try_from(height.0.min(
+                u32::try_from(POW_ADJUSTMENT_BLOCK_SPAN)
+                    .expect("the difficulty adjustment span fits in u32"),
+            ))
+            .expect("bounded height fits in usize")
         ];
         assert!(matches!(
             validate_with_expected_target(&network, height, base, &context),

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -82,10 +82,10 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -82,8 +82,8 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
 
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -82,7 +82,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/src/config.rs
+++ b/crates/zakura-network/src/config.rs
@@ -25,7 +25,7 @@ use zakura_chain::{
             self, ConfiguredActivationHeights, ConfiguredCheckpoints, ConfiguredFundingStreams,
             ConfiguredLockboxDisbursement, RegtestParameters,
         },
-        Magic, Network, NetworkKind,
+        Magic, Network, NetworkKind, V4Deprecation,
     },
     work::difficulty::U256,
 };
@@ -972,6 +972,55 @@ struct DTestnetParameters {
     /// If unset, the default activation height for the network is used; the soft fork
     /// cannot be disabled via configuration.
     temporary_orchard_disabling_soft_fork_height: Option<u32>,
+    /// When this network stops accepting version 4 transactions, see ZIP 2003.
+    ///
+    /// Accepts `"nu7"` (the default, the NU7 activation height), `"never"`, or a block
+    /// height. If unset, the network deprecates version 4 transactions at NU7.
+    v4_deprecation: Option<DV4Deprecation>,
+}
+
+/// When a network stops accepting version 4 transactions, in configuration form.
+///
+/// Serializes as `"nu7"`, `"never"`, or a block height.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum DV4Deprecation {
+    /// A block height, for a network that deprecates version 4 transactions at a height
+    /// other than the NU7 activation height.
+    Height(u32),
+    /// `"nu7"` or `"never"`.
+    Named(String),
+}
+
+impl From<V4Deprecation> for DV4Deprecation {
+    fn from(v4_deprecation: V4Deprecation) -> Self {
+        match v4_deprecation {
+            V4Deprecation::AtNu7 => DV4Deprecation::Named("nu7".to_string()),
+            V4Deprecation::AtHeight(height) => DV4Deprecation::Height(height.0),
+            V4Deprecation::Never => DV4Deprecation::Named("never".to_string()),
+        }
+    }
+}
+
+impl TryFrom<DV4Deprecation> for V4Deprecation {
+    type Error = String;
+
+    fn try_from(v4_deprecation: DV4Deprecation) -> Result<Self, Self::Error> {
+        match v4_deprecation {
+            DV4Deprecation::Height(height) => Ok(V4Deprecation::AtHeight(
+                height
+                    .try_into()
+                    .map_err(|_| format!("{height} is not a valid block height"))?,
+            )),
+            DV4Deprecation::Named(name) => match name.to_lowercase().as_str() {
+                "nu7" => Ok(V4Deprecation::AtNu7),
+                "never" => Ok(V4Deprecation::Never),
+                _ => Err(format!(
+                    "invalid v4_deprecation {name:?}, expected \"nu7\", \"never\", or a block height"
+                )),
+            },
+        }
+    }
 }
 
 /// Network configuration used during deserialization.
@@ -1089,6 +1138,7 @@ impl From<Arc<testnet::Parameters>> for DTestnetParameters {
             temporary_orchard_disabling_soft_fork_height: params
                 .temporary_orchard_disabling_soft_fork_height()
                 .map(|height| height.0),
+            v4_deprecation: Some(params.v4_deprecation().into()),
         }
     }
 }
@@ -1358,6 +1408,7 @@ where
         checkpoints,
         extend_funding_stream_addresses_as_required,
         temporary_orchard_disabling_soft_fork_height,
+        v4_deprecation,
     } = params;
 
     let mut params_builder = testnet::Parameters::build();
@@ -1449,6 +1500,13 @@ where
         params_builder = params_builder.with_temporary_orchard_disabling_soft_fork_height(
             height.try_into().map_err(de::Error::custom)?,
         );
+    }
+
+    // Retain the ZIP 2003 default of deprecating version 4 transactions at NU7 unless
+    // another deprecation is configured.
+    if let Some(v4_deprecation) = v4_deprecation {
+        params_builder = params_builder
+            .with_v4_deprecation(v4_deprecation.try_into().map_err(de::Error::custom)?);
     }
 
     // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet

--- a/crates/zakura-network/src/config/tests/vectors.rs
+++ b/crates/zakura-network/src/config/tests/vectors.rs
@@ -6,7 +6,7 @@ use zakura_chain::{
     block::Height,
     parameters::{
         testnet::{self, ConfiguredFundingStreams},
-        Network,
+        Network, V4Deprecation,
     },
 };
 
@@ -781,6 +781,39 @@ fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
         params.temporary_orchard_disabling_soft_fork_height(),
         Some(soft_fork_height),
     );
+}
+
+/// Checks that a configured Testnet's ZIP 2003 version 4 deprecation survives a
+/// serialization round-trip in each of its three forms.
+#[test]
+fn v4_deprecation_serialization_roundtrip() {
+    let _init_guard = zakura_test::init();
+
+    for v4_deprecation in [
+        V4Deprecation::AtNu7,
+        V4Deprecation::AtHeight(Height(2_000_000)),
+        V4Deprecation::Never,
+    ] {
+        let mut config = Config {
+            network: testnet::Parameters::build()
+                .with_v4_deprecation(v4_deprecation)
+                .to_network()
+                .expect("failed to build configured network"),
+            initial_testnet_peers: [].into(),
+            ..Config::for_test(P2pStack::Dual)
+        };
+        config.zakura.apply_network_defaults(&config.network);
+
+        let serialized = toml::to_string(&config).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+
+        assert_eq!(config, deserialized);
+
+        let Network::Testnet(params) = &deserialized.network else {
+            panic!("deserialized network must be a Testnet");
+        };
+        assert_eq!(params.v4_deprecation(), v4_deprecation);
+    }
 }
 
 #[test]

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -34,7 +34,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain" , version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 tower = { workspace = true }
 

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -34,8 +34,8 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "6.1.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
+zakura-chain = { path = "../zakura-chain" , version = "6.2.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "3.2.1"
+version = "3.2.2"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -34,8 +34,8 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "6.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
+zakura-chain = { path = "../zakura-chain" , version = "6.1.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -119,7 +119,7 @@ zcash_transparent = { workspace = true }
 zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = [
     "rpc-client",
@@ -146,7 +146,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = [
     "proptest-impl",
 ] }
 zakura-network = { path = "../zakura-network", version = "7.0.0", features = [

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -32,6 +32,16 @@ zip218 = [
     "zakura-state/zip218",
 ]
 
+# ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
+# `zip233Amount` field on v6 transactions, which removes value from circulation.
+#
+# Also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`; see `zakura-chain`.
+zip233 = [
+    "zakura-chain/zip233",
+    "zakura-consensus/zip233",
+    "zakura-state/zip233",
+]
+
 # Production features that activate extra dependencies, or extra features in
 # dependencies
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -24,6 +24,14 @@ categories = [
 exclude = ["*.proto"]
 
 [features]
+
+# ZIP 218 "25-second Block Target Spacing" consensus rules, dormant until NU7 activates.
+zip218 = [
+    "zakura-chain/zip218",
+    "zakura-consensus/zip218",
+    "zakura-state/zip218",
+]
+
 # Production features that activate extra dependencies, or extra features in
 # dependencies
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -116,7 +116,7 @@ zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
@@ -125,7 +125,7 @@ zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", fe
     "rpc-client",
 ] }
 zakura-script = { path = "../zakura-script", version = "3.2.2" }
-zakura-state = { path = "../zakura-state", version = "7.1.0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
@@ -143,7 +143,7 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = [
     "proptest-impl",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = [
@@ -152,7 +152,7 @@ zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features =
 zakura-network = { path = "../zakura-network", version = "7.0.1", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "7.1.0", features = [
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = [
     "proptest-impl",
 ] }
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -126,10 +126,10 @@ zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "9.0.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.1" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", features = [
     "rpc-client",
@@ -153,10 +153,10 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "9.0.0", features = [
     "proptest-impl",
 ] }
 zakura-network = { path = "../zakura-network", version = "7.0.1", features = [

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "8.0.0"
+version = "8.1.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -116,16 +116,16 @@ zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
-zakura-network = { path = "../zakura-network", version = "7.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = [
+zakura-network = { path = "../zakura-network", version = "7.0.1" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "3.2.1" }
-zakura-state = { path = "../zakura-state", version = "7.0.0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
+zakura-state = { path = "../zakura-state", version = "7.1.0" }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
@@ -143,16 +143,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = [
     "proptest-impl",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "7.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "7.0.1", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "7.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "7.1.0", features = [
     "proptest-impl",
 ] }
 

--- a/crates/zakura-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/zip317.rs
@@ -16,7 +16,10 @@ use rand::{
 use zakura_chain::{
     amount::{self, Amount},
     block::{Height, MAX_BLOCK_BYTES},
-    parameters::Network,
+    parameters::{
+        Network, NetworkUpgrade, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT,
+        SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
+    },
     serialization::{CompactSizeMessage, TrustedPreallocate, ZcashDeserializeInto, ZcashSerialize},
     transaction::{self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx},
     work::equihash::Solution,
@@ -131,18 +134,7 @@ pub fn select_mempool_transactions(
     let mut selected_txs = Vec::new();
 
     // Set up limit tracking
-    let max_block_bytes: usize = MAX_BLOCK_BYTES.try_into().expect("fits in memory");
-    let reserved_block_bytes = block_template_overhead_bytes(net)
-        .checked_add(max_coinbase_bytes(&fake_coinbase_tx))
-        .expect("block template byte reservation fits in memory");
-    let mut remaining_block_bytes = max_block_bytes
-        .checked_sub(reserved_block_bytes)
-        .expect("the fake coinbase and block overhead fit in a block");
-    let mut remaining_block_sigops = MAX_BLOCK_SIGOPS;
-    let mut remaining_block_unpaid_actions: u32 = BLOCK_UNPAID_ACTION_LIMIT;
-
-    // Adjust the sigop limit based on the coinbase transaction.
-    remaining_block_sigops -= fake_coinbase_tx.sigops;
+    let mut limits = BlockTemplateLimits::initial(net, height, &fake_coinbase_tx);
 
     // > Repeat while there is any candidate transaction
     // > that pays at least the conventional fee:
@@ -155,11 +147,7 @@ pub fn select_mempool_transactions(
             tx_weights,
             &mut selected_txs,
             &mempool_tx_deps,
-            &mut remaining_block_bytes,
-            &mut remaining_block_sigops,
-            // The number of unpaid actions is always zero for transactions that pay the
-            // conventional fee, so this check and limit is effectively ignored.
-            &mut remaining_block_unpaid_actions,
+            &mut limits,
         );
     }
 
@@ -173,9 +161,7 @@ pub fn select_mempool_transactions(
             tx_weights,
             &mut selected_txs,
             &mempool_tx_deps,
-            &mut remaining_block_bytes,
-            &mut remaining_block_sigops,
-            &mut remaining_block_unpaid_actions,
+            &mut limits,
         );
     }
 
@@ -267,20 +253,14 @@ fn checked_add_transaction_weighted_random(
     tx_weights: WeightedIndex<f32>,
     selected_txs: &mut Vec<SelectedMempoolTx>,
     mempool_tx_deps: &TransactionDependencies,
-    remaining_block_bytes: &mut usize,
-    remaining_block_sigops: &mut u32,
-    remaining_block_unpaid_actions: &mut u32,
+    limits: &mut BlockTemplateLimits,
 ) -> Option<WeightedIndex<f32>> {
     // > Pick one of those transactions at random with probability in direct proportion
     // > to its weight_ratio, and remove it from the set of candidate transactions
     let (new_tx_weights, candidate_tx) =
         choose_transaction_weighted_random(candidate_txs, tx_weights);
 
-    if !candidate_tx.try_update_block_template_limits(
-        remaining_block_bytes,
-        remaining_block_sigops,
-        remaining_block_unpaid_actions,
-    ) {
+    if !limits.try_add(&candidate_tx) {
         return new_tx_weights;
     }
 
@@ -321,11 +301,7 @@ fn checked_add_transaction_weighted_random(
                     continue;
                 }
 
-                if !candidate_tx.try_update_block_template_limits(
-                    remaining_block_bytes,
-                    remaining_block_sigops,
-                    remaining_block_unpaid_actions,
-                ) {
+                if !limits.try_add(&candidate_tx) {
                     continue;
                 }
 
@@ -348,52 +324,104 @@ fn checked_add_transaction_weighted_random(
     new_tx_weights
 }
 
-trait TryUpdateBlockLimits {
-    /// Checks if a transaction fits within the provided remaining block bytes,
-    /// sigops, and unpaid actions limits.
-    ///
-    /// Updates the limits and returns true if the transaction does fit, or
-    /// returns false otherwise.
-    fn try_update_block_template_limits(
-        &self,
-        remaining_block_bytes: &mut usize,
-        remaining_block_sigops: &mut u32,
-        remaining_block_unpaid_actions: &mut u32,
-    ) -> bool;
+/// Tracks the remaining capacity of a block template against every limit a
+/// candidate mempool transaction can exhaust: the ZIP-317 byte, sigop, and
+/// unpaid-action limits, and, once ZIP 218 is active, the per-pool shielded
+/// action limits and the global shielded budget.
+///
+/// The shielded fields start at [`u32::MAX`] while ZIP 218 is inactive, so the
+/// new limits have no effect on those templates.
+struct BlockTemplateLimits {
+    remaining_bytes: usize,
+    remaining_sigops: u32,
+    remaining_unpaid_actions: u32,
+    remaining_orchard_actions: u32,
+    remaining_sapling_ios: u32,
+    remaining_sprout_joinsplits: u32,
+    remaining_shielded_cost: u32,
 }
 
-impl TryUpdateBlockLimits for VerifiedUnminedTx {
-    fn try_update_block_template_limits(
-        &self,
-        remaining_block_bytes: &mut usize,
-        remaining_block_sigops: &mut u32,
-        remaining_block_unpaid_actions: &mut u32,
-    ) -> bool {
-        // > If the block template with this transaction included
-        // > would be within the block size limit and block sigop limit,
-        // > and block_unpaid_actions <=  block_unpaid_action_limit,
-        // > add the transaction to the block template
-        //
-        // Unpaid actions are always zero for transactions that pay the conventional fee, so the
-        // unpaid action check always passes for those transactions. Use the full block-level sigop
-        // count (legacy + P2SH) so template selection cannot produce blocks that the block verifier
-        // would reject for exceeding `MAX_BLOCK_SIGOPS`.
-        let tx_block_sigops = self.block_sigop_count();
-        if self.transaction.size() <= *remaining_block_bytes
-            && tx_block_sigops <= *remaining_block_sigops
-            && self.unpaid_actions <= *remaining_block_unpaid_actions
-        {
-            *remaining_block_bytes -= self.transaction.size();
-            *remaining_block_sigops -= tx_block_sigops;
+impl BlockTemplateLimits {
+    /// Returns the initial limits for a block template at `height`, with the
+    /// block overhead and `fake_coinbase_tx` already deducted from the byte and
+    /// sigop limits.
+    fn initial(
+        network: &Network,
+        height: Height,
+        fake_coinbase_tx: &TransactionTemplate<amount::NegativeOrZero>,
+    ) -> Self {
+        let (orchard_actions, sapling_ios, sprout_joinsplits, shielded_cost) =
+            if NetworkUpgrade::is_zip218_active(network, height) {
+                (
+                    ORCHARD_BLOCK_ACTION_LIMIT,
+                    SAPLING_BLOCK_IO_LIMIT,
+                    SPROUT_BLOCK_JOINSPLIT_LIMIT,
+                    GLOBAL_SHIELDED_BUDGET,
+                )
+            } else {
+                (u32::MAX, u32::MAX, u32::MAX, u32::MAX)
+            };
 
-            // Unpaid actions are always zero for transactions that pay the conventional fee,
-            // so this limit always remains the same after they are added.
-            *remaining_block_unpaid_actions -= self.unpaid_actions;
+        let max_block_bytes: usize = MAX_BLOCK_BYTES.try_into().expect("fits in memory");
+        let reserved_block_bytes = block_template_overhead_bytes(network)
+            .checked_add(max_coinbase_bytes(fake_coinbase_tx))
+            .expect("block template byte reservation fits in memory");
 
-            true
-        } else {
-            false
+        Self {
+            remaining_bytes: max_block_bytes
+                .checked_sub(reserved_block_bytes)
+                .expect("the fake coinbase and block overhead fit in a block"),
+            remaining_sigops: MAX_BLOCK_SIGOPS - fake_coinbase_tx.sigops,
+            remaining_unpaid_actions: BLOCK_UNPAID_ACTION_LIMIT,
+            remaining_orchard_actions: orchard_actions,
+            remaining_sapling_ios: sapling_ios,
+            remaining_sprout_joinsplits: sprout_joinsplits,
+            remaining_shielded_cost: shielded_cost,
         }
+    }
+
+    /// Adds `tx` to the block template and returns `true` if it fits within
+    /// every remaining limit. Otherwise leaves `self` unchanged and returns
+    /// `false`.
+    ///
+    /// > If the block template with this transaction included
+    /// > would be within the block size limit and block sigop limit,
+    /// > and block_unpaid_actions <= block_unpaid_action_limit,
+    /// > add the transaction to the block template
+    ///
+    /// Unpaid actions are always zero for transactions that pay the conventional
+    /// fee, so the unpaid action check always passes for those transactions. The
+    /// sigop count is the full block-level count (legacy + P2SH), so template
+    /// selection cannot produce blocks the block verifier would reject for
+    /// exceeding `MAX_BLOCK_SIGOPS`. The shielded counts come from the same
+    /// [`ShieldedActionCounts`](zakura_chain::transaction::ShieldedActionCounts)
+    /// the block verifier sums, so a template cannot exceed the ZIP 218 limits
+    /// either.
+    fn try_add(&mut self, tx: &VerifiedUnminedTx) -> bool {
+        let counts = tx.transaction.transaction().shielded_action_counts();
+        let cost = counts.cost();
+        let tx_block_sigops = tx.block_sigop_count();
+
+        if tx.transaction.size() > self.remaining_bytes
+            || tx_block_sigops > self.remaining_sigops
+            || tx.unpaid_actions > self.remaining_unpaid_actions
+            || counts.orchard_actions > self.remaining_orchard_actions
+            || counts.sapling_ios > self.remaining_sapling_ios
+            || counts.sprout_joinsplits > self.remaining_sprout_joinsplits
+            || cost > self.remaining_shielded_cost
+        {
+            return false;
+        }
+
+        self.remaining_bytes -= tx.transaction.size();
+        self.remaining_sigops -= tx_block_sigops;
+        self.remaining_unpaid_actions -= tx.unpaid_actions;
+        self.remaining_orchard_actions -= counts.orchard_actions;
+        self.remaining_sapling_ios -= counts.sapling_ios;
+        self.remaining_sprout_joinsplits -= counts.sprout_joinsplits;
+        self.remaining_shielded_cost -= cost;
+
+        true
     }
 }
 

--- a/crates/zakura-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -199,3 +199,121 @@ fn includes_tx_with_selected_dependencies() {
         "should return a dependency depth of 1 for the dependent tx"
     );
 }
+
+/// Tests that block template selection respects the ZIP 218 shielded limits, so
+/// a template cannot exceed a limit the block verifier enforces.
+mod zip218_template_limits {
+    use std::sync::Arc;
+
+    use zakura_chain::{
+        parameters::{
+            testnet::{ConfiguredActivationHeights, Parameters},
+            Network, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT, SAPLING_BLOCK_IO_LIMIT,
+            SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        },
+        transaction::{
+            arbitrary::{fake_v5_with_orchard_actions, fake_v5_with_sapling_outputs},
+            Transaction, UnminedTx, VerifiedUnminedTx,
+        },
+    };
+
+    use zcash_keys::address::Address;
+    use zcash_transparent::address::TransparentAddress;
+
+    use super::{
+        super::{BlockTemplateLimits, MinerParams},
+        Amount, Height, TransactionTemplate,
+    };
+
+    /// A transaction that fills the Orchard limit leaves no room under the
+    /// global budget for a single Sapling output, even though the Sapling
+    /// per-pool limit is untouched.
+    #[test]
+    fn the_global_budget_bounds_selection_across_pools() {
+        let mut limits = nu7_template_limits();
+
+        let orchard_tx = verified_unmined_tx(fake_v5_with_orchard_actions(
+            usize::try_from(ORCHARD_BLOCK_ACTION_LIMIT).expect("the limit fits in usize"),
+        ));
+        let sapling_tx = verified_unmined_tx(fake_v5_with_sapling_outputs(1));
+
+        assert!(
+            limits.try_add(&orchard_tx),
+            "Orchard actions exactly at the per-pool limit fit in an empty template"
+        );
+        assert!(
+            !limits.try_add(&sapling_tx),
+            "a Sapling output past the global budget must not be selected"
+        );
+    }
+
+    /// The shielded limits only bind once ZIP 218 is active, so a pre-NU7
+    /// template accepts a transaction that a post-NU7 template rejects.
+    #[test]
+    fn the_shielded_limits_only_bind_after_activation() {
+        let network = nu7_activation_testnet(2);
+        let over_limit_tx = verified_unmined_tx(fake_v5_with_orchard_actions(
+            usize::try_from(ORCHARD_BLOCK_ACTION_LIMIT + 1).expect("the limit fits in usize"),
+        ));
+
+        let mut pre_activation = template_limits(&network, Height(1));
+        assert!(
+            pre_activation.try_add(&over_limit_tx),
+            "the shielded limits are inactive below the NU7 activation height"
+        );
+
+        let mut post_activation = template_limits(&network, Height(2));
+        assert_eq!(
+            post_activation.try_add(&over_limit_tx),
+            !cfg!(feature = "zip218"),
+            "a zip218 build rejects Orchard actions above the per-block limit at NU7"
+        );
+    }
+
+    fn template_limits(network: &Network, height: Height) -> BlockTemplateLimits {
+        let miner_params =
+            MinerParams::from(Address::from(TransparentAddress::PublicKeyHash([0x7e; 20])));
+        let fake_coinbase_tx =
+            TransactionTemplate::new_coinbase(network, height, &miner_params, Amount::zero())
+                .expect("valid coinbase transaction template");
+
+        BlockTemplateLimits::initial(network, height, &fake_coinbase_tx)
+    }
+
+    fn nu7_template_limits() -> BlockTemplateLimits {
+        BlockTemplateLimits {
+            remaining_bytes: usize::MAX,
+            remaining_sigops: u32::MAX,
+            remaining_unpaid_actions: u32::MAX,
+            remaining_orchard_actions: ORCHARD_BLOCK_ACTION_LIMIT,
+            remaining_sapling_ios: SAPLING_BLOCK_IO_LIMIT,
+            remaining_sprout_joinsplits: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+            remaining_shielded_cost: GLOBAL_SHIELDED_BUDGET,
+        }
+    }
+
+    fn nu7_activation_testnet(nu7_activation_height: u32) -> Network {
+        Parameters::build()
+            .with_slow_start_interval(Height(0))
+            .with_activation_heights(ConfiguredActivationHeights {
+                // The coinbase template hashes the transaction, which the
+                // pre-Overwinter format does not support, so activate the
+                // earlier upgrades from height 1.
+                nu5: Some(1),
+                nu7: Some(nu7_activation_height),
+                ..Default::default()
+            })
+            .expect("activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid")
+    }
+
+    fn verified_unmined_tx(transaction: Arc<Transaction>) -> VerifiedUnminedTx {
+        let unmined_tx = UnminedTx::from(transaction);
+        let miner_fee = unmined_tx.conventional_fee();
+
+        VerifiedUnminedTx::new(unmined_tx, miner_fee, 0, 0, Arc::new(Vec::new()))
+            .expect("the fake transaction pays the conventional fee")
+    }
+}

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -1220,6 +1220,7 @@ mod tests {
         };
 
         let tx = Arc::new(Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: Height(1),
@@ -1275,6 +1276,7 @@ mod tests {
         let _init_guard = zakura_test::init();
 
         let tx = Arc::new(Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height: Height(1),

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "3.2.1"
+version = "3.2.2"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -89,7 +89,7 @@ sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 
 # prod feature progress-bar
@@ -122,7 +122,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -17,6 +17,12 @@ categories = ["asynchronous", "caching", "cryptography::cryptocurrencies"]
 
 [features]
 
+# ZIP 218 "25-second Block Target Spacing" consensus rules, dormant until NU7 activates.
+zip218 = [
+    "zakura-chain/zip218",
+    "zakura-header-chain/zip218",
+]
+
 # Production features that activate extra dependencies, or extra features in dependencies
 
 # Exposes narrow internal hooks used by benchmarks.

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -23,6 +23,14 @@ zip218 = [
     "zakura-header-chain/zip218",
 ]
 
+# ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
+# `zip233Amount` field on v6 transactions, which removes value from circulation.
+#
+# Also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`; see `zakura-chain`.
+zip233 = [
+    "zakura-chain/zip233",
+]
+
 # Production features that activate extra dependencies, or extra features in dependencies
 
 # Exposes narrow internal hooks used by benchmarks.

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "7.0.0"
+version = "7.1.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -80,9 +80,9 @@ tracing = { workspace = true }
 sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1" }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -94,7 +94,7 @@ derive-getters.workspace = true
 derive-new.workspace = true
 
 [dev-dependencies]
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0", features = ["test-support"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0", features = ["test-support"] }
 color-eyre = { workspace = true }
 
 once_cell = { workspace = true }
@@ -114,7 +114,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "7.1.0"
+version = "7.2.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -81,8 +81,8 @@ sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2" }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0" }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -94,7 +94,7 @@ derive-getters.workspace = true
 derive-new.workspace = true
 
 [dev-dependencies]
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0", features = ["test-support"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0", features = ["test-support"] }
 color-eyre = { workspace = true }
 
 once_cell = { workspace = true }
@@ -114,7 +114,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/src/service/check/tests/nullifier.rs
+++ b/crates/zakura-state/src/service/check/tests/nullifier.rs
@@ -1521,6 +1521,7 @@ fn transaction_v6_with_ironwood_shielded_data(
     }
 
     Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: Nu6_3,
         inputs: Vec::new(),
         outputs: Vec::new(),

--- a/crates/zakura-state/src/service/check/tests/vectors.rs
+++ b/crates/zakura-state/src/service/check/tests/vectors.rs
@@ -303,7 +303,13 @@ fn daa_context(
     let target_spacing = NetworkUpgrade::target_spacing_for_height(network, candidate_height);
     let difficulty = network.target_difficulty_limit().to_compact();
 
-    (0..difficulty::POW_ADJUSTMENT_BLOCK_SPAN)
+    // The difficulty context spans the whole chain below the adjustment span,
+    // and the span itself above it.
+    let context_len = usize::try_from(candidate_height.0)
+        .expect("test candidate height fits in usize")
+        .min(difficulty::POW_ADJUSTMENT_BLOCK_SPAN);
+
+    (0..context_len)
         .map(|offset| {
             let offset = i32::try_from(offset + 1).expect("test offset fits in i32");
             (difficulty, candidate_time - target_spacing * offset)

--- a/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/migration.rs
@@ -824,7 +824,9 @@ fn linked_validation_context(
 ) -> Result<Vec<HeaderValidationContextDisk>, HeaderChainInitializationError> {
     let mut contexts = Vec::new();
     let mut height = anchor.height;
-    for _ in 0..27 {
+    // The recovery audit requires exactly the retained predecessor span below
+    // the anchor, which widens with the difficulty averaging window.
+    for _ in 0..zakura_header_chain::POW_PREDECESSOR_CONTEXT_SPAN {
         let Ok(previous) = height.previous() else {
             break;
         };
@@ -878,10 +880,14 @@ mod tests {
     }
 
     #[test]
-    fn later_anchor_predecessor_context_has_exact_one_to_twenty_eight_boundary() {
-        let headers = linked_headers(30);
+    fn later_anchor_predecessor_context_has_the_exact_span_boundary() {
+        let predecessor_span = zakura_header_chain::POW_PREDECESSOR_CONTEXT_SPAN;
+        let span_bound =
+            u32::try_from(predecessor_span).expect("the retained predecessor span fits in u32");
+        let chain_len = span_bound + 3;
+        let headers = linked_headers(chain_len);
 
-        for anchor_height in 0..=29 {
+        for anchor_height in 0..chain_len {
             let anchor_index = usize::try_from(anchor_height).expect("the test height fits");
             let anchor_header = &headers[anchor_index];
             let anchor = Frontier::new(block::Height(anchor_height), anchor_header.hash());
@@ -894,12 +900,13 @@ mod tests {
                 .expect("the exact backward-linked context is authenticated");
 
             let expected_predecessors =
-                usize::try_from(anchor_height.min(27)).expect("the bound fits in usize");
+                usize::try_from(anchor_height.min(span_bound)).expect("the bound fits in usize");
             assert_eq!(contexts.len(), expected_predecessors);
             assert_eq!(
                 contexts.len() + 1,
-                usize::try_from((anchor_height + 1).min(28)).expect("the bound fits in usize"),
-                "the anchor plus predecessor facts has the exact one-to-28-header boundary"
+                usize::try_from((anchor_height + 1).min(span_bound + 1))
+                    .expect("the bound fits in usize"),
+                "the anchor plus its predecessor facts spans the retained context exactly"
             );
             if contexts.is_empty() {
                 continue;

--- a/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
+++ b/crates/zakura-state/src/service/finalized_state/header_chain/tests/runtime.rs
@@ -9,9 +9,15 @@ fn atomic_finality_context_can_use_a_newly_staged_anchor_path() {
         .initialize(metadata, anchor.clone())
         .expect("the empty schema initializes");
 
+    // Stage one node past the retained predecessor span, so the context cap
+    // binds whatever difficulty averaging window this build uses.
+    let predecessor_span = zakura_header_chain::POW_PREDECESSOR_CONTEXT_SPAN;
+    let staged_len =
+        u32::try_from(predecessor_span + 1).expect("the retained predecessor span fits in u32");
+
     let mut nodes = Vec::new();
     let mut parent = anchor;
-    for height in 1..=28 {
+    for height in 1..=staged_len {
         let mut header = *parent.header;
         header.previous_block_hash = parent.hash;
         header.time += chrono::Duration::seconds(1);
@@ -40,14 +46,14 @@ fn atomic_finality_context_can_use_a_newly_staged_anchor_path() {
     let staged: HashMap<_, _> = nodes.iter().map(|node| (node.hash, node)).collect();
     let contexts = authenticated_context_headers(&store, parent.hash, Some(&staged))
         .expect("the atomic batch can authenticate context from its staged node overlay");
-    assert_eq!(contexts.len(), 27);
+    assert_eq!(contexts.len(), predecessor_span);
     assert_eq!(
         contexts.first().map(|context| context.height),
         Some(block::Height(1))
     );
     assert_eq!(
         contexts.last().map(|context| context.height),
-        Some(block::Height(27))
+        Some(block::Height(staged_len - 1))
     );
     assert_eq!(
         parent.header.previous_block_hash,

--- a/crates/zakura-state/src/service/finalized_state/tests/rollback.rs
+++ b/crates/zakura-state/src/service/finalized_state/tests/rollback.rs
@@ -613,6 +613,7 @@ fn ironwood_v6_tx(expiry_height: Height) -> (Arc<Transaction>, ironwood::Nullifi
 
     (
         Arc::new(Transaction::V6 {
+            zip233_amount: Default::default(),
             network_upgrade: NetworkUpgrade::Nu6_3,
             lock_time: LockTime::unlocked(),
             expiry_height,

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -75,13 +75,13 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", optional = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "7.1.0", optional = true }
+zakura-state = { path = "../zakura-state", version = "7.2.0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -75,7 +75,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", optional = true }
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "2.2.1"
+version = "2.2.2"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -74,14 +74,14 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", optional = true }
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", optional = true }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "7.0.0", optional = true }
+zakura-state = { path = "../zakura-state", version = "7.1.0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -74,6 +74,16 @@ features = [
 ]
 
 [features]
+
+# ZIP 218 "25-second Block Target Spacing" consensus rules, dormant until NU7 activates.
+zip218 = [
+    "zakura-chain/zip218",
+    "zakura-consensus/zip218",
+    "zakura-state/zip218",
+    "zakura-rpc/zip218",
+    "zakura-header-chain/zip218",
+]
+
 # In release builds, don't compile debug logging code, to improve performance.
 default-release-binaries = ["release_max_level_info", "progress-bar", "prometheus", "sentry", "opentelemetry"]
 

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.3.0"
+version = "1.4.0"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -178,22 +178,22 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-network = { path = "../zakura-network", version = "7.0.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "8.0.0" }
-zakura-state = { path = "../zakura-state", version = "7.0.0" }
+zakura-network = { path = "../zakura-network", version = "7.0.1" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "8.1.0" }
+zakura-state = { path = "../zakura-state", version = "7.1.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "3.2.1" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "2.2.1", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "2.2.2", optional = true }
 
 abscissa_core = { workspace = true, default-features = false, features = ["application"] }
 clap = { workspace = true, features = ["cargo"] }
@@ -315,11 +315,11 @@ tonic-prost = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0", features = ["test-support"] }
-zakura-network = { path = "../zakura-network", version = "7.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0", features = ["test-support"] }
+zakura-network = { path = "../zakura-network", version = "7.0.1", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }
 
@@ -332,7 +332,7 @@ zakura-test = { path = "../zakura-test", version = "2.1.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "2.2.1" }
+zakura-utils = { path = "../zakura-utils", version = "2.2.2" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -84,6 +84,17 @@ zip218 = [
     "zakura-header-chain/zip218",
 ]
 
+# ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation": the
+# `zip233Amount` field on v6 transactions, which removes value from circulation.
+#
+# Also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`; see `zakura-chain`.
+zip233 = [
+    "zakura-chain/zip233",
+    "zakura-consensus/zip233",
+    "zakura-state/zip233",
+    "zakura-rpc/zip233",
+]
+
 # In release builds, don't compile debug logging code, to improve performance.
 default-release-binaries = ["release_max_level_info", "progress-bar", "prometheus", "sentry", "opentelemetry"]
 

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -189,8 +189,8 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "9.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.1" }
@@ -326,8 +326,8 @@ tonic-prost = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "9.0.0", features = ["proptest-impl"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0", features = ["test-support"] }
 zakura-network = { path = "../zakura-network", version = "7.0.1", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -178,14 +178,14 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "6.1.0" }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.1" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.2", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "8.1.0" }
-zakura-state = { path = "../zakura-state", version = "7.1.0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -315,11 +315,11 @@ tonic-prost = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.1.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "6.2.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "1.1.0", features = ["test-support"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "1.2.0", features = ["test-support"] }
 zakura-network = { path = "../zakura-network", version = "7.0.1", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "7.1.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }
 

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -179,7 +179,7 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
+zakura-consensus = { path = "../zakura-consensus", version = "8.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.0" }
@@ -316,7 +316,7 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0", features = ["test-support"] }
 zakura-network = { path = "../zakura-network", version = "7.0.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }

--- a/crates/zakurad/src/components/mempool/storage/tests/vectors.rs
+++ b/crates/zakurad/src/components/mempool/storage/tests/vectors.rs
@@ -51,6 +51,7 @@ fn ironwood_v6_tx(
     };
 
     std::sync::Arc::new(Transaction::V6 {
+        zip233_amount: Default::default(),
         network_upgrade: NetworkUpgrade::Nu6_3,
         lock_time: LockTime::unlocked(),
         expiry_height,

--- a/crates/zakurad/tests/common/configs/v1.4.0.toml
+++ b/crates/zakurad/tests/common/configs/v1.4.0.toml
@@ -1,0 +1,150 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+expose_peer_addresses = false
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"

--- a/docs/changelog/unreleased/851.md
+++ b/docs/changelog/unreleased/851.md
@@ -1,0 +1,9 @@
+## Added
+
+- ZIP 218 "25-second Block Target Spacing", behind the off-by-default `zip218`
+  build feature: a 25 second block target spacing, a 102-block difficulty
+  averaging window, a block subsidy divided by the spacing ratio, and per-block
+  shielded action limits, all applied from NU7 activation onwards. The rules
+  stay dormant until NU7 has an activation height on the configured network, so
+  a build with this feature follows today's consensus on Mainnet and Testnet
+  ([#851](https://github.com/zakura-core/zakura/pull/851)).

--- a/docs/changelog/unreleased/856.md
+++ b/docs/changelog/unreleased/856.md
@@ -1,0 +1,8 @@
+## Changed
+
+- ZIP 2003 "Disallow version 4 transactions": the height at which a network stops
+  accepting version 4 transactions is now configurable. It defaults to the NU7
+  activation height, which is the rule Zakura already applied, and a Testnet can
+  instead name a later height or keep accepting version 4 transactions through
+  `testnet_parameters.v4_deprecation`
+  ([#856](https://github.com/zakura-core/zakura/pull/856)).

--- a/docs/changelog/unreleased/857.md
+++ b/docs/changelog/unreleased/857.md
@@ -4,6 +4,14 @@
   behind the off-by-default `zip233` build feature: the `zip233Amount` field on v6
   transactions, which removes value from circulation instead of paying it to the
   miner. The field is serialized after `nExpiryHeight`, committed to by the ZIP 244
-  header digest, and only valid from NU7 activation onwards. A build with this
-  feature also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`, and fails to compile
-  without it ([#857](https://github.com/zakura-core/zakura/pull/857)).
+  header digest, and only valid from NU7 activation onwards. The matching
+  `zakura-primitives` code is gated on the `zcash_unstable = "nu7"` cfg as well as on
+  its own feature, and this build requires the same cfg, so a `zip233` build without
+  `RUSTFLAGS='--cfg zcash_unstable="nu7"'` follows today's consensus rather than half
+  of ZIP 233 ([#857](https://github.com/zakura-core/zakura/pull/857)).
+
+## Changed
+
+- `Transaction::V6` carries a `zip233_amount` field, and `zakura-chain` and
+  `zakura-consensus` take major version bumps for it
+  ([#857](https://github.com/zakura-core/zakura/pull/857)).

--- a/docs/changelog/unreleased/857.md
+++ b/docs/changelog/unreleased/857.md
@@ -1,0 +1,9 @@
+## Added
+
+- ZIP 233 "Network Sustainability Mechanism: Removing Funds From Circulation",
+  behind the off-by-default `zip233` build feature: the `zip233Amount` field on v6
+  transactions, which removes value from circulation instead of paying it to the
+  miner. The field is serialized after `nExpiryHeight`, committed to by the ZIP 244
+  header digest, and only valid from NU7 activation onwards. A build with this
+  feature also needs `RUSTFLAGS='--cfg zcash_unstable="nu7"'`, and fails to compile
+  without it ([#857](https://github.com/zakura-core/zakura/pull/857)).


### PR DESCRIPTION
Stacked on #856 (ZIP 2003) → #851 (ZIP 218). Third of the remaining NU7 consensus changes.

Implements [ZIP 233](https://zips.z.cash/zip-0233) "Network Sustainability Mechanism: Removing Funds From Circulation" behind the off-by-default `zip233` cargo feature. Ported from the merged upstream [zebra#8930](https://github.com/ZcashFoundation/zebra/pull/8930), extended here with the ZIP 244 commitment, the activation rule, and the build-flag guard.

ZIP 233 is one of the two ZIPs behind Q1 of the [ZCAP](https://forum.zcashcommunity.com/t/zcap-poll-now-open-nu7-august-2026/57223) and [coinholder](https://forum.zcashcommunity.com/t/nu7-coinholder-vote/56912) polls, and it is what makes ZIP 234's reissuance and ZIP 235's fee burning expressible.

## Transaction format

`Transaction::V6` gains `zip233_amount`, serialized as an 8-byte little-endian amount after `nExpiryHeight` and committed to by the ZIP 244 header digest as T.1f.

`zakura-primitives` already implements the same two changes behind its own `zip-233` feature, which `zip233` turns on, so the native ZIP 244 digests and `librustzcash` stay in lockstep. The existing `native_zip244_matches_test_vectors`, `v6_zip244_sighash_matches_librustzcash`, and `script_code_commitment_is_version_specific` cross-checks all pass with the feature on, which is what shows the two implementations agree byte for byte.

### The build flag

The `zakura-primitives` half is *also* gated on `cfg(zcash_unstable = "nu7")`, which no cargo feature can set on a dependency. A `zip233` build without `RUSTFLAGS='--cfg zcash_unstable="nu7"'` would disagree with `librustzcash` about the v6 wire format — a consensus split, not a compile error.

Cargo features have to be additive, so this cannot be a `compile_error!`: `cargo check --all-features` runs in CI and would fail. Instead `ZIP233_ENABLED` requires the cfg as well as the feature, so a build missing the flag follows today's consensus rather than half of ZIP 233. The two sides are on and off together by construction. The CI job sets the flag.

A `zcash_unstable = "nu7"` build also gives NU7 the branch ID `zcash_protocol` maps it to (`0xffffffff`) rather than Zakura's `0xfffffffe` placeholder, because `Transaction::to_librustzcash` round-trips the branch ID through it. Any other build is unchanged.

## Consensus

- `zip233_amount_is_valid` rejects a burn before NU7, which is when ZIP 233 activates. `Amount<NonNegative>` already bounds the amount to `{0 .. MAX_MONEY}`.
- `miner_fee` subtracts the burn from the transaction's remaining value. The coinbase is checked against the block subsidy plus these fees, so this one subtraction is what stops the coinbase reclaiming the burn: the block's net transparent pool change becomes `subsidy − burn`, and the money reserve ZIP 234 reads grows by the burned amount.
- `has_inputs_and_outputs` accepts a transaction whose only effect is a burn.

## Tests

- `zip233_amount_is_committed_to_by_the_txid` — two transactions differing only in the burn must have different txids, and both must round-trip and match `librustzcash`. Without this commitment the amount would be malleable.
- The v6 serialization proptest now generates random burn amounts under the feature.
- `zip233_amount_activates_at_nu7_and_is_not_a_fee` — the activation boundary and the fee exclusion.
- A `zip233` CI job mirroring the `zip218` one, with the required `RUSTFLAGS`.

Default build: 1270 tests pass across `zakura-chain`, `zakura-consensus`, `zakura-rpc`, and `zakura-state`; clippy clean.

## Follow-ups

- The RPC transaction JSON does not expose `zip233Amount`.
- A `zip233` build changes the v6 wire format from NU6.3 onward, not from NU7, because that is what `zakura-primitives` does today (`TxVersion::V6 => has_zip233() == true`). A real deployment needs the format gated on the branch ID so NU6.3-era v6 transactions keep parsing, which is a change in the fork first.
- NU7's final branch ID (`0x77190ad8`) still needs coordinating across Zakura and `librustzcash`.
