### PR TITLE
chore(release): align the v1.3.1 end-of-support halt with v1.3.0

### DIFF
--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_470_027;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_470_235;
 
 /// The estimated number of blocks per day after Blossom.
 ///
@@ -28,12 +28,12 @@ pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Currently set to 31 days
+/// - Currently set to 27 days
 ///
-/// Note: v1.3.0 is estimated to release at height 3,465,627 (~2026-08-30)
-/// and halts 31 days later at height 3,501,339 (~2026-09-30), the day before
-/// October 1st.
-pub const EOS_PANIC_AFTER: u32 = 31;
+/// Note: v1.3.1 is estimated to release at height 3,470,235 (~2026-09-03)
+/// and halts 27 days later at height 3,501,339 (~2026-09-30) — the same
+/// halt block as v1.3.0, the day before October 1st.
+pub const EOS_PANIC_AFTER: u32 = 27;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 3;

--- a/docs/changelog/unreleased/844.md
+++ b/docs/changelog/unreleased/844.md
@@ -3,7 +3,6 @@
 - Updated the Zakura Common (`zakura-core/common`) crates from `1.0.0` to
   `1.0.1`
   ([#844](https://github.com/zakura-core/zakura/pull/844)).
-  <!-- release-readiness: allow-patch; reason: The only Changed entry is the backwards-compatible Zakura Common 1.0.0 to 1.0.1 patch adoption; v1.3.1 stays on the 1.3 line to keep the v1.3.0 end-of-support schedule. -->
 
 ## Security
 

--- a/docs/changelog/unreleased/844.md
+++ b/docs/changelog/unreleased/844.md
@@ -3,6 +3,7 @@
 - Updated the Zakura Common (`zakura-core/common`) crates from `1.0.0` to
   `1.0.1`
   ([#844](https://github.com/zakura-core/zakura/pull/844)).
+  <!-- release-readiness: allow-patch; reason: The only Changed entry is the backwards-compatible Zakura Common 1.0.0 to 1.0.1 patch adoption; v1.3.1 stays on the 1.3 line to keep the v1.3.0 end-of-support schedule. -->
 
 ## Security
 

--- a/docs/changelog/unreleased/863.md
+++ b/docs/changelog/unreleased/863.md
@@ -1,0 +1,6 @@
+## Changed
+
+- Shortened the end-of-support window to 27 days so v1.3.1 halts at block
+  3,501,339 — the same halt block and date (~2026-09-30) as v1.3.0
+  ([#863](https://github.com/zakura-core/zakura/pull/863)).
+  <!-- release-readiness: allow-patch; reason: The Changed entries are the backwards-compatible Zakura Common 1.0.1 patch adoption and this end-of-support alignment; v1.3.1 stays on the 1.3 line so it keeps the v1.3.0 halt schedule. -->


### PR DESCRIPTION
## Motivation

v1.3.1 must halt at the same end-of-support block as v1.3.0 (3,501,339, ~2026-09-30, before October 1st). Merging the fresh Mainnet release state (#862) floored `ESTIMATED_RELEASE_HEIGHT` at 3,470,027, which with the inherited 31-day window would have pushed the halt to ~Oct 4. Separately, release readiness rejected the 1.3.1 tag because the pending #844 `Changed` entry raises the changelog floor to 1.4.0.

## Solution

- Set `ESTIMATED_RELEASE_HEIGHT = 3_470_235` (208 blocks above the committed-checkpoint floor, an honest ~Sep 3 estimate) and `EOS_PANIC_AFTER = 27`, so the halt lands at exactly 3,470,235 + 27×1,152 = 3,501,339 — block-for-block identical to v1.3.0. The warn threshold (halt − 3 days) is likewise unchanged.
- Add this PR's changelog fragment with the documented `release-readiness: allow-patch` waiver embedded in its `Changed` entry: the pending `Changed` entries (Zakura Common 1.0.0→1.0.1 patch adoption, this EOS alignment) are backwards compatible, and `Fixed`/`Security` already permit a patch release.

## Tests

- `cargo test -p zakura --test end_of_support`: all 5 tests pass with the new constants.
- `python3 scripts/release-readiness.py version --base-version 1.3.0 --release-tag v1.3.1` reports `minimum_level: patch` with the waiver reason recorded.
- `./scripts/changelog.py check` validates all 4 pending fragments.

## Follow-up

Unblocks the v1.3.1 `Prepare release PR` dispatch; the mechanical prep will leave these constants untouched (already at/above its floor and projection).

## AI disclosure

Prepared by Claude Code (Fable 5) in a session driven by @sbowe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)