### PR TITLE
feat(metrics): report end of service to Prometheus

### DIFF
--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -50,6 +50,22 @@ const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 /// Wait a few seconds at startup so `best_tip_height` is always `Some`.
 const INITIAL_WAIT: Duration = Duration::from_secs(10);
 
+/// The metric that reports whether end of support is enforced on this network.
+///
+/// Set to `1` on Mainnet and `0` on every other network.
+pub const EOS_ENFORCED_METRIC: &str = "end_of_support.enforced";
+
+/// The metric that reports the last height this release supports.
+///
+/// Only set when end of support is enforced.
+pub const EOS_HEIGHT_METRIC: &str = "end_of_support.last_supported_height";
+
+/// The metric that reports how many blocks are left before this release halts.
+///
+/// Only set when end of support is enforced. It is negative once the tip goes
+/// past the last supported height, which is the check that halts the node.
+pub const EOS_REMAINING_BLOCKS_METRIC: &str = "end_of_support.remaining_blocks";
+
 /// Start the end of support checking task for Mainnet.
 pub async fn start(
     network: Network,
@@ -66,6 +82,7 @@ pub async fn start(
             }
         } else {
             info!("Release always valid in Testnet");
+            metrics::gauge!(EOS_ENFORCED_METRIC).set(0.0);
         }
         tokio::time::sleep(CHECK_INTERVAL).await;
     }
@@ -81,9 +98,39 @@ pub fn end_of_support_height(network: &Network) -> Option<Height> {
     ))
 }
 
+/// Returns the number of blocks left before this release halts, or `None` when
+/// support is not enforced.
+///
+/// The count is negative once `tip_height` goes past the last supported height,
+/// which is the state that halts the node.
+pub fn remaining_blocks(tip_height: Height, network: &Network) -> Option<i64> {
+    end_of_support_height(network)
+        .map(|last_supported_height| i64::from(last_supported_height.0) - i64::from(tip_height.0))
+}
+
+/// Report the end of support state of this release to the metrics endpoint.
+///
+/// Operators alert on [`EOS_REMAINING_BLOCKS_METRIC`] to upgrade before the
+/// node halts.
+fn update_metrics(tip_height: Height, network: &Network) {
+    let (Some(last_supported_height), Some(remaining_blocks)) = (
+        end_of_support_height(network),
+        remaining_blocks(tip_height, network),
+    ) else {
+        metrics::gauge!(EOS_ENFORCED_METRIC).set(0.0);
+        return;
+    };
+
+    metrics::gauge!(EOS_ENFORCED_METRIC).set(1.0);
+    metrics::gauge!(EOS_HEIGHT_METRIC).set(f64::from(last_supported_height.0));
+    metrics::gauge!(EOS_REMAINING_BLOCKS_METRIC).set(remaining_blocks as f64);
+}
+
 /// Check if the current release is too old and panic if so.
 pub fn check(tip_height: Height, network: &Network) {
     info!("Checking if Zakura release is inside support range ...");
+
+    update_metrics(tip_height, network);
 
     let Some(panic_height) = end_of_support_height(network) else {
         info!("Release always valid outside Mainnet");

--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -53,18 +53,18 @@ const INITIAL_WAIT: Duration = Duration::from_secs(10);
 /// The metric that reports whether end of support is enforced on this network.
 ///
 /// Set to `1` on Mainnet and `0` on every other network.
-pub const EOS_ENFORCED_METRIC: &str = "end_of_support.enforced";
+const EOS_ENFORCED_METRIC: &str = "end_of_support.enforced";
 
 /// The metric that reports the last height this release supports.
 ///
 /// Only set when end of support is enforced.
-pub const EOS_HEIGHT_METRIC: &str = "end_of_support.last_supported_height";
+const EOS_HEIGHT_METRIC: &str = "end_of_support.last_supported_height";
 
 /// The metric that reports how many blocks are left before this release halts.
 ///
 /// Only set when end of support is enforced. It is negative once the tip goes
 /// past the last supported height, which is the check that halts the node.
-pub const EOS_REMAINING_BLOCKS_METRIC: &str = "end_of_support.remaining_blocks";
+const EOS_REMAINING_BLOCKS_METRIC: &str = "end_of_support.remaining_blocks";
 
 /// Start the end of support checking task for Mainnet.
 pub async fn start(
@@ -73,16 +73,26 @@ pub async fn start(
 ) -> Result<(), Report> {
     info!("Starting end of support task");
 
+    if let Some(last_supported_height) = end_of_support_height(&network) {
+        metrics::gauge!(EOS_ENFORCED_METRIC).set(1.0);
+        metrics::gauge!(EOS_HEIGHT_METRIC).set(f64::from(last_supported_height.0));
+    } else {
+        metrics::gauge!(EOS_ENFORCED_METRIC).set(0.0);
+    }
+
     tokio::time::sleep(INITIAL_WAIT).await;
 
     loop {
         if network == Network::Mainnet {
             if let Some(tip_height) = latest_chain_tip.best_tip_height() {
+                if let Some(remaining_blocks) = remaining_blocks(tip_height, &network) {
+                    // A difference between two u32 heights is exactly representable as f64.
+                    metrics::gauge!(EOS_REMAINING_BLOCKS_METRIC).set(remaining_blocks as f64);
+                }
                 check(tip_height, &network);
             }
         } else {
             info!("Release always valid in Testnet");
-            metrics::gauge!(EOS_ENFORCED_METRIC).set(0.0);
         }
         tokio::time::sleep(CHECK_INTERVAL).await;
     }
@@ -108,29 +118,9 @@ pub fn remaining_blocks(tip_height: Height, network: &Network) -> Option<i64> {
         .map(|last_supported_height| i64::from(last_supported_height.0) - i64::from(tip_height.0))
 }
 
-/// Report the end of support state of this release to the metrics endpoint.
-///
-/// Operators alert on [`EOS_REMAINING_BLOCKS_METRIC`] to upgrade before the
-/// node halts.
-fn update_metrics(tip_height: Height, network: &Network) {
-    let (Some(last_supported_height), Some(remaining_blocks)) = (
-        end_of_support_height(network),
-        remaining_blocks(tip_height, network),
-    ) else {
-        metrics::gauge!(EOS_ENFORCED_METRIC).set(0.0);
-        return;
-    };
-
-    metrics::gauge!(EOS_ENFORCED_METRIC).set(1.0);
-    metrics::gauge!(EOS_HEIGHT_METRIC).set(f64::from(last_supported_height.0));
-    metrics::gauge!(EOS_REMAINING_BLOCKS_METRIC).set(remaining_blocks as f64);
-}
-
 /// Check if the current release is too old and panic if so.
 pub fn check(tip_height: Height, network: &Network) {
     info!("Checking if Zakura release is inside support range ...");
-
-    update_metrics(tip_height, network);
 
     let Some(panic_height) = end_of_support_height(network) else {
         info!("Release always valid outside Mainnet");

--- a/crates/zakurad/tests/end_of_support.rs
+++ b/crates/zakurad/tests/end_of_support.rs
@@ -71,10 +71,20 @@ fn end_of_support_height_per_network() {
 fn end_of_support_remaining_blocks() {
     let last_supported_height =
         Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY));
+    let warning_height =
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_WARN_AFTER * ESTIMATED_BLOCKS_PER_DAY));
 
     assert_eq!(
         end_of_support::remaining_blocks(Height(ESTIMATED_RELEASE_HEIGHT), &Network::Mainnet),
         Some(i64::from(EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY)),
+    );
+    assert_eq!(
+        end_of_support::remaining_blocks(warning_height, &Network::Mainnet),
+        Some(i64::from(3 * ESTIMATED_BLOCKS_PER_DAY)),
+    );
+    assert_eq!(
+        end_of_support::remaining_blocks(Height(warning_height.0 + 1), &Network::Mainnet),
+        Some(i64::from(3 * ESTIMATED_BLOCKS_PER_DAY) - 1),
     );
     assert_eq!(
         end_of_support::remaining_blocks(last_supported_height, &Network::Mainnet),

--- a/crates/zakurad/tests/end_of_support.rs
+++ b/crates/zakurad/tests/end_of_support.rs
@@ -66,6 +66,34 @@ fn end_of_support_height_per_network() {
     end_of_support::check(Height::MAX, &testnet);
 }
 
+/// Test the end of support values reported to the metrics endpoint.
+#[test]
+fn end_of_support_remaining_blocks() {
+    let last_supported_height =
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY));
+
+    assert_eq!(
+        end_of_support::remaining_blocks(Height(ESTIMATED_RELEASE_HEIGHT), &Network::Mainnet),
+        Some(i64::from(EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY)),
+    );
+    assert_eq!(
+        end_of_support::remaining_blocks(last_supported_height, &Network::Mainnet),
+        Some(0),
+    );
+
+    // The count goes negative at the height that halts the node.
+    assert_eq!(
+        end_of_support::remaining_blocks(Height(last_supported_height.0 + 1), &Network::Mainnet),
+        Some(-1),
+    );
+
+    // Support is not enforced outside Mainnet, so there is nothing to report.
+    assert_eq!(
+        end_of_support::remaining_blocks(last_supported_height, &Network::new_default_testnet()),
+        None,
+    );
+}
+
 /// Test that we are never in end of support warning or panic.
 #[test]
 #[tracing_test::traced_test]

--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -89,8 +89,8 @@ See [jaeger/README.md](jaeger/README.md) for tracing details.
 
 Automated notifications for operational issues:
 
-- Critical: Negative value pools (ZIP-209 violation)
-- Warning: High RPC latency, sync stalls, peer connection issues
+- Critical: Negative value pools (ZIP-209 violation), release within 1 day of its end of service
+- Warning: High RPC latency, sync stalls, peer connection issues, release within 3 days of its end of service
 
 Configure alert destinations in [alertmanager/alertmanager.yml](alertmanager/alertmanager.yml).
 

--- a/docker/observability/grafana/dashboards/zakura_overview.json
+++ b/docker/observability/grafana/dashboards/zakura_overview.json
@@ -45,7 +45,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 0, "y": 1 },
+      "gridPos": { "h": 3, "w": 6, "x": 0, "y": 1 },
       "id": 1,
       "options": {
         "colorMode": "value",
@@ -84,7 +84,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 8, "y": 1 },
+      "gridPos": { "h": 3, "w": 6, "x": 6, "y": 1 },
       "id": 2,
       "options": {
         "colorMode": "value",
@@ -122,7 +122,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 3, "w": 8, "x": 16, "y": 1 },
+      "gridPos": { "h": 3, "w": 6, "x": 12, "y": 1 },
       "id": 3,
       "options": {
         "colorMode": "value",
@@ -142,6 +142,49 @@
         }
       ],
       "title": "Total Supply (ZEC)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "zakura-prometheus" },
+      "description": "Blocks left before this release reaches its end of service and halts. Mainnet only: other networks report NOT ENFORCED.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "NOT ENFORCED",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 1152 },
+              { "color": "green", "value": 3456 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "zakura-prometheus" },
+          "expr": "end_of_support_remaining_blocks",
+          "legendFormat": "Blocks",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocks Until End of Service",
       "type": "stat"
     },
     {

--- a/docker/observability/prometheus/rules/zakura_alerts.yml
+++ b/docker/observability/prometheus/rules/zakura_alerts.yml
@@ -59,6 +59,26 @@ groups:
           summary: "High error rate"
           description: "Zakura is experiencing elevated error rates (> 0.1/s for 5 minutes)."
 
+      # This release stops running when the tip passes its end of service height.
+      # 1152 blocks is one day at the 75 second target spacing.
+      - alert: ZakuraEndOfServiceApproaching
+        expr: end_of_support_remaining_blocks < 3456
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Release reaches end of service in under 3 days"
+          description: "This Zakura release halts in {{ $value }} blocks. Install the latest release before then."
+
+      - alert: ZakuraEndOfServiceImminent
+        expr: end_of_support_remaining_blocks < 1152
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Release reaches end of service in under 1 day"
+          description: "This Zakura release halts in {{ $value }} blocks. Install the latest release now."
+
   # Value Pool Alerts (Monitoring)
   - name: zakura-value-pools
     rules:

--- a/docs/changelog/unreleased/867.md
+++ b/docs/changelog/unreleased/867.md
@@ -1,0 +1,5 @@
+## Added
+
+- Added metrics, dashboard visibility, and alerts for the existing Mainnet
+  end-of-support schedule
+  ([#867](https://github.com/zakura-core/zakura/pull/867)).


### PR DESCRIPTION
## Motivation

A release halts when the tip passes its end of service height, and until now the only signal was a log warning three days out. Operators running the metrics endpoint had nothing to alert on, so a node could stop at a height nobody was watching for.

## Changes

The hourly end of support check now sets three gauges:

| Metric | Meaning |
|---|---|
| `end_of_support_enforced` | `1` on Mainnet, `0` on every other network |
| `end_of_support_last_supported_height` | the height this release runs to; it halts past this height |
| `end_of_support_remaining_blocks` | blocks left before the halt, negative once the tip passes it |

The last two are only set where end of service is enforced, so `enforced` distinguishes "not applicable" from a missing scrape.

Also included:

- a **Blocks Until End of Service** stat panel in the node overview dashboard, next to the version panel that tells an operator which release to replace
- `ZakuraEndOfServiceApproaching` (warning, 3 days) and `ZakuraEndOfServiceImminent` (critical, 1 day) alert rules; 1152 blocks is one day at the 75 second target spacing
- a unit test covering `remaining_blocks` at the release height, at the halt height, past the halt, and off Mainnet

## Testing

- `cargo test -p zakura --test end_of_support` — 6 passed
- `cargo clippy -p zakura --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean