### PR TITLE
fix(network): gate peer reads on reactor admission

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -719,6 +719,7 @@ impl BlockSyncReactor {
     async fn handle_peer_connected(&mut self, session: BlockSyncPeerSession) {
         let peer = session.peer_id().clone();
         let direction = session.direction();
+        let reactor_ready = session.clone();
         let decision = self.admission_decision_for(&peer, direction);
         if decision != ServiceAdmissionDecision::Admit {
             // Reject: cancel the session (which also cancels the already-spawned
@@ -736,6 +737,7 @@ impl BlockSyncReactor {
             self.registry.remove(&peer);
             self.publish_peer_snapshot();
             self.publish_candidate_state();
+            session.mark_reactor_ready();
             return;
         }
 
@@ -753,6 +755,7 @@ impl BlockSyncReactor {
         self.publish_peer_snapshot();
         self.publish_candidate_state();
         self.send_status_and_mark_refresh(&peer, "peer_connected", Instant::now());
+        reactor_ready.mark_reactor_ready();
         // The routine fills its own slots; it begins want-work as soon as it has
         // a status and work.
     }

--- a/crates/zakura-network/src/zakura/block_sync/service.rs
+++ b/crates/zakura-network/src/zakura/block_sync/service.rs
@@ -9,6 +9,7 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
     time::Instant,
 };
+use tokio::sync::Notify;
 
 /// Maximum frame bytes for one stream-6 body frame plus protocol framing.
 ///
@@ -41,6 +42,7 @@ pub struct BlockSyncPeerSession {
     direction: ServicePeerDirection,
     send: FramedSend,
     cancel_token: CancellationToken,
+    reactor_ready: Arc<Notify>,
 }
 
 impl BlockSyncPeerSession {
@@ -50,6 +52,7 @@ impl BlockSyncPeerSession {
             direction,
             send: session.sender(),
             cancel_token: session.cancel_token(),
+            reactor_ready: Arc::new(Notify::new()),
         }
     }
 
@@ -67,12 +70,23 @@ impl BlockSyncPeerSession {
             direction: ServicePeerDirection::Outbound,
             send,
             cancel_token,
+            reactor_ready: Arc::new(Notify::new()),
         }
     }
 
     /// Authenticated peer identity for this block-sync session.
     pub fn peer_id(&self) -> &ZakuraPeerId {
         &self.peer_id
+    }
+
+    /// Wait until the reactor has installed or rejected this session.
+    pub(super) async fn wait_until_reactor_ready(&self) {
+        self.reactor_ready.notified().await;
+    }
+
+    /// Release the peer routine after the reactor resolves session admission.
+    pub(super) fn mark_reactor_ready(&self) {
+        self.reactor_ready.notify_one();
     }
 
     /// Direction of the underlying Zakura connection.
@@ -686,39 +700,60 @@ impl Service for BlockSyncService {
             let block_sync_session = block_sync_session.clone();
             let peer_id = peer_id.clone();
             async move {
-                let result = match routine_wiring {
-                    Some(wiring) => {
-                        let generation = routine_generation.expect(
-                            "production block-sync wiring allocates a routine generation before spawn",
-                        );
-                        let routine = super::peer_routine::PeerRoutine::new(
-                            peer_id,
-                            conn_id,
-                            block_sync_session,
-                            recv,
-                            wiring.config,
-                            !re_admitted_after_no_progress,
-                            generation,
-                            wiring.budget,
-                            wiring.work,
-                            wiring.registry,
-                            wiring.received_throughput,
-                            wiring.sequencer_input,
-                            wiring.sequencer_input_bytes,
-                            wiring.sequencer_input_decoded_attributed_memory_bytes,
-                            wiring.actions,
-                            wiring.routine_to_reactor,
-                            wiring.view,
-                            run_cancel,
-                            wiring.trace,
-                        );
-                        routine.run().await
+                let reactor_ready = if routine_wiring.is_some() {
+                    tokio::select! {
+                        () = block_sync_session.wait_until_reactor_ready() => true,
+                        () = run_cancel.cancelled() => false,
                     }
-                    None => drain_inbound(recv, run_cancel).await,
+                } else {
+                    true
+                };
+                let result = if !reactor_ready || run_cancel.is_cancelled() {
+                    Ok(())
+                } else if let Some(wiring) = routine_wiring {
+                    let generation = routine_generation.expect(
+                        "production block-sync wiring allocates a routine generation before spawn",
+                    );
+                    let routine = super::peer_routine::PeerRoutine::new(
+                        peer_id,
+                        conn_id,
+                        block_sync_session,
+                        recv,
+                        wiring.config,
+                        !re_admitted_after_no_progress,
+                        generation,
+                        wiring.budget,
+                        wiring.work,
+                        wiring.registry,
+                        wiring.received_throughput,
+                        wiring.sequencer_input,
+                        wiring.sequencer_input_bytes,
+                        wiring.sequencer_input_decoded_attributed_memory_bytes,
+                        wiring.actions,
+                        wiring.routine_to_reactor,
+                        wiring.view,
+                        run_cancel,
+                        wiring.trace,
+                    );
+                    routine.run().await
+                } else {
+                    drain_inbound(recv, run_cancel).await
                 };
                 handle_pipe_exit("block-sync", &connection_cancel_token, &close_cause, result);
             }
         };
+        // Queue admission before the supervised task can emit its teardown, so
+        // even an already-cancelled transport is observed as connect then
+        // disconnect by the reactor.
+        if self
+            .inner
+            .lifecycle
+            .send(BlockSyncEvent::PeerConnected(block_sync_session))
+            .is_err()
+        {
+            service_cancel_token.cancel();
+        }
+
         // Let the returned handle drop to detach the supervised task (like
         // `tokio::spawn`); the `PipeTeardown` still runs on every exit path.
         spawn_supervised_pipe(
@@ -728,11 +763,6 @@ impl Service for BlockSyncService {
             on_panic,
             pipe,
         );
-
-        let _ = self
-            .inner
-            .lifecycle
-            .send(BlockSyncEvent::PeerConnected(block_sync_session));
     }
 
     fn owns_connection_for_peer(&self, peer: &ZakuraPeerId, conn_id: ZakuraConnId) -> bool {

--- a/docs/changelog/unreleased/868.md
+++ b/docs/changelog/unreleased/868.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Prevented block-sync peer frames from being handled before reactor admission
+  ([#868](https://github.com/zakura-core/zakura/pull/868)).


### PR DESCRIPTION
## Motivation

A block-sync peer routine can read Status and GetBlocks before the reactor has admitted that session. The reactor can then classify a valid request as GetBlocksSpam because its peer state does not exist yet.

## Solution

Give each block-sync session an admission notification. The peer routine waits for the reactor to install or reject the session before reading frames, and the service queues the connection event before supervised teardown can overtake it.

## Testing

The focused GetBlocks serving property fails on the unmodified implementation and passes when this commit is layered onto the tests-only branch. That isolated stack moves from 3 passed and 4 failed to 4 passed and 3 failed; only the admission property turns green. The property source stays byte-for-byte unchanged. The `zakura-network` test target compiles with the locked dependency graph, and the draft's lint and semver checks pass.

### Reachability evidence

A disposable probe compared affected revision `5f1e12367` with fixed commit `cdc769f19`, which is an ancestor of this PR head. It used real Iroh endpoints, the production handshake, ordered stream 6, and canonical Status and GetBlocks frames.

- Under 96 simultaneous peer connections, 90 affected sessions processed Status before the reactor received `PeerConnected`; the fixed code observed 0 of 96. The bad ordering is **peer-triggered, natural**.
- To test the concrete consequence, the probe delayed only the genuine `Connected` event. Affected ordering then produced `GetBlocksSpam` and no state query for the valid first request; fixed ordering produced the query and no spam. The dropped request is **peer-triggered, controlled schedule**.
- In 640 uncontrolled single-peer attempts and 30 additional uncontrolled two-endpoint runs, all requests reached state. Those runs do not establish how frequently the dropped-as-spam consequence occurs.

The permanent focused regression protects the same ordering invariant without making the test suite timing-dependent.

## Changelog

Added the numbered bug-fix fragment.
