### PR TITLE
fix(network)!: bind GetBlocks responses to live requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "bitflags",
  "blake2b_simd",

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "7.0.0"
+version = "8.0.0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal

--- a/crates/zakura-network/src/zakura/block_sync/events.rs
+++ b/crates/zakura-network/src/zakura/block_sync/events.rs
@@ -432,6 +432,8 @@ pub(super) enum RoutineToReactor {
     ServeGetBlocks {
         /// Peer that requested the range.
         peer: ZakuraPeerId,
+        /// Registry generation of the session routine that decoded the request.
+        session_generation: u64,
         /// First requested height.
         start_height: block::Height,
         /// Requested block count.

--- a/crates/zakura-network/src/zakura/block_sync/events.rs
+++ b/crates/zakura-network/src/zakura/block_sync/events.rs
@@ -1,7 +1,7 @@
 #[cfg(any(test, feature = "proptest-impl"))]
 use super::state::BlockSyncFrontiers;
 use super::{request::*, *};
-use std::num::NonZeroU64;
+use std::{fmt, num::NonZeroU64};
 
 /// Committed header metadata used by block sync to schedule and validate a body.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -86,7 +86,8 @@ pub enum BlockSyncEvent {
         peer: ZakuraPeerId,
         /// First requested height.
         start_height: block::Height,
-        /// Requested block count.
+        /// Driver echo retained for diagnostics. The reactor uses the count in
+        /// its serving ledger when it processes this completion.
         requested_count: u32,
         /// Number of blocks read from state and sent in the response.
         returned_count: u32,
@@ -99,7 +100,8 @@ pub enum BlockSyncEvent {
         peer: ZakuraPeerId,
         /// First requested height.
         start_height: block::Height,
-        /// Requested block count.
+        /// Driver echo retained for diagnostics. The reactor uses the count in
+        /// its serving ledger when it processes this completion.
         requested_count: u32,
         /// Bounded committed blocks returned by state.
         blocks: Vec<(block::Height, Arc<block::Block>, usize)>,
@@ -261,7 +263,29 @@ pub type BlockApplyToken = u64;
 ///
 /// The state driver echoes this identity so a delayed completion cannot release
 /// a newer serving slot or send blocks through a replacement peer session.
-pub type BlockRangeRequestId = NonZeroU64;
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BlockRangeRequestId(NonZeroU64);
+
+impl BlockRangeRequestId {
+    /// Construct an ID, returning `None` for the reserved zero value.
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Return the nonzero integer carried by this request identity.
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl fmt::Display for BlockRangeRequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
 
 /// Actions emitted by the future block-sync reactor for the service seam.
 #[derive(Clone, Debug)]

--- a/crates/zakura-network/src/zakura/block_sync/events.rs
+++ b/crates/zakura-network/src/zakura/block_sync/events.rs
@@ -80,6 +80,8 @@ pub enum BlockSyncEvent {
     },
     /// Node wiring finished or abandoned a `Block` response to an inbound `GetBlocks`.
     BlockRangeResponseFinished {
+        /// Exact inbound request being completed.
+        request_id: BlockRangeRequestId,
         /// Peer whose served-response slot can be released.
         peer: ZakuraPeerId,
         /// First requested height.
@@ -91,6 +93,8 @@ pub enum BlockSyncEvent {
     },
     /// State returned committed bodies requested by a peer and the reactor should send them.
     BlockRangeResponseReady {
+        /// Exact inbound request being completed.
+        request_id: BlockRangeRequestId,
         /// Peer whose inbound request is being served.
         peer: ZakuraPeerId,
         /// First requested height.
@@ -253,6 +257,12 @@ impl BlockApplyOutcome {
 /// ignore those stale completions instead of releasing a newer in-flight body.
 pub type BlockApplyToken = u64;
 
+/// Monotonic identity assigned to each inbound `GetBlocks` request.
+///
+/// The state driver echoes this identity so a delayed completion cannot release
+/// a newer serving slot or send blocks through a replacement peer session.
+pub type BlockRangeRequestId = NonZeroU64;
+
 /// Actions emitted by the future block-sync reactor for the service seam.
 #[derive(Clone, Debug)]
 pub enum BlockSyncAction {
@@ -271,6 +281,8 @@ pub enum BlockSyncAction {
     },
     /// Ask node wiring to read committed bodies for an inbound `GetBlocks`.
     QueryBlocksByHeightRange {
+        /// Exact inbound request identity to echo in the response event.
+        request_id: BlockRangeRequestId,
         /// Peer that requested the range.
         peer: ZakuraPeerId,
         /// First height.

--- a/crates/zakura-network/src/zakura/block_sync/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/mod.rs
@@ -67,8 +67,8 @@ pub(crate) use config::MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES;
 pub use config::{BlockSyncStatus, CwndUnit, ZakuraBlockSyncConfig, MAX_BS_RESPONSE_BYTES};
 pub use error::BlockSyncWireError;
 pub use events::{
-    BlockApplyOutcome, BlockApplyResult, BlockApplyToken, BlockSyncAction, BlockSyncBlockMeta,
-    BlockSyncEvent, BlockSyncMisbehavior,
+    BlockApplyOutcome, BlockApplyResult, BlockApplyToken, BlockRangeRequestId, BlockSyncAction,
+    BlockSyncBlockMeta, BlockSyncEvent, BlockSyncMisbehavior,
 };
 pub use reactor::spawn_block_sync_reactor;
 pub use request::BlockSizeEstimate;

--- a/crates/zakura-network/src/zakura/block_sync/peer_registry.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_registry.rs
@@ -603,6 +603,13 @@ impl PeerRegistry {
         self.lock().remove(peer);
     }
 
+    /// Return whether `generation` still owns this peer's live routine session.
+    pub(super) fn owns_generation(&self, peer: &ZakuraPeerId, generation: u64) -> bool {
+        self.lock()
+            .get(peer)
+            .is_some_and(|entry| entry.generation == generation)
+    }
+
     /// Publish a freshly-applied `Status` (routine-side, inverted inbound flow): grow
     /// servable range, clamp the advertised caps, and mark the peer as having sent
     /// a status. Generation-gated like the other routine writers so a superseded

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -566,6 +566,7 @@ impl PeerRoutine {
                     .routine_to_reactor
                     .try_send(RoutineToReactor::ServeGetBlocks {
                         peer: self.peer.clone(),
+                        session_generation: self.generation,
                         start_height,
                         count,
                     });

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -249,6 +249,7 @@ pub fn spawn_block_sync_reactor(
         pending_body_supplier_restart: None,
         pending_operator_body_retry: None,
         next_needed_query_id: NonZeroU64::new(1),
+        next_serving_request_id: NonZeroU64::new(1),
         last_reset_epoch: 0,
         last_reaction_epoch: 0,
         last_view: initial_view(startup.frontiers),
@@ -343,6 +344,9 @@ pub(super) struct BlockSyncReactor {
     /// Next reactor-local identity for a body-work state query.
     /// `None` means the reactor exhausted the identifier space and stops scheduling.
     next_needed_query_id: Option<NonZeroU64>,
+    /// Next identity for an inbound `GetBlocks` request sent to the state driver.
+    /// `None` means the reactor exhausted the identifier space and stops serving.
+    next_serving_request_id: Option<BlockRangeRequestId>,
     /// Last `reset_epoch` the reactor reacted to, so it can tell an advance from
     /// a destructive reset.
     last_reset_epoch: u64,
@@ -624,21 +628,30 @@ impl BlockSyncReactor {
                 .await
             }
             BlockSyncEvent::BlockRangeResponseReady {
+                request_id,
                 peer,
                 start_height,
                 requested_count,
                 blocks,
             } => {
-                self.handle_block_range_response_ready(peer, start_height, requested_count, blocks)
-                    .await;
+                self.handle_block_range_response_ready(
+                    request_id,
+                    peer,
+                    start_height,
+                    requested_count,
+                    blocks,
+                )
+                .await;
             }
             BlockSyncEvent::BlockRangeResponseFinished {
+                request_id,
                 peer,
                 start_height,
                 requested_count,
                 returned_count,
             } => {
                 self.handle_block_range_response_finished(
+                    request_id,
                     peer,
                     start_height,
                     requested_count,
@@ -1413,8 +1426,14 @@ impl BlockSyncReactor {
             return;
         }
 
+        let Some(request_id) = self.next_serving_request_id else {
+            let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
+            self.send_range_unavailable(&peer, start_height, unavailable_count);
+            return;
+        };
+        self.next_serving_request_id = request_id.get().checked_add(1).and_then(NonZeroU64::new);
         let started_serving = self.state.peers.get_mut(&peer).is_some_and(|peer_state| {
-            peer_state.try_start_serving_blocks(local_inflight_cap, start_height)
+            peer_state.try_start_serving_blocks(local_inflight_cap, request_id, start_height)
         });
         if !started_serving {
             let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
@@ -1426,27 +1445,32 @@ impl BlockSyncReactor {
         if requested_count == 0 {
             let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
             self.send_range_unavailable(&peer, start_height, unavailable_count);
-            self.finish_serving_blocks(&peer, start_height);
+            self.finish_serving_blocks(&peer, request_id, start_height);
             return;
         }
 
         if !self.dispatch_action(BlockSyncAction::QueryBlocksByHeightRange {
+            request_id,
             peer: peer.clone(),
             start: start_height,
             count: requested_count,
         }) {
-            self.finish_serving_blocks(&peer, start_height);
+            self.finish_serving_blocks(&peer, request_id, start_height);
         }
     }
 
     async fn handle_block_range_response_ready(
         &mut self,
+        request_id: BlockRangeRequestId,
         peer: ZakuraPeerId,
         start_height: block::Height,
         requested_count: u32,
         blocks: Vec<(block::Height, Arc<block::Block>, usize)>,
     ) {
-        let prepare_elapsed = self.serving_blocks_elapsed(&peer, start_height);
+        let Some(prepare_elapsed) = self.serving_blocks_elapsed(&peer, request_id, start_height)
+        else {
+            return;
+        };
         let send_started = Instant::now();
         let max_response_bytes = u64::from(self.startup.config.advertised_max_response_bytes());
         let mut sent_blocks = 0u32;
@@ -1484,7 +1508,7 @@ impl BlockSyncReactor {
         } else {
             self.send_blocks_done(&peer, start_height, sent_blocks);
         }
-        let total_elapsed = self.finish_serving_blocks(&peer, start_height);
+        let total_elapsed = self.finish_serving_blocks(&peer, request_id, start_height);
         self.trace_range_response_sent(
             &peer,
             RangeResponseTrace {
@@ -1493,7 +1517,7 @@ impl BlockSyncReactor {
                 sent_count: sent_blocks,
                 sent_bytes,
                 reason,
-                prepare_elapsed,
+                prepare_elapsed: Some(prepare_elapsed),
                 send_elapsed: send_started.elapsed(),
                 total_elapsed,
             },
@@ -1502,15 +1526,18 @@ impl BlockSyncReactor {
 
     async fn handle_block_range_response_finished(
         &mut self,
+        request_id: BlockRangeRequestId,
         peer: ZakuraPeerId,
         start_height: block::Height,
         requested_count: u32,
         returned_count: u32,
     ) {
+        let Some(elapsed) = self.finish_serving_blocks(&peer, request_id, start_height) else {
+            return;
+        };
         if returned_count == 0 {
             self.send_range_unavailable(&peer, start_height, requested_count);
         }
-        let elapsed = self.finish_serving_blocks(&peer, start_height);
         self.trace_range_response_sent(
             &peer,
             RangeResponseTrace {
@@ -1519,9 +1546,9 @@ impl BlockSyncReactor {
                 sent_count: returned_count,
                 sent_bytes: 0,
                 reason: "driver_finished",
-                prepare_elapsed: elapsed,
+                prepare_elapsed: Some(elapsed),
                 send_elapsed: Duration::ZERO,
-                total_elapsed: elapsed,
+                total_elapsed: Some(elapsed),
             },
         );
     }
@@ -1590,21 +1617,23 @@ impl BlockSyncReactor {
     fn serving_blocks_elapsed(
         &self,
         peer: &ZakuraPeerId,
+        request_id: BlockRangeRequestId,
         start_height: block::Height,
     ) -> Option<Duration> {
         self.state
             .peers
             .get(peer)
-            .and_then(|peer_state| peer_state.serving_blocks_elapsed(start_height))
+            .and_then(|peer_state| peer_state.serving_blocks_elapsed(request_id, start_height))
     }
 
     fn finish_serving_blocks(
         &mut self,
         peer: &ZakuraPeerId,
+        request_id: BlockRangeRequestId,
         start_height: block::Height,
     ) -> Option<Duration> {
         if let Some(peer_state) = self.state.peers.get_mut(peer) {
-            peer_state.finish_serving_blocks(start_height)
+            peer_state.finish_serving_blocks(request_id, start_height)
         } else {
             None
         }

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1414,6 +1414,14 @@ impl BlockSyncReactor {
             return;
         }
 
+        // The registry advances before the replacement session is installed in
+        // reactor state. Do not commit its request into the predecessor's ledger.
+        if !self.state.peers.get(&peer).is_some_and(|peer_state| {
+            peer_state.session.routine_generation() == Some(session_generation)
+        }) {
+            return;
+        }
+
         let local_inflight_cap = self.startup.config.advertised_max_inflight_requests();
         if !self.state.peers.contains_key(&peer) {
             self.report_misbehavior(peer, BlockSyncMisbehavior::GetBlocksSpam)

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1436,8 +1436,7 @@ impl BlockSyncReactor {
         }
 
         let Some(request_id) = self.next_serving_request_id else {
-            let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
-            self.send_range_unavailable(&peer, start_height, unavailable_count);
+            self.send_range_unavailable(&peer, start_height, count);
             return;
         };
         self.next_serving_request_id = request_id
@@ -1450,18 +1449,17 @@ impl BlockSyncReactor {
                 local_inflight_cap,
                 request_id,
                 start_height,
+                count,
                 requested_count,
             )
         });
         if !started_serving {
-            let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
-            self.send_range_unavailable(&peer, start_height, unavailable_count);
+            self.send_range_unavailable(&peer, start_height, count);
             return;
         }
 
         if requested_count == 0 {
-            let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
-            self.send_range_unavailable(&peer, start_height, unavailable_count);
+            self.send_range_unavailable(&peer, start_height, count);
             self.finish_serving_blocks(&peer, request_id, start_height);
             return;
         }
@@ -1487,6 +1485,7 @@ impl BlockSyncReactor {
         let Some(request) = self.serving_block_request(&peer, request_id, start_height) else {
             return;
         };
+        let original_count = request.original_count();
         let requested_count = request.requested_count();
         if reported_requested_count != requested_count {
             tracing::warn!(
@@ -1535,7 +1534,7 @@ impl BlockSyncReactor {
         }
 
         if sent_blocks == 0 {
-            self.send_range_unavailable(&peer, start_height, requested_count);
+            self.send_range_unavailable(&peer, start_height, original_count);
         } else {
             self.send_blocks_done(&peer, start_height, sent_blocks);
         }
@@ -1568,6 +1567,7 @@ impl BlockSyncReactor {
         let Some(request) = self.finish_serving_blocks(&peer, request_id, start_height) else {
             return;
         };
+        let original_count = request.original_count();
         let requested_count = request.requested_count();
         if reported_requested_count != requested_count {
             tracing::warn!(
@@ -1580,7 +1580,7 @@ impl BlockSyncReactor {
         }
         let elapsed = request.elapsed();
         if returned_count == 0 {
-            self.send_range_unavailable(&peer, start_height, requested_count);
+            self.send_range_unavailable(&peer, start_height, original_count);
         }
         self.trace_range_response_sent(
             &peer,

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -249,7 +249,7 @@ pub fn spawn_block_sync_reactor(
         pending_body_supplier_restart: None,
         pending_operator_body_retry: None,
         next_needed_query_id: NonZeroU64::new(1),
-        next_serving_request_id: NonZeroU64::new(1),
+        next_serving_request_id: BlockRangeRequestId::new(1),
         last_reset_epoch: 0,
         last_reaction_epoch: 0,
         last_view: initial_view(startup.frontiers),
@@ -1431,9 +1431,18 @@ impl BlockSyncReactor {
             self.send_range_unavailable(&peer, start_height, unavailable_count);
             return;
         };
-        self.next_serving_request_id = request_id.get().checked_add(1).and_then(NonZeroU64::new);
+        self.next_serving_request_id = request_id
+            .get()
+            .checked_add(1)
+            .and_then(BlockRangeRequestId::new);
+        let requested_count = self.clamp_served_block_count(start_height, count);
         let started_serving = self.state.peers.get_mut(&peer).is_some_and(|peer_state| {
-            peer_state.try_start_serving_blocks(local_inflight_cap, request_id, start_height)
+            peer_state.try_start_serving_blocks(
+                local_inflight_cap,
+                request_id,
+                start_height,
+                requested_count,
+            )
         });
         if !started_serving {
             let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
@@ -1441,7 +1450,6 @@ impl BlockSyncReactor {
             return;
         }
 
-        let requested_count = self.clamp_served_block_count(start_height, count);
         if requested_count == 0 {
             let unavailable_count = count.min(inbound_get_blocks_count_limit(&self.startup.config));
             self.send_range_unavailable(&peer, start_height, unavailable_count);
@@ -1464,13 +1472,23 @@ impl BlockSyncReactor {
         request_id: BlockRangeRequestId,
         peer: ZakuraPeerId,
         start_height: block::Height,
-        requested_count: u32,
+        reported_requested_count: u32,
         blocks: Vec<(block::Height, Arc<block::Block>, usize)>,
     ) {
-        let Some(prepare_elapsed) = self.serving_blocks_elapsed(&peer, request_id, start_height)
-        else {
+        let Some(request) = self.serving_block_request(&peer, request_id, start_height) else {
             return;
         };
+        let requested_count = request.requested_count();
+        if reported_requested_count != requested_count {
+            tracing::warn!(
+                ?peer,
+                %request_id,
+                reported_requested_count,
+                requested_count,
+                "block-range ready count did not match the serving ledger"
+            );
+        }
+        let prepare_elapsed = request.elapsed();
         let send_started = Instant::now();
         let max_response_bytes = u64::from(self.startup.config.advertised_max_response_bytes());
         let mut sent_blocks = 0u32;
@@ -1478,6 +1496,10 @@ impl BlockSyncReactor {
         let mut reason = "complete";
 
         for (height, block, size) in blocks {
+            if sent_blocks >= requested_count {
+                reason = "count_cap";
+                break;
+            }
             let Ok(size) = u64::try_from(size) else {
                 reason = "size_overflow";
                 break;
@@ -1508,7 +1530,9 @@ impl BlockSyncReactor {
         } else {
             self.send_blocks_done(&peer, start_height, sent_blocks);
         }
-        let total_elapsed = self.finish_serving_blocks(&peer, request_id, start_height);
+        let total_elapsed = self
+            .finish_serving_blocks(&peer, request_id, start_height)
+            .map(ServingBlockRequest::elapsed);
         self.trace_range_response_sent(
             &peer,
             RangeResponseTrace {
@@ -1529,12 +1553,23 @@ impl BlockSyncReactor {
         request_id: BlockRangeRequestId,
         peer: ZakuraPeerId,
         start_height: block::Height,
-        requested_count: u32,
+        reported_requested_count: u32,
         returned_count: u32,
     ) {
-        let Some(elapsed) = self.finish_serving_blocks(&peer, request_id, start_height) else {
+        let Some(request) = self.finish_serving_blocks(&peer, request_id, start_height) else {
             return;
         };
+        let requested_count = request.requested_count();
+        if reported_requested_count != requested_count {
+            tracing::warn!(
+                ?peer,
+                %request_id,
+                reported_requested_count,
+                requested_count,
+                "block-range finished count did not match the serving ledger"
+            );
+        }
+        let elapsed = request.elapsed();
         if returned_count == 0 {
             self.send_range_unavailable(&peer, start_height, requested_count);
         }
@@ -1614,16 +1649,16 @@ impl BlockSyncReactor {
         );
     }
 
-    fn serving_blocks_elapsed(
+    fn serving_block_request(
         &self,
         peer: &ZakuraPeerId,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
-    ) -> Option<Duration> {
+    ) -> Option<ServingBlockRequest> {
         self.state
             .peers
             .get(peer)
-            .and_then(|peer_state| peer_state.serving_blocks_elapsed(request_id, start_height))
+            .and_then(|peer_state| peer_state.serving_block_request(request_id, start_height))
     }
 
     fn finish_serving_blocks(
@@ -1631,7 +1666,7 @@ impl BlockSyncReactor {
         peer: &ZakuraPeerId,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
-    ) -> Option<Duration> {
+    ) -> Option<ServingBlockRequest> {
         if let Some(peer_state) = self.state.peers.get_mut(peer) {
             peer_state.finish_serving_blocks(request_id, start_height)
         } else {

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1239,13 +1239,15 @@ impl BlockSyncReactor {
             }
             RoutineToReactor::ServeGetBlocks {
                 peer,
+                session_generation,
                 start_height,
                 count,
             } => {
                 if self.state.parked_peers.contains(&peer) {
                     return;
                 }
-                self.handle_get_blocks(peer, start_height, count).await;
+                self.handle_get_blocks(peer, session_generation, start_height, count)
+                    .await;
             }
             RoutineToReactor::RequeryNeeded => {
                 self.query_needed_blocks().await;
@@ -1402,9 +1404,16 @@ impl BlockSyncReactor {
     async fn handle_get_blocks(
         &mut self,
         peer: ZakuraPeerId,
+        session_generation: u64,
         start_height: block::Height,
         count: u32,
     ) {
+        // The routine can be superseded after decoding this request but before
+        // the reactor receives it. Never apply that request to the replacement.
+        if !self.registry.owns_generation(&peer, session_generation) {
+            return;
+        }
+
         let local_inflight_cap = self.startup.config.advertised_max_inflight_requests();
         if !self.state.peers.contains_key(&peer) {
             self.report_misbehavior(peer, BlockSyncMisbehavior::GetBlocksSpam)

--- a/crates/zakura-network/src/zakura/block_sync/service.rs
+++ b/crates/zakura-network/src/zakura/block_sync/service.rs
@@ -41,6 +41,7 @@ pub struct BlockSyncPeerSession {
     direction: ServicePeerDirection,
     send: FramedSend,
     cancel_token: CancellationToken,
+    routine_generation: Option<u64>,
 }
 
 impl BlockSyncPeerSession {
@@ -50,6 +51,7 @@ impl BlockSyncPeerSession {
             direction,
             send: session.sender(),
             cancel_token: session.cancel_token(),
+            routine_generation: None,
         }
     }
 
@@ -67,12 +69,35 @@ impl BlockSyncPeerSession {
             direction: ServicePeerDirection::Outbound,
             send,
             cancel_token,
+            routine_generation: None,
+        }
+    }
+
+    /// Build a test session associated with an admitted routine generation.
+    #[cfg(test)]
+    pub(super) fn for_test_with_generation(
+        peer_id: ZakuraPeerId,
+        send: FramedSend,
+        cancel_token: CancellationToken,
+        routine_generation: u64,
+    ) -> Self {
+        Self {
+            peer_id,
+            direction: ServicePeerDirection::Outbound,
+            send,
+            cancel_token,
+            routine_generation: Some(routine_generation),
         }
     }
 
     /// Authenticated peer identity for this block-sync session.
     pub fn peer_id(&self) -> &ZakuraPeerId {
         &self.peer_id
+    }
+
+    /// Registry generation of the routine that owns this session, when present.
+    pub(super) fn routine_generation(&self) -> Option<u64> {
+        self.routine_generation
     }
 
     /// Direction of the underlying Zakura connection.
@@ -550,7 +575,7 @@ impl Service for BlockSyncService {
         let service_cancel_token = session.cancel_token();
         let connection_cancel_token = peer.cancel_token();
         let close_cause = peer.close_cause();
-        let block_sync_session = BlockSyncPeerSession::new(&session, peer.direction);
+        let mut block_sync_session = BlockSyncPeerSession::new(&session, peer.direction);
         let session_id = self.inner.next_session_id.fetch_add(1, Ordering::Relaxed);
         let conn_id = peer.conn_id;
         let (_session_peer, _stream_kind, _stream_version, recv, send, _session_cancel) =
@@ -640,6 +665,8 @@ impl Service for BlockSyncService {
                 routine_generation,
             )
         };
+        block_sync_session.routine_generation = routine_generation;
+
         if let Some(old_record) = old_record {
             old_record.cancel_token.cancel();
         }

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -796,11 +796,17 @@ pub(super) struct PeerBlockState {
 pub(super) struct ServingBlockRequest {
     id: BlockRangeRequestId,
     start_height: block::Height,
+    original_count: u32,
     requested_count: u32,
     started: Instant,
 }
 
 impl ServingBlockRequest {
+    /// Count received in the validated wire request and echoed by `RangeUnavailable`.
+    pub(super) fn original_count(self) -> u32 {
+        self.original_count
+    }
+
     /// Count accepted after the wire, configuration, and servable-range clamps.
     pub(super) fn requested_count(self) -> u32 {
         self.requested_count
@@ -827,6 +833,7 @@ impl PeerBlockState {
         local_inflight_cap: u32,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
+        original_count: u32,
         requested_count: u32,
     ) -> bool {
         if self.served_block_requests.len()
@@ -838,6 +845,7 @@ impl PeerBlockState {
         self.served_block_requests.push_back(ServingBlockRequest {
             id: request_id,
             start_height,
+            original_count,
             requested_count,
             started: Instant::now(),
         });

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -791,11 +791,25 @@ pub(super) struct PeerBlockState {
     served_block_requests: VecDeque<ServingBlockRequest>,
 }
 
-#[derive(Debug)]
-struct ServingBlockRequest {
+/// Ledger entry for one accepted inbound `GetBlocks` request.
+#[derive(Copy, Clone, Debug)]
+pub(super) struct ServingBlockRequest {
     id: BlockRangeRequestId,
     start_height: block::Height,
+    requested_count: u32,
     started: Instant,
+}
+
+impl ServingBlockRequest {
+    /// Count accepted after the wire, configuration, and servable-range clamps.
+    pub(super) fn requested_count(self) -> u32 {
+        self.requested_count
+    }
+
+    /// Time elapsed since this request acquired its serving slot.
+    pub(super) fn elapsed(self) -> Duration {
+        self.started.elapsed()
+    }
 }
 
 impl PeerBlockState {
@@ -813,6 +827,7 @@ impl PeerBlockState {
         local_inflight_cap: u32,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
+        requested_count: u32,
     ) -> bool {
         if self.served_block_requests.len()
             >= usize::try_from(local_inflight_cap)
@@ -823,32 +838,32 @@ impl PeerBlockState {
         self.served_block_requests.push_back(ServingBlockRequest {
             id: request_id,
             start_height,
+            requested_count,
             started: Instant::now(),
         });
         true
     }
 
-    pub(super) fn serving_blocks_elapsed(
+    pub(super) fn serving_block_request(
         &self,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
-    ) -> Option<Duration> {
+    ) -> Option<ServingBlockRequest> {
         self.served_block_requests
             .iter()
             .find(|request| request.id == request_id && request.start_height == start_height)
-            .map(|request| request.started.elapsed())
+            .copied()
     }
 
     pub(super) fn finish_serving_blocks(
         &mut self,
         request_id: BlockRangeRequestId,
         start_height: block::Height,
-    ) -> Option<Duration> {
+    ) -> Option<ServingBlockRequest> {
         self.served_block_requests
             .iter()
             .position(|request| request.id == request_id && request.start_height == start_height)
             .and_then(|index| self.served_block_requests.remove(index))
-            .map(|request| request.started.elapsed())
     }
 }
 

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -788,8 +788,14 @@ pub(super) struct PeerBlockState {
     /// `status_reply_meter`; this half stays reactor-side because the reactor owns
     /// serving-tip advertisement.
     pub(super) refresh_meter: RateMeter,
-    pub(super) served_blocks_inflight: u32,
-    pub(super) served_block_requests: VecDeque<(block::Height, Instant)>,
+    served_block_requests: VecDeque<ServingBlockRequest>,
+}
+
+#[derive(Debug)]
+struct ServingBlockRequest {
+    id: BlockRangeRequestId,
+    start_height: block::Height,
+    started: Instant,
 }
 
 impl PeerBlockState {
@@ -798,7 +804,6 @@ impl PeerBlockState {
             direction: session.direction(),
             session,
             refresh_meter: RateMeter::new(config.status_refresh_interval),
-            served_blocks_inflight: 0,
             served_block_requests: VecDeque::new(),
         }
     }
@@ -806,33 +811,44 @@ impl PeerBlockState {
     pub(super) fn try_start_serving_blocks(
         &mut self,
         local_inflight_cap: u32,
+        request_id: BlockRangeRequestId,
         start_height: block::Height,
     ) -> bool {
-        if self.served_blocks_inflight >= local_inflight_cap {
+        if self.served_block_requests.len()
+            >= usize::try_from(local_inflight_cap)
+                .expect("u32 serving limit fits in usize on supported targets")
+        {
             return false;
         }
-        self.served_blocks_inflight = self.served_blocks_inflight.saturating_add(1);
-        self.served_block_requests
-            .push_back((start_height, Instant::now()));
+        self.served_block_requests.push_back(ServingBlockRequest {
+            id: request_id,
+            start_height,
+            started: Instant::now(),
+        });
         true
     }
 
-    pub(super) fn serving_blocks_elapsed(&self, start_height: block::Height) -> Option<Duration> {
+    pub(super) fn serving_blocks_elapsed(
+        &self,
+        request_id: BlockRangeRequestId,
+        start_height: block::Height,
+    ) -> Option<Duration> {
         self.served_block_requests
             .iter()
-            .find_map(|(start, started)| (*start == start_height).then(|| started.elapsed()))
+            .find(|request| request.id == request_id && request.start_height == start_height)
+            .map(|request| request.started.elapsed())
     }
 
     pub(super) fn finish_serving_blocks(
         &mut self,
+        request_id: BlockRangeRequestId,
         start_height: block::Height,
     ) -> Option<Duration> {
-        self.served_blocks_inflight = self.served_blocks_inflight.saturating_sub(1);
         self.served_block_requests
             .iter()
-            .position(|(start, _)| *start == start_height)
+            .position(|request| request.id == request_id && request.start_height == start_height)
             .and_then(|index| self.served_block_requests.remove(index))
-            .map(|(_, started)| started.elapsed())
+            .map(|request| request.started.elapsed())
     }
 }
 

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -11978,7 +11978,7 @@ async fn reactor_serves_committed_blocks_with_count_and_byte_clamps() {
 }
 
 #[tokio::test]
-async fn reactor_ignores_get_blocks_from_superseded_routine_generation() {
+async fn reactor_serves_get_blocks_only_after_replacement_generation_is_installed() {
     let config = ZakuraBlockSyncConfig::default();
     let mut startup = BlockSyncStartup::inert(config.clone());
     startup.frontiers.finalized_height = block::Height(3);
@@ -12000,6 +12000,21 @@ async fn reactor_ignores_get_blocks_from_superseded_routine_generation() {
             Instant::now(),
         )
         .generation();
+
+    let (old_outbound, mut old_outbound_recv) = framed_channel(4);
+    handle
+        .send(BlockSyncEvent::PeerConnected(
+            BlockSyncPeerSession::for_test_with_generation(
+                peer_id.clone(),
+                old_outbound,
+                CancellationToken::new(),
+                old_generation,
+            ),
+        ))
+        .await
+        .expect("the predecessor peer connection queues");
+    wait_for_outbound_status(&mut old_outbound_recv).await;
+
     let current_generation = wiring
         .registry
         .admit_session(
@@ -12020,14 +12035,36 @@ async fn reactor_ignores_get_blocks_from_superseded_routine_generation() {
         },
     );
 
-    let (outbound, mut outbound_recv) = framed_channel(4);
+    wiring
+        .routine_to_reactor
+        .send(RoutineToReactor::ServeGetBlocks {
+            peer: peer_id.clone(),
+            session_generation: current_generation,
+            start_height: block::Height(1),
+            count: 1,
+        })
+        .await
+        .expect("the replacement's early serving request queues");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), actions.recv())
+            .await
+            .is_err(),
+        "a replacement request must wait until that generation is installed"
+    );
+
+    let (current_outbound, mut current_outbound_recv) = framed_channel(4);
     handle
         .send(BlockSyncEvent::PeerConnected(
-            BlockSyncPeerSession::for_test(peer_id.clone(), outbound, CancellationToken::new()),
+            BlockSyncPeerSession::for_test_with_generation(
+                peer_id.clone(),
+                current_outbound,
+                CancellationToken::new(),
+                current_generation,
+            ),
         ))
         .await
-        .expect("the peer connection queues");
-    wait_for_outbound_status(&mut outbound_recv).await;
+        .expect("the replacement peer connection queues");
+    wait_for_outbound_status(&mut current_outbound_recv).await;
 
     wiring
         .routine_to_reactor
@@ -12065,7 +12102,7 @@ async fn reactor_ignores_get_blocks_from_superseded_routine_generation() {
         "the stale serving request must not produce a second action"
     );
     assert!(
-        tokio::time::timeout(Duration::from_millis(20), outbound_recv.recv())
+        tokio::time::timeout(Duration::from_millis(20), current_outbound_recv.recv())
             .await
             .is_err(),
         "the stale serving request must not send a frame"

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -13879,11 +13879,16 @@ async fn reactor_backpressures_serving_slots_without_scoring_peer() {
             request_id,
             peer: peer_id.clone(),
             start_height: block::Height(1),
-            requested_count: 1,
-            returned_count: 1,
+            requested_count: u32::MAX,
+            returned_count: 0,
         })
         .await
         .expect("serving slot release queues");
+    assert_eq!(
+        wait_for_outbound_range_unavailable(&mut outbound_rx).await,
+        (block::Height(1), 1),
+        "the serving ledger, not the driver's echoed count, owns the response",
+    );
 
     reactor_task.abort();
 }

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -16,6 +16,7 @@ use super::{
         DEFAULT_BS_REQUEST_TIMEOUT, MAX_BS_INFLIGHT_REQUESTS, MAX_BS_RESPONSE_BYTES,
         MIN_BS_CHECKPOINT_SUBMITTED_BLOCK_APPLIES,
     },
+    events::RoutineToReactor,
     peer_registry::{OutstandingMeta, PeerRegistry},
     reactor::{
         node_id_from_block_peer_id, EMPTY_STATE_HEADER_QUIET_MIN_LAG,
@@ -11924,6 +11925,103 @@ async fn reactor_serves_committed_blocks_with_count_and_byte_clamps() {
     assert_eq!(
         wait_for_outbound_range_unavailable(&mut outbound_rx).await,
         (block::Height(4), 1)
+    );
+
+    reactor_task.abort();
+}
+
+#[tokio::test]
+async fn reactor_ignores_get_blocks_from_superseded_routine_generation() {
+    let config = ZakuraBlockSyncConfig::default();
+    let mut startup = BlockSyncStartup::inert(config.clone());
+    startup.frontiers.finalized_height = block::Height(3);
+    startup.frontiers.verified_block_tip = block::Height(3);
+    startup.best_header_tip = (block::Height(3), block::Hash([3; 32]));
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let wiring = handle
+        .routine_wiring
+        .as_ref()
+        .expect("the spawned reactor exposes routine wiring");
+    let peer_id = peer(0x6f);
+    let old_generation = wiring
+        .registry
+        .admit_session(
+            &peer_id,
+            ServicePeerDirection::Outbound,
+            &config,
+            1,
+            Instant::now(),
+        )
+        .generation();
+    let current_generation = wiring
+        .registry
+        .admit_session(
+            &peer_id,
+            ServicePeerDirection::Outbound,
+            &config,
+            2,
+            Instant::now(),
+        )
+        .generation();
+    wiring.registry.upsert_status(
+        &peer_id,
+        current_generation,
+        BlockSyncStatus {
+            servable_low: block::Height::MIN,
+            servable_high: block::Height(3),
+            ..BlockSyncStatus::default()
+        },
+    );
+
+    let (outbound, mut outbound_recv) = framed_channel(4);
+    handle
+        .send(BlockSyncEvent::PeerConnected(
+            BlockSyncPeerSession::for_test(peer_id.clone(), outbound, CancellationToken::new()),
+        ))
+        .await
+        .expect("the peer connection queues");
+    wait_for_outbound_status(&mut outbound_recv).await;
+
+    wiring
+        .routine_to_reactor
+        .send(RoutineToReactor::ServeGetBlocks {
+            peer: peer_id.clone(),
+            session_generation: old_generation,
+            start_height: block::Height(1),
+            count: 1,
+        })
+        .await
+        .expect("the stale serving request queues");
+    wiring
+        .routine_to_reactor
+        .send(RoutineToReactor::ServeGetBlocks {
+            peer: peer_id.clone(),
+            session_generation: current_generation,
+            start_height: block::Height(2),
+            count: 1,
+        })
+        .await
+        .expect("the current serving request queues");
+
+    match next_action(&mut actions).await {
+        BlockSyncAction::QueryBlocksByHeightRange {
+            peer, start, count, ..
+        } => {
+            assert_eq!(peer, peer_id);
+            assert_eq!(start, block::Height(2));
+            assert_eq!(count, 1);
+        }
+        action => panic!("stale serving request produced an observable action: {action:?}"),
+    }
+    assert!(
+        actions.try_recv().is_err(),
+        "the stale serving request must not produce a second action"
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), outbound_recv.recv())
+            .await
+            .is_err(),
+        "the stale serving request must not send a frame"
     );
 
     reactor_task.abort();

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -11859,21 +11859,27 @@ async fn reactor_serves_committed_blocks_with_count_and_byte_clamps() {
         .await
         .expect("GetBlocks frame queues");
 
-    loop {
+    let request_id = loop {
         match next_action(&mut actions).await {
-            BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => {
                 assert_eq!(peer, peer_id);
                 assert_eq!(start, block::Height(1));
                 assert_eq!(count, 2);
-                break;
+                break request_id;
             }
             BlockSyncAction::QueryNeededBlocks { .. } => {}
             action => panic!("unexpected action before block range query: {action:?}"),
         }
-    }
+    };
 
     handle
         .send(BlockSyncEvent::BlockRangeResponseReady {
+            request_id,
             peer: peer_id.clone(),
             start_height: block::Height(1),
             requested_count: 2,
@@ -13853,10 +13859,13 @@ async fn reactor_backpressures_serving_slots_without_scoring_peer() {
             .await
             .expect("GetBlocks frame queues");
     }
-    while !matches!(
-        next_action(&mut actions).await,
-        BlockSyncAction::QueryBlocksByHeightRange { .. }
-    ) {}
+    let request_id = loop {
+        if let BlockSyncAction::QueryBlocksByHeightRange { request_id, .. } =
+            next_action(&mut actions).await
+        {
+            break request_id;
+        }
+    };
 
     assert_eq!(
         wait_for_outbound_range_unavailable(&mut outbound_rx).await,
@@ -13867,6 +13876,7 @@ async fn reactor_backpressures_serving_slots_without_scoring_peer() {
 
     handle
         .send(BlockSyncEvent::BlockRangeResponseFinished {
+            request_id,
             peer: peer_id.clone(),
             start_height: block::Height(1),
             requested_count: 1,
@@ -13958,18 +13968,23 @@ async fn reactor_full_serving_queue_drops_without_disconnecting_peer() {
         )
         .await
         .expect("GetBlocks frame queues");
-    loop {
+    let first_request_id = loop {
         match next_action(&mut actions).await {
-            BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => {
                 assert_eq!(peer, peer_id);
                 assert_eq!(start, block::Height(1));
                 assert_eq!(count, 3);
-                break;
+                break request_id;
             }
             BlockSyncAction::QueryNeededBlocks { .. } => {}
             action => panic!("unexpected action before block range query: {action:?}"),
         }
-    }
+    };
     let served: Vec<_> = blocks
         .iter()
         .map(|block| {
@@ -13982,6 +13997,7 @@ async fn reactor_full_serving_queue_drops_without_disconnecting_peer() {
         .collect();
     handle
         .send(BlockSyncEvent::BlockRangeResponseReady {
+            request_id: first_request_id,
             peer: peer_id.clone(),
             start_height: block::Height(1),
             requested_count: 3,
@@ -13998,8 +14014,9 @@ async fn reactor_full_serving_queue_drops_without_disconnecting_peer() {
     );
     assert_eq!(handle.peer_snapshot().outbound_peers, 1);
 
-    // Self-heal: drain the queue, release the serving slot, and re-request. The
-    // earlier drop neither wedged nor scored the peer, so a fresh serve lands.
+    // Self-heal: drain the queue and re-request. The earlier response already
+    // released its serving slot, and the dropped sends neither wedged nor scored
+    // the peer, so a fresh serve lands.
     while tokio::time::timeout(
         Duration::from_millis(100),
         next_outbound_message(&mut outbound_rx),
@@ -14007,15 +14024,6 @@ async fn reactor_full_serving_queue_drops_without_disconnecting_peer() {
     .await
     .is_ok()
     {}
-    handle
-        .send(BlockSyncEvent::BlockRangeResponseFinished {
-            peer: peer_id.clone(),
-            start_height: block::Height(1),
-            requested_count: 3,
-            returned_count: 3,
-        })
-        .await
-        .expect("serving slot release queues");
     inbound_tx
         .send(
             BlockSyncMessage::GetBlocks {
@@ -14027,19 +14035,25 @@ async fn reactor_full_serving_queue_drops_without_disconnecting_peer() {
         )
         .await
         .expect("re-request GetBlocks frame queues");
-    loop {
+    let second_request_id = loop {
         match next_action(&mut actions).await {
-            BlockSyncAction::QueryBlocksByHeightRange { start, count, .. } => {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                start,
+                count,
+                ..
+            } => {
                 assert_eq!(start, block::Height(1));
                 assert_eq!(count, 1);
-                break;
+                break request_id;
             }
             BlockSyncAction::QueryNeededBlocks { .. } => {}
             action => panic!("unexpected action before re-request query: {action:?}"),
         }
-    }
+    };
     handle
         .send(BlockSyncEvent::BlockRangeResponseReady {
+            request_id: second_request_id,
             peer: peer_id.clone(),
             start_height: block::Height(1),
             requested_count: 1,

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -11913,8 +11913,54 @@ async fn reactor_serves_committed_blocks_with_count_and_byte_clamps() {
     inbound_tx
         .send(
             BlockSyncMessage::GetBlocks {
+                start_height: block::Height(1),
+                count: 10,
+            }
+            .encode_frame()
+            .expect("GetBlocks frame encodes"),
+        )
+        .await
+        .expect("GetBlocks frame queues");
+
+    let request_id = loop {
+        match next_action(&mut actions).await {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => {
+                assert_eq!(peer, peer_id);
+                assert_eq!(start, block::Height(1));
+                assert_eq!(count, 2);
+                break request_id;
+            }
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("unexpected action before empty block range result: {action:?}"),
+        }
+    };
+
+    handle
+        .send(BlockSyncEvent::BlockRangeResponseFinished {
+            request_id,
+            peer: peer_id.clone(),
+            start_height: block::Height(1),
+            requested_count: 2,
+            returned_count: 0,
+        })
+        .await
+        .expect("empty block response queues");
+    assert_eq!(
+        wait_for_outbound_range_unavailable(&mut outbound_rx).await,
+        (block::Height(1), 10),
+        "RangeUnavailable echoes the wire count rather than the clamped state-query count"
+    );
+
+    inbound_tx
+        .send(
+            BlockSyncMessage::GetBlocks {
                 start_height: block::Height(4),
-                count: 1,
+                count: 10,
             }
             .encode_frame()
             .expect("GetBlocks frame encodes"),
@@ -11924,7 +11970,8 @@ async fn reactor_serves_committed_blocks_with_count_and_byte_clamps() {
 
     assert_eq!(
         wait_for_outbound_range_unavailable(&mut outbound_rx).await,
-        (block::Height(4), 1)
+        (block::Height(4), 10),
+        "RangeUnavailable echoes the original wire count after the servable-range clamp"
     );
 
     reactor_task.abort();

--- a/crates/zakura-network/src/zakura/block_sync/trace.rs
+++ b/crates/zakura-network/src/zakura/block_sync/trace.rs
@@ -524,12 +524,14 @@ enum BlockEventDetail {
         verified_block_tip: Option<u64>,
     },
     BlockRangeResponseFinished {
+        request_id: u64,
         peer: String,
         range_start: u64,
         range_count: u64,
         expected_count: u64,
     },
     BlockRangeResponseReady {
+        request_id: u64,
         peer: String,
         range_start: u64,
         range_count: u64,
@@ -598,22 +600,26 @@ impl BlockEventReceived {
                 verified_block_tip: None,
             },
             BlockSyncEvent::BlockRangeResponseFinished {
+                request_id,
                 peer,
                 start_height,
                 requested_count,
                 returned_count,
             } => BlockEventDetail::BlockRangeResponseFinished {
+                request_id: request_id.get(),
                 peer: peer_label(peer),
                 range_start: height(*start_height),
                 range_count: u64::from(*returned_count),
                 expected_count: u64::from(*requested_count),
             },
             BlockSyncEvent::BlockRangeResponseReady {
+                request_id,
                 peer,
                 start_height,
                 requested_count,
                 blocks,
             } => BlockEventDetail::BlockRangeResponseReady {
+                request_id: request_id.get(),
                 peer: peer_label(peer),
                 range_start: height(*start_height),
                 range_count: saturating_usize(blocks.len()),
@@ -647,6 +653,7 @@ enum BlockActionDetail {
         best_header_tip: u64,
     },
     QueryBlocksByHeightRange {
+        request_id: u64,
         peer: String,
         range_start: u64,
         range_count: u64,
@@ -680,13 +687,17 @@ impl BlockActionDispatched {
                 range_count: u64::from(*limit),
                 best_header_tip: height(*best_header_tip),
             },
-            BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
-                BlockActionDetail::QueryBlocksByHeightRange {
-                    peer: peer_label(peer),
-                    range_start: height(*start),
-                    range_count: u64::from(*count),
-                }
-            }
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => BlockActionDetail::QueryBlocksByHeightRange {
+                request_id: request_id.get(),
+                peer: peer_label(peer),
+                range_start: height(*start),
+                range_count: u64::from(*count),
+            },
             BlockSyncAction::SubmitBlock { token, block, .. } => BlockActionDetail::SubmitBlock {
                 apply_token: *token,
                 hash: hash(block.hash()),
@@ -947,21 +958,23 @@ mod tests {
             ),
             (
                 BlockEventDetail::BlockRangeResponseFinished {
+                    request_id: 4,
                     peer: "p".into(),
                     range_start: 1,
                     range_count: 2,
                     expected_count: 3,
                 },
-                json!({"kind": "block_range_response_finished", "peer": "p", "range_start": 1, "range_count": 2, "expected_count": 3}),
+                json!({"kind": "block_range_response_finished", "request_id": 4, "peer": "p", "range_start": 1, "range_count": 2, "expected_count": 3}),
             ),
             (
                 BlockEventDetail::BlockRangeResponseReady {
+                    request_id: 4,
                     peer: "p".into(),
                     range_start: 1,
                     range_count: 2,
                     expected_count: 3,
                 },
-                json!({"kind": "block_range_response_ready", "peer": "p", "range_start": 1, "range_count": 2, "expected_count": 3}),
+                json!({"kind": "block_range_response_ready", "request_id": 4, "peer": "p", "range_start": 1, "range_count": 2, "expected_count": 3}),
             ),
         ];
 
@@ -988,11 +1001,12 @@ mod tests {
             ),
             (
                 BlockActionDetail::QueryBlocksByHeightRange {
+                    request_id: 4,
                     peer: "p".into(),
                     range_start: 1,
                     range_count: 2,
                 },
-                json!({"kind": "query_blocks_by_height_range", "peer": "p", "range_start": 1, "range_count": 2}),
+                json!({"kind": "query_blocks_by_height_range", "request_id": 4, "peer": "p", "range_start": 1, "range_count": 2}),
             ),
             (
                 BlockActionDetail::SubmitBlock {

--- a/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
+++ b/crates/zakura-network/src/zakura/testkit/blocksync_fuzz/mod.rs
@@ -284,10 +284,16 @@ fn spawn_action_driver(
                         break;
                     }
                 }
-                BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+                BlockSyncAction::QueryBlocksByHeightRange {
+                    request_id,
+                    peer,
+                    start,
+                    count,
+                } => {
                     let blocks = corpus.blocks_in_range(start, count, target);
                     if handle
                         .send(BlockSyncEvent::BlockRangeResponseReady {
+                            request_id,
                             peer,
                             start_height: start,
                             requested_count: count,

--- a/crates/zakura-network/src/zakura/testkit/cluster.rs
+++ b/crates/zakura-network/src/zakura/testkit/cluster.rs
@@ -864,9 +864,15 @@ mod tests {
                             }))
                             .await;
                     }
-                    BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+                    BlockSyncAction::QueryBlocksByHeightRange {
+                        request_id,
+                        peer,
+                        start,
+                        count,
+                    } => {
                         let _ = handle
                             .send(BlockSyncEvent::BlockRangeResponseFinished {
+                                request_id,
                                 peer,
                                 start_height: start,
                                 requested_count: count,

--- a/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
+++ b/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
@@ -602,7 +602,12 @@ async fn drive_mock_block_sync_actions(
                         })
                         .await;
                 }
-                BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+                BlockSyncAction::QueryBlocksByHeightRange {
+                    request_id,
+                    peer,
+                    start,
+                    count,
+                } => {
                     let blocks = corpus.blocks_in_range(start, count, servable_high);
                     let response_bytes = blocks
                         .iter()
@@ -610,6 +615,7 @@ async fn drive_mock_block_sync_actions(
                     stats.record_request(blocks.len(), response_bytes);
                     let _ = handle
                         .send(BlockSyncEvent::BlockRangeResponseReady {
+                            request_id,
                             peer,
                             start_height: start,
                             requested_count: count,

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -112,7 +112,7 @@ zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
-zakura-network = { path = "../zakura-network", version = "7.0.0" }
+zakura-network = { path = "../zakura-network", version = "8.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = [
     "rpc-client",
 ] }
@@ -141,7 +141,7 @@ zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = [
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "7.0.0", features = [
+zakura-network = { path = "../zakura-network", version = "8.0.0", features = [
     "proptest-impl",
 ] }
 zakura-state = { path = "../zakura-state", version = "7.0.0", features = [

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -172,7 +172,7 @@ zakura-chain = { path = "../zakura-chain", version = "6.0.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-network = { path = "../zakura-network", version = "7.0.0" }
+zakura-network = { path = "../zakura-network", version = "8.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "8.0.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
@@ -308,7 +308,7 @@ proptest-derive = { workspace = true }
 zakura-chain = { path = "../zakura-chain", version = "6.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.0", features = ["proptest-impl"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0", features = ["test-support"] }
-zakura-network = { path = "../zakura-network", version = "7.0.0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-network = { path = "../zakura-network", version = "8.0.0", features = ["proptest-impl", "zakura-testkit"] }
 zakura-state = { path = "../zakura-state", version = "7.0.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -1674,9 +1674,9 @@ mod zakura_header_sync_driver_tests {
     use zakura_chain::{block, orchard, parallel::commitment_aux::BlockCommitmentRoots, sapling};
     use zakura_network::zakura::testkit::{TraceCapture, TraceValue};
     use zakura_network::zakura::{
-        commit_state_trace as cs_trace, BlockApplyResult, BlockSizeEstimate, BlockSyncAction,
-        BlockSyncBlockMeta, BlockSyncEvent, BlockSyncFrontiers, BlockSyncMisbehavior,
-        BLOCK_SYNC_TABLE, COMMIT_STATE_TABLE, DEFAULT_HS_RANGE,
+        commit_state_trace as cs_trace, BlockApplyResult, BlockRangeRequestId, BlockSizeEstimate,
+        BlockSyncAction, BlockSyncBlockMeta, BlockSyncEvent, BlockSyncFrontiers,
+        BlockSyncMisbehavior, BLOCK_SYNC_TABLE, COMMIT_STATE_TABLE, DEFAULT_HS_RANGE,
     };
     use zakura_network::P2pStack;
     use zakura_test::vectors::{
@@ -3880,7 +3880,7 @@ mod zakura_header_sync_driver_tests {
             .expect("driver action channel stays open");
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
-                request_id: std::num::NonZeroU64::new(1)
+                request_id: BlockRangeRequestId::new(1)
                     .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(77),
                 start: block::Height(1),
@@ -4005,7 +4005,7 @@ mod zakura_header_sync_driver_tests {
             .expect("fallback acquires the lease after the apply drains");
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
-                request_id: std::num::NonZeroU64::new(1)
+                request_id: BlockRangeRequestId::new(1)
                     .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(78),
                 start: block::Height(1),
@@ -4081,7 +4081,7 @@ mod zakura_header_sync_driver_tests {
         // Send a serving query to Zakura.
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
-                request_id: std::num::NonZeroU64::new(1)
+                request_id: BlockRangeRequestId::new(1)
                     .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(79),
                 start: block::Height(1),
@@ -4172,7 +4172,7 @@ mod zakura_header_sync_driver_tests {
         }
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
-                request_id: std::num::NonZeroU64::new(1)
+                request_id: BlockRangeRequestId::new(1)
                     .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(80),
                 start: block::Height(1),

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -3880,6 +3880,8 @@ mod zakura_header_sync_driver_tests {
             .expect("driver action channel stays open");
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
+                request_id: std::num::NonZeroU64::new(1)
+                    .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(77),
                 start: block::Height(1),
                 count: 1,
@@ -4003,6 +4005,8 @@ mod zakura_header_sync_driver_tests {
             .expect("fallback acquires the lease after the apply drains");
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
+                request_id: std::num::NonZeroU64::new(1)
+                    .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(78),
                 start: block::Height(1),
                 count: 1,
@@ -4077,6 +4081,8 @@ mod zakura_header_sync_driver_tests {
         // Send a serving query to Zakura.
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
+                request_id: std::num::NonZeroU64::new(1)
+                    .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(79),
                 start: block::Height(1),
                 count: 1,
@@ -4166,6 +4172,8 @@ mod zakura_header_sync_driver_tests {
         }
         action_tx
             .send(BlockSyncAction::QueryBlocksByHeightRange {
+                request_id: std::num::NonZeroU64::new(1)
+                    .expect("test serving request ID is nonzero"),
                 peer: test_zakura_peer(80),
                 start: block::Height(1),
                 count: 2,

--- a/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/block_sync_driver.rs
@@ -475,7 +475,12 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
                     }
                 }
             }
-            BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => {
                 trace.trace_block_range_query_started(&peer, start, count);
                 let started = Instant::now();
                 match tokio::time::timeout(
@@ -500,6 +505,7 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
                             count,
                         );
                         let _ = block_sync.send_control(BlockSyncEvent::BlockRangeResponseReady {
+                            request_id,
                             peer,
                             start_height: start,
                             requested_count: count,
@@ -518,6 +524,7 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
                         trace.trace_block_range_finished(&peer, start, count, 0);
                         let _ =
                             block_sync.send_control(BlockSyncEvent::BlockRangeResponseFinished {
+                                request_id,
                                 peer,
                                 start_height: start,
                                 requested_count: count,
@@ -540,6 +547,7 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
                         trace.trace_block_range_finished(&peer, start, count, 0);
                         let _ =
                             block_sync.send_control(BlockSyncEvent::BlockRangeResponseFinished {
+                                request_id,
                                 peer,
                                 start_height: start,
                                 requested_count: count,
@@ -552,6 +560,7 @@ pub(crate) async fn drive_block_sync_actions<ReadState, BlockVerifier>(
                         trace.trace_block_range_finished(&peer, start, count, 0);
                         let _ =
                             block_sync.send_control(BlockSyncEvent::BlockRangeResponseFinished {
+                                request_id,
                                 peer,
                                 start_height: start,
                                 requested_count: count,

--- a/crates/zakurad/src/commands/start/zakura/trace/block_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/trace/block_driver.rs
@@ -260,14 +260,14 @@ impl BlockDriverTraceExt for ZakuraTrace {
                     range_count: (*limit).into(),
                     best_header_tip: best_header_tip.0.into(),
                 }),
-                BlockSyncAction::QueryBlocksByHeightRange { peer, start, count } => {
-                    ReceivedAction::BlockRange {
-                        action: "query_blocks_by_height_range",
-                        peer: zakura_trace_peer_label(peer),
-                        range_start: start.0.into(),
-                        range_count: (*count).into(),
-                    }
-                }
+                BlockSyncAction::QueryBlocksByHeightRange {
+                    peer, start, count, ..
+                } => ReceivedAction::BlockRange {
+                    action: "query_blocks_by_height_range",
+                    peer: zakura_trace_peer_label(peer),
+                    range_start: start.0.into(),
+                    range_count: (*count).into(),
+                },
                 BlockSyncAction::SubmitBlock { token, block, .. } => ReceivedAction::SubmitBlock {
                     action: "submit_block",
                     apply_token: *token,

--- a/docs/changelog/unreleased/870.md
+++ b/docs/changelog/unreleased/870.md
@@ -1,4 +1,5 @@
 ## Fixed
 
-- Bound block-sync range responses and serving capacity to the exact live request
+- Bound block-sync serving requests, range responses, and capacity to the exact
+  live session and request
   ([#870](https://github.com/zakura-core/zakura/pull/870)).

--- a/docs/changelog/unreleased/870.md
+++ b/docs/changelog/unreleased/870.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Bound block-sync range responses and serving capacity to the exact live request
+  ([#870](https://github.com/zakura-core/zakura/pull/870)).


### PR DESCRIPTION
## Motivation

GetBlocks completions were matched by peer and start height, while serving capacity was tracked separately. A delayed, duplicated, or mismatched completion could therefore send blocks for an obsolete request or release capacity owned by another live request. A second handoff gap let a GetBlocks request decoded by a superseded peer routine be accepted against the replacement session.

## Solution

Assign each accepted request a distinct `BlockRangeRequestId` and keep its start height, original wire count, accepted query count, start time, and slot in one serving ledger. The state driver echoes the ID, while response framing and slot release use only metadata owned by the matching live ledger entry.

Each `ServeGetBlocks` handoff also carries the originating routine generation. The reactor drops a handoff unless that generation still owns the peer, before emitting a query, frame, or misbehavior record. This changes public action and event shapes, so `zakura-network` moves to 8.0.0; it does not change the stream-6 wire format or version.

## Testing

Focused serving tests cover stale request handoffs, stale response ownership, duplicate slot release, count and byte clamps, and queue backpressure. The stale-handoff regression queues an older and current routine request in FIFO order and proves only the current range reaches state; removing the generation guard makes it fail. One completion deliberately echoes `u32::MAX` for a one-block request and proves the ledger-owned count controls the real wire response. A zero-result state response after a count of 10 is clamped to 2 proves that `RangeUnavailable` still echoes the original count of 10. The request-ownership properties in the test PR exercise longer generated histories.

### Reachability evidence

A disposable peer process used the real Iroh transport, native handshake, ordered stream 6, and canonical Status and GetBlocks messages against a separate Regtest `BlockSyncService`. The affected source snapshot was `38538d460`; the fixed snapshot containing the response-ownership change was `6d6ab411f`. Each peer was limited to one in-flight request.

The only timing control was a delay immediately before the production driver's real state read. No response or completion event was forged, injected, or altered. Session A requested genesis and disconnected, the same authenticated identity reconnected as B and requested it again, and request C arrived while B remained pending.

- Affected code sent the delayed result for A to B, released B's sole slot from A's stale completion, and admitted C. The peer observed three `Block`/`BlocksDone` responses, no `RangeUnavailable`, and three state queries.
- Fixed code discarded A's result and kept B's slot occupied, so C received `RangeUnavailable` without a state query. The peer observed one `Block`/`BlocksDone` response and one `RangeUnavailable`.
- Two recorded affected/fixed pairs and an independent repeat produced the same split.

Both response findings are **peer-triggered, controlled timing**. The forged-identity property is **internal robustness only** because peers cannot create driver completion events over the wire.

The stale-request regression separately uses two real framed peer routines. It delays only the older routine-to-reactor handoff until the replacement is live. Without the guard, state receives the older range through the replacement; with the guard, only the replacement range reaches state. This finding is **peer-triggered, controlled timing**.

## Changelog

Updated the numbered bug-fix fragment.

