### PR TITLE
test(network): add stateful GetBlocks serving model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocation-counter"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb9e990c0a33699f1984d85a6abead615ccc72dd8130bf3e15dcabe2ca149c9"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7963,6 +7969,7 @@ dependencies = [
 name = "zakura-network"
 version = "8.0.0"
 dependencies = [
+ "allocation-counter",
  "bitflags",
  "blake2b_simd",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ zcash_proofs = { version = "1.0.1", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
 abscissa_core = { version = "0.7", default-features = false }
+allocation-counter = "0.8.1"
 base64 = "0.22.1"
 bech32 = "0.11.0"
 bellman = { version = "1.0.1", package = "zakura-bellman" }

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -88,6 +88,7 @@ zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1" }
 
 [dev-dependencies]
+allocation-counter = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 criterion = { workspace = true }

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -63,13 +63,17 @@ const GB_WF_TEST_MANIFEST: &[(&str, &[&str])] = &[
         "GB-WF-11",
         &["gb_wf_11_incomplete_get_blocks_frame_expires_at_read_deadline"],
     ),
+    (
+        "GB-WF-12",
+        &["gb_wf_12_arbitrary_get_blocks_payloads_never_panic"],
+    ),
 ];
 
 #[test]
 fn gb_wf_contract_manifest_names_every_requirement() {
     const EXPECTED_IDS: &[&str] = &[
         "GB-WF-01", "GB-WF-02", "GB-WF-03", "GB-WF-04", "GB-WF-05", "GB-WF-06", "GB-WF-07",
-        "GB-WF-08", "GB-WF-09", "GB-WF-10", "GB-WF-11",
+        "GB-WF-08", "GB-WF-09", "GB-WF-10", "GB-WF-11", "GB-WF-12",
     ];
     assert_contract_test_manifest(EXPECTED_IDS, GB_WF_TEST_MANIFEST);
 }
@@ -350,7 +354,9 @@ proptest! {
     }
 
     #[test]
-    fn get_blocks_arbitrary_payloads_never_panic(payload in vec(any::<u8>(), 0..=256)) {
+    fn gb_wf_12_arbitrary_get_blocks_payloads_never_panic(
+        payload in vec(any::<u8>(), 0..=GET_BLOCKS_PAYLOAD_BYTES)
+    ) {
         if let Ok(message @ BlockSyncMessage::GetBlocks { .. }) = BlockSyncMessage::decode(&payload) {
             prop_assert_eq!(message.encode().expect("decoded GetBlocks re-encodes"), payload);
         }

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -32,6 +32,10 @@ const GET_BLOCKS_TYPE: u8 = 2;
 const GET_BLOCKS_PAYLOAD_BYTES: usize = 9;
 const GET_BLOCKS_MAX_HEIGHT: u32 = 0x7fff_ffff;
 const GET_BLOCKS_MAX_COUNT: u32 = 128;
+const BLOCK_TYPE: u8 = 3;
+const BLOCKS_DONE_TYPE: u8 = 4;
+const RANGE_UNAVAILABLE_TYPE: u8 = 5;
+const TERMINAL_PAYLOAD_BYTES: usize = 9;
 
 const GB_WF_TEST_MANIFEST: &[(&str, &[&str])] = &[
     ("GB-WF-01", &["gb_wf_01_payload_and_frame_type_are_two"]),
@@ -67,13 +71,42 @@ const GB_WF_TEST_MANIFEST: &[(&str, &[&str])] = &[
         "GB-WF-12",
         &["gb_wf_12_arbitrary_get_blocks_payloads_never_panic"],
     ),
+    (
+        "GB-WF-13",
+        &["gb_wf_13_response_discriminators_and_flags_match_wire_kinds"],
+    ),
+    (
+        "GB-WF-14",
+        &["gb_wf_14_block_payload_is_one_canonical_bounded_block"],
+    ),
+    (
+        "GB-WF-15",
+        &["gb_wf_15_block_payload_cap_precedes_allocation"],
+    ),
+    (
+        "GB-WF-16",
+        &["gb_wf_16_blocks_done_uses_canonical_nine_byte_layout"],
+    ),
+    (
+        "GB-WF-17",
+        &["gb_wf_17_blocks_done_payload_cap_precedes_allocation"],
+    ),
+    (
+        "GB-WF-18",
+        &["gb_wf_18_range_unavailable_uses_canonical_nine_byte_layout"],
+    ),
+    (
+        "GB-WF-19",
+        &["gb_wf_19_range_unavailable_payload_cap_precedes_allocation"],
+    ),
 ];
 
 #[test]
 fn gb_wf_contract_manifest_names_every_requirement() {
     const EXPECTED_IDS: &[&str] = &[
         "GB-WF-01", "GB-WF-02", "GB-WF-03", "GB-WF-04", "GB-WF-05", "GB-WF-06", "GB-WF-07",
-        "GB-WF-08", "GB-WF-09", "GB-WF-10", "GB-WF-11", "GB-WF-12",
+        "GB-WF-08", "GB-WF-09", "GB-WF-10", "GB-WF-11", "GB-WF-12", "GB-WF-13", "GB-WF-14",
+        "GB-WF-15", "GB-WF-16", "GB-WF-17", "GB-WF-18", "GB-WF-19",
     ];
     assert_contract_test_manifest(EXPECTED_IDS, GB_WF_TEST_MANIFEST);
 }
@@ -101,6 +134,15 @@ fn structured_payload(message_type: u8, start_height: u32, count: u32, trailing:
     payload.extend_from_slice(&start_height.to_le_bytes());
     payload.extend_from_slice(&count.to_le_bytes());
     payload.extend_from_slice(trailing);
+    payload
+}
+
+/// Build one fixed response payload from independent literal contract values.
+fn terminal_payload(message_type: u8, start_height: u32, count: u32) -> [u8; 9] {
+    let mut payload = [0; TERMINAL_PAYLOAD_BYTES];
+    payload[0] = message_type;
+    payload[1..5].copy_from_slice(&start_height.to_le_bytes());
+    payload[5..9].copy_from_slice(&count.to_le_bytes());
     payload
 }
 
@@ -384,6 +426,127 @@ proptest! {
             prop_assert_eq!(flags, 0);
             prop_assert_eq!(message_type, u16::from(message.message_type()));
         }
+    }
+}
+
+#[test]
+fn gb_wf_13_response_discriminators_and_flags_match_wire_kinds() {
+    let block = mainnet_blocks_1_to_3()[0].clone();
+    let messages = [
+        (BLOCK_TYPE, BlockSyncMessage::Block(block)),
+        (
+            BLOCKS_DONE_TYPE,
+            BlockSyncMessage::BlocksDone {
+                start_height: block::Height(1),
+                returned: 1,
+            },
+        ),
+        (
+            RANGE_UNAVAILABLE_TYPE,
+            BlockSyncMessage::RangeUnavailable {
+                start_height: block::Height(1),
+                count: 1,
+            },
+        ),
+    ];
+
+    for (expected_type, message) in messages {
+        let frame = message.encode_frame().expect("response frame encodes");
+        assert_eq!(frame.message_type, u16::from(expected_type));
+        assert_eq!(frame.payload.first(), Some(&expected_type));
+        assert_eq!(frame.flags, 0);
+        assert_eq!(
+            BlockSyncMessage::decode_frame(frame.clone()).expect("response frame decodes"),
+            message
+        );
+
+        for flags in [1, u16::MAX] {
+            let mut invalid = frame.clone();
+            invalid.flags = flags;
+            assert!(matches!(
+                BlockSyncMessage::decode_frame(invalid),
+                Err(BlockSyncWireError::UnsupportedFlags(rejected)) if rejected == flags
+            ));
+        }
+
+        let mut mismatched = frame;
+        mismatched.message_type = u16::from(expected_type.saturating_add(1));
+        assert!(BlockSyncMessage::decode_frame(mismatched).is_err());
+    }
+}
+
+#[test]
+fn gb_wf_14_block_payload_is_one_canonical_bounded_block() {
+    assert_eq!(block::MAX_BLOCK_BYTES, 2_000_000);
+    for block in mainnet_blocks_1_to_3() {
+        let message = BlockSyncMessage::Block(block);
+        let payload = message.encode().expect("fixture block encodes");
+        assert_eq!(payload.first(), Some(&BLOCK_TYPE));
+        assert!(payload.len() <= 1 + 2_000_000);
+        let decoded = BlockSyncMessage::decode(&payload).expect("fixture block decodes");
+        assert_eq!(decoded, message);
+        assert_eq!(decoded.encode().expect("block re-encodes"), payload);
+
+        let mut trailing = payload.clone();
+        trailing.push(0);
+        assert!(BlockSyncMessage::decode(&trailing).is_err());
+        assert!(BlockSyncMessage::decode(&payload[..payload.len() - 1]).is_err());
+    }
+}
+
+proptest! {
+    #[test]
+    fn gb_wf_16_blocks_done_uses_canonical_nine_byte_layout(
+        start_height in any::<u32>(),
+        returned in any::<u32>(),
+    ) {
+        let payload = terminal_payload(BLOCKS_DONE_TYPE, start_height, returned);
+        let valid = start_height <= GET_BLOCKS_MAX_HEIGHT
+            && (1..=GET_BLOCKS_MAX_COUNT).contains(&returned);
+        match BlockSyncMessage::decode(&payload) {
+            Ok(message @ BlockSyncMessage::BlocksDone {
+                start_height: decoded_start,
+                returned: decoded_returned,
+            }) => {
+                prop_assert!(valid);
+                prop_assert_eq!(decoded_start.0, start_height);
+                prop_assert_eq!(decoded_returned, returned);
+                prop_assert_eq!(message.encode().expect("terminal response re-encodes"), payload);
+            }
+            Ok(message) => prop_assert!(false, "decoded wrong message: {message:?}"),
+            Err(_) => prop_assert!(!valid),
+        }
+        let mut trailing = payload.to_vec();
+        trailing.push(0);
+        prop_assert!(BlockSyncMessage::decode(&trailing).is_err());
+        prop_assert!(BlockSyncMessage::decode(&payload[..payload.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn gb_wf_18_range_unavailable_uses_canonical_nine_byte_layout(
+        start_height in any::<u32>(),
+        count in any::<u32>(),
+    ) {
+        let payload = terminal_payload(RANGE_UNAVAILABLE_TYPE, start_height, count);
+        let valid = start_height <= GET_BLOCKS_MAX_HEIGHT
+            && (1..=GET_BLOCKS_MAX_COUNT).contains(&count);
+        match BlockSyncMessage::decode(&payload) {
+            Ok(message @ BlockSyncMessage::RangeUnavailable {
+                start_height: decoded_start,
+                count: decoded_count,
+            }) => {
+                prop_assert!(valid);
+                prop_assert_eq!(decoded_start.0, start_height);
+                prop_assert_eq!(decoded_count, count);
+                prop_assert_eq!(message.encode().expect("terminal response re-encodes"), payload);
+            }
+            Ok(message) => prop_assert!(false, "decoded wrong message: {message:?}"),
+            Err(_) => prop_assert!(!valid),
+        }
+        let mut trailing = payload.to_vec();
+        trailing.push(0);
+        prop_assert!(BlockSyncMessage::decode(&trailing).is_err());
+        prop_assert!(BlockSyncMessage::decode(&payload[..payload.len() - 1]).is_err());
     }
 }
 

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -499,6 +499,7 @@ proptest! {
     fn gb_wf_16_blocks_done_uses_canonical_nine_byte_layout(
         start_height in any::<u32>(),
         returned in any::<u32>(),
+        arbitrary_bytes in any::<[u8; TERMINAL_PAYLOAD_BYTES]>(),
     ) {
         let payload = terminal_payload(BLOCKS_DONE_TYPE, start_height, returned);
         let valid = start_height <= GET_BLOCKS_MAX_HEIGHT
@@ -519,13 +520,31 @@ proptest! {
         let mut trailing = payload.to_vec();
         trailing.push(0);
         prop_assert!(BlockSyncMessage::decode(&trailing).is_err());
-        prop_assert!(BlockSyncMessage::decode(&payload[..payload.len() - 1]).is_err());
+
+        for payload_len in 0..=TERMINAL_PAYLOAD_BYTES {
+            let mut bounded_payload = arbitrary_bytes[..payload_len].to_vec();
+            if let Some(discriminator) = bounded_payload.first_mut() {
+                *discriminator = BLOCKS_DONE_TYPE;
+            }
+            match BlockSyncMessage::decode(&bounded_payload) {
+                Ok(message @ BlockSyncMessage::BlocksDone { .. }) => {
+                    prop_assert_eq!(payload_len, TERMINAL_PAYLOAD_BYTES);
+                    prop_assert_eq!(
+                        message.encode().expect("accepted terminal response re-encodes"),
+                        bounded_payload,
+                    );
+                }
+                Ok(message) => prop_assert!(false, "decoded wrong message: {message:?}"),
+                Err(_) => {}
+            }
+        }
     }
 
     #[test]
     fn gb_wf_18_range_unavailable_uses_canonical_nine_byte_layout(
         start_height in any::<u32>(),
         count in any::<u32>(),
+        arbitrary_bytes in any::<[u8; TERMINAL_PAYLOAD_BYTES]>(),
     ) {
         let payload = terminal_payload(RANGE_UNAVAILABLE_TYPE, start_height, count);
         let valid = start_height <= GET_BLOCKS_MAX_HEIGHT
@@ -546,7 +565,24 @@ proptest! {
         let mut trailing = payload.to_vec();
         trailing.push(0);
         prop_assert!(BlockSyncMessage::decode(&trailing).is_err());
-        prop_assert!(BlockSyncMessage::decode(&payload[..payload.len() - 1]).is_err());
+
+        for payload_len in 0..=TERMINAL_PAYLOAD_BYTES {
+            let mut bounded_payload = arbitrary_bytes[..payload_len].to_vec();
+            if let Some(discriminator) = bounded_payload.first_mut() {
+                *discriminator = RANGE_UNAVAILABLE_TYPE;
+            }
+            match BlockSyncMessage::decode(&bounded_payload) {
+                Ok(message @ BlockSyncMessage::RangeUnavailable { .. }) => {
+                    prop_assert_eq!(payload_len, TERMINAL_PAYLOAD_BYTES);
+                    prop_assert_eq!(
+                        message.encode().expect("accepted terminal response re-encodes"),
+                        bounded_payload,
+                    );
+                }
+                Ok(message) => prop_assert!(false, "decoded wrong message: {message:?}"),
+                Err(_) => {}
+            }
+        }
     }
 }
 

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -59,13 +59,17 @@ const GB_WF_TEST_MANIFEST: &[(&str, &[&str])] = &[
         "GB-WF-10",
         &["gb_wf_10_fixed_fields_do_not_size_decode_allocation"],
     ),
+    (
+        "GB-WF-11",
+        &["gb_wf_11_incomplete_get_blocks_frame_expires_at_read_deadline"],
+    ),
 ];
 
 #[test]
 fn gb_wf_contract_manifest_names_every_requirement() {
     const EXPECTED_IDS: &[&str] = &[
         "GB-WF-01", "GB-WF-02", "GB-WF-03", "GB-WF-04", "GB-WF-05", "GB-WF-06", "GB-WF-07",
-        "GB-WF-08", "GB-WF-09", "GB-WF-10",
+        "GB-WF-08", "GB-WF-09", "GB-WF-10", "GB-WF-11",
     ];
     assert_contract_test_manifest(EXPECTED_IDS, GB_WF_TEST_MANIFEST);
 }

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -1,0 +1,586 @@
+//! Wire and boundary properties for the stream-6 `GetBlocks` message.
+
+use std::collections::HashMap;
+
+use allocation_counter::measure;
+use proptest::{collection::vec, prelude::*};
+use tokio::{
+    sync::watch,
+    time::{timeout, Duration},
+};
+use tokio_util::sync::CancellationToken;
+
+use super::super::super::{
+    config::MAX_BS_RESPONSE_BYTES, spawn_block_sync_reactor, wire::*, BlockSyncAction,
+    BlockSyncFrontiers, BlockSyncMisbehavior, BlockSyncService, BlockSyncStartup, BlockSyncStatus,
+    BlockSyncWireError, ZakuraBlockSyncConfig,
+};
+use super::super::{
+    connect_peer_with_status, mainnet_blocks_1_to_3, next_action, peer,
+    wait_for_outbound_range_unavailable,
+};
+use crate::zakura::{
+    framed_channel, testkit::SyntheticBlockSyncPeers, Frame, Peer, Service, ServicePeerDirection,
+};
+use zakura_chain::block;
+
+use super::runner::assert_contract_test_manifest;
+
+// These literals are the independent test contract. Keeping them separate from
+// production constants makes accidental wire drift observable.
+const GET_BLOCKS_TYPE: u8 = 2;
+const GET_BLOCKS_PAYLOAD_BYTES: usize = 9;
+const GET_BLOCKS_MAX_HEIGHT: u32 = 0x7fff_ffff;
+const GET_BLOCKS_MAX_COUNT: u32 = 128;
+
+const GB_WF_TEST_MANIFEST: &[(&str, &[&str])] = &[
+    ("GB-WF-01", &["gb_wf_01_payload_and_frame_type_are_two"]),
+    (
+        "GB-WF-02",
+        &["gb_wf_02_payload_uses_canonical_nine_byte_layout"],
+    ),
+    ("GB-WF-03", &["gb_wf_03_start_height_is_bounded"]),
+    ("GB-WF-04", &["gb_wf_04_count_is_between_one_and_128"]),
+    ("GB-WF-05", &["gb_wf_05_decoder_rejects_trailing_bytes"]),
+    ("GB-WF-06", &["gb_wf_06_frames_require_zero_flags"]),
+    (
+        "GB-WF-07",
+        &["gb_wf_07_accepted_messages_reencode_canonically"],
+    ),
+    (
+        "GB-WF-08",
+        &["gb_wf_08_maximum_start_and_count_are_safe_to_serve"],
+    ),
+    (
+        "GB-WF-09",
+        &["gb_wf_09_get_blocks_payload_cap_precedes_allocation"],
+    ),
+    (
+        "GB-WF-10",
+        &["gb_wf_10_fixed_fields_do_not_size_decode_allocation"],
+    ),
+];
+
+#[test]
+fn gb_wf_contract_manifest_names_every_requirement() {
+    const EXPECTED_IDS: &[&str] = &[
+        "GB-WF-01", "GB-WF-02", "GB-WF-03", "GB-WF-04", "GB-WF-05", "GB-WF-06", "GB-WF-07",
+        "GB-WF-08", "GB-WF-09", "GB-WF-10",
+    ];
+    assert_contract_test_manifest(EXPECTED_IDS, GB_WF_TEST_MANIFEST);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Contract-level fields used without calling the production encoder.
+struct GetBlocksFields {
+    start_height: u32,
+    count: u32,
+}
+
+/// Encode the canonical payload from independent literal contract values.
+fn contract_payload(fields: GetBlocksFields) -> [u8; GET_BLOCKS_PAYLOAD_BYTES] {
+    let mut payload = [0; GET_BLOCKS_PAYLOAD_BYTES];
+    payload[0] = GET_BLOCKS_TYPE;
+    payload[1..5].copy_from_slice(&fields.start_height.to_le_bytes());
+    payload[5..9].copy_from_slice(&fields.count.to_le_bytes());
+    payload
+}
+
+/// Build boundary payloads that may deliberately violate the contract.
+fn structured_payload(message_type: u8, start_height: u32, count: u32, trailing: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(GET_BLOCKS_PAYLOAD_BYTES + trailing.len());
+    payload.push(message_type);
+    payload.extend_from_slice(&start_height.to_le_bytes());
+    payload.extend_from_slice(&count.to_le_bytes());
+    payload.extend_from_slice(trailing);
+    payload
+}
+
+/// Decode only a production `GetBlocks` result into oracle-comparable fields.
+fn decoded_get_blocks(payload: &[u8]) -> Option<GetBlocksFields> {
+    match BlockSyncMessage::decode(payload) {
+        Ok(BlockSyncMessage::GetBlocks {
+            start_height,
+            count,
+        }) => Some(GetBlocksFields {
+            start_height: start_height.0,
+            count,
+        }),
+        Ok(_) | Err(_) => None,
+    }
+}
+
+/// Generate valid fields with extra weight on meaningful wire boundaries.
+fn legal_get_blocks() -> impl Strategy<Value = GetBlocksFields> {
+    (
+        prop_oneof![
+            3 => Just(0),
+            2 => Just(1),
+            2 => Just(GET_BLOCKS_MAX_HEIGHT),
+            8 => 0..=GET_BLOCKS_MAX_HEIGHT,
+        ],
+        prop_oneof![
+            3 => Just(1),
+            2 => Just(127),
+            3 => Just(GET_BLOCKS_MAX_COUNT),
+            8 => 1..=GET_BLOCKS_MAX_COUNT,
+        ],
+    )
+        .prop_map(|(start_height, count)| GetBlocksFields {
+            start_height,
+            count,
+        })
+}
+
+#[test]
+fn gb_wf_01_payload_and_frame_type_are_two() {
+    let fields = GetBlocksFields {
+        start_height: 1,
+        count: 1,
+    };
+    let message = BlockSyncMessage::GetBlocks {
+        start_height: block::Height(fields.start_height),
+        count: fields.count,
+    };
+    let payload = message.encode().expect("GetBlocks message encodes");
+    let frame = message.encode_frame().expect("GetBlocks frame encodes");
+
+    assert_eq!(GET_BLOCKS_TYPE, 2);
+    assert_eq!(MSG_BS_GET_BLOCKS, GET_BLOCKS_TYPE);
+    assert_eq!(payload[0], GET_BLOCKS_TYPE);
+    assert_eq!(frame.message_type, u16::from(GET_BLOCKS_TYPE));
+
+    for mismatched_type in 0..=u16::MAX {
+        if mismatched_type == u16::from(GET_BLOCKS_TYPE) {
+            continue;
+        }
+        assert!(
+            BlockSyncMessage::decode_frame(Frame {
+                message_type: mismatched_type,
+                flags: 0,
+                payload: payload.clone(),
+            })
+            .is_err(),
+            "GetBlocks payload decoded under mismatched outer type {mismatched_type}",
+        );
+    }
+}
+
+/// Anchor the independent layout to readable examples.
+#[test]
+fn gb_wf_02_payload_uses_canonical_nine_byte_layout() {
+    let vectors = [
+        (
+            GetBlocksFields {
+                start_height: 0,
+                count: 1,
+            },
+            [2, 0, 0, 0, 0, 1, 0, 0, 0],
+        ),
+        (
+            GetBlocksFields {
+                start_height: 0x0102_0304,
+                count: 128,
+            },
+            [2, 4, 3, 2, 1, 128, 0, 0, 0],
+        ),
+        (
+            GetBlocksFields {
+                start_height: GET_BLOCKS_MAX_HEIGHT,
+                count: GET_BLOCKS_MAX_COUNT,
+            },
+            [2, 255, 255, 255, 127, 128, 0, 0, 0],
+        ),
+    ];
+
+    for (fields, expected) in vectors {
+        assert_eq!(contract_payload(fields), expected);
+        assert_eq!(decoded_get_blocks(&expected), Some(fields));
+
+        let message = BlockSyncMessage::GetBlocks {
+            start_height: block::Height(fields.start_height),
+            count: fields.count,
+        };
+        assert_eq!(message.encode().expect("golden message encodes"), expected);
+        let frame = message.encode_frame().expect("golden frame encodes");
+        assert_eq!(frame.message_type, u16::from(GET_BLOCKS_TYPE));
+        assert_eq!(frame.flags, 0);
+        assert_eq!(frame.payload, expected);
+    }
+}
+
+#[test]
+fn gb_wf_03_start_height_is_bounded() {
+    assert_eq!(block::Height::MAX.0, GET_BLOCKS_MAX_HEIGHT);
+    assert_eq!(
+        decoded_get_blocks(&structured_payload(
+            GET_BLOCKS_TYPE,
+            GET_BLOCKS_MAX_HEIGHT,
+            1,
+            &[],
+        )),
+        Some(GetBlocksFields {
+            start_height: GET_BLOCKS_MAX_HEIGHT,
+            count: 1,
+        })
+    );
+    assert_eq!(
+        decoded_get_blocks(&structured_payload(
+            GET_BLOCKS_TYPE,
+            GET_BLOCKS_MAX_HEIGHT + 1,
+            1,
+            &[],
+        )),
+        None
+    );
+}
+
+#[test]
+fn gb_wf_04_count_is_between_one_and_128() {
+    assert_eq!(MAX_BS_BLOCKS_PER_REQUEST, GET_BLOCKS_MAX_COUNT);
+    for count in [1, GET_BLOCKS_MAX_COUNT] {
+        assert_eq!(
+            decoded_get_blocks(&structured_payload(GET_BLOCKS_TYPE, 1, count, &[])),
+            Some(GetBlocksFields {
+                start_height: 1,
+                count,
+            })
+        );
+    }
+    for count in [0, GET_BLOCKS_MAX_COUNT + 1] {
+        assert_eq!(
+            decoded_get_blocks(&structured_payload(GET_BLOCKS_TYPE, 1, count, &[])),
+            None
+        );
+    }
+}
+
+#[test]
+fn gb_wf_05_decoder_rejects_trailing_bytes() {
+    let payload = structured_payload(GET_BLOCKS_TYPE, 1, 1, &[0]);
+    assert_eq!(decoded_get_blocks(&payload), None);
+}
+
+#[test]
+fn gb_wf_06_frames_require_zero_flags() {
+    let payload = contract_payload(GetBlocksFields {
+        start_height: 1,
+        count: 1,
+    })
+    .to_vec();
+    let frame = Frame {
+        message_type: u16::from(GET_BLOCKS_TYPE),
+        flags: 0,
+        payload: payload.clone(),
+    };
+    assert!(matches!(
+        BlockSyncMessage::decode_frame(frame),
+        Ok(BlockSyncMessage::GetBlocks { .. })
+    ));
+    for flags in 1..=u16::MAX {
+        assert!(matches!(
+            BlockSyncMessage::decode_frame(Frame {
+                message_type: u16::from(GET_BLOCKS_TYPE),
+                flags,
+                payload: payload.clone(),
+            }),
+            Err(BlockSyncWireError::UnsupportedFlags(rejected)) if rejected == flags
+        ));
+    }
+}
+
+proptest! {
+    #[test]
+    fn gb_wf_07_accepted_messages_reencode_canonically(fields in legal_get_blocks()) {
+        let expected = contract_payload(fields);
+        let message = BlockSyncMessage::GetBlocks {
+            start_height: block::Height(fields.start_height),
+            count: fields.count,
+        };
+        let encoded = message.encode().expect("contract-legal GetBlocks encodes");
+
+        prop_assert_eq!(&encoded, &expected);
+        prop_assert_eq!(decoded_get_blocks(&encoded), Some(fields));
+        let decoded = BlockSyncMessage::decode(&encoded).expect("canonical GetBlocks decodes");
+        prop_assert_eq!(decoded.encode().expect("decoded GetBlocks re-encodes"), encoded);
+    }
+
+    #[test]
+    fn get_blocks_structured_payloads_match_contract(
+        message_type in prop_oneof![
+            8 => Just(GET_BLOCKS_TYPE),
+            2 => any::<u8>(),
+        ],
+        start_height in prop_oneof![
+            Just(0),
+            Just(GET_BLOCKS_MAX_HEIGHT),
+            Just(GET_BLOCKS_MAX_HEIGHT + 1),
+            Just(u32::MAX),
+            any::<u32>(),
+        ],
+        count in prop_oneof![
+            Just(0),
+            Just(1),
+            Just(GET_BLOCKS_MAX_COUNT),
+            Just(GET_BLOCKS_MAX_COUNT + 1),
+            Just(u32::MAX),
+            any::<u32>(),
+        ],
+        trailing in prop_oneof![
+            4 => Just(Vec::new()),
+            1 => vec(any::<u8>(), 1..=8),
+        ],
+    ) {
+        let payload = structured_payload(message_type, start_height, count, &trailing);
+        let expected = message_type == GET_BLOCKS_TYPE
+            && start_height <= GET_BLOCKS_MAX_HEIGHT
+            && (1..=GET_BLOCKS_MAX_COUNT).contains(&count)
+            && trailing.is_empty();
+        let decoded = decoded_get_blocks(&payload);
+
+        if expected {
+            prop_assert_eq!(decoded, Some(GetBlocksFields { start_height, count }));
+        } else {
+            prop_assert_eq!(decoded, None);
+        }
+    }
+
+    #[test]
+    fn get_blocks_arbitrary_payloads_never_panic(payload in vec(any::<u8>(), 0..=256)) {
+        if let Ok(message @ BlockSyncMessage::GetBlocks { .. }) = BlockSyncMessage::decode(&payload) {
+            prop_assert_eq!(message.encode().expect("decoded GetBlocks re-encodes"), payload);
+        }
+    }
+
+    #[test]
+    fn get_blocks_arbitrary_frames_match_envelope_contract(
+        message_type in any::<u16>(),
+        flags in any::<u16>(),
+        payload in vec(any::<u8>(), 0..=256),
+    ) {
+        let payload_type = payload.first().copied();
+        let envelope_matches = flags == 0
+            && payload_type.is_some_and(|payload_type| u16::from(payload_type) == message_type);
+        let decoded = BlockSyncMessage::decode_frame(Frame {
+            message_type,
+            flags,
+            payload,
+        });
+
+        if !envelope_matches {
+            prop_assert!(decoded.is_err());
+        }
+        if let Ok(message) = decoded {
+            prop_assert_eq!(flags, 0);
+            prop_assert_eq!(message_type, u16::from(message.message_type()));
+        }
+    }
+}
+
+/// Exercise the maximum legal height and count through the real peer routine
+/// and reactor, where height arithmetic and local serving limits are applied.
+#[tokio::test]
+async fn gb_wf_08_maximum_start_and_count_are_safe_to_serve() {
+    let tip = (block::Height::MAX, block::Hash([0xff; 32]));
+    let config = ZakuraBlockSyncConfig {
+        max_blocks_per_response: GET_BLOCKS_MAX_COUNT,
+        ..ZakuraBlockSyncConfig::default()
+    };
+    let (_tip_tx, tip_rx) = watch::channel(tip);
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: tip.0,
+            verified_block_tip: tip.0,
+            verified_block_hash: tip.1,
+        },
+        tip,
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let peers = SyntheticBlockSyncPeers::new(config, handle.clone(), 4);
+    let peer_id = peer(0xe8);
+    let mut synthetic_peer = peers
+        .connect_peer(peer_id.clone(), 1, ServicePeerDirection::Outbound)
+        .expect("the maximum-boundary peer connects");
+    handle
+        .barrier_for_test()
+        .await
+        .expect("peer admission reaches the reactor");
+    assert!(matches!(
+        synthetic_peer
+            .recv_timeout(Duration::from_secs(1))
+            .await
+            .expect("initial Status decodes"),
+        Some(BlockSyncMessage::Status(_))
+    ));
+    synthetic_peer
+        .try_send(BlockSyncMessage::Status(BlockSyncStatus {
+            servable_low: block::Height::MIN,
+            servable_high: tip.0,
+            tip_hash: tip.1,
+            max_blocks_per_response: GET_BLOCKS_MAX_COUNT,
+            max_inflight_requests: 1,
+            max_response_bytes: MAX_BS_RESPONSE_BYTES,
+        }))
+        .expect("peer Status queues");
+    synthetic_peer
+        .try_send(BlockSyncMessage::GetBlocks {
+            start_height: block::Height::MAX,
+            count: GET_BLOCKS_MAX_COUNT,
+        })
+        .expect("maximum GetBlocks request queues");
+    synthetic_peer
+        .barrier_for_test()
+        .await
+        .expect("peer routine handles the maximum request");
+    handle
+        .barrier_for_test()
+        .await
+        .expect("maximum request reaches the reactor");
+
+    let query = loop {
+        match next_action(&mut actions).await {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                peer, start, count, ..
+            } => break (peer, start, count),
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("maximum GetBlocks request produced {action:?}"),
+        }
+    };
+    assert_eq!(query, (peer_id, block::Height::MAX, 1));
+
+    reactor_task.abort();
+    let _ = reactor_task.await;
+}
+
+proptest! {
+    /// Prove the two peer-controlled scalar values never size an allocation
+    /// while the fixed payload is decoded.
+    #[test]
+    fn gb_wf_10_fixed_fields_do_not_size_decode_allocation(
+        start_height in any::<u32>(),
+        count in any::<u32>(),
+    ) {
+        prop_assert_eq!(
+            preallocation_payload_cap(u16::from(GET_BLOCKS_TYPE)),
+            Some(GET_BLOCKS_PAYLOAD_BYTES)
+        );
+        let fields = GetBlocksFields {
+            start_height,
+            count,
+        };
+        let payload = contract_payload(fields);
+        let mut decoded = None;
+        let allocations = measure(|| {
+            decoded = decoded_get_blocks(&payload);
+        });
+
+        prop_assert_eq!(
+            allocations.count_total,
+            0,
+            "fixed-field decode allocated for {:?}",
+            fields,
+        );
+        if start_height <= GET_BLOCKS_MAX_HEIGHT && (1..=GET_BLOCKS_MAX_COUNT).contains(&count) {
+            prop_assert_eq!(decoded, Some(fields));
+        } else {
+            prop_assert_eq!(decoded, None);
+        }
+    }
+}
+
+/// Keep malformed wire input distinct from a valid request outside our serving range.
+#[tokio::test]
+async fn malformed_get_blocks_disconnects_but_unavailable_range_does_not() {
+    let blocks = mainnet_blocks_1_to_3();
+    let tip = (block::Height(1), blocks[0].hash());
+    let config = ZakuraBlockSyncConfig::default();
+    let (_tip_tx, tip_rx) = watch::channel(tip);
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: tip.0,
+            verified_block_hash: tip.1,
+        },
+        tip,
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+
+    let malformed_peer = peer(0xe1);
+    let (malformed_inbound, malformed_recv) = framed_channel(4);
+    let (malformed_outbound, _malformed_sent) = framed_channel(4);
+    let malformed_streams = HashMap::from([(
+        ZAKURA_STREAM_BLOCK_SYNC,
+        (malformed_recv, malformed_outbound),
+    )]);
+    let malformed_connection = CancellationToken::new();
+    service.add_peer(Peer::new(
+        malformed_peer.clone(),
+        None,
+        ZAKURA_CAP_BLOCK_SYNC,
+        malformed_streams,
+        malformed_connection.clone(),
+    ));
+    malformed_inbound
+        .send(Frame {
+            message_type: u16::from(GET_BLOCKS_TYPE),
+            flags: 0,
+            payload: structured_payload(GET_BLOCKS_TYPE, 1, 1, &[0xa5]),
+        })
+        .await
+        .expect("malformed GetBlocks queues");
+
+    timeout(Duration::from_secs(1), malformed_connection.cancelled())
+        .await
+        .expect("malformed GetBlocks cancels its connection");
+    handle
+        .barrier_for_test()
+        .await
+        .expect("the malformed-message report reaches the reactor");
+
+    let reported = loop {
+        match next_action(&mut actions).await {
+            BlockSyncAction::Misbehavior { peer, reason } => break (peer, reason),
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => panic!("unexpected action before malformed-message report: {action:?}"),
+        }
+    };
+    assert_eq!(
+        reported,
+        (malformed_peer, BlockSyncMisbehavior::MalformedMessage)
+    );
+
+    let (_peer, valid_inbound, mut valid_outbound) = connect_peer_with_status(
+        &service,
+        &mut actions,
+        0xe2,
+        tip.0,
+        tip.1,
+        1,
+        MAX_BS_RESPONSE_BYTES,
+    )
+    .await;
+    let unavailable = BlockSyncMessage::GetBlocks {
+        start_height: block::Height(2),
+        count: 1,
+    }
+    .encode_frame()
+    .expect("valid unavailable request encodes");
+
+    for _ in 0..2 {
+        valid_inbound
+            .send(unavailable.clone())
+            .await
+            .expect("valid unavailable request queues");
+        assert_eq!(
+            wait_for_outbound_range_unavailable(&mut valid_outbound).await,
+            (block::Height(2), 1)
+        );
+    }
+
+    reactor_task.abort();
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs
@@ -585,7 +585,7 @@ async fn gb_wf_08_maximum_start_and_count_are_safe_to_serve() {
             .recv_timeout(Duration::from_secs(1))
             .await
             .expect("initial Status decodes"),
-        Some(BlockSyncMessage::Status(_))
+        crate::zakura::testkit::SyntheticBlockSyncReceive::Message(BlockSyncMessage::Status(_))
     ));
     synthetic_peer
         .try_send(BlockSyncMessage::Status(BlockSyncStatus {

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/lifecycle_regressions.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/lifecycle_regressions.rs
@@ -1,0 +1,447 @@
+//! Deterministic regressions for peer lifecycle ordering boundaries.
+
+use std::collections::HashMap;
+
+use tokio::{
+    runtime::Builder,
+    sync::mpsc,
+    sync::watch,
+    time::{timeout, Duration},
+};
+use tokio_util::sync::CancellationToken;
+
+use super::super::super::{
+    spawn_block_sync_reactor, BlockSyncAction, BlockSyncFrontiers, BlockSyncMessage,
+    BlockSyncPeerLifecycleEvent, BlockSyncService, BlockSyncStartup, BlockSyncStatus,
+    ZakuraBlockSyncConfig, MAX_BS_RESPONSE_BYTES,
+};
+use super::super::events::RoutineToReactor;
+use super::super::peer;
+use crate::zakura::{
+    framed_channel,
+    testkit::{SyntheticBlockSyncPeer, SyntheticBlockSyncPeers},
+    Peer, Service, ServicePeerDirection, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC,
+};
+use zakura_chain::block;
+
+/// Prove a peer routine cannot consume queued frames before reactor admission.
+///
+/// The test deliberately holds the lifecycle event while the real routine is
+/// running. Reading the queued `Status` before that event is released would
+/// recreate the admission race.
+#[test]
+fn gb_sm_16_peer_frames_wait_for_reactor_admission() {
+    Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .expect("the admission regression runtime builds")
+        .block_on(async {
+            let tip = (block::Height(3), block::Hash([3; 32]));
+            let mut reactor_config = ZakuraBlockSyncConfig::default();
+            reactor_config.peer_limits.max_outbound_peers = 0;
+            let mut service_config = reactor_config.clone();
+            service_config.peer_limits.max_outbound_peers = 1;
+            let (_tip_tx, tip_rx) = watch::channel(tip);
+            let startup = BlockSyncStartup::new(
+                BlockSyncFrontiers {
+                    finalized_height: tip.0,
+                    verified_block_tip: tip.0,
+                    verified_block_hash: tip.1,
+                },
+                tip,
+                tip_rx,
+                reactor_config,
+            );
+            let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+            let registry = handle
+                .routine_wiring
+                .as_ref()
+                .expect("the spawned reactor exposes routine wiring")
+                .registry
+                .clone();
+
+            let (lifecycle, mut held_lifecycle) = mpsc::unbounded_channel();
+            let mut intercepted_handle = handle.clone();
+            intercepted_handle.peer_lifecycle = lifecycle;
+            // Let the service entry point create the session, while the reactor's
+            // lower cap forces the later admission decision to reject it.
+            let service =
+                BlockSyncService::new_with_handle_for_test(service_config, intercepted_handle);
+            let peer_id = peer(0xa1);
+            let (inbound, inbound_recv) = framed_channel(4);
+            let (outbound, _outbound_recv) = framed_channel(4);
+            let streams = HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (inbound_recv, outbound))]);
+            service.add_peer(Peer::new_with_conn_id_and_direction(
+                1,
+                peer_id.clone(),
+                None,
+                ZAKURA_CAP_BLOCK_SYNC,
+                ServicePeerDirection::Outbound,
+                streams,
+                CancellationToken::new(),
+            ));
+            let connected_session = match timeout(Duration::from_secs(1), held_lifecycle.recv())
+                .await
+                .expect("peer admission is emitted within one second")
+                .expect("the held lifecycle receives peer admission")
+            {
+                BlockSyncPeerLifecycleEvent::Connected(session) => session,
+                event => panic!("expected peer admission, got {event:?}"),
+            };
+
+            inbound
+                .try_send(
+                    BlockSyncMessage::Status(BlockSyncStatus {
+                        servable_low: block::Height(1),
+                        servable_high: tip.0,
+                        tip_hash: tip.1,
+                        max_blocks_per_response: 4,
+                        max_inflight_requests: 2,
+                        max_response_bytes: MAX_BS_RESPONSE_BYTES,
+                    })
+                    .encode_frame()
+                    .expect("Status encodes"),
+                )
+                .expect("Status queues without yielding");
+            inbound
+                .try_send(
+                    BlockSyncMessage::GetBlocks {
+                        start_height: block::Height(1),
+                        count: 1,
+                    }
+                    .encode_frame()
+                    .expect("GetBlocks encodes"),
+                )
+                .expect("GetBlocks queues without yielding");
+            tokio::time::sleep(Duration::from_millis(1)).await;
+
+            let read_before_admission = registry.has_received_status(&peer_id);
+            assert!(
+                !read_before_admission,
+                "the peer routine read Status before the reactor resolved admission"
+            );
+
+            let rejected_cancel = connected_session.cancel_token();
+            handle
+                .peer_lifecycle
+                .send(BlockSyncPeerLifecycleEvent::Connected(connected_session))
+                .expect("the held admission reaches the real reactor");
+            timeout(Duration::from_secs(1), rejected_cancel.cancelled())
+                .await
+                .expect("the reactor rejects and cancels the session within one second");
+            handle
+                .barrier_for_test()
+                .await
+                .expect("the rejection settles through the reactor barrier");
+
+            assert_eq!(handle.peer_snapshot().outbound_peers, 0);
+            assert!(
+                !registry.has_received_status(&peer_id),
+                "a rejected peer's queued Status reached the registry"
+            );
+            while let Ok(action) = actions.try_recv() {
+                assert!(
+                    matches!(action, BlockSyncAction::QueryNeededBlocks { .. }),
+                    "a rejected peer produced {action:?}"
+                );
+            }
+
+            reactor_task.abort();
+            let _ = reactor_task.await;
+        });
+}
+
+/// Deliver a replacement admission before its predecessor and prove the older
+/// connect and disconnect cannot displace or disable the live reactor session.
+#[test]
+fn gb_sm_15_delayed_older_connect_cannot_replace_newer_session() {
+    Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .expect("the lifecycle regression runtime builds")
+        .block_on(async {
+            let tip = (block::Height(3), block::Hash([3; 32]));
+            let config = ZakuraBlockSyncConfig::default();
+            let (_tip_tx, tip_rx) = watch::channel(tip);
+            let startup = BlockSyncStartup::new(
+                BlockSyncFrontiers {
+                    finalized_height: tip.0,
+                    verified_block_tip: tip.0,
+                    verified_block_hash: tip.1,
+                },
+                tip,
+                tip_rx,
+                config.clone(),
+            );
+            let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+
+            let mut intercepted_handle = handle.clone();
+            let (intercepted_lifecycle, mut lifecycle_events) = mpsc::unbounded_channel();
+            intercepted_handle.peer_lifecycle = intercepted_lifecycle;
+            let peers = SyntheticBlockSyncPeers::new(config, intercepted_handle, 4);
+            let peer_id = peer(0xa2);
+            let older_peer = peers
+                .connect_peer(peer_id.clone(), 1, ServicePeerDirection::Outbound)
+                .expect("the older synthetic session connects");
+            let mut newer_peer = peers
+                .connect_peer(peer_id.clone(), 2, ServicePeerDirection::Outbound)
+                .expect("the replacement synthetic session connects");
+
+            let older_session = match timeout(Duration::from_secs(1), lifecycle_events.recv())
+                .await
+                .expect("the older PeerConnected event is emitted within one second")
+                .expect("the older PeerConnected event is intercepted")
+            {
+                BlockSyncPeerLifecycleEvent::Connected(session) => session,
+                event => panic!("expected older PeerConnected, got {event:?}"),
+            };
+            let newer_session = match timeout(Duration::from_secs(1), lifecycle_events.recv())
+                .await
+                .expect("the newer PeerConnected event is emitted within one second")
+                .expect("the newer PeerConnected event is intercepted")
+            {
+                BlockSyncPeerLifecycleEvent::Connected(session) => session,
+                event => panic!("expected newer PeerConnected, got {event:?}"),
+            };
+            let older_session_id = older_session.session_id();
+            assert!(newer_session.session_id() > older_session_id);
+
+            handle
+                .peer_lifecycle
+                .send(BlockSyncPeerLifecycleEvent::Connected(newer_session))
+                .expect("the newer admission queues first");
+            handle
+                .peer_lifecycle
+                .send(BlockSyncPeerLifecycleEvent::Connected(older_session))
+                .expect("the delayed older admission queues second");
+            handle
+                .barrier_for_test()
+                .await
+                .expect("both admissions settle through the reactor barrier");
+            handle
+                .peer_lifecycle
+                .send(BlockSyncPeerLifecycleEvent::Disconnected {
+                    peer: peer_id.clone(),
+                    session_id: older_session_id,
+                })
+                .expect("the older disconnect queues");
+            handle
+                .barrier_for_test()
+                .await
+                .expect("the stale disconnect settles through the reactor barrier");
+
+            assert!(older_peer.cancel_token().is_cancelled());
+            assert!(!newer_peer.cancel_token().is_cancelled());
+            assert_eq!(
+                handle.peer_snapshot().outbound_peers,
+                1,
+                "a delayed older PeerConnected event replaced the newer reactor session",
+            );
+
+            expect_initial_status(&mut newer_peer).await;
+            newer_peer
+                .try_send(BlockSyncMessage::Status(serving_status(tip)))
+                .expect("the newer Status queues without yielding");
+            newer_peer
+                .try_send(BlockSyncMessage::GetBlocks {
+                    start_height: block::Height(1),
+                    count: 1,
+                })
+                .expect("the newer GetBlocks queues without yielding");
+            match next_serving_action(&mut actions).await {
+                BlockSyncAction::QueryBlocksByHeightRange {
+                    peer, start, count, ..
+                } => {
+                    assert_eq!(peer, peer_id);
+                    assert_eq!(start, block::Height(1));
+                    assert_eq!(count, 1);
+                }
+                action => panic!("the live replacement produced {action:?}"),
+            }
+
+            reactor_task.abort();
+            let _ = reactor_task.await;
+        });
+}
+
+/// Delay a real request from one session until its replacement is live and prove
+/// the reactor does not apply it to that replacement.
+#[test]
+fn gb_sm_17_superseded_routine_request_cannot_reach_replacement_session() {
+    Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .expect("the serving ownership regression runtime builds")
+        .block_on(async {
+            let tip = (block::Height(3), block::Hash([3; 32]));
+            let config = ZakuraBlockSyncConfig::default();
+            let (_tip_tx, tip_rx) = watch::channel(tip);
+            let startup = BlockSyncStartup::new(
+                BlockSyncFrontiers {
+                    finalized_height: tip.0,
+                    verified_block_tip: tip.0,
+                    verified_block_hash: tip.1,
+                },
+                tip,
+                tip_rx,
+                config.clone(),
+            );
+            let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+            let live_routine_sender = handle
+                .routine_wiring
+                .as_ref()
+                .expect("the spawned reactor exposes routine wiring")
+                .routine_to_reactor
+                .clone();
+
+            // Keep lifecycle events on the real reactor, but intercept routine
+            // messages so the old request can be delivered after replacement.
+            let mut intercepted_handle = handle.clone();
+            let (intercepted_sender, mut intercepted_messages) = mpsc::channel(16);
+            intercepted_handle
+                .routine_wiring
+                .as_mut()
+                .expect("the intercepted handle exposes routine wiring")
+                .routine_to_reactor = intercepted_sender;
+            let peers = SyntheticBlockSyncPeers::new(config, intercepted_handle, 8);
+            let peer_id = peer(0xa3);
+
+            let mut older_peer = peers
+                .connect_peer(peer_id.clone(), 1, ServicePeerDirection::Outbound)
+                .expect("the older synthetic session connects");
+            expect_initial_status(&mut older_peer).await;
+            older_peer
+                .try_send(BlockSyncMessage::Status(serving_status(tip)))
+                .expect("the older Status queues without yielding");
+            older_peer
+                .try_send(BlockSyncMessage::GetBlocks {
+                    start_height: block::Height(1),
+                    count: 1,
+                })
+                .expect("the older GetBlocks queues without yielding");
+            let older_request = next_serving_request(&mut intercepted_messages).await;
+
+            let mut replacement_peer = peers
+                .connect_peer(peer_id.clone(), 2, ServicePeerDirection::Outbound)
+                .expect("the replacement synthetic session connects");
+            expect_initial_status(&mut replacement_peer).await;
+            assert!(older_peer.cancel_token().is_cancelled());
+            replacement_peer
+                .try_send(BlockSyncMessage::Status(serving_status(tip)))
+                .expect("the replacement Status queues without yielding");
+            replacement_peer
+                .try_send(BlockSyncMessage::GetBlocks {
+                    start_height: block::Height(2),
+                    count: 1,
+                })
+                .expect("the replacement GetBlocks queues without yielding");
+            let replacement_request = next_serving_request(&mut intercepted_messages).await;
+
+            let older_generation = serving_request_generation(&older_request);
+            let replacement_generation = serving_request_generation(&replacement_request);
+            assert!(replacement_generation > older_generation);
+
+            live_routine_sender
+                .send(older_request)
+                .await
+                .expect("the delayed older request reaches the reactor");
+            live_routine_sender
+                .send(replacement_request)
+                .await
+                .expect("the current request reaches the reactor");
+
+            let action = next_serving_action(&mut actions).await;
+            match action {
+                BlockSyncAction::QueryBlocksByHeightRange {
+                    peer, start, count, ..
+                } => {
+                    assert_eq!(peer, peer_id);
+                    assert_eq!(start, block::Height(2));
+                    assert_eq!(count, 1);
+                }
+                action => panic!("the delayed older request produced {action:?}"),
+            }
+            assert!(
+                actions.try_recv().is_err(),
+                "the superseded request must not produce another action"
+            );
+            assert!(
+                replacement_peer
+                    .recv_timeout(Duration::from_millis(1))
+                    .await
+                    .expect("the replacement outbound remains decodable")
+                    .is_none(),
+                "the superseded request must not send a frame to the replacement"
+            );
+
+            reactor_task.abort();
+            let _ = reactor_task.await;
+        });
+}
+
+/// Wait for the reactor's admission Status on one synthetic session.
+async fn expect_initial_status(peer: &mut SyntheticBlockSyncPeer) {
+    assert!(matches!(
+        peer.recv_timeout(Duration::from_secs(1))
+            .await
+            .expect("the initial outbound frame decodes"),
+        Some(BlockSyncMessage::Status(_)),
+    ));
+}
+
+/// Return the next action produced by inbound serving, skipping startup work queries.
+async fn next_serving_action(actions: &mut mpsc::Receiver<BlockSyncAction>) -> BlockSyncAction {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match actions.recv().await {
+                Some(BlockSyncAction::QueryNeededBlocks { .. }) => {}
+                Some(action) => return action,
+                None => panic!("the block-sync action channel stays open"),
+            }
+        }
+    })
+    .await
+    .expect("the serving request produces an action within one second")
+}
+
+/// Return the next serving request decoded by a real peer routine.
+async fn next_serving_request(messages: &mut mpsc::Receiver<RoutineToReactor>) -> RoutineToReactor {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let message = messages
+                .recv()
+                .await
+                .expect("the intercepted routine channel stays open");
+            if matches!(message, RoutineToReactor::ServeGetBlocks { .. }) {
+                return message;
+            }
+        }
+    })
+    .await
+    .expect("the peer routine decodes GetBlocks within one second")
+}
+
+/// Extract the session generation attached by the peer routine.
+fn serving_request_generation(message: &RoutineToReactor) -> u64 {
+    match message {
+        RoutineToReactor::ServeGetBlocks {
+            session_generation, ..
+        } => *session_generation,
+        message => panic!("expected ServeGetBlocks, got {message:?}"),
+    }
+}
+
+/// Status used by both sides of the replacement regression.
+fn serving_status(tip: (block::Height, block::Hash)) -> BlockSyncStatus {
+    BlockSyncStatus {
+        servable_low: block::Height::MIN,
+        servable_high: tip.0,
+        tip_hash: tip.1,
+        max_blocks_per_response: 4,
+        max_inflight_requests: 2,
+        max_response_bytes: MAX_BS_RESPONSE_BYTES,
+    }
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/lifecycle_regressions.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/lifecycle_regressions.rs
@@ -19,7 +19,7 @@ use super::super::events::RoutineToReactor;
 use super::super::peer;
 use crate::zakura::{
     framed_channel,
-    testkit::{SyntheticBlockSyncPeer, SyntheticBlockSyncPeers},
+    testkit::{SyntheticBlockSyncPeer, SyntheticBlockSyncPeers, SyntheticBlockSyncReceive},
     Peer, Service, ServicePeerDirection, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC,
 };
 use zakura_chain::block;
@@ -369,13 +369,41 @@ fn gb_sm_17_superseded_routine_request_cannot_reach_replacement_session() {
                 "the superseded request must not produce another action"
             );
             assert!(
-                replacement_peer
-                    .recv_timeout(Duration::from_millis(1))
-                    .await
-                    .expect("the replacement outbound remains decodable")
-                    .is_none(),
+                matches!(
+                    replacement_peer
+                        .recv_timeout(Duration::from_millis(1))
+                        .await
+                        .expect("the replacement outbound remains decodable"),
+                    SyntheticBlockSyncReceive::TimedOut,
+                ),
                 "the superseded request must not send a frame to the replacement"
             );
+            assert!(
+                !replacement_peer.cancel_token().is_cancelled(),
+                "the superseded request must not cancel the replacement"
+            );
+
+            replacement_peer
+                .try_send(BlockSyncMessage::GetBlocks {
+                    start_height: block::Height(4),
+                    count: 1,
+                })
+                .expect("the replacement remains able to send GetBlocks");
+            let later_request = next_serving_request(&mut intercepted_messages).await;
+            live_routine_sender
+                .send(later_request)
+                .await
+                .expect("the replacement's later request reaches the reactor");
+            assert!(matches!(
+                replacement_peer
+                    .recv_timeout(Duration::from_secs(1))
+                    .await
+                    .expect("the replacement receives a later response"),
+                SyntheticBlockSyncReceive::Message(BlockSyncMessage::RangeUnavailable {
+                    start_height: block::Height(4),
+                    count: 1,
+                }),
+            ));
 
             reactor_task.abort();
             let _ = reactor_task.await;
@@ -388,7 +416,7 @@ async fn expect_initial_status(peer: &mut SyntheticBlockSyncPeer) {
         peer.recv_timeout(Duration::from_secs(1))
             .await
             .expect("the initial outbound frame decodes"),
-        Some(BlockSyncMessage::Status(_)),
+        SyntheticBlockSyncReceive::Message(BlockSyncMessage::Status(_)),
     ));
 }
 

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/mod.rs
@@ -1,0 +1,11 @@
+//! Executable message contracts for native block sync.
+//!
+//! Each contract combines an independent wire oracle with the real production
+//! boundary needed for its behavioral claims. The repository-wide catalog and
+//! authoring standard live in `docs/specs/native-p2p/README.md`.
+//! `GetBlocks` is the first completed contract.
+
+mod get_blocks;
+mod lifecycle_regressions;
+mod runner;
+mod serving_model;

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/runner.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/runner.rs
@@ -1,0 +1,181 @@
+//! Shared configuration for reproducible generated contract tests.
+
+use std::env;
+
+use proptest::test_runner::{Config as ProptestConfig, RngSeed, TestRunner};
+use rand::{rngs::OsRng, RngCore};
+
+/// Prove a contract manifest contains every required ID and points only to
+/// registered tests whose names begin with that ID.
+pub(super) fn assert_contract_test_manifest(expected_ids: &[&str], manifest: &[(&str, &[&str])]) {
+    let actual: std::collections::BTreeSet<_> = manifest.iter().map(|(id, _)| *id).collect();
+    let expected: std::collections::BTreeSet<_> = expected_ids.iter().copied().collect();
+    assert_eq!(
+        actual.len(),
+        manifest.len(),
+        "contract requirement IDs must be unique"
+    );
+    assert_eq!(
+        actual, expected,
+        "missing or duplicate contract requirement IDs"
+    );
+
+    let test_binary = std::env::current_exe().expect("the test binary path is available");
+    let listed = std::process::Command::new(test_binary)
+        .args(["--list", "--format", "terse", "--color", "never"])
+        .output()
+        .expect("the test binary can list its registered tests");
+    assert!(
+        listed.status.success(),
+        "the test inventory command succeeds"
+    );
+    let listed = String::from_utf8(listed.stdout).expect("test inventory names are UTF-8");
+    let registered: std::collections::BTreeSet<_> = listed
+        .lines()
+        .filter_map(|line| line.strip_suffix(": test"))
+        .filter_map(|path| path.rsplit("::").next())
+        .collect();
+    for (id, test_names) in manifest {
+        assert!(!test_names.is_empty(), "{id} must name at least one test");
+        let id_prefix = format!("{}_", id.to_ascii_lowercase().replace('-', "_"));
+        for test_name in *test_names {
+            assert!(
+                test_name.starts_with(&id_prefix),
+                "{id} names test {test_name} without its ID prefix"
+            );
+            assert!(
+                registered.contains(test_name),
+                "{id} names unregistered test {test_name}"
+            );
+        }
+    }
+}
+
+/// Effective case count and seed for one generated test lane.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) struct GeneratedTestConfig {
+    cases: u32,
+    seed: u64,
+}
+
+impl GeneratedTestConfig {
+    /// Read strict numeric overrides, choosing and retaining a seed when none is
+    /// supplied so every generated run prints a same-generator rerun command.
+    pub(super) fn from_env(
+        cases_variable: &str,
+        seed_variable: &str,
+        default_cases: u32,
+    ) -> Result<Self, String> {
+        let cases = read_optional(cases_variable)?;
+        let seed = read_optional(seed_variable)?;
+        Self::from_values(
+            cases.as_deref(),
+            seed.as_deref(),
+            cases_variable,
+            seed_variable,
+            default_cases,
+        )
+    }
+
+    /// Return the effective generated case count.
+    pub(super) fn cases(self) -> u32 {
+        self.cases
+    }
+
+    /// Build a runner pinned to the effective seed.
+    pub(super) fn runner(self, source_file: &'static str) -> TestRunner {
+        let mut config = ProptestConfig::with_source_file(source_file);
+        config.cases = self.cases;
+        config.rng_seed = RngSeed::Fixed(self.seed);
+        TestRunner::new(config)
+    }
+
+    /// Print the inputs needed to rerun an unchanged generator.
+    #[allow(clippy::print_stdout)]
+    pub(super) fn announce(self, lane: &str, cases_variable: &str, seed_variable: &str) {
+        println!(
+            "{lane}: cases={}, seed={}; replay with {cases_variable}={} {seed_variable}={}",
+            self.cases, self.seed, self.cases, self.seed,
+        );
+    }
+
+    fn from_values(
+        cases: Option<&str>,
+        seed: Option<&str>,
+        cases_variable: &str,
+        seed_variable: &str,
+        default_cases: u32,
+    ) -> Result<Self, String> {
+        let cases = match cases {
+            Some(value) => parse_numeric::<u32>(cases_variable, value)?,
+            None => default_cases,
+        };
+        if cases == 0 {
+            return Err(format!("{cases_variable} must be greater than zero"));
+        }
+        let seed = match seed {
+            Some(value) => parse_numeric::<u64>(seed_variable, value)?,
+            None => OsRng.next_u64(),
+        };
+        Ok(Self { cases, seed })
+    }
+}
+
+fn read_optional(variable: &str) -> Result<Option<String>, String> {
+    match env::var(variable) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(format!("{variable} is not valid UTF-8")),
+    }
+}
+
+fn parse_numeric<T>(variable: &str, value: &str) -> Result<T, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|error| format!("invalid {variable} value {value:?}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GeneratedTestConfig;
+
+    #[test]
+    fn generated_test_config_uses_explicit_values() {
+        let config = GeneratedTestConfig::from_values(Some("128"), Some("42"), "CASES", "SEED", 64)
+            .expect("valid overrides parse");
+        assert_eq!(
+            config,
+            GeneratedTestConfig {
+                cases: 128,
+                seed: 42
+            }
+        );
+    }
+
+    #[test]
+    fn generated_test_config_rejects_invalid_or_empty_case_budgets() {
+        for cases in ["", "0", "abc", "-1"] {
+            assert!(
+                GeneratedTestConfig::from_values(Some(cases), Some("42"), "CASES", "SEED", 64,)
+                    .is_err(),
+                "case override {cases:?} should be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn generated_test_config_rejects_invalid_seeds() {
+        assert!(GeneratedTestConfig::from_values(
+            Some("64"),
+            Some("not-a-seed"),
+            "CASES",
+            "SEED",
+            64,
+        )
+        .is_err());
+    }
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
@@ -1,0 +1,716 @@
+//! Adapter between abstract serving histories and the real block-sync stack.
+//!
+//! Operations enter through `BlockSyncService`, framed peer streams, or the
+//! public driver handle. Observations come from real reactor actions, outbound
+//! frames, peer snapshots, and cancellation tokens. Only expected behavior is
+//! computed by the reference model.
+
+use std::{collections::BTreeMap, fmt::Display, future::Future, sync::Arc};
+
+use tokio::{
+    runtime::Builder,
+    sync::{mpsc, watch},
+    time::{timeout, Duration},
+};
+use zakura_chain::block;
+
+use super::super::super::super::{
+    spawn_block_sync_reactor, BlockRangeRequestId, BlockSyncAction, BlockSyncEvent,
+    BlockSyncFrontiers, BlockSyncHandle, BlockSyncMessage, BlockSyncStartup, BlockSyncStatus,
+    ZakuraBlockSyncConfig,
+};
+use super::{
+    model::{ReadyBlock, ReferenceModel},
+    CompletionKind, ExpectedAction, ExpectedObservation, PendingQuery, ServingAction, ServingCase,
+    ServingCoverage, ServingFrame, ServingObservation, ServingOp, ServingStep, SessionKey,
+    StatusValidity,
+};
+use crate::zakura::{
+    testkit::{
+        SyntheticBlockCorpus, SyntheticBlockShape, SyntheticBlockSyncPeer, SyntheticBlockSyncPeers,
+    },
+    ServicePeerDirection, ServicePeerLimits, ServicePeerSnapshot, ZakuraPeerId,
+};
+
+const PEER_QUEUE_DEPTH: usize = 1_024;
+const CANCEL_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+const SETTLEMENT_BARRIER_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Run one materialized case in an isolated paused runtime.
+///
+/// A fresh runtime also prevents tasks or virtual time from leaking between
+/// proptest cases and makes repeated execution of the same case deterministic.
+pub(super) fn replay_serving_case(case: &ServingCase) -> Result<ServingCoverage, String> {
+    Builder::new_current_thread()
+        .enable_all()
+        .start_paused(true)
+        .build()
+        .map_err(|error| format!("failed to build serving-model runtime: {error}"))?
+        .block_on(replay_serving_case_inner(case))
+}
+
+/// Assemble the real service, peer harness, corpus, and reference model, then
+/// compare their behavior until every step has settled.
+async fn replay_serving_case_inner(case: &ServingCase) -> Result<ServingCoverage, String> {
+    let corpus =
+        SyntheticBlockCorpus::generate(case.tip, case.corpus_seed, SyntheticBlockShape::default());
+    let first_size = corpus
+        .size_at(block::Height(1))
+        .and_then(|size| u32::try_from(size).ok())
+        .ok_or_else(|| "synthetic block 1 size must fit u32".to_string())?;
+    let second_size = corpus
+        .size_at(block::Height(2))
+        .and_then(|size| u32::try_from(size).ok())
+        .ok_or_else(|| "synthetic block 2 size must fit u32".to_string())?;
+    let response_byte_cap = case.byte_cap.resolve(first_size, second_size);
+
+    let (max_inbound_peers, max_outbound_peers) = match case.direction {
+        ServicePeerDirection::Inbound => (case.max_peers, 0),
+        ServicePeerDirection::Outbound => (0, case.max_peers),
+    };
+    let peer_limits = ServicePeerLimits {
+        max_inbound_peers,
+        max_outbound_peers,
+        ..ServicePeerLimits::default()
+    };
+    let config = ZakuraBlockSyncConfig {
+        max_blocks_per_response: case.max_blocks,
+        max_inflight_requests: case.max_inflight,
+        max_response_bytes: response_byte_cap,
+        peer_limits,
+        ..ZakuraBlockSyncConfig::default()
+    };
+    let tip = (corpus.target_height(), corpus.tip_hash());
+    let (_tip_tx, tip_rx) = watch::channel(tip);
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: tip.0,
+            verified_block_tip: tip.0,
+            verified_block_hash: tip.1,
+        },
+        tip,
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, reactor_task) = spawn_block_sync_reactor(startup);
+    let peers = SyntheticBlockSyncPeers::new(config, handle.clone(), PEER_QUEUE_DEPTH);
+    let mut sessions = BTreeMap::new();
+    let mut model = ReferenceModel::new(
+        case.max_inflight,
+        case.max_blocks,
+        response_byte_cap,
+        case.direction,
+        case.max_peers,
+        tip.0,
+    );
+
+    settle_runtime(&handle, &sessions).await?;
+    let startup_observation = observe(&mut sessions, &mut actions, handle.peer_snapshot()).await?;
+    if !startup_observation.actions.is_empty() || !startup_observation.frames.is_empty() {
+        reactor_task.abort();
+        return Err(format!(
+            "unexpected externally visible startup output: {startup_observation:?}"
+        ));
+    }
+
+    let steps = case.steps_with_prelude();
+    let result = replay_steps(
+        case,
+        &steps,
+        &corpus,
+        &peers,
+        &handle,
+        &mut actions,
+        &mut sessions,
+        &mut model,
+    )
+    .await;
+    if reactor_task.is_finished() && result.is_ok() {
+        let outcome = reactor_task.await;
+        return Err(format!(
+            "block-sync reactor stopped during replay: {outcome:?}"
+        ));
+    }
+    reactor_task.abort();
+    let _ = reactor_task.await;
+    result.map(|()| model.into_coverage())
+}
+
+#[allow(clippy::too_many_arguments)]
+/// Replay each step with indexed failure context so a shrunk history is useful
+/// without additional instrumentation.
+async fn replay_steps(
+    case: &ServingCase,
+    steps: &[ServingStep],
+    corpus: &SyntheticBlockCorpus,
+    peers: &SyntheticBlockSyncPeers,
+    handle: &BlockSyncHandle,
+    actions: &mut mpsc::Receiver<BlockSyncAction>,
+    sessions: &mut BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    model: &mut ReferenceModel,
+) -> Result<(), String> {
+    for (step_index, step) in steps.iter().enumerate() {
+        if !(1..=3).contains(&step.operations.len()) {
+            return Err(format!(
+                "serving step {step_index} has {} operations; expected 1..=3",
+                step.operations.len()
+            ));
+        }
+        model.record_step(step.operations.len());
+        let result = replay_step(step, corpus, peers, handle, actions, sessions, model).await;
+        if let Err(error) = result {
+            return Err(format!(
+                "GetBlocks serving-model failure at step {step_index}\ncase: {case:#?}\nsteps: {steps:#?}\nerror: {error}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+/// Issue all operations in one step without yielding, then compare the single
+/// settled observation with the combined model prediction.
+async fn replay_step(
+    step: &ServingStep,
+    corpus: &SyntheticBlockCorpus,
+    peers: &SyntheticBlockSyncPeers,
+    handle: &BlockSyncHandle,
+    actions: &mut mpsc::Receiver<BlockSyncAction>,
+    sessions: &mut BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    model: &mut ReferenceModel,
+) -> Result<(), String> {
+    let mut expected = ExpectedObservation::default();
+    let mut pending_queries = Vec::new();
+    let mut connected_sessions = Vec::new();
+
+    for operation in &step.operations {
+        let issued = issue_operation(operation, corpus, peers, handle, sessions, model)?;
+        expected.append(issued.expected);
+        pending_queries.extend(issued.pending_query);
+        connected_sessions.extend(issued.connected_session);
+    }
+
+    expected.required_status_sessions.extend(
+        connected_sessions
+            .into_iter()
+            .filter(|session| model.session_is_current_and_admitted(*session)),
+    );
+
+    verify_observation(model, sessions, actions, handle, expected, pending_queries).await
+}
+
+/// Model output and deferred bindings produced while issuing one operation.
+struct IssuedOperation {
+    expected: ExpectedObservation,
+    pending_query: Option<PendingQuery>,
+    connected_session: Option<SessionKey>,
+}
+
+/// Apply one total model operation at the corresponding real system boundary.
+///
+/// This function deliberately does not wait. Scheduling overlap is created by
+/// issuing every operation in the step before [`verify_observation`] settles.
+fn issue_operation(
+    operation: &ServingOp,
+    corpus: &SyntheticBlockCorpus,
+    peers: &SyntheticBlockSyncPeers,
+    handle: &BlockSyncHandle,
+    sessions: &mut BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    model: &mut ReferenceModel,
+) -> Result<IssuedOperation, String> {
+    let (expected, pending_query, connected_session) = match *operation {
+        ServingOp::Connect { peer } => {
+            let (session, _admitted) = model.connect(peer);
+            let synthetic_peer = peers
+                .connect_peer(
+                    logical_peer(session.peer),
+                    session.conn_id,
+                    model.direction(),
+                )
+                .map_err(|error| format!("connect failed: {error}"))?;
+            sessions.insert(session, synthetic_peer);
+            (ExpectedObservation::default(), None, Some(session))
+        }
+        ServingOp::Disconnect { peer, which } => {
+            if let Some(conn_id) = model.disconnect(peer, which) {
+                peers.remove_peer(&logical_peer(peer), conn_id);
+            }
+            (ExpectedObservation::default(), None, None)
+        }
+        ServingOp::Cancel { peer } => {
+            if let Some(session) = model.cancel(peer) {
+                session_peer(sessions, session)?.cancel();
+            }
+            (ExpectedObservation::default(), None, None)
+        }
+        ServingOp::Status { peer, validity } => {
+            let (session, expected) = model.status(peer, validity);
+            if let Some(session) = session {
+                let status = status_for(validity, corpus);
+                session_peer(sessions, session)?
+                    .try_send(BlockSyncMessage::Status(status))
+                    .map_err(|error| format!("Status send failed: {error}"))?;
+            }
+            (expected, None, None)
+        }
+        ServingOp::GetBlocks { peer, start, count } => {
+            let (session, expected, pending) = model.get_blocks(peer, start, count);
+            if let Some(session) = session {
+                session_peer(sessions, session)?
+                    .try_send(BlockSyncMessage::GetBlocks {
+                        start_height: block::Height(start),
+                        count,
+                    })
+                    .map_err(|error| format!("GetBlocks send failed: {error}"))?;
+            }
+            (expected, pending, None)
+        }
+        ServingOp::Complete { query, kind } => {
+            let Some(target) = model.completion_target(query) else {
+                return Ok(IssuedOperation {
+                    expected: ExpectedObservation::default(),
+                    pending_query: None,
+                    connected_session: None,
+                });
+            };
+            let blocks = ready_blocks(corpus, target.start, target.requested, kind);
+            let expected_blocks: Vec<_> = blocks
+                .iter()
+                .map(|(height, body, size)| ReadyBlock {
+                    height: *height,
+                    hash: body.hash(),
+                    size: *size,
+                })
+                .collect();
+            let expected = model.complete(&target, kind, &expected_blocks);
+            let event = match kind {
+                CompletionKind::Ready
+                | CompletionKind::ReadyOverlong
+                | CompletionKind::ReadyPrefix(_)
+                | CompletionKind::ReadyWithGap => BlockSyncEvent::BlockRangeResponseReady {
+                    request_id: target.request_id,
+                    peer: logical_peer(target.peer),
+                    start_height: target.start,
+                    requested_count: target.requested,
+                    blocks,
+                },
+                CompletionKind::FinishedUnavailable => BlockSyncEvent::BlockRangeResponseFinished {
+                    request_id: target.request_id,
+                    peer: logical_peer(target.peer),
+                    start_height: target.start,
+                    requested_count: target.requested,
+                    returned_count: 0,
+                },
+            };
+            handle
+                .send_control(event)
+                .map_err(|error| format!("completion event send failed: {error}"))?;
+            (expected, None, None)
+        }
+    };
+
+    Ok(IssuedOperation {
+        expected,
+        pending_query,
+        connected_session,
+    })
+}
+
+/// Settle the runtime, drain visible output, bind production request IDs, and
+/// compare all modeled frames, actions, sessions, and invariants.
+async fn verify_observation(
+    model: &mut ReferenceModel,
+    sessions: &mut BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    actions: &mut mpsc::Receiver<BlockSyncAction>,
+    handle: &BlockSyncHandle,
+    expected: ExpectedObservation,
+    pending_queries: Vec<PendingQuery>,
+) -> Result<(), String> {
+    settle_runtime(handle, sessions).await?;
+    wait_for_cancelled_session_teardown(handle, sessions, model.snapshot()).await?;
+    let actual = observe(sessions, actions, handle.peer_snapshot()).await?;
+
+    let request_ids = compare_actions(&expected.actions, &actual.actions)?;
+    if let Some(session) = expected
+        .required_status_sessions
+        .iter()
+        .find(|session| !actual.status_frames_by_session.contains_key(session))
+    {
+        return Err(format!(
+            "admitted session {session:?} did not receive its initial Status; observed Status frames by session: {:#?}",
+            actual.status_frames_by_session
+        ));
+    }
+    if actual.frames != expected.frames {
+        return Err(format!(
+            "frame mismatch\nexpected: {:#?}\nactual: {:#?}",
+            expected.frames, actual.frames
+        ));
+    }
+    if actual.snapshot != model.snapshot() {
+        return Err(format!(
+            "peer accounting mismatch\nexpected: {:?}\nactual: {:?}",
+            model.snapshot(),
+            actual.snapshot
+        ));
+    }
+    if actual.cancelled != model.cancellations() {
+        return Err(format!(
+            "GB-SM-01/GB-SM-02/GB-SM-12 session cancellation mismatch\nexpected: {:#?}\nactual: {:#?}",
+            model.cancellations(),
+            actual.cancelled
+        ));
+    }
+
+    if pending_queries.len() != request_ids.len() {
+        return Err(format!(
+            "pending query count {} did not match observed request ID count {}",
+            pending_queries.len(),
+            request_ids.len()
+        ));
+    }
+    for (pending, request_id) in pending_queries.into_iter().zip(request_ids) {
+        model.bind_query(pending, request_id)?;
+    }
+
+    let coverage = model.coverage_mut();
+    let status_frames = actual
+        .status_frames_by_session
+        .values()
+        .copied()
+        .fold(0u64, u64::saturating_add);
+    coverage.status_frames = coverage.status_frames.saturating_add(status_frames);
+    for frames in actual.frames.values() {
+        for frame in frames {
+            match frame {
+                ServingFrame::Block(_) => {
+                    coverage.blocks_observed = coverage.blocks_observed.saturating_add(1)
+                }
+                ServingFrame::BlocksDone { .. } | ServingFrame::RangeUnavailable { .. } => {
+                    coverage.terminal_frames = coverage.terminal_frames.saturating_add(1)
+                }
+                ServingFrame::Unexpected(_) => {}
+            }
+        }
+    }
+    model.assert_invariants()?;
+    model.commit_verified_step();
+    Ok(())
+}
+
+/// Wait for token-driven routine teardown to reach the reactor before reading
+/// the peer snapshot. Reactor barriers alone cannot order a disconnect event
+/// that the canceled routine has not queued yet.
+async fn wait_for_cancelled_session_teardown(
+    handle: &BlockSyncHandle,
+    sessions: &BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    expected_snapshot: ServicePeerSnapshot,
+) -> Result<(), String> {
+    if !sessions
+        .values()
+        .any(|peer| peer.cancel_token().is_cancelled())
+    {
+        return Ok(());
+    }
+
+    let mut snapshots = handle.subscribe_peer_snapshot();
+    let wait_for_expected_snapshot = async {
+        loop {
+            let observed = *snapshots.borrow_and_update();
+            if observed == expected_snapshot {
+                return Ok::<(), &'static str>(());
+            }
+            snapshots
+                .changed()
+                .await
+                .map_err(|_| "peer snapshot channel closed during canceled-session teardown")?;
+        }
+    };
+
+    timeout(CANCEL_TEARDOWN_TIMEOUT, wait_for_expected_snapshot)
+        .await
+        .map_err(|_| {
+            format!(
+                "canceled-session teardown did not publish {expected_snapshot:?}; observed {:?}",
+                *snapshots.borrow()
+            )
+        })??;
+
+    await_settlement_barrier(
+        "reactor canceled-session barrier",
+        handle.barrier_for_test(),
+    )
+    .await
+}
+
+/// Compare ordered actions while extracting opaque request IDs from matching
+/// production queries for later model binding.
+fn compare_actions(
+    expected: &[ExpectedAction],
+    actual: &[ServingAction],
+) -> Result<Vec<BlockRangeRequestId>, String> {
+    if expected.len() != actual.len() {
+        return Err(format!(
+            "action mismatch\nexpected: {expected:#?}\nactual: {actual:#?}"
+        ));
+    }
+
+    let mut request_ids = Vec::new();
+    for (expected_action, actual_action) in expected.iter().zip(actual) {
+        match (expected_action, actual_action) {
+            (
+                ExpectedAction::Query { peer, start, count },
+                ServingAction::Query {
+                    request_id,
+                    peer: actual_peer,
+                    start: actual_start,
+                    count: actual_count,
+                },
+            ) if peer == actual_peer && start == actual_start && count == actual_count => {
+                request_ids.push(*request_id);
+            }
+            (
+                ExpectedAction::Misbehavior { peer, reason },
+                ServingAction::Misbehavior {
+                    peer: actual_peer,
+                    reason: actual_reason,
+                },
+            ) if peer == actual_peer && reason == actual_reason => {}
+            _ => {
+                return Err(format!(
+                    "action mismatch\nexpected: {expected:#?}\nactual: {actual:#?}"
+                ));
+            }
+        }
+    }
+    Ok(request_ids)
+}
+
+/// Drain all currently available driver actions and node-to-peer frames into a
+/// normalized observation, retaining each frame's owning session.
+async fn observe(
+    sessions: &mut BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    actions: &mut mpsc::Receiver<BlockSyncAction>,
+    snapshot: crate::zakura::ServicePeerSnapshot,
+) -> Result<ServingObservation, String> {
+    let mut observation = ServingObservation {
+        snapshot,
+        ..ServingObservation::default()
+    };
+
+    for (session, peer) in sessions.iter() {
+        observation
+            .cancelled
+            .insert(*session, peer.cancel_token().is_cancelled());
+    }
+
+    while let Ok(action) = actions.try_recv() {
+        match action {
+            BlockSyncAction::QueryBlocksByHeightRange {
+                request_id,
+                peer,
+                start,
+                count,
+            } => observation.actions.push(ServingAction::Query {
+                request_id,
+                peer: peer_slot(&peer)?,
+                start,
+                count,
+            }),
+            BlockSyncAction::Misbehavior { peer, reason } => {
+                observation.actions.push(ServingAction::Misbehavior {
+                    peer: peer_slot(&peer)?,
+                    reason,
+                });
+            }
+            BlockSyncAction::QueryNeededBlocks { .. } => {}
+            action => observation
+                .actions
+                .push(ServingAction::Unexpected(format!("{action:?}"))),
+        }
+    }
+
+    for (session, peer) in sessions.iter_mut() {
+        loop {
+            let message = peer
+                .recv_timeout(Duration::from_nanos(1))
+                .await
+                .map_err(|error| format!("outbound frame decode failed: {error}"))?;
+            let Some(message) = message else {
+                break;
+            };
+            match message {
+                BlockSyncMessage::Status(_) => {
+                    let count = observation
+                        .status_frames_by_session
+                        .entry(*session)
+                        .or_default();
+                    *count = count.saturating_add(1);
+                }
+                BlockSyncMessage::Block(body) => observation
+                    .frames
+                    .entry(*session)
+                    .or_default()
+                    .push(ServingFrame::Block(body.hash())),
+                BlockSyncMessage::BlocksDone {
+                    start_height,
+                    returned,
+                } => {
+                    observation
+                        .frames
+                        .entry(*session)
+                        .or_default()
+                        .push(ServingFrame::BlocksDone {
+                            start: start_height,
+                            returned,
+                        })
+                }
+                BlockSyncMessage::RangeUnavailable {
+                    start_height,
+                    count,
+                } => observation.frames.entry(*session).or_default().push(
+                    ServingFrame::RangeUnavailable {
+                        start: start_height,
+                        count,
+                    },
+                ),
+                message => observation
+                    .frames
+                    .entry(*session)
+                    .or_default()
+                    .push(ServingFrame::Unexpected(message.message_type())),
+            }
+        }
+    }
+
+    Ok(observation)
+}
+
+/// Establish a deterministic happens-before boundary across every input path
+/// used by the serving model.
+async fn settle_runtime(
+    handle: &BlockSyncHandle,
+    sessions: &BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+) -> Result<(), String> {
+    await_settlement_barrier("reactor pre-frame barrier", handle.barrier_for_test()).await?;
+    for (session, peer) in sessions {
+        if peer.cancel_token().is_cancelled() {
+            continue;
+        }
+        await_settlement_barrier(
+            &format!("peer routine barrier for {session:?}"),
+            peer.barrier_for_test(),
+        )
+        .await?;
+    }
+    await_settlement_barrier("reactor post-frame barrier", handle.barrier_for_test()).await
+}
+
+/// Bound one harness barrier so a scheduling regression produces a replayable
+/// error instead of hanging the property-test process.
+async fn await_settlement_barrier<E>(
+    phase: &str,
+    barrier: impl Future<Output = Result<(), E>>,
+) -> Result<(), String>
+where
+    E: Display,
+{
+    match timeout(SETTLEMENT_BARRIER_TIMEOUT, barrier).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(format!("{phase} failed: {error}")),
+        Err(_) => Err(format!(
+            "{phase} timed out after {SETTLEMENT_BARRIER_TIMEOUT:?}"
+        )),
+    }
+}
+
+/// Build the synthetic state response selected by a completion operation.
+fn ready_blocks(
+    corpus: &SyntheticBlockCorpus,
+    start: block::Height,
+    requested: u32,
+    kind: CompletionKind,
+) -> Vec<(block::Height, Arc<block::Block>, usize)> {
+    let offsets: Vec<_> = match kind {
+        CompletionKind::Ready => (0..requested).collect(),
+        CompletionKind::ReadyOverlong => (0..requested.saturating_add(1)).collect(),
+        CompletionKind::ReadyPrefix(ordinal) => {
+            let returned = u32::from(ordinal) % requested.saturating_add(1);
+            (0..returned).collect()
+        }
+        CompletionKind::ReadyWithGap => {
+            if requested > 1 {
+                vec![0, 2]
+            } else {
+                vec![1]
+            }
+        }
+        CompletionKind::FinishedUnavailable => Vec::new(),
+    };
+    offsets
+        .into_iter()
+        .filter_map(|offset| {
+            let height = start.0.checked_add(offset).map(block::Height)?;
+            Some((height, corpus.block_at(height)?, corpus.size_at(height)?))
+        })
+        .collect()
+}
+
+/// Build either a contract-valid Status or the modeled invalid-range class.
+fn status_for(validity: StatusValidity, corpus: &SyntheticBlockCorpus) -> BlockSyncStatus {
+    let (servable_low, servable_high) = match validity {
+        StatusValidity::Valid => (block::Height(1), corpus.target_height()),
+        StatusValidity::InvalidRange => (corpus.target_height(), block::Height(1)),
+    };
+    BlockSyncStatus {
+        servable_low,
+        servable_high,
+        tip_hash: corpus.tip_hash(),
+        max_blocks_per_response: 128,
+        max_inflight_requests: 8,
+        max_response_bytes: super::super::super::super::MAX_BS_RESPONSE_BYTES,
+    }
+}
+
+/// Resolve a modeled session to the exact synthetic connection that owns it.
+fn session_peer(
+    sessions: &BTreeMap<SessionKey, SyntheticBlockSyncPeer>,
+    session: SessionKey,
+) -> Result<&SyntheticBlockSyncPeer, String> {
+    sessions
+        .get(&session)
+        .ok_or_else(|| format!("model selected missing synthetic session {session:?}"))
+}
+
+/// Map a small model slot to a stable authenticated peer identity.
+fn logical_peer(slot: u8) -> ZakuraPeerId {
+    ZakuraPeerId::new(vec![0xa0u8.saturating_add(slot); 32])
+        .expect("logical property-test peer IDs are bounded")
+}
+
+/// Map an observed authenticated identity back to its model slot.
+fn peer_slot(peer: &ZakuraPeerId) -> Result<u8, String> {
+    (0..super::LOGICAL_PEER_COUNT)
+        .find(|slot| logical_peer(*slot) == *peer)
+        .ok_or_else(|| format!("reactor emitted action for unknown peer {peer:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn settlement_barrier_timeout_names_the_stuck_phase() {
+        let error = await_settlement_barrier(
+            "stuck test barrier",
+            std::future::pending::<Result<(), &'static str>>(),
+        )
+        .await
+        .expect_err("a pending barrier must time out");
+
+        assert_eq!(
+            error, "stuck test barrier timed out after 1s",
+            "timeout diagnostics identify the settlement phase"
+        );
+    }
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
@@ -21,9 +21,9 @@ use super::super::super::super::{
 };
 use super::{
     model::{ReadyBlock, ReferenceModel},
-    CompletionKind, ExpectedAction, ExpectedObservation, PendingQuery, ServingAction, ServingCase,
-    ServingCoverage, ServingFrame, ServingObservation, ServingOp, ServingStep, SessionKey,
-    StatusValidity,
+    ByteCap, CompletionKind, ExpectedAction, ExpectedObservation, PendingQuery, ServingAction,
+    ServingCase, ServingCoverage, ServingFrame, ServingObservation, ServingOp, ServingStep,
+    SessionKey, StatusValidity,
 };
 use crate::zakura::{
     testkit::{
@@ -52,8 +52,18 @@ pub(super) fn replay_serving_case(case: &ServingCase) -> Result<ServingCoverage,
 /// Assemble the real service, peer harness, corpus, and reference model, then
 /// compare their behavior until every step has settled.
 async fn replay_serving_case_inner(case: &ServingCase) -> Result<ServingCoverage, String> {
-    let corpus =
-        SyntheticBlockCorpus::generate(case.tip, case.corpus_seed, SyntheticBlockShape::default());
+    let target_block_bytes = match case.byte_cap {
+        ByteCap::All => None,
+        ByteCap::ExactlyFirst | ByteCap::ExactlyFirstTwo => Some(
+            usize::try_from(block::MAX_BLOCK_BYTES / 2 + 64 * 1024)
+                .expect("the synthetic block target fits usize"),
+        ),
+    };
+    let corpus = SyntheticBlockCorpus::generate(
+        case.tip,
+        case.corpus_seed,
+        SyntheticBlockShape { target_block_bytes },
+    );
     let first_size = corpus
         .size_at(block::Height(1))
         .and_then(|size| u32::try_from(size).ok())
@@ -62,6 +72,11 @@ async fn replay_serving_case_inner(case: &ServingCase) -> Result<ServingCoverage
         .size_at(block::Height(2))
         .and_then(|size| u32::try_from(size).ok())
         .ok_or_else(|| "synthetic block 2 size must fit u32".to_string())?;
+    if !matches!(case.byte_cap, ByteCap::All)
+        && u64::from(first_size).saturating_add(u64::from(second_size)) <= block::MAX_BLOCK_BYTES
+    {
+        return Err("byte-boundary corpus must exceed one maximum block across two bodies".into());
+    }
     let response_byte_cap = case.byte_cap.resolve(first_size, second_size);
 
     let (max_inbound_peers, max_outbound_peers) = match case.direction {

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs
@@ -28,6 +28,7 @@ use super::{
 use crate::zakura::{
     testkit::{
         SyntheticBlockCorpus, SyntheticBlockShape, SyntheticBlockSyncPeer, SyntheticBlockSyncPeers,
+        SyntheticBlockSyncReceive,
     },
     ServicePeerDirection, ServicePeerLimits, ServicePeerSnapshot, ZakuraPeerId,
 };
@@ -547,12 +548,19 @@ async fn observe(
 
     for (session, peer) in sessions.iter_mut() {
         loop {
-            let message = peer
+            let received = peer
                 .recv_timeout(Duration::from_nanos(1))
                 .await
                 .map_err(|error| format!("outbound frame decode failed: {error}"))?;
-            let Some(message) = message else {
-                break;
+            let message = match received {
+                SyntheticBlockSyncReceive::Message(message) => message,
+                SyntheticBlockSyncReceive::TimedOut => break,
+                SyntheticBlockSyncReceive::Closed if peer.cancel_token().is_cancelled() => break,
+                SyntheticBlockSyncReceive::Closed => {
+                    return Err(format!(
+                        "outbound stream closed for live synthetic session {session:?}"
+                    ));
+                }
             };
             match message {
                 BlockSyncMessage::Status(_) => {

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
@@ -269,6 +269,7 @@ struct CompletionTarget {
     session: SessionKey,
     peer: u8,
     start: block::Height,
+    original_count: u32,
     requested: u32,
     query_index: Option<usize>,
 }

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
@@ -1,0 +1,674 @@
+//! Stateful reference model for the GetBlocks serving contract.
+//!
+//! Generated steps use logical peers and queries. A step issues one to three
+//! operations before the runtime settles, which makes lifecycle ordering races
+//! reachable without giving up deterministic observations between steps. The
+//! harness binds logical queries to request identities observed from the real
+//! reactor, so the model does not duplicate the implementation's allocator.
+
+mod harness;
+mod model;
+mod tests;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    ops::AddAssign,
+};
+
+use super::super::super::{BlockRangeRequestId, BlockSyncMisbehavior};
+use crate::zakura::{ServicePeerDirection, ServicePeerSnapshot, ZakuraConnId};
+use zakura_chain::block;
+
+const LOGICAL_PEER_COUNT: u8 = 4;
+
+/// One reproducible configuration and operation history for the serving model.
+#[derive(Clone, Debug)]
+pub(super) struct ServingCase {
+    /// Seed used to build deterministic synthetic block bodies.
+    pub(super) corpus_seed: u64,
+    /// Highest block height available from the synthetic state driver.
+    pub(super) tip: u32,
+    /// Per-peer serving ledger limit.
+    pub(super) max_inflight: u32,
+    /// Local count limit applied to each request.
+    pub(super) max_blocks: u32,
+    /// Direction shared by the generated peer sessions in this case.
+    pub(super) direction: ServicePeerDirection,
+    /// Number of distinct peers the service may admit in that direction.
+    pub(super) max_peers: usize,
+    /// Response byte boundary selected relative to generated block sizes.
+    pub(super) byte_cap: ByteCap,
+    /// Focused and generated operations appended after the coverage prelude.
+    pub(super) steps: Vec<ServingStep>,
+}
+
+impl ServingCase {
+    /// Prepend a small successful exchange so every replay proves the full
+    /// query-to-wire path before exploring adversarial history.
+    fn steps_with_prelude(&self) -> Vec<ServingStep> {
+        let mut steps = vec![
+            ServingStep::single(ServingOp::Connect { peer: 0 }),
+            ServingStep::single(ServingOp::Status {
+                peer: 0,
+                validity: StatusValidity::Valid,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+        ];
+        steps.extend(self.steps.iter().cloned());
+        steps
+    }
+}
+
+/// Operations issued back-to-back before observing the settled serving state.
+#[derive(Clone, Debug)]
+pub(super) struct ServingStep {
+    /// Operations submitted before the harness next settles and observes.
+    pub(super) operations: Vec<ServingOp>,
+}
+
+impl ServingStep {
+    /// Build a settled step containing one operation.
+    fn single(operation: ServingOp) -> Self {
+        Self {
+            operations: vec![operation],
+        }
+    }
+
+    /// Build a step whose operations are issued back-to-back before observation.
+    fn unsettled(operations: impl IntoIterator<Item = ServingOp>) -> Self {
+        Self {
+            operations: operations.into_iter().collect(),
+        }
+    }
+}
+
+/// Response byte caps expressed relative to the synthetic corpus.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum ByteCap {
+    /// Use the production maximum.
+    All,
+    /// Stop before even the first block fits.
+    BeforeFirst,
+    /// End exactly after the first block.
+    ExactlyFirst,
+    /// End exactly after the first two blocks.
+    ExactlyFirstTwo,
+}
+
+/// Total operation alphabet accepted by the reference model and real harness.
+///
+/// Operations against missing peers or queries are intentional no-ops, which
+/// keeps shrinking and arbitrary history generation well defined.
+#[derive(Clone, Debug)]
+pub(super) enum ServingOp {
+    /// Attach a new connection generation for one logical peer.
+    Connect { peer: u8 },
+    /// Remove either the current connection or a stale predecessor.
+    Disconnect { peer: u8, which: DisconnectWhich },
+    /// Cancel the current connection token to exercise routine teardown.
+    Cancel { peer: u8 },
+    /// Send a Status frame through the synthetic peer's real framed stream.
+    Status { peer: u8, validity: StatusValidity },
+    /// Send a GetBlocks frame through the synthetic peer's real framed stream.
+    GetBlocks { peer: u8, start: u32, count: u32 },
+    /// Return a selected state-driver completion to the real reactor.
+    Complete {
+        query: QuerySelector,
+        kind: CompletionKind,
+    },
+}
+
+/// Whether a disconnect names the live connection or an older generation.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum DisconnectWhich {
+    /// Remove the generation that currently owns the logical peer.
+    Current,
+    /// Re-deliver removal for an older connection generation.
+    Stale,
+}
+
+/// Status classes that cross the real peer wire boundary.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum StatusValidity {
+    /// Advertise an internally consistent block range.
+    Valid,
+    /// Advertise a range whose high point precedes its low point.
+    InvalidRange,
+}
+
+/// Select a completion by lifecycle class and ordinal within that class.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum QuerySelector {
+    /// Select an outstanding request owned by a live session.
+    Live(u8),
+    /// Select a request that already received a terminal completion.
+    Retired(u8),
+    /// Select a request whose owning session was replaced or disconnected.
+    Orphaned(u8),
+    /// Derive a request identity that no accepted request owns.
+    Unknown(u8),
+    /// Reuse a live request identity with a mismatched start height.
+    MismatchedStart(u8),
+    /// Reuse a live request identity and start height for another connected peer.
+    MismatchedPeer(u8),
+}
+
+/// Driver completion shapes supplied to a selected query.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum CompletionKind {
+    /// Return every synthetic block available for the accepted range.
+    Ready,
+    /// Return one more contiguous block than the request permits.
+    ReadyOverlong,
+    /// Return a selected prefix, including the empty prefix.
+    ReadyPrefix(u8),
+    /// Return the first block followed by a later block, leaving a height gap.
+    ReadyWithGap,
+    /// Report that the state driver could not serve the range.
+    FinishedUnavailable,
+}
+
+/// Stable model identity for one logical peer connection.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct SessionKey {
+    peer: u8,
+    conn_id: ZakuraConnId,
+}
+
+/// Relevant node-to-peer frames after status advertisements are counted.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ServingFrame {
+    Block(block::Hash),
+    BlocksDone { start: block::Height, returned: u32 },
+    RangeUnavailable { start: block::Height, count: u32 },
+    Unexpected(u8),
+}
+
+/// Relevant reactor-to-driver actions observed for one settled step.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ServingAction {
+    Query {
+        request_id: BlockRangeRequestId,
+        peer: u8,
+        start: block::Height,
+        count: u32,
+    },
+    Misbehavior {
+        peer: u8,
+        reason: BlockSyncMisbehavior,
+    },
+    Unexpected(String),
+}
+
+/// Complete externally visible state drained from the real implementation.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ServingObservation {
+    frames: BTreeMap<SessionKey, Vec<ServingFrame>>,
+    actions: Vec<ServingAction>,
+    snapshot: ServicePeerSnapshot,
+    cancelled: BTreeMap<SessionKey, bool>,
+    status_frames_by_session: BTreeMap<SessionKey, u64>,
+}
+
+/// Independent model prediction for one unsettled step.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct ExpectedObservation {
+    frames: BTreeMap<SessionKey, Vec<ServingFrame>>,
+    actions: Vec<ExpectedAction>,
+    required_status_sessions: BTreeSet<SessionKey>,
+}
+
+impl ExpectedObservation {
+    /// Preserve operation order while combining predictions for one step.
+    fn append(&mut self, other: Self) {
+        for (session, frames) in other.frames {
+            self.frames.entry(session).or_default().extend(frames);
+        }
+        self.actions.extend(other.actions);
+        self.required_status_sessions
+            .extend(other.required_status_sessions);
+    }
+}
+
+/// Model action without a request ID, which must come from production.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum ExpectedAction {
+    Query {
+        peer: u8,
+        start: block::Height,
+        count: u32,
+    },
+    Misbehavior {
+        peer: u8,
+        reason: BlockSyncMisbehavior,
+    },
+}
+
+/// Accepted model query waiting to be bound to a production request ID.
+#[derive(Clone, Debug)]
+struct PendingQuery {
+    query_index: usize,
+    session: SessionKey,
+    peer: u8,
+    start: block::Height,
+    requested: u32,
+}
+
+/// Query metadata selected for a simulated driver completion.
+#[derive(Clone, Debug)]
+struct CompletionTarget {
+    class: QueryClass,
+    request_id: BlockRangeRequestId,
+    session: SessionKey,
+    peer: u8,
+    start: block::Height,
+    requested: u32,
+    query_index: Option<usize>,
+}
+
+/// Lifecycle classification for a completion target.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum QueryClass {
+    Live,
+    Retired,
+    Orphaned,
+    Unknown,
+    MismatchedStart,
+    MismatchedPeer,
+}
+
+/// Stable identifiers for the documented GetBlocks serving requirements.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum ServingRequirement {
+    ReplacementCancelsPreviousSession,
+    StaleDisconnectPreservesCurrentSession,
+    MissingStatusIsRejectedAsSpam,
+    PeerLedgersAreIndependentAndBounded,
+    SaturatedLedgerRejectsWithoutStateQuery,
+    AboveTipRequestIsUnavailableWithoutStateQuery,
+    AcceptedQueryCountRespectsAllBounds,
+    RequestIdsAreNonzeroAndUnique,
+    ReadyResponseSendsLargestValidPrefixAndOneTerminal,
+    InvalidCompletionHasNoServingEffect,
+    RepeatedCompletionDoesNotReleaseLiveSlot,
+    EndedSessionResponsesDoNotReachReplacement,
+    SaturatedPeerDoesNotBlockOtherPeers,
+    FramesAreAttributableToLiveRequestOwner,
+    DelayedOlderConnectCannotReplaceNewerSession,
+    PeerFramesWaitForReactorAdmission,
+    SupersededRoutineRequestCannotReachReplacementSession,
+    LiveUnavailableCompletionSendsTerminalAndReleasesSlot,
+    InboundSessionsServeAndUseInboundCap,
+}
+
+impl ServingRequirement {
+    /// Requirements reached by concrete operations in the serving model.
+    pub(super) const OCCURRENCE: [Self; 14] = [
+        Self::ReplacementCancelsPreviousSession,
+        Self::StaleDisconnectPreservesCurrentSession,
+        Self::MissingStatusIsRejectedAsSpam,
+        Self::SaturatedLedgerRejectsWithoutStateQuery,
+        Self::AboveTipRequestIsUnavailableWithoutStateQuery,
+        Self::AcceptedQueryCountRespectsAllBounds,
+        Self::RequestIdsAreNonzeroAndUnique,
+        Self::ReadyResponseSendsLargestValidPrefixAndOneTerminal,
+        Self::InvalidCompletionHasNoServingEffect,
+        Self::RepeatedCompletionDoesNotReleaseLiveSlot,
+        Self::EndedSessionResponsesDoNotReachReplacement,
+        Self::SaturatedPeerDoesNotBlockOtherPeers,
+        Self::LiveUnavailableCompletionSendsTerminalAndReleasesSlot,
+        Self::InboundSessionsServeAndUseInboundCap,
+    ];
+
+    /// Requirements checked after every successfully compared model step.
+    pub(super) const INVARIANTS: [Self; 2] = [
+        Self::PeerLedgersAreIndependentAndBounded,
+        Self::FramesAreAttributableToLiveRequestOwner,
+    ];
+
+    /// Requirements that need separately forced task orderings.
+    pub(super) const REGRESSION_ONLY: [Self; 3] = [
+        Self::DelayedOlderConnectCannotReplaceNewerSession,
+        Self::PeerFramesWaitForReactorAdmission,
+        Self::SupersededRoutineRequestCannotReachReplacementSession,
+    ];
+
+    /// Return the contract identifier printed in failures and coverage reports.
+    pub(super) const fn id(self) -> &'static str {
+        match self {
+            Self::ReplacementCancelsPreviousSession => "GB-SM-01",
+            Self::StaleDisconnectPreservesCurrentSession => "GB-SM-02",
+            Self::MissingStatusIsRejectedAsSpam => "GB-SM-03",
+            Self::PeerLedgersAreIndependentAndBounded => "GB-SM-04",
+            Self::SaturatedLedgerRejectsWithoutStateQuery => "GB-SM-05",
+            Self::AboveTipRequestIsUnavailableWithoutStateQuery => "GB-SM-06",
+            Self::AcceptedQueryCountRespectsAllBounds => "GB-SM-07",
+            Self::RequestIdsAreNonzeroAndUnique => "GB-SM-08",
+            Self::ReadyResponseSendsLargestValidPrefixAndOneTerminal => "GB-SM-09",
+            Self::InvalidCompletionHasNoServingEffect => "GB-SM-10",
+            Self::RepeatedCompletionDoesNotReleaseLiveSlot => "GB-SM-11",
+            Self::EndedSessionResponsesDoNotReachReplacement => "GB-SM-12",
+            Self::SaturatedPeerDoesNotBlockOtherPeers => "GB-SM-13",
+            Self::FramesAreAttributableToLiveRequestOwner => "GB-SM-14",
+            Self::DelayedOlderConnectCannotReplaceNewerSession => "GB-SM-15",
+            Self::PeerFramesWaitForReactorAdmission => "GB-SM-16",
+            Self::SupersededRoutineRequestCannotReachReplacementSession => "GB-SM-17",
+            Self::LiveUnavailableCompletionSendsTerminalAndReleasesSlot => "GB-SM-18",
+            Self::InboundSessionsServeAndUseInboundCap => "GB-SM-19",
+        }
+    }
+}
+
+/// Exact preconditions observed by a successfully compared model step.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum ServingEvidence {
+    ReplacementCancelled,
+    ServiceStaleDisconnectIgnored,
+    ReactorStaleDisconnectIgnored,
+    MissingStatusRejected,
+    SaturatedLedgerRejected,
+    AboveTipRejected,
+    WireCountBound,
+    LocalCountBound,
+    AvailableRangeBound,
+    MultipleRequestIdsValidated,
+    ReadyResponseCompleted,
+    OverlongResponseStoppedAtRequestedCount,
+    GenesisReadyResponseCompleted,
+    ByteCapStoppedPrefix,
+    ByteCapStoppedBeforeFirstBlock,
+    NonContiguousResponseStopped,
+    EmptyReadyResponseTerminated,
+    NonEmptyReadyResponseTerminated,
+    UnknownCompletionIgnored,
+    RetiredCompletionIgnored,
+    MismatchedStartCompletionIgnored,
+    MismatchedPeerCompletionIgnored,
+    OrphanedCompletionIgnored,
+    OrphanedCompletionWithoutReplacementIgnored,
+    RetiredCompletionWithLiveSiblingIgnored,
+    OrphanedCompletionWithLiveReplacementIgnored,
+    SaturatedPeerAllowedOtherPeerProgress,
+    LiveUnavailableResponseTerminated,
+    RequestAcceptedAfterLiveUnavailableCompletion,
+    InboundServingCompleted,
+    InboundCapRejected,
+}
+
+/// Evidence that generated replays reached the important contract classes.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ServingCoverage {
+    /// Preconditions whose complete model step matched production.
+    verified_evidence: BTreeSet<ServingEvidence>,
+    /// Successful steps on which the per-peer ledger invariant was checked.
+    ledger_invariant_checks: u64,
+    /// Successful steps on which response ownership was checked.
+    frame_ownership_checks: u64,
+    pub(super) cases: u64,
+    pub(super) steps: u64,
+    pub(super) operations: u64,
+    pub(super) multi_operation_steps: u64,
+    pub(super) connected_sessions: u64,
+    pub(super) replacement_sessions: u64,
+    pub(super) rejected_sessions: u64,
+    pub(super) current_disconnects: u64,
+    pub(super) stale_disconnects: u64,
+    pub(super) token_cancellations: u64,
+    pub(super) valid_statuses: u64,
+    pub(super) invalid_statuses: u64,
+    pub(super) accepted_requests: u64,
+    pub(super) no_status_requests: u64,
+    pub(super) cap_rejections: u64,
+    pub(super) above_tip_rejections: u64,
+    pub(super) live_completions: u64,
+    pub(super) empty_ready_completions: u64,
+    pub(super) short_ready_completions: u64,
+    pub(super) retired_completions: u64,
+    pub(super) orphaned_completions: u64,
+    pub(super) unknown_completions: u64,
+    pub(super) mismatched_completions: u64,
+    pub(super) captured_request_ids: u64,
+    pub(super) cross_peer_progress: u64,
+    pub(super) byte_cap_stops: u64,
+    pub(super) exact_cap_endings: u64,
+    pub(super) blocks_observed: u64,
+    pub(super) terminal_frames: u64,
+    pub(super) status_frames: u64,
+    pub(super) max_peer_ledger: usize,
+}
+
+impl AddAssign for ServingCoverage {
+    fn add_assign(&mut self, other: Self) {
+        self.verified_evidence.extend(other.verified_evidence);
+        self.ledger_invariant_checks = self
+            .ledger_invariant_checks
+            .saturating_add(other.ledger_invariant_checks);
+        self.frame_ownership_checks = self
+            .frame_ownership_checks
+            .saturating_add(other.frame_ownership_checks);
+        self.cases = self.cases.saturating_add(other.cases);
+        self.steps = self.steps.saturating_add(other.steps);
+        self.operations = self.operations.saturating_add(other.operations);
+        self.multi_operation_steps = self
+            .multi_operation_steps
+            .saturating_add(other.multi_operation_steps);
+        self.connected_sessions = self
+            .connected_sessions
+            .saturating_add(other.connected_sessions);
+        self.replacement_sessions = self
+            .replacement_sessions
+            .saturating_add(other.replacement_sessions);
+        self.rejected_sessions = self
+            .rejected_sessions
+            .saturating_add(other.rejected_sessions);
+        self.current_disconnects = self
+            .current_disconnects
+            .saturating_add(other.current_disconnects);
+        self.stale_disconnects = self
+            .stale_disconnects
+            .saturating_add(other.stale_disconnects);
+        self.token_cancellations = self
+            .token_cancellations
+            .saturating_add(other.token_cancellations);
+        self.valid_statuses = self.valid_statuses.saturating_add(other.valid_statuses);
+        self.invalid_statuses = self.invalid_statuses.saturating_add(other.invalid_statuses);
+        self.accepted_requests = self
+            .accepted_requests
+            .saturating_add(other.accepted_requests);
+        self.no_status_requests = self
+            .no_status_requests
+            .saturating_add(other.no_status_requests);
+        self.cap_rejections = self.cap_rejections.saturating_add(other.cap_rejections);
+        self.above_tip_rejections = self
+            .above_tip_rejections
+            .saturating_add(other.above_tip_rejections);
+        self.live_completions = self.live_completions.saturating_add(other.live_completions);
+        self.empty_ready_completions = self
+            .empty_ready_completions
+            .saturating_add(other.empty_ready_completions);
+        self.short_ready_completions = self
+            .short_ready_completions
+            .saturating_add(other.short_ready_completions);
+        self.retired_completions = self
+            .retired_completions
+            .saturating_add(other.retired_completions);
+        self.orphaned_completions = self
+            .orphaned_completions
+            .saturating_add(other.orphaned_completions);
+        self.unknown_completions = self
+            .unknown_completions
+            .saturating_add(other.unknown_completions);
+        self.mismatched_completions = self
+            .mismatched_completions
+            .saturating_add(other.mismatched_completions);
+        self.captured_request_ids = self
+            .captured_request_ids
+            .saturating_add(other.captured_request_ids);
+        self.cross_peer_progress = self
+            .cross_peer_progress
+            .saturating_add(other.cross_peer_progress);
+        self.byte_cap_stops = self.byte_cap_stops.saturating_add(other.byte_cap_stops);
+        self.exact_cap_endings = self
+            .exact_cap_endings
+            .saturating_add(other.exact_cap_endings);
+        self.blocks_observed = self.blocks_observed.saturating_add(other.blocks_observed);
+        self.terminal_frames = self.terminal_frames.saturating_add(other.terminal_frames);
+        self.status_frames = self.status_frames.saturating_add(other.status_frames);
+        self.max_peer_ledger = self.max_peer_ledger.max(other.max_peer_ledger);
+    }
+}
+
+impl ServingCoverage {
+    /// Record evidence only after the corresponding model step matched production.
+    fn commit_verified_step(&mut self, evidence: BTreeSet<ServingEvidence>) {
+        self.verified_evidence.extend(evidence);
+        self.ledger_invariant_checks = self.ledger_invariant_checks.saturating_add(1);
+        self.frame_ownership_checks = self.frame_ownership_checks.saturating_add(1);
+    }
+
+    /// Return whether this replay exercised and checked one documented requirement.
+    pub(super) fn requirement_is_covered(&self, requirement: ServingRequirement) -> bool {
+        use ServingEvidence as Evidence;
+        use ServingRequirement as Requirement;
+
+        let has = |evidence| self.verified_evidence.contains(&evidence);
+        match requirement {
+            Requirement::ReplacementCancelsPreviousSession => has(Evidence::ReplacementCancelled),
+            Requirement::StaleDisconnectPreservesCurrentSession => {
+                has(Evidence::ServiceStaleDisconnectIgnored)
+                    && has(Evidence::ReactorStaleDisconnectIgnored)
+            }
+            Requirement::MissingStatusIsRejectedAsSpam => has(Evidence::MissingStatusRejected),
+            Requirement::PeerLedgersAreIndependentAndBounded => {
+                self.steps > 0
+                    && self.ledger_invariant_checks == self.steps
+                    && has(Evidence::SaturatedLedgerRejected)
+                    && has(Evidence::SaturatedPeerAllowedOtherPeerProgress)
+            }
+            Requirement::SaturatedLedgerRejectsWithoutStateQuery => {
+                has(Evidence::SaturatedLedgerRejected)
+            }
+            Requirement::AboveTipRequestIsUnavailableWithoutStateQuery => {
+                has(Evidence::AboveTipRejected)
+            }
+            Requirement::AcceptedQueryCountRespectsAllBounds => {
+                has(Evidence::WireCountBound)
+                    && has(Evidence::LocalCountBound)
+                    && has(Evidence::AvailableRangeBound)
+            }
+            Requirement::RequestIdsAreNonzeroAndUnique => {
+                has(Evidence::MultipleRequestIdsValidated)
+            }
+            Requirement::ReadyResponseSendsLargestValidPrefixAndOneTerminal => {
+                has(Evidence::ReadyResponseCompleted)
+                    && has(Evidence::OverlongResponseStoppedAtRequestedCount)
+                    && has(Evidence::GenesisReadyResponseCompleted)
+                    && has(Evidence::ByteCapStoppedPrefix)
+                    && has(Evidence::ByteCapStoppedBeforeFirstBlock)
+                    && has(Evidence::NonContiguousResponseStopped)
+                    && has(Evidence::EmptyReadyResponseTerminated)
+                    && has(Evidence::NonEmptyReadyResponseTerminated)
+            }
+            Requirement::InvalidCompletionHasNoServingEffect => {
+                has(Evidence::UnknownCompletionIgnored)
+                    && has(Evidence::RetiredCompletionIgnored)
+                    && has(Evidence::MismatchedStartCompletionIgnored)
+                    && has(Evidence::MismatchedPeerCompletionIgnored)
+                    && has(Evidence::OrphanedCompletionIgnored)
+            }
+            Requirement::RepeatedCompletionDoesNotReleaseLiveSlot => {
+                has(Evidence::RetiredCompletionWithLiveSiblingIgnored)
+            }
+            Requirement::EndedSessionResponsesDoNotReachReplacement => {
+                has(Evidence::OrphanedCompletionWithoutReplacementIgnored)
+                    && has(Evidence::OrphanedCompletionWithLiveReplacementIgnored)
+            }
+            Requirement::SaturatedPeerDoesNotBlockOtherPeers => {
+                has(Evidence::SaturatedPeerAllowedOtherPeerProgress)
+            }
+            Requirement::LiveUnavailableCompletionSendsTerminalAndReleasesSlot => {
+                has(Evidence::LiveUnavailableResponseTerminated)
+                    && has(Evidence::RequestAcceptedAfterLiveUnavailableCompletion)
+            }
+            Requirement::InboundSessionsServeAndUseInboundCap => {
+                has(Evidence::InboundServingCompleted) && has(Evidence::InboundCapRejected)
+            }
+            Requirement::FramesAreAttributableToLiveRequestOwner => {
+                self.steps > 0
+                    && self.frame_ownership_checks == self.steps
+                    && self.blocks_observed > 0
+                    && self.terminal_frames > 0
+            }
+            Requirement::DelayedOlderConnectCannotReplaceNewerSession
+            | Requirement::PeerFramesWaitForReactorAdmission
+            | Requirement::SupersededRoutineRequestCannotReachReplacementSession => false,
+        }
+    }
+
+    /// Return the named model requirements missing from this coverage summary.
+    pub(super) fn missing_model_requirements(&self) -> Vec<ServingRequirement> {
+        ServingRequirement::OCCURRENCE
+            .into_iter()
+            .chain(ServingRequirement::INVARIANTS)
+            .filter(|requirement| !self.requirement_is_covered(*requirement))
+            .collect()
+    }
+
+    /// Return successful invariant-check counts for the human-readable report.
+    pub(super) fn invariant_check_counts(&self) -> (u64, u64) {
+        (self.ledger_invariant_checks, self.frame_ownership_checks)
+    }
+}
+
+impl fmt::Display for ServingCoverage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} cases, {} steps ({} multi-operation), {} operations, sessions admitted/replaced/rejected {}/{}/{}, disconnects current/stale/cancel {}/{}/{}, status valid/invalid {}/{}, {} accepted requests, {} no-status, {} cap-rejected, {} above-tip, completions live/retired/orphaned/unknown/mismatched {}/{}/{}/{}/{}, ready empty/short {}/{}, {} request IDs, {} cross-peer progress, byte-cap stops/exact endings {}/{}, {} blocks, {} terminals, max ledger {}",
+            self.cases,
+            self.steps,
+            self.multi_operation_steps,
+            self.operations,
+            self.connected_sessions,
+            self.replacement_sessions,
+            self.rejected_sessions,
+            self.current_disconnects,
+            self.stale_disconnects,
+            self.token_cancellations,
+            self.valid_statuses,
+            self.invalid_statuses,
+            self.accepted_requests,
+            self.no_status_requests,
+            self.cap_rejections,
+            self.above_tip_rejections,
+            self.live_completions,
+            self.retired_completions,
+            self.orphaned_completions,
+            self.unknown_completions,
+            self.mismatched_completions,
+            self.empty_ready_completions,
+            self.short_ready_completions,
+            self.captured_request_ids,
+            self.cross_peer_progress,
+            self.byte_cap_stops,
+            self.exact_cap_endings,
+            self.blocks_observed,
+            self.terminal_frames,
+            self.max_peer_ledger,
+        )
+    }
+}
+
+/// Replay one case against the real node path and its independent model.
+pub(super) fn replay_serving_case(case: &ServingCase) -> Result<ServingCoverage, String> {
+    harness::replay_serving_case(case)
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/mod.rs
@@ -96,9 +96,7 @@ impl ServingStep {
 pub(super) enum ByteCap {
     /// Use the production maximum.
     All,
-    /// Stop before even the first block fits.
-    BeforeFirst,
-    /// End exactly after the first block.
+    /// Fit one block but stop before the second.
     ExactlyFirst,
     /// End exactly after the first two blocks.
     ExactlyFirstTwo,
@@ -385,7 +383,6 @@ pub(super) enum ServingEvidence {
     OverlongResponseStoppedAtRequestedCount,
     GenesisReadyResponseCompleted,
     ByteCapStoppedPrefix,
-    ByteCapStoppedBeforeFirstBlock,
     NonContiguousResponseStopped,
     EmptyReadyResponseTerminated,
     NonEmptyReadyResponseTerminated,
@@ -573,7 +570,6 @@ impl ServingCoverage {
                     && has(Evidence::OverlongResponseStoppedAtRequestedCount)
                     && has(Evidence::GenesisReadyResponseCompleted)
                     && has(Evidence::ByteCapStoppedPrefix)
-                    && has(Evidence::ByteCapStoppedBeforeFirstBlock)
                     && has(Evidence::NonContiguousResponseStopped)
                     && has(Evidence::EmptyReadyResponseTerminated)
                     && has(Evidence::NonEmptyReadyResponseTerminated)

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
@@ -1,0 +1,881 @@
+//! Independent logical model for block-range serving.
+//!
+//! The model tracks only contract-visible peer sessions, Status admission,
+//! request ownership, completions, and expected output. It does not call the
+//! production reactor, registry, serving ledger, or wire codec.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::super::super::super::{
+    BlockRangeRequestId, BlockSyncMisbehavior, MAX_BS_RESPONSE_BYTES,
+};
+use super::{
+    ByteCap, CompletionKind, CompletionTarget, DisconnectWhich, ExpectedAction,
+    ExpectedObservation, PendingQuery, QueryClass, QuerySelector, ServingCoverage, ServingEvidence,
+    ServingFrame, SessionKey, StatusValidity, LOGICAL_PEER_COUNT,
+};
+use crate::zakura::{ServicePeerDirection, ServicePeerLimits, ServicePeerSnapshot};
+use zakura_chain::block;
+
+/// Contract state owned by one logical peer identity.
+#[derive(Clone, Debug)]
+struct PeerModel {
+    next_conn_id: u64,
+    current: Option<SessionKey>,
+    received_status: bool,
+    ledger: Vec<usize>,
+}
+
+impl Default for PeerModel {
+    fn default() -> Self {
+        Self {
+            next_conn_id: 1,
+            current: None,
+            received_status: false,
+            ledger: Vec::new(),
+        }
+    }
+}
+
+/// Admission and cancellation state retained for every created connection.
+#[derive(Clone, Debug)]
+struct SessionModel {
+    cancelled: bool,
+    admitted: bool,
+}
+
+/// Whether a query can still affect serving output.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum QueryState {
+    Live,
+    Retired,
+    Orphaned,
+}
+
+/// Model-owned request metadata, with an ID bound from production later.
+#[derive(Clone, Debug)]
+struct QueryModel {
+    id: Option<BlockRangeRequestId>,
+    session: SessionKey,
+    peer: u8,
+    start: block::Height,
+    requested: u32,
+    state: QueryState,
+    finished_unavailable: bool,
+}
+
+/// State-driver block metadata needed to predict response framing.
+#[derive(Clone, Debug)]
+pub(super) struct ReadyBlock {
+    pub(super) height: block::Height,
+    pub(super) hash: block::Hash,
+    pub(super) size: usize,
+}
+
+/// Minimal executable specification for GetBlocks serving behavior.
+///
+/// Transitions are deliberately independent of production helpers. Each one
+/// predicts only externally visible output and updates coverage for the input
+/// class it exercised.
+#[derive(Debug)]
+pub(super) struct ReferenceModel {
+    peers: Vec<PeerModel>,
+    sessions: BTreeMap<SessionKey, SessionModel>,
+    queries: Vec<QueryModel>,
+    max_inflight: usize,
+    max_blocks: u32,
+    max_response_bytes: u64,
+    direction: ServicePeerDirection,
+    max_peers: usize,
+    servable_high: block::Height,
+    overlapping_reconnect_status: Vec<Option<bool>>,
+    step_evidence: BTreeSet<ServingEvidence>,
+    coverage: ServingCoverage,
+}
+
+impl ReferenceModel {
+    /// Initialize an empty logical node with the generated serving limits.
+    pub(super) fn new(
+        max_inflight: u32,
+        max_blocks: u32,
+        max_response_bytes: u32,
+        direction: ServicePeerDirection,
+        max_peers: usize,
+        servable_high: block::Height,
+    ) -> Self {
+        Self {
+            peers: (0..LOGICAL_PEER_COUNT)
+                .map(|_| PeerModel::default())
+                .collect(),
+            sessions: BTreeMap::new(),
+            queries: Vec::new(),
+            max_inflight: usize::try_from(max_inflight)
+                .expect("the configured u32 serving cap fits usize"),
+            max_blocks,
+            max_response_bytes: u64::from(max_response_bytes),
+            direction,
+            max_peers,
+            servable_high,
+            overlapping_reconnect_status: vec![None; usize::from(LOGICAL_PEER_COUNT)],
+            step_evidence: BTreeSet::new(),
+            coverage: ServingCoverage {
+                cases: 1,
+                ..ServingCoverage::default()
+            },
+        }
+    }
+
+    /// Map arbitrary generated peer bytes into the fixed logical peer set.
+    fn peer_index(peer: u8) -> usize {
+        usize::from(peer % LOGICAL_PEER_COUNT)
+    }
+
+    /// Start a new settled interval and record whether it contains overlap.
+    pub(super) fn record_step(&mut self, operation_count: usize) {
+        self.overlapping_reconnect_status.fill(None);
+        self.step_evidence.clear();
+        self.coverage.steps = self.coverage.steps.saturating_add(1);
+        self.coverage.operations = self
+            .coverage
+            .operations
+            .saturating_add(u64::try_from(operation_count).unwrap_or(u64::MAX));
+        if operation_count > 1 {
+            self.coverage.multi_operation_steps =
+                self.coverage.multi_operation_steps.saturating_add(1);
+        }
+    }
+
+    /// Create the next connection generation, applying replacement and peer-cap
+    /// rules before returning its stable session key.
+    pub(super) fn connect(&mut self, peer: u8) -> (SessionKey, bool) {
+        let peer = peer % LOGICAL_PEER_COUNT;
+        let index = Self::peer_index(peer);
+        let conn_id = self.peers[index].next_conn_id;
+        self.peers[index].next_conn_id = conn_id.saturating_add(1);
+        let key = SessionKey { peer, conn_id };
+
+        let replacement = self.peers[index].current;
+        let reconnect_after_unsettled_disconnect =
+            self.overlapping_reconnect_status[index].is_some();
+        let replacement_received_status = (replacement.is_some()
+            && self.peers[index].received_status)
+            || self.overlapping_reconnect_status[index]
+                .take()
+                .unwrap_or(false);
+        if let Some(previous) = replacement {
+            self.coverage.replacement_sessions =
+                self.coverage.replacement_sessions.saturating_add(1);
+            if let Some(session) = self.sessions.get_mut(&previous) {
+                session.cancelled = true;
+                session.admitted = false;
+            }
+            self.orphan_peer_queries(peer);
+        }
+
+        let current_count = self
+            .peers
+            .iter()
+            .filter(|peer| peer.current.is_some())
+            .count();
+        let admitted = replacement.is_some() || current_count < self.max_peers;
+        self.sessions.insert(
+            key,
+            SessionModel {
+                cancelled: !admitted,
+                admitted,
+            },
+        );
+        if admitted {
+            self.peers[index].current = Some(key);
+            self.peers[index].received_status = replacement_received_status;
+            self.peers[index].ledger.clear();
+            self.coverage.connected_sessions = self.coverage.connected_sessions.saturating_add(1);
+        } else {
+            self.coverage.rejected_sessions = self.coverage.rejected_sessions.saturating_add(1);
+            if self.direction == ServicePeerDirection::Inbound {
+                self.mark_evidence(ServingEvidence::InboundCapRejected);
+            }
+        }
+
+        if replacement.is_some() {
+            self.mark_evidence(ServingEvidence::ReplacementCancelled);
+        }
+        if reconnect_after_unsettled_disconnect {
+            self.mark_evidence(ServingEvidence::ReactorStaleDisconnectIgnored);
+        }
+
+        (key, admitted)
+    }
+
+    /// Apply a current or stale transport removal and return the connection ID
+    /// that the real service should receive.
+    pub(super) fn disconnect(&mut self, peer: u8, which: DisconnectWhich) -> Option<u64> {
+        let peer = peer % LOGICAL_PEER_COUNT;
+        let index = Self::peer_index(peer);
+        match which {
+            DisconnectWhich::Current => {
+                let current = self.peers[index].current.take()?;
+                self.overlapping_reconnect_status[index] = Some(self.peers[index].received_status);
+                self.coverage.current_disconnects =
+                    self.coverage.current_disconnects.saturating_add(1);
+                self.peers[index].received_status = false;
+                self.peers[index].ledger.clear();
+                if let Some(session) = self.sessions.get_mut(&current) {
+                    session.cancelled = true;
+                    session.admitted = false;
+                }
+                self.orphan_peer_queries(peer);
+                Some(current.conn_id)
+            }
+            DisconnectWhich::Stale => {
+                let stale = self
+                    .sessions
+                    .keys()
+                    .rev()
+                    .find(|session| {
+                        session.peer == peer && Some(**session) != self.peers[index].current
+                    })
+                    .map(|session| session.conn_id)
+                    .or_else(|| {
+                        self.peers[index]
+                            .current
+                            .map(|session| session.conn_id.saturating_sub(1))
+                    });
+                if stale.is_some() {
+                    self.coverage.stale_disconnects =
+                        self.coverage.stale_disconnects.saturating_add(1);
+                    self.mark_evidence(ServingEvidence::ServiceStaleDisconnectIgnored);
+                }
+                stale
+            }
+        }
+    }
+
+    /// Cancel the current session token, modeling teardown-driven disconnect.
+    pub(super) fn cancel(&mut self, peer: u8) -> Option<SessionKey> {
+        let peer = peer % LOGICAL_PEER_COUNT;
+        let index = Self::peer_index(peer);
+        let current = self.peers[index].current.take()?;
+        self.overlapping_reconnect_status[index] = Some(self.peers[index].received_status);
+        self.coverage.token_cancellations = self.coverage.token_cancellations.saturating_add(1);
+        self.peers[index].received_status = false;
+        self.peers[index].ledger.clear();
+        if let Some(session) = self.sessions.get_mut(&current) {
+            session.cancelled = true;
+            session.admitted = false;
+        }
+        self.orphan_peer_queries(peer);
+        Some(current)
+    }
+
+    /// Return whether a newly connected session should receive initial Status.
+    pub(super) fn session_is_current_and_admitted(&self, session: SessionKey) -> bool {
+        self.peers[Self::peer_index(session.peer)].current == Some(session)
+            && self
+                .sessions
+                .get(&session)
+                .is_some_and(|state| state.admitted)
+    }
+
+    /// Model Status handling and any expected misbehavior report.
+    pub(super) fn status(
+        &mut self,
+        peer: u8,
+        validity: StatusValidity,
+    ) -> (Option<SessionKey>, ExpectedObservation) {
+        let peer = peer % LOGICAL_PEER_COUNT;
+        let Some(session) = self.peers[Self::peer_index(peer)].current else {
+            return (None, ExpectedObservation::default());
+        };
+
+        let mut expected = ExpectedObservation::default();
+        match validity {
+            StatusValidity::Valid => {
+                self.peers[Self::peer_index(peer)].received_status = true;
+                self.coverage.valid_statuses = self.coverage.valid_statuses.saturating_add(1);
+            }
+            StatusValidity::InvalidRange => {
+                expected.actions.push(ExpectedAction::Misbehavior {
+                    peer,
+                    reason: BlockSyncMisbehavior::InvalidStatus,
+                });
+                self.coverage.invalid_statuses = self.coverage.invalid_statuses.saturating_add(1);
+            }
+        }
+
+        (Some(session), expected)
+    }
+
+    /// Model request admission, per-peer saturation, range clamping, and the
+    /// expected query or terminal response.
+    pub(super) fn get_blocks(
+        &mut self,
+        peer: u8,
+        start: u32,
+        count: u32,
+    ) -> (
+        Option<SessionKey>,
+        ExpectedObservation,
+        Option<PendingQuery>,
+    ) {
+        let peer = peer % LOGICAL_PEER_COUNT;
+        let index = Self::peer_index(peer);
+        let Some(session) = self.peers[index].current else {
+            return (None, ExpectedObservation::default(), None);
+        };
+        let start = block::Height(start);
+        let mut expected = ExpectedObservation::default();
+
+        if !self.peers[index].received_status {
+            expected.actions.push(ExpectedAction::Misbehavior {
+                peer,
+                reason: BlockSyncMisbehavior::GetBlocksSpam,
+            });
+            self.coverage.no_status_requests = self.coverage.no_status_requests.saturating_add(1);
+            self.mark_evidence(ServingEvidence::MissingStatusRejected);
+            return (Some(session), expected, None);
+        }
+
+        if self.peers[index].ledger.len() >= self.max_inflight {
+            Self::push_frame(
+                &mut expected,
+                session,
+                ServingFrame::RangeUnavailable {
+                    start,
+                    count: count.min(self.max_blocks).max(1),
+                },
+            );
+            self.coverage.cap_rejections = self.coverage.cap_rejections.saturating_add(1);
+            self.mark_evidence(ServingEvidence::SaturatedLedgerRejected);
+            return (Some(session), expected, None);
+        }
+
+        let available = self
+            .servable_high
+            .0
+            .checked_sub(start.0)
+            .and_then(|difference| difference.checked_add(1))
+            .unwrap_or(0);
+        let requested = count.min(self.max_blocks).min(available);
+        if requested == 0 {
+            Self::push_frame(
+                &mut expected,
+                session,
+                ServingFrame::RangeUnavailable {
+                    start,
+                    count: count.min(self.max_blocks).max(1),
+                },
+            );
+            self.coverage.above_tip_rejections =
+                self.coverage.above_tip_rejections.saturating_add(1);
+            self.mark_evidence(ServingEvidence::AboveTipRejected);
+            return (Some(session), expected, None);
+        }
+
+        if count < self.max_blocks && count < available {
+            self.mark_evidence(ServingEvidence::WireCountBound);
+        }
+        if self.max_blocks < count && self.max_blocks < available {
+            self.mark_evidence(ServingEvidence::LocalCountBound);
+        }
+        if available < count && available < self.max_blocks {
+            self.mark_evidence(ServingEvidence::AvailableRangeBound);
+        }
+
+        expected.actions.push(ExpectedAction::Query {
+            peer,
+            start,
+            count: requested,
+        });
+        if self.queries.iter().any(|query| {
+            query.session == session
+                && query.state == QueryState::Retired
+                && query.finished_unavailable
+        }) {
+            self.mark_evidence(ServingEvidence::RequestAcceptedAfterLiveUnavailableCompletion);
+        }
+        let query_index = self.queries.len();
+        self.queries.push(QueryModel {
+            id: None,
+            session,
+            peer,
+            start,
+            requested,
+            state: QueryState::Live,
+            finished_unavailable: false,
+        });
+        if self.peers.iter().enumerate().any(|(other_index, peer)| {
+            other_index != index && peer.ledger.len() >= self.max_inflight
+        }) {
+            self.coverage.cross_peer_progress = self.coverage.cross_peer_progress.saturating_add(1);
+            self.mark_evidence(ServingEvidence::SaturatedPeerAllowedOtherPeerProgress);
+        }
+        self.peers[index].ledger.push(query_index);
+        self.coverage.accepted_requests = self.coverage.accepted_requests.saturating_add(1);
+        self.coverage.max_peer_ledger = self
+            .coverage
+            .max_peer_ledger
+            .max(self.peers[index].ledger.len());
+        (
+            Some(session),
+            expected,
+            Some(PendingQuery {
+                query_index,
+                session,
+                peer,
+                start,
+                requested,
+            }),
+        )
+    }
+
+    /// Bind an accepted model query to the opaque ID observed on the real action.
+    /// Duplicate IDs or a changed pending query fail the replay.
+    pub(super) fn bind_query(
+        &mut self,
+        pending: PendingQuery,
+        request_id: BlockRangeRequestId,
+    ) -> Result<(), String> {
+        if self
+            .queries
+            .iter()
+            .any(|query| query.id == Some(request_id))
+        {
+            return Err(format!(
+                "GB-SM-08: reactor reused serving request identity {request_id}"
+            ));
+        }
+        let has_previous_request_id = self.queries.iter().any(|query| query.id.is_some());
+        let query = self
+            .queries
+            .get_mut(pending.query_index)
+            .ok_or_else(|| format!("missing pending query {}", pending.query_index))?;
+        if query.id.is_some()
+            || query.session != pending.session
+            || query.peer != pending.peer
+            || query.start != pending.start
+            || query.requested != pending.requested
+        {
+            return Err(format!(
+                "pending query {} no longer matches its model entry",
+                pending.query_index
+            ));
+        }
+        query.id = Some(request_id);
+        self.coverage.captured_request_ids = self.coverage.captured_request_ids.saturating_add(1);
+        if has_previous_request_id {
+            self.mark_evidence(ServingEvidence::MultipleRequestIdsValidated);
+        }
+        Ok(())
+    }
+
+    /// Resolve a generated selector to live, retired, orphaned, unknown, or
+    /// mismatched completion metadata.
+    pub(super) fn completion_target(&self, selector: QuerySelector) -> Option<CompletionTarget> {
+        let (class, ordinal) = match selector {
+            QuerySelector::Live(ordinal) => (QueryClass::Live, ordinal),
+            QuerySelector::Retired(ordinal) => (QueryClass::Retired, ordinal),
+            QuerySelector::Orphaned(ordinal) => (QueryClass::Orphaned, ordinal),
+            QuerySelector::Unknown(ordinal) => (QueryClass::Unknown, ordinal),
+            QuerySelector::MismatchedStart(ordinal) => (QueryClass::MismatchedStart, ordinal),
+            QuerySelector::MismatchedPeer(ordinal) => (QueryClass::MismatchedPeer, ordinal),
+        };
+        let wanted_state = match class {
+            QueryClass::Live
+            | QueryClass::Unknown
+            | QueryClass::MismatchedStart
+            | QueryClass::MismatchedPeer => None,
+            QueryClass::Retired => Some(QueryState::Retired),
+            QueryClass::Orphaned => Some(QueryState::Orphaned),
+        };
+        let candidates: Vec<_> = self
+            .queries
+            .iter()
+            .enumerate()
+            .filter(|(_, query)| {
+                query.id.is_some()
+                    && wanted_state.map_or(query.state == QueryState::Live, |state| {
+                        query.state == state
+                    })
+            })
+            .collect();
+        if candidates.is_empty() {
+            return None;
+        }
+        let (query_index, query) = candidates.get(usize::from(ordinal) % candidates.len())?;
+        let request_id = query.id?;
+
+        if !matches!(
+            class,
+            QueryClass::Unknown | QueryClass::MismatchedStart | QueryClass::MismatchedPeer
+        ) {
+            return Some(CompletionTarget {
+                class,
+                request_id,
+                session: query.session,
+                peer: query.peer,
+                start: query.start,
+                requested: query.requested,
+                query_index: Some(*query_index),
+            });
+        }
+
+        if class == QueryClass::Unknown {
+            let request_id = self.unused_request_id(request_id);
+            Some(CompletionTarget {
+                class,
+                request_id,
+                session: query.session,
+                peer: query.peer,
+                start: query.start,
+                requested: query.requested,
+                query_index: None,
+            })
+        } else if class == QueryClass::MismatchedStart {
+            Some(CompletionTarget {
+                class,
+                request_id,
+                session: query.session,
+                peer: query.peer,
+                start: block::Height(query.start.0.saturating_add(1)),
+                requested: query.requested,
+                query_index: None,
+            })
+        } else {
+            let (peer, session) = self
+                .peers
+                .iter()
+                .enumerate()
+                .filter_map(|(peer, state)| {
+                    let peer = u8::try_from(peer).ok()?;
+                    (peer != query.peer).then_some((peer, state.current?))
+                })
+                .find(|(_, session)| {
+                    self.sessions
+                        .get(session)
+                        .is_some_and(|state| state.admitted && !state.cancelled)
+                })?;
+            Some(CompletionTarget {
+                class,
+                request_id,
+                session,
+                peer,
+                start: query.start,
+                requested: query.requested,
+                query_index: None,
+            })
+        }
+    }
+
+    /// Apply a state-driver completion and predict frames only when the exact
+    /// live request and session still own it.
+    pub(super) fn complete(
+        &mut self,
+        target: &CompletionTarget,
+        kind: CompletionKind,
+        blocks: &[ReadyBlock],
+    ) -> ExpectedObservation {
+        let retired_with_live_sibling = target.class == QueryClass::Retired
+            && self.peers[Self::peer_index(target.peer)].ledger.len() >= self.max_inflight
+            && self.peers[Self::peer_index(target.peer)]
+                .ledger
+                .iter()
+                .any(|query_index| self.queries[*query_index].state == QueryState::Live);
+        let orphaned_with_live_replacement = target.class == QueryClass::Orphaned
+            && self.peers[Self::peer_index(target.peer)]
+                .current
+                .is_some_and(|session| session != target.session);
+        let orphaned_without_replacement = target.class == QueryClass::Orphaned
+            && self.peers[Self::peer_index(target.peer)].current.is_none();
+
+        match target.class {
+            QueryClass::Live => {
+                self.coverage.live_completions = self.coverage.live_completions.saturating_add(1)
+            }
+            QueryClass::Retired => {
+                self.coverage.retired_completions =
+                    self.coverage.retired_completions.saturating_add(1);
+                self.mark_evidence(ServingEvidence::RetiredCompletionIgnored);
+                if retired_with_live_sibling {
+                    self.mark_evidence(ServingEvidence::RetiredCompletionWithLiveSiblingIgnored);
+                }
+            }
+            QueryClass::Orphaned => {
+                self.coverage.orphaned_completions =
+                    self.coverage.orphaned_completions.saturating_add(1);
+                self.mark_evidence(ServingEvidence::OrphanedCompletionIgnored);
+                if orphaned_without_replacement {
+                    self.mark_evidence(
+                        ServingEvidence::OrphanedCompletionWithoutReplacementIgnored,
+                    );
+                }
+                if orphaned_with_live_replacement {
+                    self.mark_evidence(
+                        ServingEvidence::OrphanedCompletionWithLiveReplacementIgnored,
+                    );
+                }
+            }
+            QueryClass::Unknown => {
+                self.coverage.unknown_completions =
+                    self.coverage.unknown_completions.saturating_add(1);
+                self.mark_evidence(ServingEvidence::UnknownCompletionIgnored);
+            }
+            QueryClass::MismatchedStart => {
+                self.coverage.mismatched_completions =
+                    self.coverage.mismatched_completions.saturating_add(1);
+                self.mark_evidence(ServingEvidence::MismatchedStartCompletionIgnored);
+            }
+            QueryClass::MismatchedPeer => {
+                self.coverage.mismatched_completions =
+                    self.coverage.mismatched_completions.saturating_add(1);
+                self.mark_evidence(ServingEvidence::MismatchedPeerCompletionIgnored);
+            }
+        }
+
+        let Some(query_index) = target.query_index else {
+            return ExpectedObservation::default();
+        };
+        if self.queries[query_index].state != QueryState::Live
+            || self.peers[Self::peer_index(target.peer)].current != Some(target.session)
+        {
+            return ExpectedObservation::default();
+        }
+
+        self.queries[query_index].state = QueryState::Retired;
+        self.queries[query_index].finished_unavailable =
+            matches!(kind, CompletionKind::FinishedUnavailable);
+        let peer = &mut self.peers[Self::peer_index(target.peer)];
+        if let Some(position) = peer
+            .ledger
+            .iter()
+            .position(|candidate| *candidate == query_index)
+        {
+            peer.ledger.remove(position);
+        }
+
+        let mut expected = ExpectedObservation::default();
+        match kind {
+            CompletionKind::FinishedUnavailable => {
+                self.mark_evidence(ServingEvidence::LiveUnavailableResponseTerminated);
+                Self::push_frame(
+                    &mut expected,
+                    target.session,
+                    ServingFrame::RangeUnavailable {
+                        start: target.start,
+                        count: target.requested.max(1),
+                    },
+                );
+            }
+            CompletionKind::Ready
+            | CompletionKind::ReadyOverlong
+            | CompletionKind::ReadyPrefix(_)
+            | CompletionKind::ReadyWithGap => {
+                self.mark_evidence(ServingEvidence::ReadyResponseCompleted);
+                if self.direction == ServicePeerDirection::Inbound {
+                    self.mark_evidence(ServingEvidence::InboundServingCompleted);
+                }
+                if blocks.is_empty() {
+                    self.coverage.empty_ready_completions =
+                        self.coverage.empty_ready_completions.saturating_add(1);
+                } else if blocks.len()
+                    < usize::try_from(target.requested)
+                        .expect("the requested u32 block count fits usize")
+                {
+                    self.coverage.short_ready_completions =
+                        self.coverage.short_ready_completions.saturating_add(1);
+                }
+                let mut sent_bytes = 0u64;
+                let mut sent = 0u32;
+                for block in blocks {
+                    if sent >= target.requested {
+                        self.mark_evidence(
+                            ServingEvidence::OverlongResponseStoppedAtRequestedCount,
+                        );
+                        break;
+                    }
+                    let expected_height = target.start.0.checked_add(sent).map(block::Height);
+                    let size = u64::try_from(block.size).unwrap_or(u64::MAX);
+                    let Some(next_bytes) = sent_bytes.checked_add(size) else {
+                        break;
+                    };
+                    if expected_height != Some(block.height) {
+                        self.mark_evidence(ServingEvidence::NonContiguousResponseStopped);
+                        break;
+                    }
+                    if next_bytes > self.max_response_bytes {
+                        self.coverage.byte_cap_stops =
+                            self.coverage.byte_cap_stops.saturating_add(1);
+                        self.mark_evidence(ServingEvidence::ByteCapStoppedPrefix);
+                        if sent == 0 {
+                            self.mark_evidence(ServingEvidence::ByteCapStoppedBeforeFirstBlock);
+                        }
+                        break;
+                    }
+                    Self::push_frame(
+                        &mut expected,
+                        target.session,
+                        ServingFrame::Block(block.hash),
+                    );
+                    sent = sent.saturating_add(1);
+                    sent_bytes = next_bytes;
+                }
+                if target.start == block::Height::MIN && sent > 0 {
+                    self.mark_evidence(ServingEvidence::GenesisReadyResponseCompleted);
+                }
+                if sent > 0 && sent_bytes == self.max_response_bytes {
+                    self.coverage.exact_cap_endings =
+                        self.coverage.exact_cap_endings.saturating_add(1);
+                }
+                if sent == 0 {
+                    self.mark_evidence(ServingEvidence::EmptyReadyResponseTerminated);
+                    Self::push_frame(
+                        &mut expected,
+                        target.session,
+                        ServingFrame::RangeUnavailable {
+                            start: target.start,
+                            count: target.requested.max(1),
+                        },
+                    );
+                } else {
+                    self.mark_evidence(ServingEvidence::NonEmptyReadyResponseTerminated);
+                    Self::push_frame(
+                        &mut expected,
+                        target.session,
+                        ServingFrame::BlocksDone {
+                            start: target.start,
+                            returned: sent,
+                        },
+                    );
+                }
+            }
+        }
+        expected
+    }
+
+    /// Produce the peer-slot snapshot expected from all admitted sessions.
+    pub(super) fn snapshot(&self) -> ServicePeerSnapshot {
+        let admitted = self
+            .sessions
+            .values()
+            .filter(|session| session.admitted)
+            .count();
+        let (inbound, outbound, max_inbound_peers, max_outbound_peers) = match self.direction {
+            ServicePeerDirection::Inbound => (admitted, 0, self.max_peers, 0),
+            ServicePeerDirection::Outbound => (0, admitted, 0, self.max_peers),
+        };
+        ServicePeerSnapshot::new(
+            inbound,
+            outbound,
+            ServicePeerLimits {
+                max_inbound_peers,
+                max_outbound_peers,
+                ..ServicePeerLimits::default()
+            },
+        )
+    }
+
+    /// Return the connection direction selected for every peer in this case.
+    pub(super) fn direction(&self) -> ServicePeerDirection {
+        self.direction
+    }
+
+    /// Report cancellation state for every connection created by the history.
+    pub(super) fn cancellations(&self) -> BTreeMap<SessionKey, bool> {
+        self.sessions
+            .iter()
+            .map(|(key, session)| (*key, session.cancelled))
+            .collect()
+    }
+
+    /// Borrow coverage so the harness can add observations unavailable to the model.
+    pub(super) fn coverage_mut(&mut self) -> &mut ServingCoverage {
+        &mut self.coverage
+    }
+
+    /// Commit this step's evidence after every production observation matched.
+    pub(super) fn commit_verified_step(&mut self) {
+        self.coverage
+            .commit_verified_step(std::mem::take(&mut self.step_evidence));
+    }
+
+    /// Finish a replay and return all accumulated reachability evidence.
+    pub(super) fn into_coverage(self) -> ServingCoverage {
+        self.coverage
+    }
+
+    /// Check model-internal ledger bounds and live-query ownership after a step.
+    pub(super) fn assert_invariants(&self) -> Result<(), String> {
+        for (index, peer) in self.peers.iter().enumerate() {
+            if peer.ledger.len() > self.max_inflight {
+                return Err(format!(
+                    "GB-SM-04: peer {index} ledger length {} exceeded cap {}",
+                    peer.ledger.len(),
+                    self.max_inflight
+                ));
+            }
+            for query_index in &peer.ledger {
+                let query = self
+                    .queries
+                    .get(*query_index)
+                    .ok_or_else(|| format!("ledger references missing query {query_index}"))?;
+                if query.state != QueryState::Live {
+                    return Err(format!(
+                        "ledger references non-live query {} ({:?})",
+                        query
+                            .id
+                            .map_or_else(|| "pending".to_string(), |id| id.to_string()),
+                        query.state
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Retire every live query whose output session no longer exists.
+    fn orphan_peer_queries(&mut self, peer: u8) {
+        for query in &mut self.queries {
+            if query.peer == peer && query.state == QueryState::Live {
+                query.state = QueryState::Orphaned;
+            }
+        }
+    }
+
+    /// Mark an exact requirement precondition for commit after step verification.
+    fn mark_evidence(&mut self, evidence: ServingEvidence) {
+        self.step_evidence.insert(evidence);
+    }
+
+    /// Derive a valid nonzero identity that no modeled request owns.
+    fn unused_request_id(&self, base: BlockRangeRequestId) -> BlockRangeRequestId {
+        let mut candidate = base.get().checked_add(1).unwrap_or(1);
+        loop {
+            let request_id = BlockRangeRequestId::new(candidate).expect("candidate is nonzero");
+            if self
+                .queries
+                .iter()
+                .all(|query| query.id != Some(request_id))
+            {
+                return request_id;
+            }
+            candidate = candidate.checked_add(1).unwrap_or(1);
+        }
+    }
+
+    /// Append an expected frame while retaining the session that must receive it.
+    fn push_frame(expected: &mut ExpectedObservation, session: SessionKey, frame: ServingFrame) {
+        expected.frames.entry(session).or_default().push(frame);
+    }
+}
+
+impl ByteCap {
+    /// Resolve a symbolic boundary against actual generated block sizes.
+    pub(super) fn resolve(self, first: u32, second: u32) -> u32 {
+        match self {
+            Self::All => MAX_BS_RESPONSE_BYTES,
+            Self::BeforeFirst => first.saturating_sub(1).max(1),
+            Self::ExactlyFirst => first.max(1),
+            Self::ExactlyFirstTwo => first.saturating_add(second).max(1),
+        }
+    }
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
@@ -59,6 +59,7 @@ struct QueryModel {
     session: SessionKey,
     peer: u8,
     start: block::Height,
+    original_count: u32,
     requested: u32,
     state: QueryState,
     finished_unavailable: bool,
@@ -340,10 +341,7 @@ impl ReferenceModel {
             Self::push_frame(
                 &mut expected,
                 session,
-                ServingFrame::RangeUnavailable {
-                    start,
-                    count: count.min(self.max_blocks).max(1),
-                },
+                ServingFrame::RangeUnavailable { start, count },
             );
             self.coverage.cap_rejections = self.coverage.cap_rejections.saturating_add(1);
             self.mark_evidence(ServingEvidence::SaturatedLedgerRejected);
@@ -361,10 +359,7 @@ impl ReferenceModel {
             Self::push_frame(
                 &mut expected,
                 session,
-                ServingFrame::RangeUnavailable {
-                    start,
-                    count: count.min(self.max_blocks).max(1),
-                },
+                ServingFrame::RangeUnavailable { start, count },
             );
             self.coverage.above_tip_rejections =
                 self.coverage.above_tip_rejections.saturating_add(1);
@@ -400,6 +395,7 @@ impl ReferenceModel {
             session,
             peer,
             start,
+            original_count: count,
             requested,
             state: QueryState::Live,
             finished_unavailable: false,
@@ -515,6 +511,7 @@ impl ReferenceModel {
                 session: query.session,
                 peer: query.peer,
                 start: query.start,
+                original_count: query.original_count,
                 requested: query.requested,
                 query_index: Some(*query_index),
             });
@@ -528,6 +525,7 @@ impl ReferenceModel {
                 session: query.session,
                 peer: query.peer,
                 start: query.start,
+                original_count: query.original_count,
                 requested: query.requested,
                 query_index: None,
             })
@@ -538,6 +536,7 @@ impl ReferenceModel {
                 session: query.session,
                 peer: query.peer,
                 start: block::Height(query.start.0.saturating_add(1)),
+                original_count: query.original_count,
                 requested: query.requested,
                 query_index: None,
             })
@@ -561,6 +560,7 @@ impl ReferenceModel {
                 session,
                 peer,
                 start: query.start,
+                original_count: query.original_count,
                 requested: query.requested,
                 query_index: None,
             })
@@ -662,7 +662,7 @@ impl ReferenceModel {
                     target.session,
                     ServingFrame::RangeUnavailable {
                         start: target.start,
-                        count: target.requested.max(1),
+                        count: target.original_count,
                     },
                 );
             }
@@ -730,7 +730,7 @@ impl ReferenceModel {
                         target.session,
                         ServingFrame::RangeUnavailable {
                             start: target.start,
-                            count: target.requested.max(1),
+                            count: target.original_count,
                         },
                     );
                 } else {

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs
@@ -706,9 +706,6 @@ impl ReferenceModel {
                         self.coverage.byte_cap_stops =
                             self.coverage.byte_cap_stops.saturating_add(1);
                         self.mark_evidence(ServingEvidence::ByteCapStoppedPrefix);
-                        if sent == 0 {
-                            self.mark_evidence(ServingEvidence::ByteCapStoppedBeforeFirstBlock);
-                        }
                         break;
                     }
                     Self::push_frame(
@@ -871,11 +868,12 @@ impl ReferenceModel {
 impl ByteCap {
     /// Resolve a symbolic boundary against actual generated block sizes.
     pub(super) fn resolve(self, first: u32, second: u32) -> u32 {
+        let minimum = u32::try_from(block::MAX_BLOCK_BYTES)
+            .expect("maximum block bytes fit the response-limit wire field");
         match self {
             Self::All => MAX_BS_RESPONSE_BYTES,
-            Self::BeforeFirst => first.saturating_sub(1).max(1),
-            Self::ExactlyFirst => first.max(1),
-            Self::ExactlyFirstTwo => first.saturating_add(second).max(1),
+            Self::ExactlyFirst => first.max(minimum),
+            Self::ExactlyFirstTwo => first.saturating_add(second).max(minimum),
         }
     }
 }

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
@@ -1,0 +1,914 @@
+//! Boundary-biased generators, focused histories, and coverage assertions.
+//!
+//! Focused cases make required contract classes deterministic. Random cases
+//! then compose the same total operations into longer histories that proptest
+//! can shrink and replay.
+
+use std::cell::RefCell;
+
+use proptest::{collection::vec, prelude::*, test_runner::TestCaseError};
+
+use super::super::runner::{assert_contract_test_manifest, GeneratedTestConfig};
+use super::{
+    replay_serving_case, ByteCap, CompletionKind, DisconnectWhich, QuerySelector, ServingCase,
+    ServingCoverage, ServingOp, ServingRequirement, ServingStep, StatusValidity,
+};
+use crate::zakura::ServicePeerDirection;
+
+const CASES_VARIABLE: &str = "ZAKURA_SERVING_MODEL_CASES";
+const SEED_VARIABLE: &str = "ZAKURA_SERVING_MODEL_SEED";
+const DEFAULT_CASES: u32 = 64;
+
+const GB_SM_TEST_MANIFEST: &[(&str, &[&str])] = &[
+    (
+        "GB-SM-01",
+        &["gb_sm_01_replacement_cancels_previous_session"],
+    ),
+    (
+        "GB-SM-02",
+        &["gb_sm_02_stale_disconnect_preserves_current_session"],
+    ),
+    ("GB-SM-03", &["gb_sm_03_missing_status_is_rejected_as_spam"]),
+    (
+        "GB-SM-04",
+        &["gb_sm_04_peer_ledgers_are_independent_and_bounded"],
+    ),
+    (
+        "GB-SM-05",
+        &["gb_sm_05_saturated_ledger_rejects_without_state_query"],
+    ),
+    (
+        "GB-SM-06",
+        &["gb_sm_06_above_tip_request_is_unavailable_without_state_query"],
+    ),
+    (
+        "GB-SM-07",
+        &["gb_sm_07_accepted_query_count_respects_all_bounds"],
+    ),
+    ("GB-SM-08", &["gb_sm_08_request_ids_are_nonzero_and_unique"]),
+    (
+        "GB-SM-09",
+        &["gb_sm_09_ready_response_sends_largest_valid_prefix_and_one_terminal"],
+    ),
+    (
+        "GB-SM-10",
+        &["gb_sm_10_invalid_completion_has_no_serving_effect"],
+    ),
+    (
+        "GB-SM-11",
+        &["gb_sm_11_repeated_completion_does_not_release_live_slot"],
+    ),
+    (
+        "GB-SM-12",
+        &["gb_sm_12_ended_session_responses_do_not_reach_replacement"],
+    ),
+    (
+        "GB-SM-13",
+        &["gb_sm_13_saturated_peer_does_not_block_other_peers"],
+    ),
+    (
+        "GB-SM-14",
+        &["gb_sm_14_frames_are_attributable_to_live_request_owner"],
+    ),
+    (
+        "GB-SM-15",
+        &["gb_sm_15_delayed_older_connect_cannot_replace_newer_session"],
+    ),
+    (
+        "GB-SM-16",
+        &["gb_sm_16_peer_frames_wait_for_reactor_admission"],
+    ),
+    (
+        "GB-SM-17",
+        &["gb_sm_17_superseded_routine_request_cannot_reach_replacement_session"],
+    ),
+    (
+        "GB-SM-18",
+        &["gb_sm_18_live_unavailable_completion_sends_terminal_and_releases_slot"],
+    ),
+    (
+        "GB-SM-19",
+        &["gb_sm_19_inbound_sessions_serve_and_use_inbound_cap"],
+    ),
+];
+
+#[test]
+fn gb_sm_contract_manifest_names_every_requirement() {
+    const EXPECTED_IDS: &[&str] = &[
+        "GB-SM-01", "GB-SM-02", "GB-SM-03", "GB-SM-04", "GB-SM-05", "GB-SM-06", "GB-SM-07",
+        "GB-SM-08", "GB-SM-09", "GB-SM-10", "GB-SM-11", "GB-SM-12", "GB-SM-13", "GB-SM-14",
+        "GB-SM-15", "GB-SM-16", "GB-SM-17", "GB-SM-18", "GB-SM-19",
+    ];
+    assert_contract_test_manifest(EXPECTED_IDS, GB_SM_TEST_MANIFEST);
+}
+
+const SCENARIO_RECONNECT_AFTER_DISCONNECT: u8 = 0;
+const SCENARIO_LEDGER_SATURATION: u8 = 1;
+const SCENARIO_ORPHANED_RESPONSE: u8 = 2;
+const SCENARIO_RETIRED_COMPLETION: u8 = 3;
+const SCENARIO_ABOVE_TIP: u8 = 4;
+const SCENARIO_UNKNOWN_COMPLETION: u8 = 5;
+const SCENARIO_MISMATCHED_COMPLETION: u8 = 6;
+const SCENARIO_CROSS_PEER_PROGRESS: u8 = 7;
+const SCENARIO_CANCEL_AND_RECONNECT: u8 = 8;
+const SCENARIO_FAST_ADMISSION: u8 = 9;
+const SCENARIO_REPLACEMENT_ADMISSION: u8 = 10;
+const SCENARIO_MISSING_STATUS: u8 = 11;
+const SCENARIO_COUNT_BOUNDS: u8 = 12;
+const SCENARIO_RESPONSE_BOUNDARIES: u8 = 13;
+const SCENARIO_NON_CONTIGUOUS_RESPONSE: u8 = 14;
+const SCENARIO_GENESIS_RESPONSE: u8 = 15;
+const SCENARIO_LIVE_UNAVAILABLE: u8 = 16;
+const SCENARIO_INBOUND_SERVING: u8 = 17;
+const SCENARIO_DISCONNECTED_RESPONSE: u8 = 18;
+const LAST_FOCUSED_SCENARIO: u8 = SCENARIO_DISCONNECTED_RESPONSE;
+
+/// Generate total operations with extra weight on requests and completion
+/// ownership, plus explicit protocol boundaries for height and count.
+fn operation_strategy() -> impl Strategy<Value = ServingOp> {
+    let peer = 0u8..super::LOGICAL_PEER_COUNT;
+    let start = prop_oneof![
+        1 => Just(0),
+        6 => 1u32..=40,
+        1 => Just(0x7fff_ffff),
+    ];
+    let count = prop_oneof![
+        3 => 1u32..=8,
+        1 => Just(1),
+        1 => Just(127),
+        1 => Just(128),
+    ];
+    let selector = prop_oneof![
+        5 => (0u8..=15).prop_map(QuerySelector::Live),
+        2 => (0u8..=15).prop_map(QuerySelector::Retired),
+        2 => (0u8..=15).prop_map(QuerySelector::Orphaned),
+        1 => (0u8..=15).prop_map(QuerySelector::Unknown),
+        1 => (0u8..=15).prop_map(QuerySelector::MismatchedStart),
+        1 => (0u8..=15).prop_map(QuerySelector::MismatchedPeer),
+    ];
+    let completion_kind = prop_oneof![
+        3 => Just(CompletionKind::Ready),
+        1 => Just(CompletionKind::ReadyOverlong),
+        2 => (0u8..=15).prop_map(CompletionKind::ReadyPrefix),
+        1 => Just(CompletionKind::ReadyWithGap),
+        1 => Just(CompletionKind::FinishedUnavailable),
+    ];
+    let completion =
+        (selector, completion_kind).prop_map(|(query, kind)| ServingOp::Complete { query, kind });
+
+    prop_oneof![
+        2 => peer.clone().prop_map(|peer| ServingOp::Connect { peer }),
+        2 => (peer.clone(), any::<bool>()).prop_map(|(peer, current)| ServingOp::Disconnect {
+            peer,
+            which: if current { DisconnectWhich::Current } else { DisconnectWhich::Stale },
+        }),
+        1 => peer.clone().prop_map(|peer| ServingOp::Cancel { peer }),
+        3 => (peer.clone(), any::<bool>()).prop_map(|(peer, valid)| ServingOp::Status {
+            peer,
+            validity: if valid { StatusValidity::Valid } else { StatusValidity::InvalidRange },
+        }),
+        8 => (peer, start, count).prop_map(|(peer, start, count)| ServingOp::GetBlocks {
+            peer,
+            start,
+            count,
+        }),
+        6 => completion,
+    ]
+}
+
+/// Generate singleton steps and realistic two- or three-operation races that
+/// must enter the runtime before it is allowed to settle.
+fn step_strategy() -> impl Strategy<Value = ServingStep> {
+    let singleton = operation_strategy().prop_map(ServingStep::single);
+    let peer = 0u8..super::LOGICAL_PEER_COUNT;
+    let start = 1u32..=24;
+    let lifecycle_race = peer.clone().prop_map(|peer| {
+        ServingStep::unsettled([
+            ServingOp::Disconnect {
+                peer,
+                which: DisconnectWhich::Current,
+            },
+            ServingOp::Connect { peer },
+        ])
+    });
+    let fast_request = (peer.clone(), start.clone()).prop_map(|(peer, start)| {
+        ServingStep::unsettled([
+            ServingOp::Status {
+                peer,
+                validity: StatusValidity::Valid,
+            },
+            ServingOp::GetBlocks {
+                peer,
+                start,
+                count: 1,
+            },
+        ])
+    });
+    let fast_admission = (peer.clone(), start).prop_map(|(peer, start)| {
+        ServingStep::unsettled([
+            ServingOp::Connect { peer },
+            ServingOp::Status {
+                peer,
+                validity: StatusValidity::Valid,
+            },
+            ServingOp::GetBlocks {
+                peer,
+                start,
+                count: 1,
+            },
+        ])
+    });
+    let replacement_admission = peer.prop_map(|peer| {
+        ServingStep::unsettled([ServingOp::Connect { peer }, ServingOp::Connect { peer }])
+    });
+
+    prop_oneof![
+        12 => singleton,
+        2 => lifecycle_race,
+        2 => fast_request,
+        1 => fast_admission,
+        1 => replacement_admission,
+    ]
+}
+
+/// Generate a complete node configuration, focused prelude, and random history.
+fn serving_case_strategy() -> impl Strategy<Value = ServingCase> {
+    (
+        any::<u64>(),
+        4u32..=24,
+        1u32..=4,
+        1u32..=8,
+        1usize..=4,
+        any::<bool>(),
+        SCENARIO_RECONNECT_AFTER_DISCONNECT..=LAST_FOCUSED_SCENARIO,
+        prop_oneof![
+            3 => Just(ByteCap::All),
+            1 => Just(ByteCap::BeforeFirst),
+            1 => Just(ByteCap::ExactlyFirst),
+            1 => Just(ByteCap::ExactlyFirstTwo),
+        ],
+        vec(step_strategy(), 8..=32),
+    )
+        .prop_map(
+            |(
+                corpus_seed,
+                tip,
+                max_inflight,
+                max_blocks,
+                max_peers,
+                inbound,
+                scenario,
+                byte_cap,
+                random_steps,
+            )| {
+                let max_peers = if matches!(
+                    scenario,
+                    SCENARIO_CROSS_PEER_PROGRESS
+                        | SCENARIO_FAST_ADMISSION
+                        | SCENARIO_REPLACEMENT_ADMISSION
+                        | SCENARIO_MISSING_STATUS
+                ) {
+                    max_peers.max(2)
+                } else if scenario == SCENARIO_INBOUND_SERVING {
+                    1
+                } else {
+                    max_peers
+                };
+                let direction = if scenario == SCENARIO_INBOUND_SERVING || inbound {
+                    ServicePeerDirection::Inbound
+                } else {
+                    ServicePeerDirection::Outbound
+                };
+                let max_inflight = match scenario {
+                    SCENARIO_RETIRED_COMPLETION => 2,
+                    SCENARIO_LIVE_UNAVAILABLE => 1,
+                    _ => max_inflight,
+                };
+                let max_blocks = if scenario == SCENARIO_COUNT_BOUNDS {
+                    4
+                } else {
+                    max_blocks
+                };
+                let byte_cap = if scenario == SCENARIO_RESPONSE_BOUNDARIES {
+                    ByteCap::ExactlyFirst
+                } else {
+                    byte_cap
+                };
+                let mut steps = focused_scenario(scenario, tip, max_inflight);
+                steps.extend(random_steps);
+                ServingCase {
+                    corpus_seed,
+                    tip,
+                    max_inflight,
+                    max_blocks,
+                    direction,
+                    max_peers,
+                    byte_cap,
+                    steps,
+                }
+            },
+        )
+}
+
+/// Return a named, deterministic history that guarantees one important class
+/// is exercised before random operations are appended.
+fn focused_scenario(scenario: u8, tip: u32, max_inflight: u32) -> Vec<ServingStep> {
+    match scenario {
+        SCENARIO_RECONNECT_AFTER_DISCONNECT => vec![
+            ServingStep::unsettled([
+                ServingOp::Disconnect {
+                    peer: 0,
+                    which: DisconnectWhich::Current,
+                },
+                ServingOp::Connect { peer: 0 },
+            ]),
+            // The replacement must use the retained Status without a refresh.
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Status {
+                peer: 0,
+                validity: StatusValidity::InvalidRange,
+            }),
+        ],
+        SCENARIO_LEDGER_SATURATION => {
+            let mut steps = vec![ServingStep::single(ServingOp::Status {
+                peer: 0,
+                validity: StatusValidity::Valid,
+            })];
+            steps.extend((0..=max_inflight).map(|offset| {
+                ServingStep::single(ServingOp::GetBlocks {
+                    peer: 0,
+                    start: 1 + (offset % tip),
+                    count: 1,
+                })
+            }));
+            steps
+        }
+        SCENARIO_ORPHANED_RESPONSE => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 2,
+            }),
+            ServingStep::unsettled([
+                ServingOp::Connect { peer: 0 },
+                ServingOp::Disconnect {
+                    peer: 0,
+                    which: DisconnectWhich::Stale,
+                },
+            ]),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Orphaned(0),
+                kind: CompletionKind::Ready,
+            }),
+        ],
+        SCENARIO_DISCONNECTED_RESPONSE => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 2,
+            }),
+            ServingStep::single(ServingOp::Disconnect {
+                peer: 0,
+                which: DisconnectWhich::Current,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Orphaned(0),
+                kind: CompletionKind::Ready,
+            }),
+        ],
+        SCENARIO_RETIRED_COMPLETION => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 2,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Retired(u8::MAX),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 3,
+                count: 1,
+            }),
+        ],
+        SCENARIO_ABOVE_TIP => vec![ServingStep::single(ServingOp::GetBlocks {
+            peer: 0,
+            start: tip.saturating_add(1),
+            count: 1,
+        })],
+        SCENARIO_UNKNOWN_COMPLETION => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Unknown(0),
+                kind: CompletionKind::FinishedUnavailable,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyPrefix(1),
+            }),
+        ],
+        SCENARIO_MISMATCHED_COMPLETION => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Connect { peer: 1 }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::MismatchedStart(0),
+                kind: CompletionKind::FinishedUnavailable,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::MismatchedPeer(0),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyPrefix(1),
+            }),
+        ],
+        SCENARIO_CROSS_PEER_PROGRESS => {
+            let mut steps = Vec::new();
+            steps.extend((0..max_inflight).map(|offset| {
+                ServingStep::single(ServingOp::GetBlocks {
+                    peer: 0,
+                    start: 1 + (offset % tip),
+                    count: 1,
+                })
+            }));
+            steps.extend([
+                ServingStep::single(ServingOp::Connect { peer: 1 }),
+                ServingStep::single(ServingOp::Status {
+                    peer: 1,
+                    validity: StatusValidity::Valid,
+                }),
+                ServingStep::single(ServingOp::GetBlocks {
+                    peer: 1,
+                    start: 1,
+                    count: 1,
+                }),
+                ServingStep::single(ServingOp::Connect { peer: 2 }),
+            ]);
+            steps
+        }
+        SCENARIO_CANCEL_AND_RECONNECT => vec![
+            ServingStep::single(ServingOp::Cancel { peer: 0 }),
+            ServingStep::single(ServingOp::Connect { peer: 0 }),
+            ServingStep::unsettled([
+                ServingOp::Status {
+                    peer: 0,
+                    validity: StatusValidity::Valid,
+                },
+                ServingOp::GetBlocks {
+                    peer: 0,
+                    start: 1,
+                    count: 1,
+                },
+            ]),
+        ],
+        SCENARIO_FAST_ADMISSION => vec![ServingStep::unsettled([
+            ServingOp::Connect { peer: 1 },
+            ServingOp::Status {
+                peer: 1,
+                validity: StatusValidity::Valid,
+            },
+            ServingOp::GetBlocks {
+                peer: 1,
+                start: 1,
+                count: 1,
+            },
+        ])],
+        SCENARIO_REPLACEMENT_ADMISSION => vec![
+            ServingStep::unsettled([
+                ServingOp::Connect { peer: 1 },
+                ServingOp::Connect { peer: 1 },
+            ]),
+            ServingStep::unsettled([
+                ServingOp::Status {
+                    peer: 1,
+                    validity: StatusValidity::Valid,
+                },
+                ServingOp::GetBlocks {
+                    peer: 1,
+                    start: 1,
+                    count: 1,
+                },
+            ]),
+        ],
+        SCENARIO_MISSING_STATUS => vec![
+            ServingStep::single(ServingOp::Connect { peer: 1 }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 1,
+                start: 1,
+                count: 1,
+            }),
+        ],
+        SCENARIO_COUNT_BOUNDS => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 2,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 8,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: tip.saturating_sub(1).max(1),
+                count: 8,
+            }),
+        ],
+        SCENARIO_RESPONSE_BOUNDARIES => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyPrefix(0),
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyPrefix(1),
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyOverlong,
+            }),
+        ],
+        SCENARIO_NON_CONTIGUOUS_RESPONSE => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 3,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::ReadyWithGap,
+            }),
+        ],
+        SCENARIO_GENESIS_RESPONSE => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 0,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::Ready,
+            }),
+        ],
+        SCENARIO_LIVE_UNAVAILABLE => vec![
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 1,
+                count: 1,
+            }),
+            ServingStep::single(ServingOp::Complete {
+                query: QuerySelector::Live(0),
+                kind: CompletionKind::FinishedUnavailable,
+            }),
+            ServingStep::single(ServingOp::GetBlocks {
+                peer: 0,
+                start: 2,
+                count: 1,
+            }),
+        ],
+        SCENARIO_INBOUND_SERVING => vec![ServingStep::single(ServingOp::Connect { peer: 1 })],
+        _ => unreachable!("the case strategy generates only named focused scenarios"),
+    }
+}
+
+/// Build a stable standalone case for one named focused history.
+fn focused_case(scenario: u8, byte_cap: ByteCap) -> ServingCase {
+    let tip = 12;
+    let max_inflight = if scenario == SCENARIO_LIVE_UNAVAILABLE {
+        1
+    } else {
+        2
+    };
+    ServingCase {
+        corpus_seed: 0x5e7e_0000_u64.saturating_add(u64::from(scenario)),
+        tip,
+        max_inflight,
+        max_blocks: 4,
+        direction: if scenario == SCENARIO_INBOUND_SERVING {
+            ServicePeerDirection::Inbound
+        } else {
+            ServicePeerDirection::Outbound
+        },
+        max_peers: if scenario == SCENARIO_INBOUND_SERVING {
+            1
+        } else {
+            2
+        },
+        byte_cap,
+        steps: focused_scenario(scenario, tip, max_inflight),
+    }
+}
+
+const ALL_FOCUSED_CASES: &[(u8, ByteCap)] = &[
+    (SCENARIO_RECONNECT_AFTER_DISCONNECT, ByteCap::All),
+    (SCENARIO_LEDGER_SATURATION, ByteCap::All),
+    (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+    (SCENARIO_RETIRED_COMPLETION, ByteCap::All),
+    (SCENARIO_ABOVE_TIP, ByteCap::All),
+    (SCENARIO_UNKNOWN_COMPLETION, ByteCap::ExactlyFirst),
+    (SCENARIO_MISMATCHED_COMPLETION, ByteCap::ExactlyFirst),
+    (SCENARIO_CROSS_PEER_PROGRESS, ByteCap::All),
+    (SCENARIO_CANCEL_AND_RECONNECT, ByteCap::All),
+    (SCENARIO_FAST_ADMISSION, ByteCap::All),
+    (SCENARIO_REPLACEMENT_ADMISSION, ByteCap::All),
+    (SCENARIO_MISSING_STATUS, ByteCap::All),
+    (SCENARIO_COUNT_BOUNDS, ByteCap::All),
+    (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::BeforeFirst),
+    (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
+    (SCENARIO_NON_CONTIGUOUS_RESPONSE, ByteCap::All),
+    (SCENARIO_GENESIS_RESPONSE, ByteCap::All),
+    (SCENARIO_LIVE_UNAVAILABLE, ByteCap::All),
+    (SCENARIO_INBOUND_SERVING, ByteCap::All),
+    (SCENARIO_DISCONNECTED_RESPONSE, ByteCap::All),
+];
+
+/// Replay focused cases and combine their verified requirement evidence.
+fn focused_coverage(cases: &[(u8, ByteCap)]) -> ServingCoverage {
+    let mut coverage = ServingCoverage::default();
+    for (scenario, byte_cap) in cases {
+        coverage += replay_serving_case(&focused_case(*scenario, *byte_cap))
+            .unwrap_or_else(|error| panic!("focused serving scenario {scenario} failed: {error}"));
+    }
+    coverage
+}
+
+/// Require a named property to be exercised by its deterministic scenarios.
+fn assert_requirement_covered(requirement: ServingRequirement, cases: &[(u8, ByteCap)]) {
+    let coverage = focused_coverage(cases);
+    assert!(
+        coverage.requirement_is_covered(requirement),
+        "{} was not fully exercised by its focused scenarios\ncoverage: {coverage}",
+        requirement.id(),
+    );
+}
+
+#[test]
+fn gb_sm_01_replacement_cancels_previous_session() {
+    assert_requirement_covered(
+        ServingRequirement::ReplacementCancelsPreviousSession,
+        &[(SCENARIO_REPLACEMENT_ADMISSION, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_02_stale_disconnect_preserves_current_session() {
+    assert_requirement_covered(
+        ServingRequirement::StaleDisconnectPreservesCurrentSession,
+        &[
+            (SCENARIO_RECONNECT_AFTER_DISCONNECT, ByteCap::All),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_03_missing_status_is_rejected_as_spam() {
+    assert_requirement_covered(
+        ServingRequirement::MissingStatusIsRejectedAsSpam,
+        &[(SCENARIO_MISSING_STATUS, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_04_peer_ledgers_are_independent_and_bounded() {
+    assert_requirement_covered(
+        ServingRequirement::PeerLedgersAreIndependentAndBounded,
+        &[
+            (SCENARIO_LEDGER_SATURATION, ByteCap::All),
+            (SCENARIO_CROSS_PEER_PROGRESS, ByteCap::All),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_05_saturated_ledger_rejects_without_state_query() {
+    assert_requirement_covered(
+        ServingRequirement::SaturatedLedgerRejectsWithoutStateQuery,
+        &[(SCENARIO_LEDGER_SATURATION, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_06_above_tip_request_is_unavailable_without_state_query() {
+    assert_requirement_covered(
+        ServingRequirement::AboveTipRequestIsUnavailableWithoutStateQuery,
+        &[(SCENARIO_ABOVE_TIP, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_07_accepted_query_count_respects_all_bounds() {
+    assert_requirement_covered(
+        ServingRequirement::AcceptedQueryCountRespectsAllBounds,
+        &[(SCENARIO_COUNT_BOUNDS, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_08_request_ids_are_nonzero_and_unique() {
+    assert_requirement_covered(
+        ServingRequirement::RequestIdsAreNonzeroAndUnique,
+        &[(SCENARIO_COUNT_BOUNDS, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_09_ready_response_sends_largest_valid_prefix_and_one_terminal() {
+    assert_requirement_covered(
+        ServingRequirement::ReadyResponseSendsLargestValidPrefixAndOneTerminal,
+        &[
+            (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::BeforeFirst),
+            (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
+            (SCENARIO_NON_CONTIGUOUS_RESPONSE, ByteCap::All),
+            (SCENARIO_GENESIS_RESPONSE, ByteCap::All),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_10_invalid_completion_has_no_serving_effect() {
+    assert_requirement_covered(
+        ServingRequirement::InvalidCompletionHasNoServingEffect,
+        &[
+            (SCENARIO_UNKNOWN_COMPLETION, ByteCap::ExactlyFirst),
+            (SCENARIO_MISMATCHED_COMPLETION, ByteCap::ExactlyFirst),
+            (SCENARIO_RETIRED_COMPLETION, ByteCap::All),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_11_repeated_completion_does_not_release_live_slot() {
+    assert_requirement_covered(
+        ServingRequirement::RepeatedCompletionDoesNotReleaseLiveSlot,
+        &[(SCENARIO_RETIRED_COMPLETION, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_12_ended_session_responses_do_not_reach_replacement() {
+    assert_requirement_covered(
+        ServingRequirement::EndedSessionResponsesDoNotReachReplacement,
+        &[
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+            (SCENARIO_DISCONNECTED_RESPONSE, ByteCap::All),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_13_saturated_peer_does_not_block_other_peers() {
+    assert_requirement_covered(
+        ServingRequirement::SaturatedPeerDoesNotBlockOtherPeers,
+        &[(SCENARIO_CROSS_PEER_PROGRESS, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_14_frames_are_attributable_to_live_request_owner() {
+    assert_requirement_covered(
+        ServingRequirement::FramesAreAttributableToLiveRequestOwner,
+        &[
+            (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+        ],
+    );
+}
+
+#[test]
+fn gb_sm_18_live_unavailable_completion_sends_terminal_and_releases_slot() {
+    assert_requirement_covered(
+        ServingRequirement::LiveUnavailableCompletionSendsTerminalAndReleasesSlot,
+        &[(SCENARIO_LIVE_UNAVAILABLE, ByteCap::All)],
+    );
+}
+
+#[test]
+fn gb_sm_19_inbound_sessions_serve_and_use_inbound_cap() {
+    assert_requirement_covered(
+        ServingRequirement::InboundSessionsServeAndUseInboundCap,
+        &[(SCENARIO_INBOUND_SERVING, ByteCap::All)],
+    );
+}
+
+/// Prove the deterministic floor covers every model-checkable requirement,
+/// then search longer generated histories for unexpected interactions.
+#[test]
+#[allow(clippy::print_stdout)]
+fn get_blocks_generated_histories_match_reference_model() {
+    let generated = GeneratedTestConfig::from_env(CASES_VARIABLE, SEED_VARIABLE, DEFAULT_CASES)
+        .unwrap_or_else(|error| panic!("invalid serving-model configuration: {error}"));
+    generated.announce("GetBlocks serving model", CASES_VARIABLE, SEED_VARIABLE);
+    let focused_coverage = focused_coverage(ALL_FOCUSED_CASES);
+    let missing = focused_coverage.missing_model_requirements();
+    assert!(
+        missing.is_empty(),
+        "focused scenarios did not cover: {}",
+        missing
+            .iter()
+            .map(|requirement| requirement.id())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
+    let coverage = RefCell::new(focused_coverage);
+    generated
+        .runner(file!())
+        .run(&serving_case_strategy(), |case| {
+            let case_coverage = replay_serving_case(&case).map_err(TestCaseError::fail)?;
+            *coverage.borrow_mut() += case_coverage;
+            Ok(())
+        })
+        .expect("generated GetBlocks serving histories satisfy the reference model");
+
+    let coverage = coverage.into_inner();
+    println!("GetBlocks serving-model coverage: {coverage}");
+    let (ledger_checks, frame_ownership_checks) = coverage.invariant_check_counts();
+    let regression_only = ServingRequirement::REGRESSION_ONLY
+        .iter()
+        .map(|requirement| requirement.id())
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!(
+        "GetBlocks requirement coverage: occurrence {}/{}, missing: none; {} ledger checks; {} frame-ownership checks; {} regression-only",
+        ServingRequirement::OCCURRENCE.len(),
+        ServingRequirement::OCCURRENCE.len(),
+        ledger_checks,
+        frame_ownership_checks,
+        regression_only,
+    );
+    assert!(
+        coverage.cases
+            >= u64::from(generated.cases()).saturating_add(
+                u64::try_from(ALL_FOCUSED_CASES.len()).expect("focused case count fits u64")
+            )
+    );
+    assert!(coverage.steps >= coverage.cases);
+    assert!(coverage.operations >= coverage.steps);
+    assert!(coverage.multi_operation_steps > 0);
+    assert!(coverage.accepted_requests >= coverage.cases);
+    assert_eq!(coverage.captured_request_ids, coverage.accepted_requests);
+    assert!(coverage.live_completions >= coverage.cases);
+}

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
@@ -337,7 +337,7 @@ fn focused_scenario(scenario: u8, tip: u32, max_inflight: u32) -> Vec<ServingSte
                 ServingStep::single(ServingOp::GetBlocks {
                     peer: 0,
                     start: 1 + (offset % tip),
-                    count: 1,
+                    count: if offset == max_inflight { 8 } else { 1 },
                 })
             }));
             steps
@@ -408,7 +408,7 @@ fn focused_scenario(scenario: u8, tip: u32, max_inflight: u32) -> Vec<ServingSte
         SCENARIO_ABOVE_TIP => vec![ServingStep::single(ServingOp::GetBlocks {
             peer: 0,
             start: tip.saturating_add(1),
-            count: 1,
+            count: 8,
         })],
         SCENARIO_UNKNOWN_COMPLETION => vec![
             ServingStep::single(ServingOp::GetBlocks {
@@ -610,7 +610,7 @@ fn focused_scenario(scenario: u8, tip: u32, max_inflight: u32) -> Vec<ServingSte
             ServingStep::single(ServingOp::GetBlocks {
                 peer: 0,
                 start: 1,
-                count: 1,
+                count: 8,
             }),
             ServingStep::single(ServingOp::Complete {
                 query: QuerySelector::Live(0),

--- a/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs
@@ -241,12 +241,7 @@ fn serving_case_strategy() -> impl Strategy<Value = ServingCase> {
         1usize..=4,
         any::<bool>(),
         SCENARIO_RECONNECT_AFTER_DISCONNECT..=LAST_FOCUSED_SCENARIO,
-        prop_oneof![
-            3 => Just(ByteCap::All),
-            1 => Just(ByteCap::BeforeFirst),
-            1 => Just(ByteCap::ExactlyFirst),
-            1 => Just(ByteCap::ExactlyFirstTwo),
-        ],
+        Just(ByteCap::All),
         vec(step_strategy(), 8..=32),
     )
         .prop_map(
@@ -634,7 +629,11 @@ fn focused_scenario(scenario: u8, tip: u32, max_inflight: u32) -> Vec<ServingSte
 
 /// Build a stable standalone case for one named focused history.
 fn focused_case(scenario: u8, byte_cap: ByteCap) -> ServingCase {
-    let tip = 12;
+    let tip = if matches!(byte_cap, ByteCap::All) {
+        12
+    } else {
+        4
+    };
     let max_inflight = if scenario == SCENARIO_LIVE_UNAVAILABLE {
         1
     } else {
@@ -663,19 +662,19 @@ fn focused_case(scenario: u8, byte_cap: ByteCap) -> ServingCase {
 const ALL_FOCUSED_CASES: &[(u8, ByteCap)] = &[
     (SCENARIO_RECONNECT_AFTER_DISCONNECT, ByteCap::All),
     (SCENARIO_LEDGER_SATURATION, ByteCap::All),
-    (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+    (SCENARIO_ORPHANED_RESPONSE, ByteCap::All),
     (SCENARIO_RETIRED_COMPLETION, ByteCap::All),
     (SCENARIO_ABOVE_TIP, ByteCap::All),
-    (SCENARIO_UNKNOWN_COMPLETION, ByteCap::ExactlyFirst),
-    (SCENARIO_MISMATCHED_COMPLETION, ByteCap::ExactlyFirst),
+    (SCENARIO_UNKNOWN_COMPLETION, ByteCap::All),
+    (SCENARIO_MISMATCHED_COMPLETION, ByteCap::All),
     (SCENARIO_CROSS_PEER_PROGRESS, ByteCap::All),
     (SCENARIO_CANCEL_AND_RECONNECT, ByteCap::All),
     (SCENARIO_FAST_ADMISSION, ByteCap::All),
     (SCENARIO_REPLACEMENT_ADMISSION, ByteCap::All),
     (SCENARIO_MISSING_STATUS, ByteCap::All),
     (SCENARIO_COUNT_BOUNDS, ByteCap::All),
-    (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::BeforeFirst),
     (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
+    (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirstTwo),
     (SCENARIO_NON_CONTIGUOUS_RESPONSE, ByteCap::All),
     (SCENARIO_GENESIS_RESPONSE, ByteCap::All),
     (SCENARIO_LIVE_UNAVAILABLE, ByteCap::All),
@@ -717,7 +716,7 @@ fn gb_sm_02_stale_disconnect_preserves_current_session() {
         ServingRequirement::StaleDisconnectPreservesCurrentSession,
         &[
             (SCENARIO_RECONNECT_AFTER_DISCONNECT, ByteCap::All),
-            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::All),
         ],
     );
 }
@@ -778,8 +777,8 @@ fn gb_sm_09_ready_response_sends_largest_valid_prefix_and_one_terminal() {
     assert_requirement_covered(
         ServingRequirement::ReadyResponseSendsLargestValidPrefixAndOneTerminal,
         &[
-            (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::BeforeFirst),
             (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
+            (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirstTwo),
             (SCENARIO_NON_CONTIGUOUS_RESPONSE, ByteCap::All),
             (SCENARIO_GENESIS_RESPONSE, ByteCap::All),
         ],
@@ -791,10 +790,10 @@ fn gb_sm_10_invalid_completion_has_no_serving_effect() {
     assert_requirement_covered(
         ServingRequirement::InvalidCompletionHasNoServingEffect,
         &[
-            (SCENARIO_UNKNOWN_COMPLETION, ByteCap::ExactlyFirst),
-            (SCENARIO_MISMATCHED_COMPLETION, ByteCap::ExactlyFirst),
+            (SCENARIO_UNKNOWN_COMPLETION, ByteCap::All),
+            (SCENARIO_MISMATCHED_COMPLETION, ByteCap::All),
             (SCENARIO_RETIRED_COMPLETION, ByteCap::All),
-            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::All),
         ],
     );
 }
@@ -812,7 +811,7 @@ fn gb_sm_12_ended_session_responses_do_not_reach_replacement() {
     assert_requirement_covered(
         ServingRequirement::EndedSessionResponsesDoNotReachReplacement,
         &[
-            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::All),
             (SCENARIO_DISCONNECTED_RESPONSE, ByteCap::All),
         ],
     );
@@ -832,7 +831,7 @@ fn gb_sm_14_frames_are_attributable_to_live_request_owner() {
         ServingRequirement::FramesAreAttributableToLiveRequestOwner,
         &[
             (SCENARIO_RESPONSE_BOUNDARIES, ByteCap::ExactlyFirst),
-            (SCENARIO_ORPHANED_RESPONSE, ByteCap::ExactlyFirstTwo),
+            (SCENARIO_ORPHANED_RESPONSE, ByteCap::All),
         ],
     );
 }

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -135,6 +135,10 @@ pub fn spawn_block_sync_reactor(
     let (lifecycle_tx, lifecycle_rx) = mpsc::unbounded_channel();
     let lifecycle_keepalive = lifecycle_tx.clone();
     let (peer_lifecycle_tx, peer_lifecycle_rx) = mpsc::unbounded_channel();
+    #[cfg(test)]
+    let (test_barriers_tx, test_barriers_rx) = mpsc::unbounded_channel();
+    #[cfg(test)]
+    let test_barriers_keepalive = test_barriers_tx.clone();
     // Size the action channel so the Sequencer can dispatch a full checkpoint
     // window of `SubmitBlock`s (`submitted_apply_limit`) plus the query/misbehavior
     // spare pool. The resident look-ahead gate — not this channel — bounds body
@@ -244,6 +248,8 @@ pub fn spawn_block_sync_reactor(
         status: status_rx,
         candidates: candidates_rx,
         routine_wiring: Some(routine_wiring),
+        #[cfg(test)]
+        test_barriers: test_barriers_tx,
     };
     let reactor = BlockSyncReactor {
         verified_block_tip: startup.frontiers.verified_block_tip,
@@ -283,6 +289,10 @@ pub fn spawn_block_sync_reactor(
         sequencer_input_decoded_attributed_memory_bytes,
         sequencer_control: sequencer_control_tx,
         sequencer_view: sequencer_view_rx,
+        #[cfg(test)]
+        test_barriers: test_barriers_rx,
+        #[cfg(test)]
+        _test_barriers_keepalive: test_barriers_keepalive,
     };
     let task = tokio::spawn(reactor.run());
 
@@ -338,6 +348,14 @@ pub(super) struct BlockSyncReactor {
     sequencer_control: mpsc::UnboundedSender<SequencerControlInput>,
     /// Latest-wins progress view published by the Sequencer task.
     sequencer_view: watch::Receiver<SequencerView>,
+    /// Test-only control path that acknowledges only after all currently
+    /// queued reactor inputs have passed through their production handlers.
+    #[cfg(test)]
+    test_barriers: mpsc::UnboundedReceiver<tokio::sync::oneshot::Sender<()>>,
+    /// Keep the optional test barrier path open when a production-shaped test
+    /// moves or drops every external [`BlockSyncHandle`].
+    #[cfg(test)]
+    _test_barriers_keepalive: mpsc::UnboundedSender<tokio::sync::oneshot::Sender<()>>,
     /// Reactor-side mirror of the Sequencer's verified tip (it no longer lives
     /// in `state`). Updated from the progress view; initialized from startup.
     verified_block_tip: block::Height,
@@ -497,6 +515,25 @@ impl BlockSyncReactor {
                         None => break,
                     }
                 }
+                _barrier = async {
+                    #[cfg(test)]
+                    {
+                        self.test_barriers.recv().await
+                    }
+                    #[cfg(not(test))]
+                    {
+                        std::future::pending::<Option<tokio::sync::oneshot::Sender<()>>>().await
+                    }
+                } => {
+                    #[cfg(test)]
+                    {
+                        let Some(barrier) = _barrier else { break };
+                        self.drain_test_inputs().await;
+                        let _ = barrier.send(());
+                    }
+                    #[cfg(not(test))]
+                    unreachable!("the production test-barrier future never resolves");
+                }
                 _ = metrics_ticks.tick() => {
                     self.publish_metrics();
                     self.refresh_throughput();
@@ -513,6 +550,34 @@ impl BlockSyncReactor {
                     self.empty_state_header_quiet_until = None;
                     self.query_needed_blocks_with_options(true).await;
                 }
+            }
+        }
+    }
+
+    /// Run every input already visible to the reactor through the same handlers
+    /// as the main select loop before acknowledging a deterministic test step.
+    #[cfg(test)]
+    async fn drain_test_inputs(&mut self) {
+        loop {
+            let mut drained = false;
+            while let Ok(event) = self.lifecycle.try_recv() {
+                self.handle_event(event).await;
+                drained = true;
+            }
+            while let Ok(event) = self.peer_lifecycle.try_recv() {
+                self.handle_peer_lifecycle_event(event).await;
+                drained = true;
+            }
+            while let Ok(event) = self.events.try_recv() {
+                self.handle_event(event).await;
+                drained = true;
+            }
+            while let Ok(message) = self.routine_to_reactor.try_recv() {
+                self.handle_routine_message(message).await;
+                drained = true;
+            }
+            if !drained {
+                break;
             }
         }
     }

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -15,6 +15,9 @@ use crate::zakura::{ServicePeerDirection, ServicePeerSnapshot, ZakuraBlockSyncCa
 // `MAX_BS_INFLIGHT_REQUESTS` is a `u32`, which fits in `usize` on supported targets.
 pub(super) const EFFECTIVE_BS_OUTBOUND_INFLIGHT_PER_PEER: usize = MAX_BS_INFLIGHT_REQUESTS as usize;
 
+#[cfg(test)]
+const TEST_BARRIER_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Cached chain frontiers used by the block-sync reactor.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct BlockSyncFrontiers {
@@ -125,6 +128,9 @@ pub struct BlockSyncHandle {
     /// (`service::add_peer`). `None` for the inert/handle-less test constructors
     /// that never spawn routines.
     pub(super) routine_wiring: Option<RoutineWiring>,
+    /// Explicit acknowledgement path used by deterministic reactor tests.
+    #[cfg(test)]
+    pub(super) test_barriers: mpsc::UnboundedSender<tokio::sync::oneshot::Sender<()>>,
 }
 
 /// The shared download primitives a per-peer pipe-routine is constructed with.
@@ -147,6 +153,20 @@ pub(super) struct RoutineWiring {
 }
 
 impl BlockSyncHandle {
+    /// Wait until the reactor has drained every input already queued on its
+    /// driver, lifecycle, peer-lifecycle, and peer-routine paths.
+    #[cfg(test)]
+    pub(crate) async fn barrier_for_test(&self) -> Result<(), &'static str> {
+        let (acknowledge, acknowledged) = tokio::sync::oneshot::channel();
+        self.test_barriers
+            .send(acknowledge)
+            .map_err(|_| "the block-sync reactor closed before the test barrier")?;
+        time::timeout(TEST_BARRIER_TIMEOUT, acknowledged)
+            .await
+            .map_err(|_| "the block-sync reactor timed out before the test barrier")?
+            .map_err(|_| "the block-sync reactor dropped the test barrier")
+    }
+
     /// Send a fact/event to the block-sync reactor.
     pub async fn send(
         &self,

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -44,6 +44,9 @@ use zakura_chain::{
 };
 use zakura_test::vectors::{BLOCK_MAINNET_1_BYTES, BLOCK_MAINNET_2_BYTES, BLOCK_MAINNET_3_BYTES};
 
+#[path = "property_tests/mod.rs"]
+mod message_contracts;
+
 fn peer(byte: u8) -> ZakuraPeerId {
     ZakuraPeerId::new(vec![byte; 32]).expect("test peer id is within bounds")
 }
@@ -6437,6 +6440,7 @@ async fn lifecycle_events_bypass_full_bounded_wire_queue() {
         // No reactor wiring: `add_peer` drains inbound (no routine), and this test
         // only checks the lifecycle-bypass plumbing.
         routine_wiring: None,
+        test_barriers: mpsc::unbounded_channel().0,
     };
     let service = BlockSyncService::new_with_handle_for_test(config, handle);
     let peer = peer(91);

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -8780,7 +8780,7 @@ mod tests {
         let _guard = zakura_test::init();
         let server = LocalEndpointFactory::new().endpoint(server_seed).await?;
         let (connection_tx, _connection_rx) = mpsc::channel(1);
-        let (stream_tx, mut stream_rx) = mpsc::channel(1);
+        let (stream_tx, mut stream_rx) = mpsc::channel(2);
         let router = Router::builder(server)
             .accept(
                 alpn,
@@ -8829,6 +8829,50 @@ mod tests {
         .await;
         assert!(matches!(
             rejected,
+            Err(ZakuraHandlerError::OversizeFrame {
+                payload_len,
+                max_frame_bytes,
+                ..
+            }) if payload_len == usize::try_from(oversized_payload).expect("u32 fits usize")
+                && max_frame_bytes == FRAME_HEADER_BYTES + payload_cap
+        ));
+
+        let (mut mismatched_send, _mismatched_recv) =
+            timeout(Duration::from_secs(1), connection.open_bi())
+                .await
+                .expect("client opens the mismatched block-sync stream")?;
+        let mut mismatched_prefix = Vec::with_capacity(FRAME_HEADER_BYTES + 1);
+        mismatched_prefix.extend_from_slice(&u16::from(crate::zakura::MSG_BS_STATUS).to_le_bytes());
+        mismatched_prefix.extend_from_slice(&0u16.to_le_bytes());
+        mismatched_prefix.extend_from_slice(&oversized_payload.to_le_bytes());
+        mismatched_prefix.push(message_type);
+        timeout(
+            Duration::from_secs(1),
+            mismatched_send.write_all(&mismatched_prefix),
+        )
+        .await
+        .expect("client writes the mismatched block-sync prefix")?;
+
+        let (_server_send, mut mismatched_server_recv) =
+            timeout(Duration::from_secs(1), stream_rx.recv())
+                .await
+                .expect("server accepts the mismatched block-sync stream")
+                .expect("capture handler forwards the mismatched block-sync stream");
+        let mismatched_rejection = timeout(
+            Duration::from_secs(1),
+            read_service_frame(
+                &mut mismatched_server_recv,
+                ZAKURA_STREAM_BLOCK_SYNC,
+                ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+                MAX_BS_FRAME_BYTES,
+                Duration::from_secs(2),
+                Some(Duration::from_secs(2)),
+            ),
+        )
+        .await
+        .expect("the response discriminator rejects before its declared remainder is read");
+        assert!(matches!(
+            mismatched_rejection,
             Err(ZakuraHandlerError::OversizeFrame {
                 payload_len,
                 max_frame_bytes,

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -8771,6 +8771,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gb_wf_11_incomplete_get_blocks_frame_expires_at_read_deadline() -> Result<(), BoxError>
+    {
+        const ALPN: &[u8] = b"/zakura/testkit/get-blocks-incomplete-frame/0";
+        const READ_DEADLINE: Duration = Duration::from_millis(100);
+
+        let _guard = zakura_test::init();
+        let server = LocalEndpointFactory::new().endpoint(94).await?;
+        let (connection_tx, _connection_rx) = mpsc::channel(1);
+        let (stream_tx, mut stream_rx) = mpsc::channel(2);
+        let router = Router::builder(server)
+            .accept(
+                ALPN,
+                CaptureConnection {
+                    connection_tx,
+                    stream_tx,
+                },
+            )
+            .spawn();
+        let client = LocalEndpointFactory::new().endpoint(95).await?;
+        let server_addr = router.endpoint().node_addr().initialized().await;
+        client.add_node_addr(server_addr.clone())?;
+        let connection = timeout(Duration::from_secs(10), client.connect(server_addr, ALPN))
+            .await
+            .expect("client connects for the incomplete GetBlocks frame test")?;
+
+        let (mut header_send, _header_recv) = timeout(Duration::from_secs(1), connection.open_bi())
+            .await
+            .expect("client opens the incomplete-header stream")?;
+        timeout(
+            Duration::from_secs(1),
+            header_send.write_all(&[crate::zakura::MSG_BS_GET_BLOCKS]),
+        )
+        .await
+        .expect("client writes the first GetBlocks frame byte")?;
+        let (_server_send, mut header_server_recv) =
+            timeout(Duration::from_secs(1), stream_rx.recv())
+                .await
+                .expect("server accepts the incomplete-header stream")
+                .expect("capture handler forwards the incomplete-header stream");
+        let header_result = timeout(
+            Duration::from_secs(1),
+            read_service_frame(
+                &mut header_server_recv,
+                ZAKURA_STREAM_BLOCK_SYNC,
+                ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+                MAX_BS_FRAME_BYTES,
+                READ_DEADLINE,
+                Some(Duration::from_secs(1)),
+            ),
+        )
+        .await
+        .expect("the frame read enforces its internal header deadline");
+        assert!(matches!(
+            header_result,
+            Err(ZakuraHandlerError::Timeout("frame header"))
+        ));
+
+        let (mut payload_send, _payload_recv) =
+            timeout(Duration::from_secs(1), connection.open_bi())
+                .await
+                .expect("client opens the incomplete-payload stream")?;
+        let mut incomplete_payload = Vec::with_capacity(FRAME_HEADER_BYTES + 1);
+        incomplete_payload
+            .extend_from_slice(&u16::from(crate::zakura::MSG_BS_GET_BLOCKS).to_le_bytes());
+        incomplete_payload.extend_from_slice(&0u16.to_le_bytes());
+        incomplete_payload.extend_from_slice(&9u32.to_le_bytes());
+        incomplete_payload.push(crate::zakura::MSG_BS_GET_BLOCKS);
+        timeout(
+            Duration::from_secs(1),
+            payload_send.write_all(&incomplete_payload),
+        )
+        .await
+        .expect("client writes a partial GetBlocks payload")?;
+        let (_server_send, mut payload_server_recv) =
+            timeout(Duration::from_secs(1), stream_rx.recv())
+                .await
+                .expect("server accepts the incomplete-payload stream")
+                .expect("capture handler forwards the incomplete-payload stream");
+        let payload_result = timeout(
+            Duration::from_secs(1),
+            read_service_frame(
+                &mut payload_server_recv,
+                ZAKURA_STREAM_BLOCK_SYNC,
+                ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+                MAX_BS_FRAME_BYTES,
+                READ_DEADLINE,
+                Some(Duration::from_secs(1)),
+            ),
+        )
+        .await
+        .expect("the frame read enforces its internal payload deadline");
+        assert!(matches!(
+            payload_result,
+            Err(ZakuraHandlerError::Timeout("frame payload"))
+        ));
+
+        connection.close(0u32.into(), b"done");
+        client.close().await;
+        router.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn invalid_prelude_stream_churn_charges_open_rate_token() -> Result<(), BoxError> {
         // claude-invalid-stream-prelude-churn-bypasses-open-rate: a peer that
         // opens a stream naming an unregistered kind is reset stream-only and the

--- a/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
+++ b/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
@@ -15,6 +15,17 @@ use crate::zakura::{
     ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC,
 };
 
+/// Result of waiting for one node-to-peer block-sync message.
+#[derive(Debug)]
+pub enum SyntheticBlockSyncReceive {
+    /// A complete frame was received and decoded.
+    Message(BlockSyncMessage),
+    /// No frame arrived before the requested deadline.
+    TimedOut,
+    /// The node closed its outbound stream.
+    Closed,
+}
+
 /// A connected synthetic block-sync peer backed by in-memory stream channels.
 #[derive(Debug)]
 pub struct SyntheticBlockSyncPeer {
@@ -80,10 +91,13 @@ impl SyntheticBlockSyncPeer {
     pub async fn recv_timeout(
         &mut self,
         duration: Duration,
-    ) -> Result<Option<BlockSyncMessage>, crate::BoxError> {
-        match timeout(duration, self.recv()).await {
-            Ok(result) => result,
-            Err(_) => Ok(None),
+    ) -> Result<SyntheticBlockSyncReceive, crate::BoxError> {
+        match timeout(duration, self.outbound.recv()).await {
+            Ok(Some(frame)) => Ok(SyntheticBlockSyncReceive::Message(
+                BlockSyncMessage::decode_frame(frame)?,
+            )),
+            Ok(None) => Ok(SyntheticBlockSyncReceive::Closed),
+            Err(_) => Ok(SyntheticBlockSyncReceive::TimedOut),
         }
     }
 

--- a/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
+++ b/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
@@ -63,6 +63,7 @@ impl SyntheticBlockSyncPeer {
 
     /// Wait until the real peer routine has handled all messages queued before
     /// this call and returned to its inbound receive loop.
+    #[cfg(test)]
     pub(crate) async fn barrier_for_test(&self) -> Result<(), crate::BoxError> {
         self.inbound.barrier_for_test().await.map_err(Into::into)
     }

--- a/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
+++ b/crates/zakura-network/src/zakura/testkit/block_sync_peer.rs
@@ -10,14 +10,17 @@ use tokio_util::sync::CancellationToken;
 
 use crate::zakura::{
     framed_channel, BlockSyncHandle, BlockSyncMessage, BlockSyncService, BlockSyncStatus,
-    FramedRecv, FramedSend, Peer, Service, ServicePeerDirection, ZakuraBlockSyncConfig,
-    ZakuraPeerId, ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC,
+    CloseCause, FramedRecv, FramedSend, Peer, Service, ServicePeerDirection, ServiceStream,
+    ZakuraBlockSyncConfig, ZakuraConnId, ZakuraPeerId, ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+    ZAKURA_CAP_BLOCK_SYNC, ZAKURA_STREAM_BLOCK_SYNC,
 };
 
 /// A connected synthetic block-sync peer backed by in-memory stream channels.
 #[derive(Debug)]
 pub struct SyntheticBlockSyncPeer {
     peer_id: ZakuraPeerId,
+    conn_id: ZakuraConnId,
+    direction: ServicePeerDirection,
     inbound: FramedSend,
     outbound: FramedRecv,
     cancel: CancellationToken,
@@ -29,11 +32,39 @@ impl SyntheticBlockSyncPeer {
         &self.peer_id
     }
 
+    /// Synthetic transport connection identity.
+    pub fn conn_id(&self) -> ZakuraConnId {
+        self.conn_id
+    }
+
+    /// Direction used for service admission.
+    pub fn direction(&self) -> ServicePeerDirection {
+        self.direction
+    }
+
+    /// Cancellation token for observing session ownership and teardown.
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
     /// Queue a real stream-6 message as inbound peer traffic to the node.
     pub async fn send(&self, msg: BlockSyncMessage) -> Result<(), crate::BoxError> {
         let frame = msg.encode_frame()?;
         self.inbound.send(frame).await?;
         Ok(())
+    }
+
+    /// Queue a real stream-6 message without yielding to the node runtime.
+    pub fn try_send(&self, msg: BlockSyncMessage) -> Result<(), crate::BoxError> {
+        let frame = msg.encode_frame()?;
+        self.inbound.try_send(frame)?;
+        Ok(())
+    }
+
+    /// Wait until the real peer routine has handled all messages queued before
+    /// this call and returned to its inbound receive loop.
+    pub(crate) async fn barrier_for_test(&self) -> Result<(), crate::BoxError> {
+        self.inbound.barrier_for_test().await.map_err(Into::into)
     }
 
     /// Receive the next real stream-6 message sent by the node to this peer.
@@ -83,27 +114,60 @@ impl SyntheticBlockSyncPeers {
         peer_id: ZakuraPeerId,
         status: BlockSyncStatus,
     ) -> Result<SyntheticBlockSyncPeer, crate::BoxError> {
+        let peer = self.connect_peer(peer_id, 0, ServicePeerDirection::Outbound)?;
+        peer.send(BlockSyncMessage::Status(status)).await?;
+        Ok(peer)
+    }
+
+    /// Attach a synthetic peer without sending its first `Status`.
+    ///
+    /// The explicit connection id and direction let lifecycle tests distinguish
+    /// a current session from a stale predecessor.
+    pub fn connect_peer(
+        &self,
+        peer_id: ZakuraPeerId,
+        conn_id: ZakuraConnId,
+        direction: ServicePeerDirection,
+    ) -> Result<SyntheticBlockSyncPeer, crate::BoxError> {
         let (inbound_tx, inbound_rx) = framed_channel(self.queue_depth);
         let (outbound_tx, outbound_rx) = framed_channel(self.queue_depth);
-        let cancel = CancellationToken::new();
-        let streams = HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (inbound_rx, outbound_tx))]);
+        let connection_cancel = CancellationToken::new();
+        let service_cancel = connection_cancel.child_token();
+        let streams = HashMap::from([(
+            ZAKURA_STREAM_BLOCK_SYNC,
+            ServiceStream::new(
+                0,
+                ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+                inbound_rx,
+                outbound_tx,
+                service_cancel.clone(),
+            ),
+        )]);
 
-        self.service.add_peer(Peer::new_with_direction(
+        self.service.add_peer(Peer::new_with_service_cancel_token(
+            conn_id,
             peer_id.clone(),
             None,
             ZAKURA_CAP_BLOCK_SYNC,
-            ServicePeerDirection::Outbound,
+            direction,
             streams,
-            cancel.clone(),
+            connection_cancel,
+            service_cancel.clone(),
+            CloseCause::default(),
         ));
 
-        let peer = SyntheticBlockSyncPeer {
+        Ok(SyntheticBlockSyncPeer {
             peer_id,
+            conn_id,
+            direction,
             inbound: inbound_tx,
             outbound: outbound_rx,
-            cancel,
-        };
-        peer.send(BlockSyncMessage::Status(status)).await?;
-        Ok(peer)
+            cancel: service_cancel,
+        })
+    }
+
+    /// Remove exactly one synthetic connection from the service.
+    pub fn remove_peer(&self, peer_id: &ZakuraPeerId, conn_id: ZakuraConnId) {
+        self.service.remove_peer(peer_id, conn_id);
     }
 }

--- a/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
+++ b/crates/zakura-network/src/zakura/testkit/mock_blocksync.rs
@@ -58,6 +58,8 @@ impl SyntheticBlockShape {
 
 #[derive(Clone)]
 pub(crate) struct SyntheticBlockCorpus {
+    genesis: Arc<block::Block>,
+    genesis_size: usize,
     blocks: Arc<Vec<Arc<block::Block>>>,
     sizes: Arc<Vec<usize>>,
     by_hash: Arc<HashMap<block::Hash, block::Height>>,
@@ -65,12 +67,14 @@ pub(crate) struct SyntheticBlockCorpus {
 
 impl SyntheticBlockCorpus {
     pub(crate) fn generate(count: u32, seed: u64, shape: SyntheticBlockShape) -> Self {
+        let genesis = mainnet_block(&BLOCK_MAINNET_GENESIS_BYTES);
+        let genesis_size = block_size(&genesis);
         let template = mainnet_block(&BLOCK_MAINNET_1_BYTES);
         let fixed_tx_count = shape.fixed_tx_count(&template);
         let mut blocks = Vec::with_capacity(usize::try_from(count).expect("u32 fits usize"));
         let mut sizes = Vec::with_capacity(usize::try_from(count).expect("u32 fits usize"));
-        let mut by_hash = HashMap::new();
-        let mut previous_hash = mainnet_genesis_hash();
+        let mut by_hash = HashMap::from([(genesis.hash(), block::Height::MIN)]);
+        let mut previous_hash = genesis.hash();
 
         for height in 1..=count {
             let random = splitmix64(seed ^ u64::from(height));
@@ -89,6 +93,8 @@ impl SyntheticBlockCorpus {
         }
 
         Self {
+            genesis,
+            genesis_size,
             blocks: Arc::new(blocks),
             sizes: Arc::new(sizes),
             by_hash: Arc::new(by_hash),
@@ -108,6 +114,9 @@ impl SyntheticBlockCorpus {
     }
 
     pub(crate) fn block_at(&self, height: block::Height) -> Option<Arc<block::Block>> {
+        if height == block::Height::MIN {
+            return Some(self.genesis.clone());
+        }
         let index = height.0.checked_sub(1)?;
         self.blocks
             .get(usize::try_from(index).expect("u32 fits usize"))
@@ -115,6 +124,9 @@ impl SyntheticBlockCorpus {
     }
 
     pub(crate) fn size_at(&self, height: block::Height) -> Option<usize> {
+        if height == block::Height::MIN {
+            return Some(self.genesis_size);
+        }
         let index = height.0.checked_sub(1)?;
         self.sizes
             .get(usize::try_from(index).expect("u32 fits usize"))
@@ -941,6 +953,17 @@ fn synthetic_block_generation_is_stable_and_serializable() {
     let repeat =
         SyntheticBlockCorpus::generate(64, SYNTHETIC_CORPUS_SEED, SyntheticBlockShape::default());
     let mut previous_hash = mainnet_genesis_hash();
+
+    let genesis = corpus.block_at(block::Height::MIN).expect("genesis exists");
+    assert_eq!(genesis.hash(), previous_hash);
+    assert_eq!(
+        corpus.size_at(block::Height::MIN),
+        Some(BLOCK_MAINNET_GENESIS_BYTES.len())
+    );
+    assert_eq!(
+        corpus.height_for_hash(previous_hash),
+        Some(block::Height::MIN)
+    );
 
     for height in 1..=64 {
         let height = block::Height(height);

--- a/crates/zakura-network/src/zakura/testkit/mod.rs
+++ b/crates/zakura-network/src/zakura/testkit/mod.rs
@@ -18,7 +18,9 @@ mod trace_capture;
 mod trace_reader;
 mod wait;
 
-pub use block_sync_peer::{SyntheticBlockSyncPeer, SyntheticBlockSyncPeers};
+pub use block_sync_peer::{
+    SyntheticBlockSyncPeer, SyntheticBlockSyncPeers, SyntheticBlockSyncReceive,
+};
 pub use clock::{Clock, RealClock, TestClock};
 pub use cluster::{ClusterTopology, ZakuraTestCluster};
 pub use endpoint::LocalEndpointFactory;

--- a/crates/zakura-network/src/zakura/testkit/mod.rs
+++ b/crates/zakura-network/src/zakura/testkit/mod.rs
@@ -28,6 +28,8 @@ pub use matrix::{
     default_profiles, default_remote_profiles, expected_outcomes, run_default_matrix,
     ExpectedOutcome, MatrixCell, MatrixExpectation, ProfileId,
 };
+#[cfg(test)]
+pub(crate) use mock_blocksync::{SyntheticBlockCorpus, SyntheticBlockShape};
 pub use node::{ZakuraTestNode, ZakuraTestNodeBuilder};
 pub use pinned::{
     PeerProfile, PinnedNegotiation, PinnedPeer, PinnedProfileError, PinnedZakuraProfile,

--- a/crates/zakura-network/src/zakura/transport/io.rs
+++ b/crates/zakura-network/src/zakura/transport/io.rs
@@ -6,23 +6,50 @@
 //! before frames reach these handles.
 
 use tokio::sync::mpsc;
+#[cfg(test)]
+use tokio::sync::oneshot;
+#[cfg(test)]
+use tokio::time::{timeout, Duration};
 
 use super::Frame;
+
+#[cfg(test)]
+const TEST_BARRIER_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Receive half for bounded, rate-admitted Zakura frames.
 #[derive(Debug)]
 pub struct FramedRecv {
     receiver: mpsc::Receiver<Frame>,
+    #[cfg(test)]
+    barrier_receiver: Option<mpsc::UnboundedReceiver<oneshot::Sender<()>>>,
 }
 
 impl FramedRecv {
     /// Wrap a bounded frame receiver.
     pub fn new(receiver: mpsc::Receiver<Frame>) -> Self {
-        Self { receiver }
+        Self {
+            receiver,
+            #[cfg(test)]
+            barrier_receiver: None,
+        }
     }
 
     /// Receive the next admitted frame, or `None` after the transport closes the stream.
     pub async fn recv(&mut self) -> Option<Frame> {
+        #[cfg(test)]
+        if let Some(barriers) = self.barrier_receiver.as_mut() {
+            loop {
+                tokio::select! {
+                    biased;
+                    frame = self.receiver.recv() => return frame,
+                    barrier = barriers.recv() => {
+                        let barrier = barrier?;
+                        let _ = barrier.send(());
+                    }
+                }
+            }
+        }
+
         self.receiver.recv().await
     }
 }
@@ -31,12 +58,18 @@ impl FramedRecv {
 #[derive(Clone, Debug)]
 pub struct FramedSend {
     sender: mpsc::Sender<Frame>,
+    #[cfg(test)]
+    barrier_sender: Option<mpsc::UnboundedSender<oneshot::Sender<()>>>,
 }
 
 impl FramedSend {
     /// Wrap a bounded frame sender.
     pub fn new(sender: mpsc::Sender<Frame>) -> Self {
-        Self { sender }
+        Self {
+            sender,
+            #[cfg(test)]
+            barrier_sender: None,
+        }
     }
 
     /// Queue a frame for transport-owned encoding and writing.
@@ -58,10 +91,61 @@ impl FramedSend {
     pub fn max_capacity(&self) -> usize {
         self.sender.max_capacity()
     }
+
+    /// Wait until the receiving task has consumed every frame queued before
+    /// this call and returned to its receive loop.
+    #[cfg(test)]
+    pub(crate) async fn barrier_for_test(&self) -> Result<(), &'static str> {
+        let barriers = self
+            .barrier_sender
+            .as_ref()
+            .ok_or("this framed sender has no test barrier")?;
+        let (acknowledge, acknowledged) = oneshot::channel();
+        barriers
+            .send(acknowledge)
+            .map_err(|_| "the framed receiver closed before the test barrier")?;
+        timeout(TEST_BARRIER_TIMEOUT, acknowledged)
+            .await
+            .map_err(|_| "the framed receiver timed out before the test barrier")?
+            .map_err(|_| "the framed receiver dropped the test barrier")
+    }
 }
 
 /// Build a bounded in-memory framed channel for scaffolding and tests.
 pub fn framed_channel(depth: usize) -> (FramedSend, FramedRecv) {
     let (sender, receiver) = mpsc::channel(depth);
-    (FramedSend::new(sender), FramedRecv::new(receiver))
+    #[cfg(test)]
+    {
+        let (barrier_sender, barrier_receiver) = mpsc::unbounded_channel();
+        (
+            FramedSend {
+                sender,
+                barrier_sender: Some(barrier_sender),
+            },
+            FramedRecv {
+                receiver,
+                barrier_receiver: Some(barrier_receiver),
+            },
+        )
+    }
+
+    #[cfg(not(test))]
+    {
+        (FramedSend::new(sender), FramedRecv::new(receiver))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn framed_barrier_times_out_when_receiver_stops_progressing() {
+        let (sender, _receiver) = framed_channel(1);
+
+        assert_eq!(
+            sender.barrier_for_test().await,
+            Err("the framed receiver timed out before the test barrier")
+        );
+    }
 }

--- a/docs/changelog/unreleased/872.md
+++ b/docs/changelog/unreleased/872.md
@@ -1,0 +1,3 @@
+<!-- changelog: none -->
+
+This PR only changes tests and test documentation, with no operator-visible effect.

--- a/docs/specs/native-p2p/README.md
+++ b/docs/specs/native-p2p/README.md
@@ -25,6 +25,8 @@ Status is tracked separately for each contract layer:
 - **Draft:** an earlier proposal is preserved, but it still needs stable IDs
   and reconciliation with the production protocol.
 - **Specified:** requirements exist, but implementation evidence is incomplete.
+- **Partially implemented:** some requirements have evidence and the contract
+  names what remains.
 - **Implemented:** the contract links every requirement to passing evidence.
 - **Covered by request:** response load is owned by the initiating request;
   this does not complete the response's wire or receiving-side contract.
@@ -46,10 +48,10 @@ original proposal. They do not specify the currently deployed stream versions.
 |  |  | ↳ `Headers` — response | TBD; [v9 successor draft](header-lookup.md) | TBD; [v9 successor draft](header-lookup.md) | Covered by future request contract |
 |  |  | ↳ `HeadersOutcome` — terminal response | TBD; [v9 successor draft](header-lookup.md) | TBD; [v9 successor draft](header-lookup.md) | Covered by future request contract |
 | Block sync (6) | Advertisement | `Status` | [Draft](block-advertisement.md) | [Draft](block-advertisement.md) | [Draft](block-advertisement.md) |
-| Block sync (6) | Block range | `GetBlocks` — request | [Specified](block-range.md#wire-format-contract) | [Specified](block-range.md#serving-model-contract) | [Specified](block-range.md#regulated-load-contract) |
-|  |  | ↳ `Block` — response item | [Draft](block-range.md#draft-response-receiving-contract) | [Sending specified](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
-|  |  | ↳ `BlocksDone` — terminal response | [Draft](block-range.md#draft-response-receiving-contract) | [Sending specified](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
-|  |  | ↳ `RangeUnavailable` — terminal response | [Draft](block-range.md#draft-response-receiving-contract) | [Sending specified](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
+| Block sync (6) | Block range | `GetBlocks` — request | [Implemented](block-range.md#wire-format-contract) | [Implemented](block-range.md#serving-model-contract) | [Specified](block-range.md#regulated-load-contract) |
+|  |  | ↳ `Block` — response item | [Draft](block-range.md#draft-response-receiving-contract) | [Sending implemented](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
+|  |  | ↳ `BlocksDone` — terminal response | [Draft](block-range.md#draft-response-receiving-contract) | [Sending implemented](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
+|  |  | ↳ `RangeUnavailable` — terminal response | [Draft](block-range.md#draft-response-receiving-contract) | [Sending implemented](block-range.md#serving-model-contract); [receiving draft](block-range.md#draft-response-receiving-contract) | [Covered by `GetBlocks`](block-range.md#regulated-load-contract) |
 
 The indented rows are protocol roles, not Rust subtypes.
 

--- a/docs/specs/native-p2p/block-range.md
+++ b/docs/specs/native-p2p/block-range.md
@@ -399,7 +399,7 @@ Run the current wire-format and serving-model evidence:
 
 ```sh
 cargo test -p zakura-network --lib message_contracts -- --nocapture --test-threads=1
-cargo test -p zakura-network --lib gb_wf_09 -- --nocapture
+cargo test -p zakura-network --lib payload_cap_precedes_allocation -- --nocapture --test-threads=1
 ```
 
 Run more generated serving scenarios before changing block-sync lifecycle or

--- a/docs/specs/native-p2p/block-range.md
+++ b/docs/specs/native-p2p/block-range.md
@@ -1,7 +1,8 @@
 # Block-range exchange (`GetBlocks`)
 
-> **Status: specified.** Implementation PRs must add evidence before changing
-> any layer to implemented.
+> **Status: partially implemented.** The wire-format and serving-model layers
+> are implemented. Regulated load is specified here and gains implementation
+> evidence in the regulation layer of the stack.
 
 This contract covers the stream-6 block-range serving exchange initiated by
 `GetBlocks`. It specifies the request wire format, the server's state and
@@ -33,18 +34,18 @@ the reactor, or request identity allocation.
 
 ## Wire format contract
 
-| ID | Requirement |
-| --- | --- |
-| GB-WF-01 | The outer frame type and payload discriminator are both `2`. |
-| GB-WF-02 | The canonical payload is nine bytes: discriminator, little-endian start height, and little-endian count. |
-| GB-WF-03 | The start height is in `0..=0x7fff_ffff`. |
-| GB-WF-04 | The count is in `1..=128`. |
-| GB-WF-05 | The decoder consumes the payload exactly and rejects trailing bytes. |
-| GB-WF-06 | Accepted frames have zero flags. |
-| GB-WF-07 | Every accepted request re-encodes to the same canonical payload. |
-| GB-WF-08 | Start and count are independently valid. A request beginning at `Height::MAX` with count 128 is valid; serving safely clamps it to the representable and available prefix. |
-| GB-WF-09 | The frame reader rejects a `GetBlocks` payload longer than nine bytes before allocating its payload buffer. |
-| GB-WF-10 | Decoding the fixed payload performs no allocation sized from peer-provided fields. |
+| ID | Test | Requirement |
+| --- | --- | --- |
+| GB-WF-01 | `gb_wf_01_payload_and_frame_type_are_two` | The outer frame type and payload discriminator are both `2`. |
+| GB-WF-02 | `gb_wf_02_payload_uses_canonical_nine_byte_layout` | The canonical payload is nine bytes: discriminator, little-endian start height, and little-endian count. |
+| GB-WF-03 | `gb_wf_03_start_height_is_bounded` | The start height is in `0..=0x7fff_ffff`. |
+| GB-WF-04 | `gb_wf_04_count_is_between_one_and_128` | The count is in `1..=128`. |
+| GB-WF-05 | `gb_wf_05_decoder_rejects_trailing_bytes` | The decoder consumes the payload exactly and rejects trailing bytes. |
+| GB-WF-06 | `gb_wf_06_frames_require_zero_flags` | Accepted frames have zero flags. |
+| GB-WF-07 | `gb_wf_07_accepted_messages_reencode_canonically` | Every accepted request re-encodes to the same canonical payload. |
+| GB-WF-08 | `gb_wf_08_maximum_start_and_count_are_safe_to_serve` | Start and count are independently valid. A request beginning at `Height::MAX` with count 128 is valid; serving safely clamps it to the representable and available prefix. |
+| GB-WF-09 | `gb_wf_09_get_blocks_payload_cap_precedes_allocation` | The frame reader rejects a payload longer than nine bytes before allocation when either its outer frame type or payload discriminator identifies `GetBlocks`. |
+| GB-WF-10 | `gb_wf_10_fixed_fields_do_not_size_decode_allocation` | Decoding the fixed payload performs no allocation sized from peer-provided fields. |
 
 Deterministic cases cover:
 
@@ -72,27 +73,27 @@ Input classes identify who can create each event:
   behavior.
 - **All:** invariants checked after each settled step.
 
-| ID | Class | Requirement |
-| --- | --- | --- |
-| GB-SM-01 | Peer | A replacement connection cancels the preceding session for the same peer. |
-| GB-SM-02 | Peer | A stale disconnect does not close or mutate the current session. |
-| GB-SM-03 | Peer | A peer without retained valid `Status` cannot start a request; the attempt is recorded as `GetBlocksSpam`. |
-| GB-SM-04 | All | Each peer has an independent request ledger bounded by the configured local in-flight cap. |
-| GB-SM-05 | Peer | A cap-rejected request emits no state query and receives `RangeUnavailable` while output capacity is available. |
-| GB-SM-06 | Peer | A request starting above the servable tip emits no state query and receives `RangeUnavailable`. |
-| GB-SM-07 | Peer | An accepted query count is clamped by the wire count, local count limit, representable heights, and available range. |
-| GB-SM-08 | Driver | Request identities are nonzero and are not reused during one replay. |
-| GB-SM-09 | Driver | A matching ready response sends the largest contiguous prefix within the byte cap followed by exactly one appropriate terminal frame. |
-| GB-SM-10 | Internal | Unknown, retired, mismatched, repeated, or orphaned completion identities have no serving effect. |
-| GB-SM-11 | Internal | Repeating a completed response does not release another live request slot. |
-| GB-SM-12 | Peer | Disconnecting or replacing a session orphans its queries; later results never reach the replacement. |
-| GB-SM-13 | Peer | Saturating one peer does not consume another peer's request ledger. |
-| GB-SM-14 | All | Every `Block` or terminal frame is attributable to the live session and request that owns it. |
-| GB-SM-15 | Peer | A delayed older `PeerConnected` event cannot replace a newer reactor session for the same peer. |
-| GB-SM-16 | Peer | A peer routine does not process frames until the reactor admits or rejects its session. |
-| GB-SM-17 | Peer | A request decoded by a superseded routine produces no state query, reply, or misbehavior record for its replacement session. |
-| GB-SM-18 | Driver | A matching zero-result state completion sends `RangeUnavailable`, retires the request, and releases its slot. |
-| GB-SM-19 | Peer | Inbound sessions serve `GetBlocks` through the same path and use the inbound peer cap independently of the outbound cap. |
+| ID | Test | Class | Requirement |
+| --- | --- | --- | --- |
+| GB-SM-01 | `gb_sm_01_replacement_cancels_previous_session` | Peer | A replacement connection cancels the preceding session for the same peer. |
+| GB-SM-02 | `gb_sm_02_stale_disconnect_preserves_current_session` | Peer | A stale disconnect does not close or mutate the current session. |
+| GB-SM-03 | `gb_sm_03_missing_status_is_rejected_as_spam` | Peer | A peer without retained valid `Status` cannot start a request; the attempt is recorded as `GetBlocksSpam`. |
+| GB-SM-04 | `gb_sm_04_peer_ledgers_are_independent_and_bounded` | All | Each peer has an independent request ledger bounded by the configured local in-flight cap. |
+| GB-SM-05 | `gb_sm_05_saturated_ledger_rejects_without_state_query` | Peer | A cap-rejected request emits no state query and receives `RangeUnavailable` while output capacity is available. |
+| GB-SM-06 | `gb_sm_06_above_tip_request_is_unavailable_without_state_query` | Peer | A request starting above the servable tip emits no state query and receives `RangeUnavailable`. |
+| GB-SM-07 | `gb_sm_07_accepted_query_count_respects_all_bounds` | Peer | An accepted query count is clamped by the wire count, local count limit, representable heights, and available range. |
+| GB-SM-08 | `gb_sm_08_request_ids_are_nonzero_and_unique` | Driver | Request identities are nonzero and are not reused during one replay. |
+| GB-SM-09 | `gb_sm_09_ready_response_sends_largest_valid_prefix_and_one_terminal` | Driver | A matching ready response sends the largest contiguous prefix within the requested count and byte cap, followed by exactly one appropriate terminal frame. |
+| GB-SM-10 | `gb_sm_10_invalid_completion_has_no_serving_effect` | Internal | Unknown, retired, mismatched, repeated, or orphaned completion identities have no serving effect. |
+| GB-SM-11 | `gb_sm_11_repeated_completion_does_not_release_live_slot` | Internal | Repeating a completed response does not release another live request slot. |
+| GB-SM-12 | `gb_sm_12_ended_session_responses_do_not_reach_replacement` | Peer | Disconnecting or replacing a session orphans its queries; later results never reach the replacement. |
+| GB-SM-13 | `gb_sm_13_saturated_peer_does_not_block_other_peers` | Peer | Saturating one peer does not consume another peer's request ledger. |
+| GB-SM-14 | `gb_sm_14_frames_are_attributable_to_live_request_owner` | All | Every `Block` or terminal frame is attributable to the live session and request that owns it. |
+| GB-SM-15 | `gb_sm_15_delayed_older_connect_cannot_replace_newer_session` | Peer | A delayed older `PeerConnected` event cannot replace a newer reactor session for the same peer. |
+| GB-SM-16 | `gb_sm_16_peer_frames_wait_for_reactor_admission` | Peer | A peer routine does not process frames until the reactor admits or rejects its session. |
+| GB-SM-17 | `gb_sm_17_superseded_routine_request_cannot_reach_replacement_session` | Peer | A request decoded by a superseded routine produces no state query, reply, or misbehavior record for its replacement session. |
+| GB-SM-18 | `gb_sm_18_live_unavailable_completion_sends_terminal_and_releases_slot` | Driver | A matching zero-result state completion sends `RangeUnavailable`, retires the request, and releases its slot. |
+| GB-SM-19 | `gb_sm_19_inbound_sessions_serve_and_use_inbound_cap` | Peer | Inbound sessions serve `GetBlocks` through the same path and use the inbound peer cap independently of the outbound cap. |
 
 Serving `Status` survives an overlapping replacement for the same authenticated
 peer, but not a fully settled disconnect. Changing that policy requires a
@@ -109,7 +110,8 @@ limit, request size, and response-byte limit. It contains:
 
 1. A successful exchange proving the full path works.
 2. One focused boundary or lifecycle scenario.
-3. Generated steps that search interactions among the requirements.
+3. Between 8 and 32 generated steps that search interactions among the
+   requirements.
 
 | Operation | Effect |
 | --- | --- |
@@ -121,13 +123,14 @@ limit, request size, and response-byte limit. It contains:
 | `Complete` | Return a result for a live, completed, orphaned, unknown, or mismatched query. |
 
 A step may issue several operations before settling only when they share a
-defined FIFO order or happens-before relationship. Normal settled steps use an
-explicit production barrier. Fixed sleeps or yield counts are not a settlement
-contract.
+defined FIFO order or happens-before relationship. Focused scenarios cover
+every model-checkable `GB-SM` occurrence before random histories run, and
+forced regressions cover task orderings the normal runner cannot reliably
+place.
 
-Focused scenarios cover every model-checkable `GB-SM` occurrence before random
-histories run. Invariants report their successful comparison count. Forced
-regressions cover task orderings the normal runner cannot reliably place.
+The runner settles each step with explicit acknowledgements from the reactor
+and every live peer routine. It rejects invalid case-count or seed overrides
+and prints the effective values for rerunning the unchanged generator.
 
 ## Regulated load contract
 
@@ -308,17 +311,79 @@ The first implementation deliberately leaves these policies separate:
 - A successor stream version may add a wire request ID and block hashes to make
   response ownership explicit.
 
-## Implementation evidence
+## Peer reachability evidence
 
-The implementation PR for each layer must add:
+The contract records eight failure scenarios in three fix areas. Several
+scenarios share one ownership or ordering fix, so there are three production
+fixes rather than eight.
 
-- the ID-named Rust test for every requirement;
-- a machine-checked ID-to-test manifest;
-- run and replay commands;
-- generated case and successful comparison counts;
-- focused regressions for forced schedules;
-- sensitivity results for historical defects and observation channels; and
-- peer-reachability or native-load evidence for operational claims.
+- **Natural** means peer traffic triggered the behavior without timing
+  controls.
+- **Controlled schedule** means a delay made a production-valid ordering
+  repeatable.
+- **Internal only** means a peer cannot create the event.
 
-Until that evidence exists, the catalog must continue to show the layer as
-**Specified**, not **Implemented**.
+| Fix area | Scenario exercised | Reachability |
+| --- | --- | --- |
+| Admission ordering | Peer reads begin before reactor admission | Natural |
+| Admission ordering | A valid first request is treated as spam | Controlled schedule |
+| Connection lifecycle | An older connection replaces the current session | Controlled schedule |
+| Connection lifecycle | A stale disconnect removes the replacement | Controlled schedule |
+| Request ownership | An old response reaches a replacement session | Controlled schedule |
+| Request ownership | A stale completion releases a live request slot | Controlled schedule |
+| Request ownership | A forged response identity changes serving state | Internal only |
+| Request ownership | A superseded routine's request reaches its replacement session | Controlled schedule |
+
+The three production fixes are:
+
+1. **Admission ordering:** prevent peer reads until reactor admission finishes.
+2. **Connection lifecycle:** tie connect and disconnect events to the correct
+   connection generation.
+3. **Request ownership:** bind serving requests to the originating session and
+   responses and capacity to the exact live request.
+
+### Confirmation results
+
+Temporary local-network probes compared complete source snapshots before and
+after each fix. The probes were removed after recording the results. The
+superseded-routine case remains as a forced-ordering regression because its
+exact handoff must be intercepted deterministically.
+
+| Fix area | Before-fix snapshot | Fixed snapshot | Result |
+| --- | --- | --- | --- |
+| Admission ordering | `5f1e12367` | `cdc769f19` | Under simultaneous peer load, `Status` preceded admission in 90 of 96 sessions before the fix and 0 of 96 after it. Reproducing the dropped-as-spam consequence required delaying the real `Connected` event. |
+| Connection lifecycle | `5f1e12367` | `28b4aef9e` | Delaying real lifecycle events displaced the current session 6 of 6 times before the fix. A stronger wire replay failed 3 of 3 times before the fix. Neither failed afterward. |
+| Request ownership | `38538d460` | `6d6ab411f` | Before the fix, a delayed state result produced three `Block`/`BlocksDone` sequences and no rejection. After the fix, Zakura produced one valid sequence and rejected the stale request with `RangeUnavailable`. |
+| Request session ownership | `6d6ab411f` | `070247cbe` | Two real peer routines decoded requests around a replacement. Delaying the older routine's request made the pre-fix reactor query its range through the replacement; the fixed reactor ignored it and queried only the replacement's range. |
+
+See [reachability claims](../../design/property-testing.md#reachability-claims) for
+the evidence required by each label.
+
+## Running and replaying
+
+Run the current wire-format and serving-model evidence:
+
+```sh
+cargo test -p zakura-network --lib message_contracts -- --nocapture --test-threads=1
+cargo test -p zakura-network --lib gb_wf_09 -- --nocapture
+```
+
+Run more generated serving scenarios before changing block-sync lifecycle or
+serving logic:
+
+```sh
+ZAKURA_SERVING_MODEL_CASES=1000 \
+  cargo test -p zakura-network --lib message_contracts::serving_model \
+  -- --nocapture --test-threads=1
+```
+
+Every generated run prints its effective case count and seed. Set both values
+to rerun the same cases on the same revision and generator, and preserve
+important failures as focused regressions:
+
+```sh
+ZAKURA_SERVING_MODEL_CASES=1000 \
+ZAKURA_SERVING_MODEL_SEED=<printed-seed> \
+  cargo test -p zakura-network --lib message_contracts::serving_model \
+  -- --nocapture --test-threads=1
+```


### PR DESCRIPTION
## Motivation

Make native P2P property testing understandable and reusable while proving the approach on the block-range serving exchange. The contract links all eleven `GB-WF` requirements and all nineteen `GB-SM` requirements to registered ID-named tests. Generated histories run through the real service, peer routine, reactor, state interface, and framed stream, with explicit acknowledgements between steps and strict printed replay inputs.

The production fixes remain separate. This PR adds tests, test-only instrumentation, and documentation, and temporarily targets their integration branch.

## Review map

1. Read the [native P2P contract catalog](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/docs/specs/native-p2p/README.md), then the [block-range contract](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/docs/specs/native-p2p/block-range.md).
2. Review [get_blocks.rs](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/crates/zakura-network/src/zakura/block_sync/property_tests/get_blocks.rs) for wire and boundary evidence. The `GB-WF-09` allocation fix and real-QUIC regression remain in the separate production fix incorporated by this PR's integration base.
3. Review [serving_model/tests.rs](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/tests.rs) for focused cases and generated histories, [model.rs](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/model.rs) for independent predictions, and [harness.rs](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/crates/zakura-network/src/zakura/block_sync/property_tests/serving_model/harness.rs) for the real production seam.
4. Review [lifecycle_regressions.rs](https://github.com/zakura-core/zakura/blob/adam/getblocks-serving-model/crates/zakura-network/src/zakura/block_sync/property_tests/lifecycle_regressions.rs) for forced schedules the generated lane cannot guarantee.

## How to run

```sh
cargo test -p zakura-network --lib message_contracts -- --nocapture --test-threads=1
cargo test -p zakura-network --lib gb_wf_09 -- --nocapture
cargo test -p zakura-network --lib gb_wf_11 -- --nocapture
```

For a deeper generated run, set `ZAKURA_SERVING_MODEL_CASES`. Every run prints the effective case count and seed; set `ZAKURA_SERVING_MODEL_SEED` to rerun the same cases on the same revision and generator.

