### PR TITLE
fix(continuous-sync): advertise public addresses for native discovery

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -68,6 +68,10 @@ Tracked repository files:
 - Each node's `public_ip` controls its advertised legacy and Zakura addresses.
   The legacy address uses port 8233. Zakura combines the same public IP with
   its port 8234 listener when it creates the signed discovery record.
+- `health_min_connected_peers` controls the health endpoint's legacy peer
+  threshold. The v2-only node sets this threshold to zero because the health
+  endpoint does not count Zakura connections. Its readiness check still
+  requires a recent chain tip within the configured block distance.
 - `continuous-sync.py` is the host-local controller.
 - `alert-monitor.py` is the cluster Slack alerter.
 - `alert-status.py` emits one node's local status as JSON for peer queries.

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -65,6 +65,9 @@ or run the **Zakura continuous genesis sync fleet** workflow with
 Tracked repository files:
 
 - `nodes.toml` is the source-of-truth fleet inventory and policy.
+- Each node's `public_ip` controls its advertised legacy and Zakura addresses.
+  The legacy address uses port 8233. Zakura combines the same public IP with
+  its port 8234 listener when it creates the signed discovery record.
 - `continuous-sync.py` is the host-local controller.
 - `alert-monitor.py` is the cluster Slack alerter.
 - `alert-status.py` emits one node's local status as JSON for peer queries.

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -174,6 +174,7 @@ def subst_for(node: Node) -> dict[str, str]:
         "MAX_RUN_SECONDS": str(raw["max_run_seconds"]),
         "READY_SAMPLES": str(raw["ready_samples"]),
         "READY_SAMPLE_INTERVAL_SECONDS": str(raw["ready_sample_interval_seconds"]),
+        "HEALTH_MIN_CONNECTED_PEERS": str(raw["health_min_connected_peers"]),
         "MIN_FREE_BYTES": str(raw["min_free_bytes"]),
         "RETENTION_RUNS": str(raw["retention_runs"]),
         "COOLDOWN_SECONDS": str(raw["cooldown_seconds"]),

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -90,9 +90,20 @@ def load_nodes(path: Path, selected: list[str] | None) -> list[Node]:
     for raw_node in data.get("nodes", []):
         merged = dict(defaults)
         merged.update(raw_node)
-        for required in ("name", "ssh_string", "hostname", "mode_label", "p2p_stack"):
+        for required in (
+            "name",
+            "ssh_string",
+            "hostname",
+            "mode_label",
+            "p2p_stack",
+            "public_ip",
+        ):
             if required not in merged:
                 raise DeployError(f"node missing required field {required!r}: {raw_node}")
+        if not str(merged["public_ip"]).strip():
+            raise DeployError(
+                f"node {merged['name']!r} has empty required field 'public_ip'"
+            )
         if merged["name"] in seen:
             raise DeployError(f"duplicate node name: {merged['name']}")
         seen.add(merged["name"])

--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -33,6 +33,7 @@ stall_seconds = 600
 max_run_seconds = 172800
 ready_samples = 6
 ready_sample_interval_seconds = 30
+health_min_connected_peers = 1
 min_free_bytes = 10737418240
 retention_runs = 3
 cooldown_seconds = 60
@@ -68,6 +69,7 @@ alias = "temp-zakura-sync-test-2"
 public_ip = "138.197.218.91"
 mode_label = "Zakura/v2-only"
 p2p_stack = "zakura"
+health_min_connected_peers = 0
 
 [[nodes]]
 name = "temp-zakura-sync-test-5"

--- a/deploy/continuous-sync/templates/zakurad.toml.template
+++ b/deploy/continuous-sync/templates/zakurad.toml.template
@@ -27,7 +27,7 @@ endpoint_addr = "127.0.0.1:9999"
 
 [health]
 listen_addr = "127.0.0.1:8080"
-min_connected_peers = 1
+min_connected_peers = {{HEALTH_MIN_CONNECTED_PEERS}}
 ready_max_blocks_behind = 2
 ready_max_tip_age = "5m"
 enforce_on_test_networks = true

--- a/deploy/continuous-sync/templates/zakurad.toml.template
+++ b/deploy/continuous-sync/templates/zakurad.toml.template
@@ -4,6 +4,7 @@
 [network]
 network = "Mainnet"
 listen_addr = "0.0.0.0:8233"
+external_addr = "{{PUBLIC_IP}}:8233"
 cache_dir = "{{STATE_CACHE_DIR}}"
 p2p_stack = "{{P2P_STACK}}"
 

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -278,6 +278,26 @@ class ContinuousSyncTests(unittest.TestCase):
                     f"{node.raw['public_ip']}:8233",
                 )
 
+    def test_deploy_disables_legacy_peer_health_gate_only_for_v2_only_node(self):
+        nodes = deploy.load_nodes(
+            ROOT / "deploy" / "continuous-sync" / "nodes.toml",
+            None,
+        )
+        expected = {
+            "temp-zakura-sync-test-1": 1,
+            "temp-zakura-sync-test-2": 0,
+            "temp-zakura-sync-test-5": 1,
+        }
+
+        for node in nodes:
+            with self.subTest(node=node.name):
+                rendered = deploy.render_files(node)
+                config = tomllib.loads(rendered["zakurad.toml.template"])
+                self.assertEqual(
+                    config["health"]["min_connected_peers"],
+                    expected[node.name],
+                )
+
     def test_deploy_rejects_node_without_public_ip(self):
         inventory = """
 [[nodes]]

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -261,6 +262,40 @@ class ContinuousSyncTests(unittest.TestCase):
         self.assertIn("OnUnitActiveSec=1m", rendered["zakura-monitor.timer"])
         self.assertIn("down_confirmation_samples = 2", rendered["alert-monitor.toml"])
         self.assertIn("zakura.service", rendered)
+
+    def test_deploy_renders_each_node_public_ip_as_external_address(self):
+        nodes = deploy.load_nodes(
+            ROOT / "deploy" / "continuous-sync" / "nodes.toml",
+            None,
+        )
+
+        for node in nodes:
+            with self.subTest(node=node.name):
+                rendered = deploy.render_files(node)
+                config = tomllib.loads(rendered["zakurad.toml.template"])
+                self.assertEqual(
+                    config["network"]["external_addr"],
+                    f"{node.raw['public_ip']}:8233",
+                )
+
+    def test_deploy_rejects_node_without_public_ip(self):
+        inventory = """
+[[nodes]]
+name = "missing-public-ip"
+hostname = "missing-public-ip"
+ssh_string = "root@example.test"
+mode_label = "test"
+p2p_stack = "zakura"
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nodes.toml"
+            path.write_text(inventory, encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                deploy.DeployError,
+                "node missing required field 'public_ip'",
+            ):
+                deploy.load_nodes(path, None)
 
     def test_deploy_renders_expanded_legacy_alert_inventory(self):
         nodes = deploy.load_nodes(


### PR DESCRIPTION
## Motivation

The v2-only continuous-sync node had seven initiator connections and no responder connections. Native discovery saw only nine identities and did not expand the supplier set. Six usable block peers saturated every request slot at about 130 blocks/s.

The harness stored `public_ip` in controller policy but omitted `network.external_addr` from the generated node configuration. The node therefore did not advertise a reachable public address. Public bootstrappers that configured `external_addr` maintained 26 Zakura connections.

The PR audit found a second harness issue that blocked completion alerts. The health endpoint counts legacy address-book peers, so the v2-only node reported `insufficient peers` while it held 22 active Zakura connections. The controller requires readiness before it records a successful cycle and posts the completion alert. A previous v2-only cycle reached the tip, remained unready, and failed the 600-second stall check.

## Solution

The renderer now sets `network.external_addr` to each inventory node public IP on port 8233. Zakura keeps its listener on port 8234 and combines the external IP with that listener port when it builds the signed discovery record.

Deployment input loading now requires a non-empty `public_ip` for every inventory node. The README documents how `public_ip` controls the advertised legacy and Zakura addresses.

The inventory now configures the health endpoint's legacy peer threshold per node. The v2-only node uses zero because the endpoint does not count Zakura connections. The dual-stack and legacy-only controls retain one. Readiness still requires near-tip sync state, a recent committed tip, and at most two blocks of estimated lag. The controller still checks process health, disk space, and 600-second progress stalls.

This PR does not change Rust code, discovery wire formats, node identity handling, bootstrap lists, or block-sync logic.

## Testing

- `python3 deploy/continuous-sync/tests/test_continuous_sync.py` (52 tests)
- `cargo fmt --all -- --check`
- `./scripts/changelog.py check`
- `git diff --check`

The renderer test parses every generated TOML configuration and checks `network.external_addr` against the inventory public IP on port 8233. The missing-`public_ip` test verifies that deployment input loading reports a clear error. A second renderer test verifies that only the v2-only node disables the legacy peer health threshold.

### Live acceptance

The smoke branch is `smoke/continuous-sync-native-discovery-address`. It differs from PR head only by the `temp-zakura-sync-test-2` branch override.

- Refreshed install-only deployment: https://github.com/zakura-core/zakura/actions/runs/33691432386
- Refreshed start deployment: https://github.com/zakura-core/zakura/actions/runs/33691508806
- Refreshed targeted v2-only audit: https://github.com/zakura-core/zakura/actions/runs/33692735573

The install-only deployment rendered `external_addr = "138.197.218.91:8233"` and `min_connected_peers = 0`. Run `20260902T224056Z-b43e75eb6070` recorded exact PR SHA `b43e75eb6070f0aa0127c486cd4213a0fe60a620`. The generated run configuration contains both expected values.

The readiness endpoint now reports `syncing` instead of `insufficient peers`. The node accepted its first responder-side connection 57 seconds after startup. The connection trace recorded 34 responder accepts and 13 initiator accepts by height 136,585.

Eleven samples from 22:55:34Z through 23:00:34Z reported 22 active Zakura connections. The block-sync reactor reported 15 to 22 active connections for the same five-minute interval. The verified height advanced from 7,426 to 46,828.

A later block-sync sample at height 138,258 reported 19 peers: 11 inbound and eight outbound. It reported 97 received blocks/s. The 650k through 1M throughput gate remains pending.

At height 136,585, both services were active. `zakura.service` reported zero restarts, a successful result, and zero panic or crash lines. The refreshed targeted v2-only audit passed.

Trace sizes at height 136,585:

- `block_sync.jsonl`: 1,157,962,864 bytes
- `commit_state.jsonl`: 218,708,300 bytes
- `conn.jsonl`: 25,017 bytes
- `discovery.jsonl`: 2,958 bytes
- `handshake.jsonl`: 37,696 bytes
- `header_sync.jsonl`: 110,657,014 bytes
- `legacy_request.jsonl`: 110,104 bytes
- `legacy_sync.jsonl`: 2,142 bytes
- `stream.jsonl`: 321,176 bytes

The refreshed run remains active. The height-400k discovery gate, 650k through 1M mean throughput, genesis-to-tip completion, completion alert, and next scheduled whole-fleet audit remain pending. The pre-existing dual-stack control failure will prevent a whole-fleet audit from passing until its owner repairs it.

## Changelog

No changelog fragment is required because this PR changes no Rust source file or Cargo manifest.

### Specifications & References

None.

### Follow-up Work

Complete the active v2-only cycle and the remaining time-gated acceptance checks before marking this PR ready for review.
