### PR TITLE
fix(rpc): segment unauthenticated and admin methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8165,7 +8165,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8194,6 +8194,7 @@ dependencies = [
  "prost",
  "rand 0.10.2",
  "rand 0.8.6",
+ "reqwest 0.12.28",
  "rustls",
  "schemars 1.2.1",
  "semver",

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "8.0.0"
+version = "9.0.0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -128,6 +128,7 @@ bytes = { workspace = true }
 http-body = { workspace = true }
 insta = { workspace = true, features = ["redactions", "json", "ron"] }
 anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 tempfile = { workspace = true }
 toml = { workspace = true }
 

--- a/crates/zakura-rpc/src/config/rpc.rs
+++ b/crates/zakura-rpc/src/config/rpc.rs
@@ -25,10 +25,33 @@ pub struct Config {
     ///
     /// # Security
     ///
-    /// If you bind Zebra's RPC port to a public IP address,
-    /// anyone on the internet can send transactions via your node.
-    /// They can also query your node's state.
+    /// On Mainnet and Testnet, disabling [`Self::enable_cookie_auth`] restricts
+    /// this listener to the explicitly classified public RPC methods. Public
+    /// clients can still query chain state, submit transactions, and use the
+    /// mining RPCs, but they cannot call administrative methods such as
+    /// `invalidateblock` or `reconsiderblock`.
+    ///
+    /// Do not expose a cookie-authenticated listener over an untrusted plaintext
+    /// network. HTTP Basic credentials are reusable; keep authenticated RPC on
+    /// loopback or configure [`Self::tls`] on the primary listener.
     pub listen_addr: Option<SocketAddr>,
+
+    /// Optional loopback-only listener for authenticated administrative RPCs.
+    ///
+    /// This listener exposes the full RPC method set and always requires the
+    /// cookie in [`Self::cookie_dir`] and [`Self::cookie_file_name`]. It is a
+    /// companion to an unauthenticated public [`Self::listen_addr`]:
+    /// ```toml
+    /// [rpc]
+    /// listen_addr = '0.0.0.0:8232'
+    /// enable_cookie_auth = false
+    /// admin_listen_addr = '127.0.0.1:8231'
+    /// ```
+    ///
+    /// The admin listener uses plaintext HTTP on loopback and does not inherit
+    /// [`Self::tls`]. Use SSH or another secure local access mechanism to call
+    /// it from a different machine. It cannot bind to a non-loopback address.
+    pub admin_listen_addr: Option<SocketAddr>,
 
     /// IP address and port for the indexer RPC server.
     ///
@@ -90,13 +113,18 @@ pub struct Config {
     #[serde(default = "default_cookie_file_name")]
     pub cookie_file_name: String,
 
-    /// Enable cookie-based authentication for RPCs.
+    /// Enable cookie-based authentication for the primary RPC listener.
+    ///
+    /// Authenticated listeners expose the full RPC method set. On Mainnet and
+    /// Testnet, unauthenticated listeners expose only the public method set.
+    /// Regtest keeps the full method set so its local test-control RPCs remain
+    /// available.
     pub enable_cookie_auth: bool,
 
     /// The maximum size of the response body in bytes.
     pub max_response_body_size: usize,
 
-    /// Optional TLS configuration for this RPC listener.
+    /// Optional TLS configuration for the primary RPC listener.
     pub tls: Option<TlsConfig>,
 }
 
@@ -132,6 +160,7 @@ impl Default for Config {
         Self {
             // Disable RPCs by default.
             listen_addr: None,
+            admin_listen_addr: None,
 
             // Disable indexer RPCs by default.
             indexer_listen_addr: None,
@@ -159,6 +188,41 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// Validates the relationship between the public and admin RPC listeners.
+    pub fn validate(&self) -> Result<(), String> {
+        let Some(admin_listen_addr) = self.admin_listen_addr else {
+            return Ok(());
+        };
+
+        if !admin_listen_addr.ip().is_loopback() {
+            return Err("rpc.admin_listen_addr must use a loopback address".to_string());
+        }
+
+        let Some(listen_addr) = self.listen_addr else {
+            return Err(
+                "rpc.admin_listen_addr requires rpc.listen_addr; use rpc.listen_addr with cookie authentication for an admin-only server"
+                    .to_string(),
+            );
+        };
+
+        if self.enable_cookie_auth {
+            return Err(
+                "rpc.admin_listen_addr requires rpc.enable_cookie_auth = false; an authenticated primary listener already exposes the full RPC method set"
+                    .to_string(),
+            );
+        }
+
+        if admin_listen_addr.port() != 0 && admin_listen_addr.port() == listen_addr.port() {
+            return Err(
+                "rpc.admin_listen_addr must use a different port from rpc.listen_addr".to_string(),
+            );
+        }
+
+        Ok(())
+    }
+}
+
 fn default_cookie_file_name() -> String {
     ".cookie".to_string()
 }
@@ -183,6 +247,73 @@ mod tests {
             super::default_cookie_file_name(),
             "missing cookie file names should use the default value"
         );
+    }
+
+    #[test]
+    fn validates_segmented_rpc_listeners() {
+        let config: Config = toml::from_str(
+            r#"
+            listen_addr = "0.0.0.0:8232"
+            admin_listen_addr = "127.0.0.1:8231"
+            enable_cookie_auth = false
+            "#,
+        )
+        .expect("segmented RPC config should deserialize");
+
+        config
+            .validate()
+            .expect("a loopback admin listener should be valid");
+    }
+
+    #[test]
+    fn rejects_non_loopback_admin_listener() {
+        let config: Config = toml::from_str(
+            r#"
+            listen_addr = "0.0.0.0:8232"
+            admin_listen_addr = "0.0.0.0:8231"
+            enable_cookie_auth = false
+            "#,
+        )
+        .expect("RPC config should deserialize before validation");
+
+        assert_eq!(
+            config.validate(),
+            Err("rpc.admin_listen_addr must use a loopback address".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_redundant_admin_listener_for_authenticated_rpc() {
+        let config: Config = toml::from_str(
+            r#"
+            listen_addr = "127.0.0.1:8232"
+            admin_listen_addr = "127.0.0.1:8231"
+            enable_cookie_auth = true
+            "#,
+        )
+        .expect("RPC config should deserialize before validation");
+
+        assert!(config
+            .validate()
+            .expect_err("an authenticated primary listener makes the admin listener redundant")
+            .contains("enable_cookie_auth = false"));
+    }
+
+    #[test]
+    fn rejects_admin_port_overlapped_by_public_wildcard_listener() {
+        let config: Config = toml::from_str(
+            r#"
+            listen_addr = "0.0.0.0:8232"
+            admin_listen_addr = "127.0.0.1:8232"
+            enable_cookie_auth = false
+            "#,
+        )
+        .expect("RPC config should deserialize before validation");
+
+        assert!(config
+            .validate()
+            .expect_err("a wildcard primary listener would overlap the admin listener")
+            .contains("different port"));
     }
 
     #[test]

--- a/crates/zakura-rpc/src/config/rpc.rs
+++ b/crates/zakura-rpc/src/config/rpc.rs
@@ -30,6 +30,8 @@ pub struct Config {
     /// methods. Clients can still query chain state, submit transactions, and
     /// use the mining RPCs, but they cannot call administrative methods such as
     /// `invalidateblock` or `reconsiderblock`.
+    /// Set [`Self::enable_cookie_auth`] when every method should require
+    /// credentials.
     ///
     /// The restricted method set is defense in depth, not Internet hardening.
     /// Allowed methods can expose node metadata or consume significant

--- a/crates/zakura-rpc/src/config/rpc.rs
+++ b/crates/zakura-rpc/src/config/rpc.rs
@@ -26,10 +26,15 @@ pub struct Config {
     /// # Security
     ///
     /// On Mainnet and Testnet, disabling [`Self::enable_cookie_auth`] restricts
-    /// this listener to the explicitly classified public RPC methods. Public
-    /// clients can still query chain state, submit transactions, and use the
-    /// mining RPCs, but they cannot call administrative methods such as
+    /// this listener to the explicitly classified unauthenticated compatibility
+    /// methods. Clients can still query chain state, submit transactions, and
+    /// use the mining RPCs, but they cannot call administrative methods such as
     /// `invalidateblock` or `reconsiderblock`.
+    ///
+    /// The restricted method set is defense in depth, not Internet hardening.
+    /// Allowed methods can expose node metadata or consume significant
+    /// resources. Keep unauthenticated RPC behind a firewall, private network,
+    /// or gateway that limits access to trusted clients.
     ///
     /// Do not expose a cookie-authenticated listener over an untrusted plaintext
     /// network. HTTP Basic credentials are reusable; keep authenticated RPC on
@@ -40,7 +45,7 @@ pub struct Config {
     ///
     /// This listener exposes the full RPC method set and always requires the
     /// cookie in [`Self::cookie_dir`] and [`Self::cookie_file_name`]. It is a
-    /// companion to an unauthenticated public [`Self::listen_addr`]:
+    /// companion to a restricted unauthenticated [`Self::listen_addr`]:
     /// ```toml
     /// [rpc]
     /// listen_addr = '0.0.0.0:8232'
@@ -116,9 +121,9 @@ pub struct Config {
     /// Enable cookie-based authentication for the primary RPC listener.
     ///
     /// Authenticated listeners expose the full RPC method set. On Mainnet and
-    /// Testnet, unauthenticated listeners expose only the public method set.
-    /// Regtest keeps the full method set so its local test-control RPCs remain
-    /// available.
+    /// Testnet, unauthenticated listeners expose only the restricted
+    /// compatibility method set. Regtest keeps the full method set so its local
+    /// test-control RPCs remain available.
     pub enable_cookie_auth: bool,
 
     /// The maximum size of the response body in bytes.
@@ -189,7 +194,7 @@ impl Default for Config {
 }
 
 impl Config {
-    /// Validates the relationship between the public and admin RPC listeners.
+    /// Validates the relationship between the primary and admin RPC listeners.
     pub fn validate(&self) -> Result<(), String> {
         let Some(admin_listen_addr) = self.admin_listen_addr else {
             return Ok(());
@@ -300,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_admin_port_overlapped_by_public_wildcard_listener() {
+    fn rejects_admin_port_overlapped_by_primary_wildcard_listener() {
         let config: Config = toml::from_str(
             r#"
             listen_addr = "0.0.0.0:8232"

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -157,8 +157,8 @@ include!("methods/rpc_openrpc.rs");
 /// fail closed until their intended exposure is reviewed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RpcAccess {
-    /// Available on unauthenticated Mainnet and Testnet RPC listeners.
-    Public,
+    /// Available on restricted unauthenticated Mainnet and Testnet RPC listeners.
+    Unauthenticated,
 
     /// Available only on authenticated listeners, except on Regtest.
     Admin,
@@ -170,8 +170,8 @@ pub(crate) enum RpcAccess {
 /// The method set exposed by one RPC listener.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RpcSurface {
-    /// The explicitly classified public method set.
-    Public,
+    /// The explicitly classified unauthenticated compatibility method set.
+    Restricted,
 
     /// Every registered method.
     Full,
@@ -181,7 +181,7 @@ impl RpcSurface {
     /// Returns whether this surface exposes `method_name`.
     pub(crate) fn exposes(self, method_name: &str) -> bool {
         match self {
-            Self::Public => rpc_method_access(method_name) == Some(RpcAccess::Public),
+            Self::Restricted => rpc_method_access(method_name) == Some(RpcAccess::Unauthenticated),
             Self::Full => true,
         }
     }
@@ -189,48 +189,53 @@ impl RpcSurface {
 
 /// The reviewed access class for every registered JSON-RPC method.
 ///
+/// The unauthenticated set preserves compatibility with existing lightwalletd,
+/// mining, and fleet health consumers. It does not mean that these methods are
+/// hardened for arbitrary Internet traffic. Narrowing this set requires a
+/// coordinated migration of those consumers and their node configuration.
+///
 /// Keep this list synchronized with the generated [`RpcServer`] trait. Server
 /// startup and unit tests reject methods that are missing from either side.
 pub(crate) const RPC_METHOD_ACCESS: &[(&str, RpcAccess)] = &[
-    ("getinfo", RpcAccess::Public),
-    ("getdeprecationinfo", RpcAccess::Public),
-    ("getblockchaininfo", RpcAccess::Public),
-    ("getaddressbalance", RpcAccess::Public),
-    ("sendrawtransaction", RpcAccess::Public),
-    ("getblock", RpcAccess::Public),
-    ("getblockheader", RpcAccess::Public),
-    ("getbestblockhash", RpcAccess::Public),
-    ("getbestblockheightandhash", RpcAccess::Public),
-    ("getchaintips", RpcAccess::Public),
-    ("getmempoolinfo", RpcAccess::Public),
-    ("getrawmempool", RpcAccess::Public),
-    ("z_gettreestate", RpcAccess::Public),
-    ("z_getsubtreesbyindex", RpcAccess::Public),
-    ("getrawtransaction", RpcAccess::Public),
-    ("getaddresstxids", RpcAccess::Public),
-    ("getaddressutxos", RpcAccess::Public),
+    ("getinfo", RpcAccess::Unauthenticated),
+    ("getdeprecationinfo", RpcAccess::Unauthenticated),
+    ("getblockchaininfo", RpcAccess::Unauthenticated),
+    ("getaddressbalance", RpcAccess::Unauthenticated),
+    ("sendrawtransaction", RpcAccess::Unauthenticated),
+    ("getblock", RpcAccess::Unauthenticated),
+    ("getblockheader", RpcAccess::Unauthenticated),
+    ("getbestblockhash", RpcAccess::Unauthenticated),
+    ("getbestblockheightandhash", RpcAccess::Unauthenticated),
+    ("getchaintips", RpcAccess::Unauthenticated),
+    ("getmempoolinfo", RpcAccess::Unauthenticated),
+    ("getrawmempool", RpcAccess::Unauthenticated),
+    ("z_gettreestate", RpcAccess::Unauthenticated),
+    ("z_getsubtreesbyindex", RpcAccess::Unauthenticated),
+    ("getrawtransaction", RpcAccess::Unauthenticated),
+    ("getaddresstxids", RpcAccess::Unauthenticated),
+    ("getaddressutxos", RpcAccess::Unauthenticated),
     ("stop", RpcAccess::Test),
-    ("getblockcount", RpcAccess::Public),
-    ("getblockhash", RpcAccess::Public),
-    ("getblocktemplate", RpcAccess::Public),
-    ("submitblock", RpcAccess::Public),
-    ("getmininginfo", RpcAccess::Public),
-    ("getnetworksolps", RpcAccess::Public),
-    ("getnetworkhashps", RpcAccess::Public),
-    ("getnetworkinfo", RpcAccess::Public),
-    ("getpeerinfo", RpcAccess::Public),
-    ("ping", RpcAccess::Public),
-    ("validateaddress", RpcAccess::Public),
-    ("z_validateaddress", RpcAccess::Public),
-    ("getblocksubsidy", RpcAccess::Public),
-    ("getdifficulty", RpcAccess::Public),
-    ("z_listunifiedreceivers", RpcAccess::Public),
+    ("getblockcount", RpcAccess::Unauthenticated),
+    ("getblockhash", RpcAccess::Unauthenticated),
+    ("getblocktemplate", RpcAccess::Unauthenticated),
+    ("submitblock", RpcAccess::Unauthenticated),
+    ("getmininginfo", RpcAccess::Unauthenticated),
+    ("getnetworksolps", RpcAccess::Unauthenticated),
+    ("getnetworkhashps", RpcAccess::Unauthenticated),
+    ("getnetworkinfo", RpcAccess::Unauthenticated),
+    ("getpeerinfo", RpcAccess::Unauthenticated),
+    ("ping", RpcAccess::Unauthenticated),
+    ("validateaddress", RpcAccess::Unauthenticated),
+    ("z_validateaddress", RpcAccess::Unauthenticated),
+    ("getblocksubsidy", RpcAccess::Unauthenticated),
+    ("getdifficulty", RpcAccess::Unauthenticated),
+    ("z_listunifiedreceivers", RpcAccess::Unauthenticated),
     ("invalidateblock", RpcAccess::Admin),
     ("reconsiderblock", RpcAccess::Admin),
     ("generate", RpcAccess::Test),
     ("addnode", RpcAccess::Test),
-    ("rpc.discover", RpcAccess::Public),
-    ("gettxout", RpcAccess::Public),
+    ("rpc.discover", RpcAccess::Unauthenticated),
+    ("gettxout", RpcAccess::Unauthenticated),
 ];
 
 /// Returns the reviewed access class for `method_name`.

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -189,10 +189,11 @@ impl RpcSurface {
 
 /// The reviewed access class for every registered JSON-RPC method.
 ///
-/// The unauthenticated set preserves compatibility with existing lightwalletd,
-/// mining, and fleet health consumers. It does not mean that these methods are
-/// hardened for arbitrary Internet traffic. Narrowing this set requires a
-/// coordinated migration of those consumers and their node configuration.
+/// The unauthenticated set intentionally preserves existing access for normal
+/// query, transaction submission, mining, lightwalletd, and fleet health use.
+/// Operators that want credentials on every method can enable cookie
+/// authentication. This classification does not mean that these methods are
+/// hardened for arbitrary Internet traffic.
 ///
 /// Keep this list synchronized with the generated [`RpcServer`] trait. Server
 /// startup and unit tests reject methods that are missing from either side.

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -151,6 +151,95 @@ where
 
 include!("methods/rpc_openrpc.rs");
 
+/// The access class assigned to an RPC method.
+///
+/// Every registered method must have exactly one class. This makes additions
+/// fail closed until their intended exposure is reviewed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RpcAccess {
+    /// Available on unauthenticated Mainnet and Testnet RPC listeners.
+    Public,
+
+    /// Available only on authenticated listeners, except on Regtest.
+    Admin,
+
+    /// A Regtest control method retained on the full RPC surface.
+    Test,
+}
+
+/// The method set exposed by one RPC listener.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RpcSurface {
+    /// The explicitly classified public method set.
+    Public,
+
+    /// Every registered method.
+    Full,
+}
+
+impl RpcSurface {
+    /// Returns whether this surface exposes `method_name`.
+    pub(crate) fn exposes(self, method_name: &str) -> bool {
+        match self {
+            Self::Public => rpc_method_access(method_name) == Some(RpcAccess::Public),
+            Self::Full => true,
+        }
+    }
+}
+
+/// The reviewed access class for every registered JSON-RPC method.
+///
+/// Keep this list synchronized with the generated [`RpcServer`] trait. Server
+/// startup and unit tests reject methods that are missing from either side.
+pub(crate) const RPC_METHOD_ACCESS: &[(&str, RpcAccess)] = &[
+    ("getinfo", RpcAccess::Public),
+    ("getdeprecationinfo", RpcAccess::Public),
+    ("getblockchaininfo", RpcAccess::Public),
+    ("getaddressbalance", RpcAccess::Public),
+    ("sendrawtransaction", RpcAccess::Public),
+    ("getblock", RpcAccess::Public),
+    ("getblockheader", RpcAccess::Public),
+    ("getbestblockhash", RpcAccess::Public),
+    ("getbestblockheightandhash", RpcAccess::Public),
+    ("getchaintips", RpcAccess::Public),
+    ("getmempoolinfo", RpcAccess::Public),
+    ("getrawmempool", RpcAccess::Public),
+    ("z_gettreestate", RpcAccess::Public),
+    ("z_getsubtreesbyindex", RpcAccess::Public),
+    ("getrawtransaction", RpcAccess::Public),
+    ("getaddresstxids", RpcAccess::Public),
+    ("getaddressutxos", RpcAccess::Public),
+    ("stop", RpcAccess::Test),
+    ("getblockcount", RpcAccess::Public),
+    ("getblockhash", RpcAccess::Public),
+    ("getblocktemplate", RpcAccess::Public),
+    ("submitblock", RpcAccess::Public),
+    ("getmininginfo", RpcAccess::Public),
+    ("getnetworksolps", RpcAccess::Public),
+    ("getnetworkhashps", RpcAccess::Public),
+    ("getnetworkinfo", RpcAccess::Public),
+    ("getpeerinfo", RpcAccess::Public),
+    ("ping", RpcAccess::Public),
+    ("validateaddress", RpcAccess::Public),
+    ("z_validateaddress", RpcAccess::Public),
+    ("getblocksubsidy", RpcAccess::Public),
+    ("getdifficulty", RpcAccess::Public),
+    ("z_listunifiedreceivers", RpcAccess::Public),
+    ("invalidateblock", RpcAccess::Admin),
+    ("reconsiderblock", RpcAccess::Admin),
+    ("generate", RpcAccess::Test),
+    ("addnode", RpcAccess::Test),
+    ("rpc.discover", RpcAccess::Public),
+    ("gettxout", RpcAccess::Public),
+];
+
+/// Returns the reviewed access class for `method_name`.
+pub(crate) fn rpc_method_access(method_name: &str) -> Option<RpcAccess> {
+    RPC_METHOD_ACCESS
+        .iter()
+        .find_map(|(name, access)| (*name == method_name).then_some(*access))
+}
+
 // TODO: Review the parameter descriptions below, and update them as needed:
 // https://github.com/ZcashFoundation/zebra/issues/10320
 pub(super) const PARAM_VERBOSE_DESC: &str =
@@ -888,6 +977,9 @@ where
     /// no matter what the estimated height or local clock is.
     debug_force_finished_sync: bool,
 
+    /// The RPC methods and OpenRPC schema exposed by this instance.
+    rpc_surface: RpcSurface,
+
     /// The estimated last height this release supports, if enforced.
     end_of_support_height: Option<Height>,
 
@@ -1005,6 +1097,7 @@ where
             user_agent,
             network: network.clone(),
             debug_force_finished_sync,
+            rpc_surface: RpcSurface::Full,
             end_of_support_height: None,
             mempool: mempool.clone(),
             state: state.clone(),
@@ -1036,6 +1129,12 @@ where
     /// When unset, or set to `None`, the RPC omits `end_of_service`.
     pub fn with_end_of_support_height(mut self, end_of_support_height: Option<Height>) -> Self {
         self.end_of_support_height = end_of_support_height;
+        self
+    }
+
+    /// Selects the method set and OpenRPC schema exposed by this instance.
+    pub(crate) fn with_rpc_surface(mut self, rpc_surface: RpcSurface) -> Self {
+        self.rpc_surface = rpc_surface;
         self
     }
 }
@@ -3240,6 +3339,7 @@ where
 
         let methods = METHODS
             .into_iter()
+            .filter(|(name, _)| self.rpc_surface.exposes(name))
             .map(|(name, method)| method.generate(&mut generator, name))
             .collect();
 

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -7,7 +7,7 @@
 //! See the full list of
 //! [Differences between JSON-RPC 1.0 and 2.0.](https://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0)
 
-use std::{fmt, fs::File, io::Read, panic, path::Path, sync::Arc};
+use std::{collections::BTreeSet, fmt, fs::File, io::Read, panic, path::Path, sync::Arc};
 
 use chrono::{TimeZone, Utc};
 use cookie::Cookie;
@@ -32,7 +32,9 @@ use zakura_state::{ReadState as ReadStateService, State as StateService};
 
 use crate::{
     config,
-    methods::{RpcImpl, RpcServer as _},
+    methods::{
+        rpc_method_access, RpcAccess, RpcImpl, RpcServer as _, RpcSurface, RPC_METHOD_ACCESS,
+    },
     server::{
         http_request_compatibility::HttpRequestMiddlewareLayer,
         rpc_call_compatibility::FixRpcResponseMiddleware, rpc_metrics::RpcMetricsMiddleware,
@@ -84,16 +86,17 @@ impl fmt::Debug for RpcServer {
 /// The message to log when logging the RPC server's listen address
 pub const OPENED_RPC_ENDPOINT_MSG: &str = "Opened RPC endpoint at ";
 
+/// The message to log when logging the admin RPC server's listen address.
+pub const OPENED_ADMIN_RPC_ENDPOINT_MSG: &str = "Opened admin RPC endpoint at ";
+
 type ServerTask = JoinHandle<Result<(), tower::BoxError>>;
 
 impl RpcServer {
-    /// Starts the RPC server.
+    /// Starts the primary RPC server.
     ///
-    /// `build_version` and `user_agent` are version strings for the application,
-    /// which are used in RPC responses.
-    ///
-    /// Returns [`JoinHandle`]s for the RPC server and `sendrawtransaction` queue tasks,
-    /// and a [`RpcServer`] handle, which can be used to shut down the RPC server task.
+    /// Authenticated listeners and Regtest listeners expose the full method
+    /// set. Unauthenticated Mainnet and Testnet listeners expose only methods
+    /// explicitly classified as public.
     ///
     /// # Panics
     ///
@@ -123,9 +126,83 @@ impl RpcServer {
         BlockVerifierRouter: BlockVerifierService,
         SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
     {
+        conf.validate().map_err(std::io::Error::other)?;
+
+        let surface = primary_rpc_surface(rpc.network(), conf.enable_cookie_auth);
+
+        Self::start_inner(rpc, conf, surface, OPENED_RPC_ENDPOINT_MSG).await
+    }
+
+    /// Starts the loopback-only, cookie-authenticated admin RPC server.
+    ///
+    /// # Panics
+    ///
+    /// - If [`Config::admin_listen_addr`](config::rpc::Config::admin_listen_addr) is `None`.
+    pub async fn start_admin<
+        Mempool,
+        State,
+        ReadState,
+        Tip,
+        BlockVerifierRouter,
+        SyncStatus,
+        AddressBook,
+    >(
+        rpc: RpcImpl<Mempool, State, ReadState, Tip, AddressBook, BlockVerifierRouter, SyncStatus>,
+        mut conf: config::rpc::Config,
+    ) -> Result<ServerTask, tower::BoxError>
+    where
+        Mempool: MempoolService,
+        State: StateService,
+        ReadState: ReadStateService,
+        Tip: ChainTip + Clone + Send + Sync + 'static,
+        AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+        BlockVerifierRouter: BlockVerifierService,
+        SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    {
+        conf.validate().map_err(std::io::Error::other)?;
+
+        conf.listen_addr = Some(
+            conf.admin_listen_addr
+                .expect("caller should make sure admin_listen_addr is set"),
+        );
+        conf.admin_listen_addr = None;
+        conf.enable_cookie_auth = true;
+        conf.tls = None;
+
+        Self::start_inner(rpc, conf, RpcSurface::Full, OPENED_ADMIN_RPC_ENDPOINT_MSG).await
+    }
+
+    /// Starts one RPC listener with the selected method surface.
+    async fn start_inner<
+        Mempool,
+        State,
+        ReadState,
+        Tip,
+        BlockVerifierRouter,
+        SyncStatus,
+        AddressBook,
+    >(
+        rpc: RpcImpl<Mempool, State, ReadState, Tip, AddressBook, BlockVerifierRouter, SyncStatus>,
+        conf: config::rpc::Config,
+        surface: RpcSurface,
+        opened_endpoint_msg: &'static str,
+    ) -> Result<ServerTask, tower::BoxError>
+    where
+        Mempool: MempoolService,
+        State: StateService,
+        ReadState: ReadStateService,
+        Tip: ChainTip + Clone + Send + Sync + 'static,
+        AddressBook: AddressBookPeers + Clone + Send + Sync + 'static,
+        BlockVerifierRouter: BlockVerifierService,
+        SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+    {
         let listen_addr = conf
             .listen_addr
             .expect("caller should make sure listen_addr is set");
+
+        let rpc = rpc.with_rpc_surface(surface);
+        let mut methods = rpc.into_rpc();
+        configure_rpc_methods(&mut methods, surface)?;
 
         // The largest RPC request is submitblock, which sends a full block
         // as a hex string (2x MAX_BLOCK_BYTES) plus a small JSON-RPC wrapper.
@@ -163,10 +240,9 @@ impl RpcServer {
                         .expect("should be valid"),
                 )
                 .to_service_builder();
-            let methods = rpc.into_rpc();
             let (stop_handle, server_handle) = stop_channel();
 
-            info!("{OPENED_RPC_ENDPOINT_MSG}{local_addr}");
+            info!("{opened_endpoint_msg}{local_addr}");
 
             return Ok(tokio::spawn(async move {
                 loop {
@@ -225,10 +301,10 @@ impl RpcServer {
             .build(listen_addr)
             .await?;
 
-        info!("{OPENED_RPC_ENDPOINT_MSG}{}", server.local_addr()?);
+        info!("{opened_endpoint_msg}{}", server.local_addr()?);
 
         Ok(tokio::spawn(async move {
-            server.start(rpc.into_rpc()).stopped().await;
+            server.start(methods).stopped().await;
             Ok(())
         }))
     }
@@ -287,6 +363,55 @@ impl RpcServer {
             Ok(()) => (),
             Err(panic_object) => panic::resume_unwind(panic_object),
         })
+    }
+}
+
+/// Validates the RPC method classification and removes non-public methods from
+/// public listeners.
+fn configure_rpc_methods<Context>(
+    methods: &mut jsonrpsee::RpcModule<Context>,
+    surface: RpcSurface,
+) -> Result<(), std::io::Error>
+where
+    Context: Send + Sync + 'static,
+{
+    let registered: BTreeSet<_> = methods.method_names().collect();
+    let classified: BTreeSet<_> = RPC_METHOD_ACCESS.iter().map(|(name, _)| *name).collect();
+
+    if classified.len() != RPC_METHOD_ACCESS.len() {
+        return Err(std::io::Error::other(
+            "RPC method access classifications contain duplicate method names",
+        ));
+    }
+
+    if registered != classified {
+        let unclassified: Vec<_> = registered.difference(&classified).copied().collect();
+        let unregistered: Vec<_> = classified.difference(&registered).copied().collect();
+
+        return Err(std::io::Error::other(format!(
+            "RPC method access classification mismatch; unclassified registered methods: {unclassified:?}; classified but unregistered methods: {unregistered:?}"
+        )));
+    }
+
+    if surface == RpcSurface::Public {
+        for method_name in registered {
+            if rpc_method_access(method_name) != Some(RpcAccess::Public) {
+                methods
+                    .remove_method(method_name)
+                    .expect("method exists because it came from method_names");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Selects the primary listener's method surface.
+fn primary_rpc_surface(network: &Network, enable_cookie_auth: bool) -> RpcSurface {
+    if enable_cookie_auth || network.is_regtest() {
+        RpcSurface::Full
+    } else {
+        RpcSurface::Public
     }
 }
 

--- a/crates/zakura-rpc/src/server.rs
+++ b/crates/zakura-rpc/src/server.rs
@@ -95,8 +95,8 @@ impl RpcServer {
     /// Starts the primary RPC server.
     ///
     /// Authenticated listeners and Regtest listeners expose the full method
-    /// set. Unauthenticated Mainnet and Testnet listeners expose only methods
-    /// explicitly classified as public.
+    /// set. Unauthenticated Mainnet and Testnet listeners expose only the
+    /// restricted compatibility method set.
     ///
     /// # Panics
     ///
@@ -366,8 +366,8 @@ impl RpcServer {
     }
 }
 
-/// Validates the RPC method classification and removes non-public methods from
-/// public listeners.
+/// Validates the RPC method classification and removes methods that are not
+/// available on restricted unauthenticated listeners.
 fn configure_rpc_methods<Context>(
     methods: &mut jsonrpsee::RpcModule<Context>,
     surface: RpcSurface,
@@ -393,9 +393,9 @@ where
         )));
     }
 
-    if surface == RpcSurface::Public {
+    if surface == RpcSurface::Restricted {
         for method_name in registered {
-            if rpc_method_access(method_name) != Some(RpcAccess::Public) {
+            if rpc_method_access(method_name) != Some(RpcAccess::Unauthenticated) {
                 methods
                     .remove_method(method_name)
                     .expect("method exists because it came from method_names");
@@ -411,7 +411,7 @@ fn primary_rpc_surface(network: &Network, enable_cookie_auth: bool) -> RpcSurfac
     if enable_cookie_auth || network.is_regtest() {
         RpcSurface::Full
     } else {
-        RpcSurface::Public
+        RpcSurface::Restricted
     }
 }
 

--- a/crates/zakura-rpc/src/server/tests.rs
+++ b/crates/zakura-rpc/src/server/tests.rs
@@ -4,5 +4,6 @@
 
 mod cookie;
 mod http_request_compatibility;
+mod surface;
 mod tls;
 mod vectors;

--- a/crates/zakura-rpc/src/server/tests/surface.rs
+++ b/crates/zakura-rpc/src/server/tests/surface.rs
@@ -1,4 +1,4 @@
-//! Tests for public and authenticated RPC method surfaces.
+//! Tests for restricted unauthenticated and authenticated RPC method surfaces.
 
 use std::{
     collections::BTreeSet,
@@ -54,15 +54,15 @@ fn access_policy_matches_the_openrpc_method_set() {
 }
 
 #[test]
-fn public_surface_contains_only_allowlisted_methods() {
+fn restricted_surface_contains_only_unauthenticated_methods() {
     let mut module = classified_module();
-    configure_rpc_methods(&mut module, RpcSurface::Public)
+    configure_rpc_methods(&mut module, RpcSurface::Restricted)
         .expect("the reviewed method classification should be complete");
 
     let actual: BTreeSet<_> = module.method_names().collect();
     let expected: BTreeSet<_> = RPC_METHOD_ACCESS
         .iter()
-        .filter_map(|(name, access)| (*access == RpcAccess::Public).then_some(*name))
+        .filter_map(|(name, access)| (*access == RpcAccess::Unauthenticated).then_some(*name))
         .collect();
 
     assert_eq!(actual, expected);
@@ -97,21 +97,21 @@ fn unclassified_methods_fail_closed() {
         })
         .expect("test method should register");
 
-    let error = configure_rpc_methods(&mut module, RpcSurface::Public)
+    let error = configure_rpc_methods(&mut module, RpcSurface::Restricted)
         .expect_err("an unclassified method must prevent server startup");
 
     assert!(error.to_string().contains("new_unreviewed_method"));
 }
 
 #[test]
-fn unauthenticated_production_networks_use_the_public_surface() {
+fn unauthenticated_production_networks_use_the_restricted_surface() {
     assert_eq!(
         primary_rpc_surface(&Network::Mainnet, false),
-        RpcSurface::Public
+        RpcSurface::Restricted
     );
     assert_eq!(
         primary_rpc_surface(&Network::new_default_testnet(), false),
-        RpcSurface::Public
+        RpcSurface::Restricted
     );
 
     assert_eq!(
@@ -128,18 +128,19 @@ fn unauthenticated_production_networks_use_the_public_surface() {
 async fn segmented_listeners_enforce_methods_and_cookie_auth() {
     let _init_guard = zakura_test::init();
 
-    let public_port = zakura_test::net::random_known_port();
+    let restricted_port = zakura_test::net::random_known_port();
     let admin_port = loop {
         let port = zakura_test::net::random_known_port();
-        if port != public_port {
+        if port != restricted_port {
             break port;
         }
     };
-    let public_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, public_port).into();
+    let restricted_addr: SocketAddr =
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, restricted_port).into();
     let admin_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, admin_port).into();
     let cookie_dir = tempfile::tempdir().expect("temporary cookie directory should be created");
     let conf = Config {
-        listen_addr: Some(public_addr),
+        listen_addr: Some(restricted_addr),
         admin_listen_addr: Some(admin_addr),
         cookie_dir: cookie_dir.path().to_path_buf(),
         cookie_file_name: "admin.cookie".to_string(),
@@ -170,9 +171,9 @@ async fn segmented_listeners_enforce_methods_and_cookie_auth() {
         None,
     );
 
-    let public_task = RpcServer::start(rpc_impl.clone(), conf.clone())
+    let restricted_task = RpcServer::start(rpc_impl.clone(), conf.clone())
         .await
-        .expect("public RPC listener should start");
+        .expect("restricted RPC listener should start");
     let admin_task = RpcServer::start_admin(rpc_impl, conf)
         .await
         .expect("admin RPC listener should start");
@@ -182,61 +183,68 @@ async fn segmented_listeners_enforce_methods_and_cookie_auth() {
         .build()
         .expect("test HTTP client should build");
 
-    let public_discovery = client
-        .post(format!("http://{public_addr}"))
+    let restricted_discovery = client
+        .post(format!("http://{restricted_addr}"))
         .header("content-type", "application/json")
         .body(r#"{"jsonrpc":"2.0","method":"rpc.discover","id":1}"#)
         .send()
         .await
-        .expect("public discovery request should complete")
+        .expect("restricted discovery request should complete")
         .text()
         .await
-        .expect("public discovery response body should be readable");
-    let public_discovery: serde_json::Value =
-        serde_json::from_str(&public_discovery).expect("public discovery response should be JSON");
-    let public_methods = discovered_methods(&public_discovery);
+        .expect("restricted discovery response body should be readable");
+    let restricted_discovery: serde_json::Value = serde_json::from_str(&restricted_discovery)
+        .expect("restricted discovery response should be JSON");
+    let restricted_methods = discovered_methods(&restricted_discovery);
     for method in [
+        "getinfo",
+        "getblockchaininfo",
+        "getpeerinfo",
         "getblockcount",
+        "getrawtransaction",
+        "getaddresstxids",
+        "getaddressbalance",
+        "getaddressutxos",
         "sendrawtransaction",
         "getblocktemplate",
         "submitblock",
     ] {
         assert!(
-            public_methods.contains(method),
-            "required public method {method} should remain available"
+            restricted_methods.contains(method),
+            "existing unauthenticated integrations require {method}"
         );
     }
-    assert!(!public_methods.contains("invalidateblock"));
-    assert!(!public_methods.contains("reconsiderblock"));
+    assert!(!restricted_methods.contains("invalidateblock"));
+    assert!(!restricted_methods.contains("reconsiderblock"));
 
     let blocked_call = client
-        .post(format!("http://{public_addr}"))
+        .post(format!("http://{restricted_addr}"))
         .header("content-type", "application/json")
         .body(r#"{"jsonrpc":"2.0","method":"invalidateblock","params":["00"],"id":2}"#)
         .send()
         .await
-        .expect("blocked public request should complete")
+        .expect("blocked restricted request should complete")
         .text()
         .await
-        .expect("blocked public response body should be readable");
+        .expect("blocked restricted response body should be readable");
     let blocked_call: serde_json::Value =
-        serde_json::from_str(&blocked_call).expect("blocked public response should be JSON");
+        serde_json::from_str(&blocked_call).expect("blocked restricted response should be JSON");
     assert_eq!(blocked_call["error"]["code"], -32601);
 
     let batch_call = client
-        .post(format!("http://{public_addr}"))
+        .post(format!("http://{restricted_addr}"))
         .header("content-type", "application/json")
         .body(
             r#"[{"jsonrpc":"2.0","method":"getblockcount","id":6},{"jsonrpc":"2.0","method":"reconsiderblock","params":["00"],"id":7}]"#,
         )
         .send()
         .await
-        .expect("mixed public batch request should complete")
+        .expect("mixed restricted batch request should complete")
         .text()
         .await
-        .expect("mixed public batch response body should be readable");
+        .expect("mixed restricted batch response body should be readable");
     let batch_call: serde_json::Value =
-        serde_json::from_str(&batch_call).expect("mixed public batch response should be JSON");
+        serde_json::from_str(&batch_call).expect("mixed restricted batch response should be JSON");
     let blocked_batch_item = batch_call
         .as_array()
         .expect("batch response should be an array")
@@ -301,7 +309,7 @@ async fn segmented_listeners_enforce_methods_and_cookie_auth() {
         "authenticated admin methods must remain registered"
     );
 
-    public_task.abort();
+    restricted_task.abort();
     admin_task.abort();
     rpc_queue_task.abort();
 }

--- a/crates/zakura-rpc/src/server/tests/surface.rs
+++ b/crates/zakura-rpc/src/server/tests/surface.rs
@@ -1,0 +1,321 @@
+//! Tests for public and authenticated RPC method surfaces.
+
+use std::{
+    collections::BTreeSet,
+    fs,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    time::Duration,
+};
+
+use jsonrpsee::RpcModule;
+use reqwest::Client;
+use tokio::sync::watch;
+use tower::buffer::Buffer;
+
+use crate::{
+    config::rpc::Config,
+    methods::{RpcAccess, RpcImpl, RpcSurface, METHODS, RPC_METHOD_ACCESS},
+    server::{configure_rpc_methods, primary_rpc_surface},
+};
+use zakura_chain::{chain_sync_status::MockSyncStatus, chain_tip::NoChainTip, parameters::Network};
+use zakura_network::address_book_peers::MockAddressBookPeers;
+use zakura_node_services::BoxError;
+use zakura_test::mock_service::MockService;
+
+use super::super::RpcServer;
+
+/// Builds a module containing every explicitly classified method.
+fn classified_module() -> RpcModule<()> {
+    let mut module = RpcModule::new(());
+
+    for (method_name, _) in RPC_METHOD_ACCESS {
+        module
+            .register_method(method_name, |_params, _context, _extensions| true)
+            .expect("classified method names should be unique and valid");
+    }
+
+    module
+}
+
+#[test]
+fn access_policy_matches_the_openrpc_method_set() {
+    let classified: BTreeSet<_> = RPC_METHOD_ACCESS.iter().map(|(name, _)| *name).collect();
+    let documented: BTreeSet<_> = METHODS.keys().copied().collect();
+
+    assert_eq!(
+        classified.len(),
+        RPC_METHOD_ACCESS.len(),
+        "each RPC method must be classified exactly once"
+    );
+    assert_eq!(
+        classified, documented,
+        "registered OpenRPC methods and access classifications must match"
+    );
+}
+
+#[test]
+fn public_surface_contains_only_allowlisted_methods() {
+    let mut module = classified_module();
+    configure_rpc_methods(&mut module, RpcSurface::Public)
+        .expect("the reviewed method classification should be complete");
+
+    let actual: BTreeSet<_> = module.method_names().collect();
+    let expected: BTreeSet<_> = RPC_METHOD_ACCESS
+        .iter()
+        .filter_map(|(name, access)| (*access == RpcAccess::Public).then_some(*name))
+        .collect();
+
+    assert_eq!(actual, expected);
+    assert!(!actual.contains("invalidateblock"));
+    assert!(!actual.contains("reconsiderblock"));
+    assert!(!actual.contains("stop"));
+    assert!(!actual.contains("generate"));
+    assert!(!actual.contains("addnode"));
+}
+
+#[test]
+fn full_surface_retains_admin_and_test_methods() {
+    let mut module = classified_module();
+    configure_rpc_methods(&mut module, RpcSurface::Full)
+        .expect("the reviewed method classification should be complete");
+
+    let actual: BTreeSet<_> = module.method_names().collect();
+
+    assert!(actual.contains("invalidateblock"));
+    assert!(actual.contains("reconsiderblock"));
+    assert!(actual.contains("stop"));
+    assert!(actual.contains("generate"));
+    assert!(actual.contains("addnode"));
+}
+
+#[test]
+fn unclassified_methods_fail_closed() {
+    let mut module = classified_module();
+    module
+        .register_method("new_unreviewed_method", |_params, _context, _extensions| {
+            true
+        })
+        .expect("test method should register");
+
+    let error = configure_rpc_methods(&mut module, RpcSurface::Public)
+        .expect_err("an unclassified method must prevent server startup");
+
+    assert!(error.to_string().contains("new_unreviewed_method"));
+}
+
+#[test]
+fn unauthenticated_production_networks_use_the_public_surface() {
+    assert_eq!(
+        primary_rpc_surface(&Network::Mainnet, false),
+        RpcSurface::Public
+    );
+    assert_eq!(
+        primary_rpc_surface(&Network::new_default_testnet(), false),
+        RpcSurface::Public
+    );
+
+    assert_eq!(
+        primary_rpc_surface(&Network::Mainnet, true),
+        RpcSurface::Full
+    );
+    assert_eq!(
+        primary_rpc_surface(&Network::new_regtest(Default::default()), false),
+        RpcSurface::Full
+    );
+}
+
+#[tokio::test]
+async fn segmented_listeners_enforce_methods_and_cookie_auth() {
+    let _init_guard = zakura_test::init();
+
+    let public_port = zakura_test::net::random_known_port();
+    let admin_port = loop {
+        let port = zakura_test::net::random_known_port();
+        if port != public_port {
+            break port;
+        }
+    };
+    let public_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, public_port).into();
+    let admin_addr: SocketAddr = SocketAddrV4::new(Ipv4Addr::LOCALHOST, admin_port).into();
+    let cookie_dir = tempfile::tempdir().expect("temporary cookie directory should be created");
+    let conf = Config {
+        listen_addr: Some(public_addr),
+        admin_listen_addr: Some(admin_addr),
+        cookie_dir: cookie_dir.path().to_path_buf(),
+        cookie_file_name: "admin.cookie".to_string(),
+        enable_cookie_auth: false,
+        ..Config::default()
+    };
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let block_verifier_router: MockService<_, _, _, BoxError> =
+        MockService::build().for_unit_tests();
+    let (_tx, rx) = watch::channel(None);
+    let (rpc_impl, rpc_queue_task) = RpcImpl::new(
+        Network::Mainnet,
+        Default::default(),
+        false,
+        "RPC surface test",
+        "RPC surface test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state, 1),
+        Buffer::new(block_verifier_router, 1),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let public_task = RpcServer::start(rpc_impl.clone(), conf.clone())
+        .await
+        .expect("public RPC listener should start");
+    let admin_task = RpcServer::start_admin(rpc_impl, conf)
+        .await
+        .expect("admin RPC listener should start");
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("test HTTP client should build");
+
+    let public_discovery = client
+        .post(format!("http://{public_addr}"))
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","method":"rpc.discover","id":1}"#)
+        .send()
+        .await
+        .expect("public discovery request should complete")
+        .text()
+        .await
+        .expect("public discovery response body should be readable");
+    let public_discovery: serde_json::Value =
+        serde_json::from_str(&public_discovery).expect("public discovery response should be JSON");
+    let public_methods = discovered_methods(&public_discovery);
+    for method in [
+        "getblockcount",
+        "sendrawtransaction",
+        "getblocktemplate",
+        "submitblock",
+    ] {
+        assert!(
+            public_methods.contains(method),
+            "required public method {method} should remain available"
+        );
+    }
+    assert!(!public_methods.contains("invalidateblock"));
+    assert!(!public_methods.contains("reconsiderblock"));
+
+    let blocked_call = client
+        .post(format!("http://{public_addr}"))
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","method":"invalidateblock","params":["00"],"id":2}"#)
+        .send()
+        .await
+        .expect("blocked public request should complete")
+        .text()
+        .await
+        .expect("blocked public response body should be readable");
+    let blocked_call: serde_json::Value =
+        serde_json::from_str(&blocked_call).expect("blocked public response should be JSON");
+    assert_eq!(blocked_call["error"]["code"], -32601);
+
+    let batch_call = client
+        .post(format!("http://{public_addr}"))
+        .header("content-type", "application/json")
+        .body(
+            r#"[{"jsonrpc":"2.0","method":"getblockcount","id":6},{"jsonrpc":"2.0","method":"reconsiderblock","params":["00"],"id":7}]"#,
+        )
+        .send()
+        .await
+        .expect("mixed public batch request should complete")
+        .text()
+        .await
+        .expect("mixed public batch response body should be readable");
+    let batch_call: serde_json::Value =
+        serde_json::from_str(&batch_call).expect("mixed public batch response should be JSON");
+    let blocked_batch_item = batch_call
+        .as_array()
+        .expect("batch response should be an array")
+        .iter()
+        .find(|response| response["id"] == 7)
+        .expect("batch response should contain the blocked request");
+    assert_eq!(blocked_batch_item["error"]["code"], -32601);
+
+    let unauthenticated_admin = client
+        .post(format!("http://{admin_addr}"))
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","method":"rpc.discover","id":3}"#)
+        .send()
+        .await;
+    if let Ok(response) = unauthenticated_admin {
+        assert!(
+            !response.status().is_success(),
+            "the admin listener must reject requests without its cookie"
+        );
+    }
+
+    let cookie = fs::read_to_string(cookie_dir.path().join("admin.cookie"))
+        .expect("admin listener should write its cookie");
+    let (username, password) = cookie
+        .split_once(':')
+        .expect("cookie should contain basic-auth credentials");
+    let admin_discovery = client
+        .post(format!("http://{admin_addr}"))
+        .basic_auth(username, Some(password))
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","method":"rpc.discover","id":4}"#)
+        .send()
+        .await
+        .expect("authenticated admin request should complete")
+        .text()
+        .await
+        .expect("admin discovery response body should be readable");
+    let admin_discovery: serde_json::Value =
+        serde_json::from_str(&admin_discovery).expect("admin discovery response should be JSON");
+    let admin_methods = discovered_methods(&admin_discovery);
+    assert!(admin_methods.contains("invalidateblock"));
+    assert!(admin_methods.contains("reconsiderblock"));
+
+    let admin_call = client
+        .post(format!("http://{admin_addr}"))
+        .basic_auth(username, Some(password))
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","method":"invalidateblock","params":["00"],"id":5}"#)
+        .send()
+        .await
+        .expect("authenticated admin method request should complete")
+        .text()
+        .await
+        .expect("admin method response body should be readable");
+    let admin_call: serde_json::Value =
+        serde_json::from_str(&admin_call).expect("admin method response should be JSON");
+    let admin_error_code = admin_call["error"]["code"]
+        .as_i64()
+        .expect("an invalid block hash should return an RPC error");
+    assert_ne!(
+        admin_error_code, -32601,
+        "authenticated admin methods must remain registered"
+    );
+
+    public_task.abort();
+    admin_task.abort();
+    rpc_queue_task.abort();
+}
+
+/// Returns method names from an `rpc.discover` JSON-RPC response.
+fn discovered_methods(response: &serde_json::Value) -> BTreeSet<&str> {
+    response["result"]["methods"]
+        .as_array()
+        .expect("discovery response should contain a method array")
+        .iter()
+        .map(|method| {
+            method["name"]
+                .as_str()
+                .expect("each discovered method should have a name")
+        })
+        .collect()
+}

--- a/crates/zakura-rpc/src/server/tests/vectors.rs
+++ b/crates/zakura-rpc/src/server/tests/vectors.rs
@@ -32,6 +32,7 @@ async fn rpc_server_spawn() {
 
     let conf = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into()),
+        admin_listen_addr: None,
         indexer_listen_addr: None,
         indexer_tls: None,
         parallel_cpu_threads: 0,
@@ -106,6 +107,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
     #[allow(clippy::bool_to_int_with_if)]
     let conf = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
+        admin_listen_addr: None,
         indexer_listen_addr: None,
         indexer_tls: None,
         parallel_cpu_threads: 0,
@@ -169,6 +171,7 @@ async fn rpc_server_spawn_port_conflict() {
     let port = zakura_test::net::random_known_port();
     let conf = Config {
         listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
+        admin_listen_addr: None,
         indexer_listen_addr: None,
         indexer_tls: None,
         debug_force_finished_sync: false,

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -174,7 +174,7 @@ zakura-header-chain = { path = "../zakura-header-chain", version = "1.0.0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-network = { path = "../zakura-network", version = "7.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.1", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "8.0.0" }
+zakura-rpc = { path = "../zakura-rpc", version = "9.0.0" }
 zakura-state = { path = "../zakura-state", version = "7.0.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of

--- a/crates/zakurad/src/commands/start.rs
+++ b/crates/zakurad/src/commands/start.rs
@@ -341,6 +341,7 @@ impl StartCmd {
 
         Self::validate_consensus_config(&config)?;
         Self::validate_debug_blocksync_throughput_config(&config)?;
+        config.rpc.validate().map_err(|error| eyre!(error))?;
 
         if config.zcashd_compat.enabled {
             zcashd_compat::run_preflight(&config, self.unsafe_low_specs)?;
@@ -675,6 +676,15 @@ impl StartCmd {
         };
         node_tasks.track(&rpc_task_handle);
 
+        let admin_rpc_task_handle = if config.rpc.admin_listen_addr.is_some() {
+            RpcServer::start_admin(rpc_impl.clone(), config.rpc.clone())
+                .await
+                .expect("admin server should start")
+        } else {
+            tokio::spawn(std::future::pending().in_current_span())
+        };
+        node_tasks.track(&admin_rpc_task_handle);
+
         let zcashd_compat_shutdown_timeout =
             Self::zcashd_compat_supervisor_shutdown_timeout(&config);
         let zcashd_compat_supervisor_config =
@@ -907,6 +917,7 @@ impl StartCmd {
 
         // ongoing tasks
         pin!(rpc_task_handle);
+        pin!(admin_rpc_task_handle);
         pin!(indexer_rpc_task_handle);
         pin!(syncer_task_handle);
         pin!(block_gossip_task_handle);
@@ -958,6 +969,13 @@ impl StartCmd {
                     let rpc_server_result = rpc_join_result
                         .expect("unexpected panic in the rpc task");
                     info!(?rpc_server_result, "rpc task exited");
+                    Ok(())
+                }
+
+                admin_rpc_join_result = &mut admin_rpc_task_handle => {
+                    let admin_rpc_server_result = admin_rpc_join_result
+                        .expect("unexpected panic in the admin rpc task");
+                    info!(?admin_rpc_server_result, "admin rpc task exited");
                     Ok(())
                 }
 
@@ -1073,6 +1091,7 @@ impl StartCmd {
 
         // ongoing tasks
         rpc_task_handle.abort();
+        admin_rpc_task_handle.abort();
         rpc_tx_queue_handle.abort();
         health_task_handle.abort();
         syncer_task_handle.abort();
@@ -1274,6 +1293,7 @@ impl config::Override<ZakuradConfig> for StartCmd {
             .map_err(|err| std::io::Error::other(err.to_string()))?;
         Self::validate_debug_blocksync_throughput_config(&config)
             .map_err(|err| std::io::Error::other(err.to_string()))?;
+        config.rpc.validate().map_err(std::io::Error::other)?;
 
         Ok(config)
     }

--- a/docker/default-zakura-config.toml
+++ b/docker/default-zakura-config.toml
@@ -37,10 +37,18 @@ cache_dir = "/home/zebra/.cache/zakura"
 
 cookie_dir = "/home/zebra/.cache/zakura"
 
-# To disable cookie authentication, uncomment the line below and set the value
-# to false.
+# Cookie authentication is enabled by default. To serve the public Mainnet or
+# Testnet RPC method set without authentication, set this value to false.
+# Administrative methods such as invalidateblock and reconsiderblock are not
+# registered on that public listener.
 
 # enable_cookie_auth = true
+
+# An unauthenticated public listener can expose the full administrative method
+# set separately on a cookie-authenticated loopback listener. Use a different
+# port and connect remotely through SSH or another secure local access path.
+
+# admin_listen_addr = "127.0.0.1:8231"
 
 [state]
 cache_dir = "/home/zebra/.cache/zakura"

--- a/docker/default-zakura-config.toml
+++ b/docker/default-zakura-config.toml
@@ -39,7 +39,7 @@ cookie_dir = "/home/zebra/.cache/zakura"
 
 # Cookie authentication is enabled by default. To serve the restricted Mainnet
 # or Testnet compatibility method set without authentication, set this value to
-# false.
+# false. Leave it enabled when every method should require credentials.
 # Administrative methods such as invalidateblock and reconsiderblock are not
 # registered on that listener. This restriction is defense in depth, not a
 # substitute for network access controls. Keep unauthenticated RPC behind a

--- a/docker/default-zakura-config.toml
+++ b/docker/default-zakura-config.toml
@@ -37,16 +37,20 @@ cache_dir = "/home/zebra/.cache/zakura"
 
 cookie_dir = "/home/zebra/.cache/zakura"
 
-# Cookie authentication is enabled by default. To serve the public Mainnet or
-# Testnet RPC method set without authentication, set this value to false.
+# Cookie authentication is enabled by default. To serve the restricted Mainnet
+# or Testnet compatibility method set without authentication, set this value to
+# false.
 # Administrative methods such as invalidateblock and reconsiderblock are not
-# registered on that public listener.
+# registered on that listener. This restriction is defense in depth, not a
+# substitute for network access controls. Keep unauthenticated RPC behind a
+# firewall, private network, or gateway that limits access to trusted clients.
 
 # enable_cookie_auth = true
 
-# An unauthenticated public listener can expose the full administrative method
-# set separately on a cookie-authenticated loopback listener. Use a different
-# port and connect remotely through SSH or another secure local access path.
+# A restricted unauthenticated listener can expose the full administrative
+# method set separately on a cookie-authenticated loopback listener. Use a
+# different port and connect remotely through SSH or another secure local
+# access path.
 
 # admin_listen_addr = "127.0.0.1:8231"
 

--- a/docs/changelog/unreleased/876.md
+++ b/docs/changelog/unreleased/876.md
@@ -1,5 +1,7 @@
 ## Security
 
 - Restricted administrative RPC methods to authenticated Mainnet and Testnet
-  listeners while keeping them available through an optional loopback admin
-  listener ([#876](https://github.com/zakura-core/zakura/pull/876)).
+  listeners while keeping them available through an optional
+  `rpc.admin_listen_addr` loopback listener. The unauthenticated listener
+  remains intended for protected downstream connectivity, not arbitrary
+  Internet traffic ([#876](https://github.com/zakura-core/zakura/pull/876)).

--- a/docs/changelog/unreleased/876.md
+++ b/docs/changelog/unreleased/876.md
@@ -1,0 +1,5 @@
+## Security
+
+- Restricted administrative RPC methods to authenticated Mainnet and Testnet
+  listeners while keeping them available through an optional loopback admin
+  listener ([#876](https://github.com/zakura-core/zakura/pull/876)).


### PR DESCRIPTION
## Motivation

Unauthenticated Mainnet and Testnet RPC listeners registered administrative chain-control methods, allowing any network client to call `invalidateblock` or `reconsiderblock`. Normal query, transaction submission, mining, lightwalletd, and fleet-health uses should remain available without credentials by default.

## Solution

Every registered RPC method now has a fail-closed access classification. On Mainnet and Testnet, `rpc.listen_addr` without cookie authentication exposes the normal compatibility surface but omits chain-control and test methods. Authenticated primary listeners and Regtest retain the full surface. Operators that disable authentication but still need administrative methods can configure a different loopback port with `rpc.admin_listen_addr`; that listener always requires the existing cookie.

Existing authenticated deployments need no configuration change. Existing unauthenticated deployments lose `invalidateblock` and `reconsiderblock`, while methods such as `getrawtransaction`, `getinfo`, `getpeerinfo`, transaction submission, and mining remain available. Operators that want credentials on every method can set `rpc.enable_cookie_auth = true`. The unauthenticated surface is defense in depth, not Internet hardening, so its network exposure still needs an appropriate firewall, private network, or access-controlled gateway.

The `zakura-rpc` crate moves to version 9 because the new public configuration field is a breaking change for Rust struct-literal consumers.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura-rpc -p zakura --all-targets --locked -- -D warnings`
- `cargo test -p zakura-rpc --lib --locked` (125 passed, 1 ignored)
- `cargo test -p zakura --test config --locked` (23 passed)
- `cargo test -p zakura --test acceptance invalidate_and_reconsider_block --locked -- --nocapture`
- `./scripts/changelog.py check` and repository-wide Markdown lint

The RPC tests exercise the actual HTTP listeners: unauthenticated discovery and batches omit administrative methods, current unauthenticated compatibility methods remain available, unauthenticated admin requests are rejected, authenticated admin calls remain registered, and incomplete classifications fail closed. The acceptance test confirms Regtest can still invalidate and reconsider blocks.

## Changelog

Added `docs/changelog/unreleased/876.md` under Security.