### PR TITLE
fix(network): cap block-range payloads before allocation

### DIFF
--- a/crates/zakura-network/src/zakura/block_sync/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/mod.rs
@@ -79,6 +79,7 @@ pub(crate) use service::BlockSyncService;
 #[cfg(test)]
 pub(crate) use service::MAX_BS_FRAME_BYTES;
 pub use state::{BlockSyncFrontiers, BlockSyncHandle, BlockSyncStartup};
+pub(crate) use wire::preallocation_payload_cap;
 pub use wire::{
     BlockSyncMessage, MAX_BS_BLOCKS_PER_REQUEST, MAX_BS_MESSAGE_BYTES, MSG_BS_BLOCK,
     MSG_BS_BLOCKS_DONE, MSG_BS_GET_BLOCKS, MSG_BS_RANGE_UNAVAILABLE, MSG_BS_STATUS,

--- a/crates/zakura-network/src/zakura/block_sync/wire.rs
+++ b/crates/zakura-network/src/zakura/block_sync/wire.rs
@@ -30,18 +30,26 @@ pub const MAX_BS_MESSAGE_BYTES: usize = 3 * 1024 * 1024;
 
 pub(super) const BLOCK_SYNC_MESSAGE_TYPE_BYTES: usize = 1;
 const GET_BLOCKS_PAYLOAD_BYTES: usize = BLOCK_SYNC_MESSAGE_TYPE_BYTES + 4 + 4;
+const BLOCK_PAYLOAD_BYTES: usize = BLOCK_SYNC_MESSAGE_TYPE_BYTES + 2_000_000;
+const TERMINAL_PAYLOAD_BYTES: usize = BLOCK_SYNC_MESSAGE_TYPE_BYTES + 4 + 4;
 
 const _: () = assert!(MAX_BS_MESSAGE_BYTES < 4 * 1024 * 1024);
 const _: () = assert!(MAX_BS_MESSAGE_BYTES > block::MAX_BLOCK_BYTES as usize);
+const _: () = assert!(block::MAX_BLOCK_BYTES == 2_000_000);
 
-/// Return the payload cap that must be enforced before allocating a buffer for
-/// a fixed-size inbound message.
+/// Return the wire payload cap enforced before allocating an inbound buffer.
 ///
-/// Variable-size messages return `None` and remain bounded by the stream cap.
-/// Keeping this table beside the codec makes each future fixed-size message's
-/// allocation boundary part of its wire definition.
+/// Messages without a specified per-kind cap return `None` and remain bounded
+/// by the stream cap. Keeping this table beside the codec makes each allocation
+/// boundary part of its wire definition.
 pub(crate) fn preallocation_payload_cap(message_type: u16) -> Option<usize> {
-    (message_type == u16::from(MSG_BS_GET_BLOCKS)).then_some(GET_BLOCKS_PAYLOAD_BYTES)
+    match message_type {
+        value if value == u16::from(MSG_BS_GET_BLOCKS) => Some(GET_BLOCKS_PAYLOAD_BYTES),
+        value if value == u16::from(MSG_BS_BLOCK) => Some(BLOCK_PAYLOAD_BYTES),
+        value if value == u16::from(MSG_BS_BLOCKS_DONE) => Some(TERMINAL_PAYLOAD_BYTES),
+        value if value == u16::from(MSG_BS_RANGE_UNAVAILABLE) => Some(TERMINAL_PAYLOAD_BYTES),
+        _ => None,
+    }
 }
 
 /// Native stream-6 block-sync message.

--- a/crates/zakura-network/src/zakura/block_sync/wire.rs
+++ b/crates/zakura-network/src/zakura/block_sync/wire.rs
@@ -29,9 +29,20 @@ pub const MAX_BS_BLOCKS_PER_REQUEST: u32 = 128;
 pub const MAX_BS_MESSAGE_BYTES: usize = 3 * 1024 * 1024;
 
 pub(super) const BLOCK_SYNC_MESSAGE_TYPE_BYTES: usize = 1;
+const GET_BLOCKS_PAYLOAD_BYTES: usize = BLOCK_SYNC_MESSAGE_TYPE_BYTES + 4 + 4;
 
 const _: () = assert!(MAX_BS_MESSAGE_BYTES < 4 * 1024 * 1024);
 const _: () = assert!(MAX_BS_MESSAGE_BYTES > block::MAX_BLOCK_BYTES as usize);
+
+/// Return the payload cap that must be enforced before allocating a buffer for
+/// a fixed-size inbound message.
+///
+/// Variable-size messages return `None` and remain bounded by the stream cap.
+/// Keeping this table beside the codec makes each future fixed-size message's
+/// allocation boundary part of its wire definition.
+pub(crate) fn preallocation_payload_cap(message_type: u16) -> Option<usize> {
+    (message_type == u16::from(MSG_BS_GET_BLOCKS)).then_some(GET_BLOCKS_PAYLOAD_BYTES)
+}
 
 /// Native stream-6 block-sync message.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -4044,8 +4044,10 @@ async fn persistent_stream_worker(
                 biased;
                 _ = reader_context.connection_token.cancelled() => break,
                 _ = reader_context.stream_token.cancelled() => break,
-                frame = read_frame(
+                frame = read_service_frame(
                     &mut recv,
+                    prelude.stream_kind,
+                    prelude.stream_version,
                     reader_context.inbound_frame_cap,
                     reader_context.limits.idle_timeout,
                     // A persistent ordered stream is legitimately quiet between
@@ -4223,8 +4225,10 @@ async fn request_stream_worker(
     let frame = tokio::select! {
         biased;
         _ = context.connection_token.cancelled() => return,
-        frame = read_frame(
+        frame = read_service_frame(
             &mut recv,
+            prelude.stream_kind,
+            prelude.stream_version,
             context.inbound_frame_cap,
             context.limits.idle_timeout,
             // A request stream carries its request frame immediately after the
@@ -4375,30 +4379,60 @@ async fn read_stream_prelude(
     })
 }
 
-/// Read one length-prefixed frame from an ordered/request stream.
-///
-/// `read_timeout` always bounds a frame that is *in progress*: once its first
-/// byte has arrived, a peer cannot stall the rest of the header or the payload
-/// past this deadline.
-///
-/// `first_byte_timeout` bounds only the wait for the *next* frame to begin.
-/// Passing `None` waits indefinitely for that first byte -- correct for a
-/// long-lived ordered stream that is legitimately quiet between frames (e.g. the
-/// gossip stream while syncing far below the tip, or header sync after the
-/// header frontier has caught up while bodies download). Treating that
-/// inter-frame quiet as a fatal read timeout would `connection_token.cancel()`
-/// the whole connection -- dropping every active sibling stream on it -- even
-/// though the connection-level [`freshness_reaper`] (which resets on ANY
-/// stream's activity) and the QUIC idle timeout already own connection-level
-/// idleness. Callers race this future against their cancellation tokens, so a
-/// genuinely dead connection is still torn down promptly. Passing `Some(_)` is
-/// for one-shot streams (a request/response stream where the request, or a
-/// response frame, is expected promptly).
+/// Read a raw frame without a service-owned message cap in transport tests.
+#[cfg(test)]
 async fn read_frame(
     recv: &mut RecvStream,
     max_frame_bytes: u32,
     read_timeout: Duration,
     first_byte_timeout: Option<Duration>,
+) -> Result<Frame, ZakuraHandlerError> {
+    read_frame_with_message_cap(
+        recv,
+        max_frame_bytes,
+        read_timeout,
+        first_byte_timeout,
+        None,
+    )
+    .await
+}
+
+/// Read a service frame while enforcing any fixed-size allocation cap declared
+/// by the codec that owns the negotiated stream.
+async fn read_service_frame(
+    recv: &mut RecvStream,
+    stream_kind: u16,
+    stream_version: u16,
+    max_frame_bytes: u32,
+    read_timeout: Duration,
+    first_byte_timeout: Option<Duration>,
+) -> Result<Frame, ZakuraHandlerError> {
+    read_frame_with_message_cap(
+        recv,
+        max_frame_bytes,
+        read_timeout,
+        first_byte_timeout,
+        Some((stream_kind, stream_version)),
+    )
+    .await
+}
+
+/// Read one length-prefixed frame from an ordered or request stream.
+///
+/// `read_timeout` bounds a frame after its first byte arrives. The optional
+/// `first_byte_timeout` separately bounds how long a one-shot stream may remain
+/// silent before its next frame. Long-lived ordered streams pass `None` because
+/// connection freshness and the QUIC idle timeout own inter-frame idleness.
+///
+/// When `service_message` is present, the owning codec may lower the effective
+/// cap after the fixed header reveals the message type. This check happens
+/// before allocating or reading the payload.
+async fn read_frame_with_message_cap(
+    recv: &mut RecvStream,
+    max_frame_bytes: u32,
+    read_timeout: Duration,
+    first_byte_timeout: Option<Duration>,
+    service_message: Option<(u16, u16)>,
 ) -> Result<Frame, ZakuraHandlerError> {
     let mut header = [0; FRAME_HEADER_BYTES];
     // The first header byte is the boundary between "waiting for the next frame"
@@ -4429,8 +4463,15 @@ async fn read_frame(
     let flags = reader.read_u16::<LittleEndian>()?;
     let payload_len = usize::try_from(reader.read_u32::<LittleEndian>()?)
         .expect("u32 payload lengths fit usize on supported targets");
-    let max_frame_bytes =
+    let mut max_frame_bytes =
         usize::try_from(max_frame_bytes).expect("u32 frame cap fits usize on supported targets");
+    if let Some((stream_kind, stream_version)) = service_message {
+        if let Some(payload_cap) =
+            preallocation_payload_cap(stream_kind, stream_version, message_type)
+        {
+            max_frame_bytes = max_frame_bytes.min(FRAME_HEADER_BYTES.saturating_add(payload_cap));
+        }
+    }
     let frame_len = FRAME_HEADER_BYTES.saturating_add(payload_len);
     if frame_len > max_frame_bytes {
         metrics::counter!("zakura.p2p.ratelimit.frame.oversize").increment(1);
@@ -4449,6 +4490,21 @@ async fn read_frame(
         flags,
         payload,
     })
+}
+
+/// Resolve message-specific allocation caps through the codec that owns the
+/// negotiated stream. Unknown and variable-size messages use the stream cap.
+fn preallocation_payload_cap(
+    stream_kind: u16,
+    stream_version: u16,
+    message_type: u16,
+) -> Option<usize> {
+    match (stream_kind, stream_version) {
+        (ZAKURA_STREAM_BLOCK_SYNC, super::block_sync::ZAKURA_BLOCK_SYNC_STREAM_VERSION) => {
+            super::block_sync::preallocation_payload_cap(message_type)
+        }
+        _ => None,
+    }
 }
 
 async fn read_control_payload(
@@ -4603,8 +4659,10 @@ async fn write_outbound_request_frame_inner(
 
     let mut frames = Vec::new();
     loop {
-        match read_frame(
+        match read_service_frame(
             &mut recv,
+            stream.kind,
+            stream.version,
             inbound_frame_cap,
             limits.idle_timeout,
             // This is the requester side of a one-shot legacy request/response:
@@ -8511,6 +8569,106 @@ mod tests {
 
         conn_a.close(0u32.into(), b"done");
         conn_b.close(0u32.into(), b"done");
+        client.close().await;
+        router.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gb_wf_09_get_blocks_payload_cap_precedes_allocation() -> Result<(), BoxError> {
+        const ALPN: &[u8] = b"/zakura/testkit/get-blocks-payload-cap/0";
+        const OVERSIZE_GET_BLOCKS_PAYLOAD: u32 = 10;
+
+        let _guard = zakura_test::init();
+        let server = LocalEndpointFactory::new().endpoint(92).await?;
+        let (connection_tx, _connection_rx) = mpsc::channel(1);
+        let (stream_tx, mut stream_rx) = mpsc::channel(1);
+        let router = Router::builder(server)
+            .accept(
+                ALPN,
+                CaptureConnection {
+                    connection_tx,
+                    stream_tx,
+                },
+            )
+            .spawn();
+        let client = LocalEndpointFactory::new().endpoint(93).await?;
+        let server_addr = router.endpoint().node_addr().initialized().await;
+        client.add_node_addr(server_addr.clone())?;
+        let connection = timeout(Duration::from_secs(10), client.connect(server_addr, ALPN))
+            .await
+            .expect("client connects for the GetBlocks cap test")?;
+        let (mut peer_send, _peer_recv) = timeout(Duration::from_secs(1), connection.open_bi())
+            .await
+            .expect("client opens the block-sync stream")?;
+
+        let mut header = Vec::with_capacity(FRAME_HEADER_BYTES);
+        header.extend_from_slice(&u16::from(crate::zakura::MSG_BS_GET_BLOCKS).to_le_bytes());
+        header.extend_from_slice(&0u16.to_le_bytes());
+        header.extend_from_slice(&OVERSIZE_GET_BLOCKS_PAYLOAD.to_le_bytes());
+        timeout(Duration::from_secs(1), peer_send.write_all(&header))
+            .await
+            .expect("client writes the oversized GetBlocks header")?;
+        let _ = peer_send.finish();
+
+        let (_server_send, mut server_recv) = timeout(Duration::from_secs(1), stream_rx.recv())
+            .await
+            .expect("server accepts the block-sync stream")
+            .expect("capture handler forwards the block-sync stream");
+        let rejected = read_service_frame(
+            &mut server_recv,
+            ZAKURA_STREAM_BLOCK_SYNC,
+            ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+            MAX_BS_FRAME_BYTES,
+            Duration::from_secs(2),
+            Some(Duration::from_secs(2)),
+        )
+        .await;
+        assert!(matches!(
+            rejected,
+            Err(ZakuraHandlerError::OversizeFrame {
+                payload_len: 10,
+                max_frame_bytes: 17,
+                ..
+            })
+        ));
+
+        let valid_payload = [crate::zakura::MSG_BS_GET_BLOCKS, 1, 0, 0, 0, 1, 0, 0, 0];
+        let (mut valid_send, _valid_recv) = timeout(Duration::from_secs(1), connection.open_bi())
+            .await
+            .expect("client opens the valid block-sync stream")?;
+        let mut valid_frame = Vec::with_capacity(FRAME_HEADER_BYTES + valid_payload.len());
+        valid_frame.extend_from_slice(&u16::from(crate::zakura::MSG_BS_GET_BLOCKS).to_le_bytes());
+        valid_frame.extend_from_slice(&0u16.to_le_bytes());
+        valid_frame.extend_from_slice(
+            &u32::try_from(valid_payload.len())
+                .expect("the fixed GetBlocks payload length fits u32")
+                .to_le_bytes(),
+        );
+        valid_frame.extend_from_slice(&valid_payload);
+        timeout(Duration::from_secs(1), valid_send.write_all(&valid_frame))
+            .await
+            .expect("client writes the valid GetBlocks frame")?;
+        let _ = valid_send.finish();
+
+        let (_server_send, mut valid_server_recv) =
+            timeout(Duration::from_secs(1), stream_rx.recv())
+                .await
+                .expect("server accepts the valid block-sync stream")
+                .expect("capture handler forwards the valid block-sync stream");
+        let valid = read_service_frame(
+            &mut valid_server_recv,
+            ZAKURA_STREAM_BLOCK_SYNC,
+            ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+            MAX_BS_FRAME_BYTES,
+            Duration::from_secs(2),
+            Some(Duration::from_secs(2)),
+        )
+        .await
+        .expect("the exact GetBlocks payload is admitted");
+        assert_eq!(valid.payload, valid_payload);
+
+        connection.close(0u32.into(), b"done");
         client.close().await;
         router.shutdown().await?;
         Ok(())

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -4425,8 +4425,9 @@ async fn read_service_frame(
 /// connection freshness and the QUIC idle timeout own inter-frame idleness.
 ///
 /// When `service_message` is present, the owning codec may lower the effective
-/// cap after the fixed header reveals the message type. This check happens
-/// before allocating or reading the payload.
+/// cap after the fixed header reveals the outer message type. The first payload
+/// byte is then read separately so its duplicate discriminator can lower the
+/// cap before allocating or reading the rest of the payload.
 async fn read_frame_with_message_cap(
     recv: &mut RecvStream,
     max_frame_bytes: u32,
@@ -4472,6 +4473,47 @@ async fn read_frame_with_message_cap(
             max_frame_bytes = max_frame_bytes.min(FRAME_HEADER_BYTES.saturating_add(payload_cap));
         }
     }
+    validate_declared_frame_len(payload_len, max_frame_bytes)?;
+    let payload = timeout(read_timeout, async {
+        if payload_len == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut payload_discriminator = [0];
+        recv.read_exact(&mut payload_discriminator).await?;
+        if let Some((stream_kind, stream_version)) = service_message {
+            if let Some(payload_cap) = preallocation_payload_cap(
+                stream_kind,
+                stream_version,
+                u16::from(payload_discriminator[0]),
+            ) {
+                let discriminator_frame_cap = FRAME_HEADER_BYTES.saturating_add(payload_cap);
+                validate_declared_frame_len(
+                    payload_len,
+                    max_frame_bytes.min(discriminator_frame_cap),
+                )?;
+            }
+        }
+
+        let mut payload = vec![0; payload_len];
+        payload[0] = payload_discriminator[0];
+        recv.read_exact(&mut payload[1..]).await?;
+        Ok::<_, ZakuraHandlerError>(payload)
+    })
+    .await
+    .map_err(|_| ZakuraHandlerError::Timeout("frame payload"))??;
+    Ok(Frame {
+        message_type,
+        flags,
+        payload,
+    })
+}
+
+/// Reject a peer-declared frame length before allocating its payload.
+fn validate_declared_frame_len(
+    payload_len: usize,
+    max_frame_bytes: usize,
+) -> Result<(), ZakuraHandlerError> {
     let frame_len = FRAME_HEADER_BYTES.saturating_add(payload_len);
     if frame_len > max_frame_bytes {
         metrics::counter!("zakura.p2p.ratelimit.frame.oversize").increment(1);
@@ -4481,15 +4523,7 @@ async fn read_frame_with_message_cap(
             max_frame_bytes,
         });
     }
-    let mut payload = vec![0; payload_len];
-    timeout(read_timeout, recv.read_exact(&mut payload))
-        .await
-        .map_err(|_| ZakuraHandlerError::Timeout("frame payload"))??;
-    Ok(Frame {
-        message_type,
-        flags,
-        payload,
-    })
+    Ok(())
 }
 
 /// Resolve message-specific allocation caps through the codec that owns the
@@ -8577,15 +8611,23 @@ mod tests {
     #[tokio::test]
     async fn gb_wf_09_get_blocks_payload_cap_precedes_allocation() -> Result<(), BoxError> {
         const ALPN: &[u8] = b"/zakura/testkit/get-blocks-payload-cap/0";
+        const VALID_ALPN: &[u8] = b"/zakura/testkit/get-blocks-payload-cap-valid/0";
         const OVERSIZE_GET_BLOCKS_PAYLOAD: u32 = 10;
 
         let _guard = zakura_test::init();
         let server = LocalEndpointFactory::new().endpoint(92).await?;
-        let (connection_tx, _connection_rx) = mpsc::channel(1);
+        let (connection_tx, _connection_rx) = mpsc::channel(2);
         let (stream_tx, mut stream_rx) = mpsc::channel(1);
         let router = Router::builder(server)
             .accept(
                 ALPN,
+                CaptureConnection {
+                    connection_tx: connection_tx.clone(),
+                    stream_tx: stream_tx.clone(),
+                },
+            )
+            .accept(
+                VALID_ALPN,
                 CaptureConnection {
                     connection_tx,
                     stream_tx,
@@ -8595,9 +8637,12 @@ mod tests {
         let client = LocalEndpointFactory::new().endpoint(93).await?;
         let server_addr = router.endpoint().node_addr().initialized().await;
         client.add_node_addr(server_addr.clone())?;
-        let connection = timeout(Duration::from_secs(10), client.connect(server_addr, ALPN))
-            .await
-            .expect("client connects for the GetBlocks cap test")?;
+        let connection = timeout(
+            Duration::from_secs(10),
+            client.connect(server_addr.clone(), ALPN),
+        )
+        .await
+        .expect("client connects for the GetBlocks cap test")?;
         let (mut peer_send, _peer_recv) = timeout(Duration::from_secs(1), connection.open_bi())
             .await
             .expect("client opens the block-sync stream")?;
@@ -8633,10 +8678,60 @@ mod tests {
             })
         ));
 
+        let (mut mismatched_send, _mismatched_recv) =
+            timeout(Duration::from_secs(1), connection.open_bi())
+                .await
+                .expect("client opens the mismatched block-sync stream")?;
+        let mut mismatched_prefix = Vec::with_capacity(FRAME_HEADER_BYTES + 1);
+        mismatched_prefix.extend_from_slice(&u16::from(crate::zakura::MSG_BS_BLOCK).to_le_bytes());
+        mismatched_prefix.extend_from_slice(&0u16.to_le_bytes());
+        mismatched_prefix.extend_from_slice(&OVERSIZE_GET_BLOCKS_PAYLOAD.to_le_bytes());
+        mismatched_prefix.push(crate::zakura::MSG_BS_GET_BLOCKS);
+        timeout(
+            Duration::from_secs(1),
+            mismatched_send.write_all(&mismatched_prefix),
+        )
+        .await
+        .expect("client writes the mismatched GetBlocks prefix")?;
+
+        let (_server_send, mut mismatched_server_recv) =
+            timeout(Duration::from_secs(1), stream_rx.recv())
+                .await
+                .expect("server accepts the mismatched block-sync stream")
+                .expect("capture handler forwards the mismatched block-sync stream");
+        let mismatched_rejection = timeout(
+            Duration::from_secs(1),
+            read_service_frame(
+                &mut mismatched_server_recv,
+                ZAKURA_STREAM_BLOCK_SYNC,
+                ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+                MAX_BS_FRAME_BYTES,
+                Duration::from_secs(2),
+                Some(Duration::from_secs(2)),
+            ),
+        )
+        .await
+        .expect("the payload discriminator rejects before its declared remainder is read");
+        assert!(matches!(
+            mismatched_rejection,
+            Err(ZakuraHandlerError::OversizeFrame {
+                payload_len: 10,
+                max_frame_bytes: 17,
+                ..
+            })
+        ));
+
         let valid_payload = [crate::zakura::MSG_BS_GET_BLOCKS, 1, 0, 0, 0, 1, 0, 0, 0];
-        let (mut valid_send, _valid_recv) = timeout(Duration::from_secs(1), connection.open_bi())
-            .await
-            .expect("client opens the valid block-sync stream")?;
+        let valid_connection = timeout(
+            Duration::from_secs(10),
+            client.connect(server_addr, VALID_ALPN),
+        )
+        .await
+        .expect("client connects for the valid GetBlocks frame")?;
+        let (mut valid_send, _valid_recv) =
+            timeout(Duration::from_secs(1), valid_connection.open_bi())
+                .await
+                .expect("client opens the valid block-sync stream")?;
         let mut valid_frame = Vec::with_capacity(FRAME_HEADER_BYTES + valid_payload.len());
         valid_frame.extend_from_slice(&u16::from(crate::zakura::MSG_BS_GET_BLOCKS).to_le_bytes());
         valid_frame.extend_from_slice(&0u16.to_le_bytes());
@@ -8669,6 +8764,7 @@ mod tests {
         assert_eq!(valid.payload, valid_payload);
 
         connection.close(0u32.into(), b"done");
+        valid_connection.close(0u32.into(), b"done");
         client.close().await;
         router.shutdown().await?;
         Ok(())

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -8770,6 +8770,116 @@ mod tests {
         Ok(())
     }
 
+    async fn assert_block_sync_payload_cap_precedes_allocation(
+        alpn: &'static [u8],
+        server_seed: u64,
+        client_seed: u64,
+        message_type: u8,
+        payload_cap: usize,
+    ) -> Result<(), BoxError> {
+        let _guard = zakura_test::init();
+        let server = LocalEndpointFactory::new().endpoint(server_seed).await?;
+        let (connection_tx, _connection_rx) = mpsc::channel(1);
+        let (stream_tx, mut stream_rx) = mpsc::channel(1);
+        let router = Router::builder(server)
+            .accept(
+                alpn,
+                CaptureConnection {
+                    connection_tx,
+                    stream_tx,
+                },
+            )
+            .spawn();
+        let client = LocalEndpointFactory::new().endpoint(client_seed).await?;
+        let server_addr = router.endpoint().node_addr().initialized().await;
+        client.add_node_addr(server_addr.clone())?;
+        let connection = timeout(Duration::from_secs(10), client.connect(server_addr, alpn))
+            .await
+            .expect("client connects for the block-sync payload cap test")?;
+        let (mut peer_send, _peer_recv) = timeout(Duration::from_secs(1), connection.open_bi())
+            .await
+            .expect("client opens the block-sync stream")?;
+
+        let oversized_payload = payload_cap
+            .checked_add(1)
+            .expect("the specified payload caps fit usize");
+        let oversized_payload = u32::try_from(oversized_payload)
+            .expect("the specified payload caps fit the wire length field");
+        let mut header = Vec::with_capacity(FRAME_HEADER_BYTES);
+        header.extend_from_slice(&u16::from(message_type).to_le_bytes());
+        header.extend_from_slice(&0u16.to_le_bytes());
+        header.extend_from_slice(&oversized_payload.to_le_bytes());
+        timeout(Duration::from_secs(1), peer_send.write_all(&header))
+            .await
+            .expect("client writes the oversized block-sync header")?;
+        let _ = peer_send.finish();
+
+        let (_server_send, mut server_recv) = timeout(Duration::from_secs(1), stream_rx.recv())
+            .await
+            .expect("server accepts the block-sync stream")
+            .expect("capture handler forwards the block-sync stream");
+        let rejected = read_service_frame(
+            &mut server_recv,
+            ZAKURA_STREAM_BLOCK_SYNC,
+            ZAKURA_BLOCK_SYNC_STREAM_VERSION,
+            MAX_BS_FRAME_BYTES,
+            Duration::from_secs(2),
+            Some(Duration::from_secs(2)),
+        )
+        .await;
+        assert!(matches!(
+            rejected,
+            Err(ZakuraHandlerError::OversizeFrame {
+                payload_len,
+                max_frame_bytes,
+                ..
+            }) if payload_len == usize::try_from(oversized_payload).expect("u32 fits usize")
+                && max_frame_bytes == FRAME_HEADER_BYTES + payload_cap
+        ));
+
+        connection.close(0u32.into(), b"done");
+        client.close().await;
+        router.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn gb_wf_15_block_payload_cap_precedes_allocation() -> Result<(), BoxError> {
+        assert_block_sync_payload_cap_precedes_allocation(
+            b"/zakura/testkit/block-payload-cap/0",
+            194,
+            195,
+            crate::zakura::MSG_BS_BLOCK,
+            1 + usize::try_from(zakura_chain::block::MAX_BLOCK_BYTES)
+                .expect("the consensus block cap fits usize"),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn gb_wf_17_blocks_done_payload_cap_precedes_allocation() -> Result<(), BoxError> {
+        assert_block_sync_payload_cap_precedes_allocation(
+            b"/zakura/testkit/blocks-done-payload-cap/0",
+            196,
+            197,
+            crate::zakura::MSG_BS_BLOCKS_DONE,
+            9,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn gb_wf_19_range_unavailable_payload_cap_precedes_allocation() -> Result<(), BoxError> {
+        assert_block_sync_payload_cap_precedes_allocation(
+            b"/zakura/testkit/range-unavailable-payload-cap/0",
+            198,
+            199,
+            crate::zakura::MSG_BS_RANGE_UNAVAILABLE,
+            9,
+        )
+        .await
+    }
+
     #[tokio::test]
     async fn invalid_prelude_stream_churn_charges_open_rate_token() -> Result<(), BoxError> {
         // claude-invalid-stream-prelude-churn-bypasses-open-rate: a peer that

--- a/docs/changelog/unreleased/879.md
+++ b/docs/changelog/unreleased/879.md
@@ -1,4 +1,4 @@
 ## Fixed
 
-- Reject oversized native `GetBlocks` frames before allocating their declared
-  payload ([#879](https://github.com/zakura-core/zakura/pull/879)).
+- Reject oversized native block-range request and response frames before
+  allocating their declared payload ([#879](https://github.com/zakura-core/zakura/pull/879)).

--- a/docs/changelog/unreleased/879.md
+++ b/docs/changelog/unreleased/879.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Reject oversized native `GetBlocks` frames before allocating their declared
+  payload ([#879](https://github.com/zakura-core/zakura/pull/879)).


### PR DESCRIPTION
## Motivation

Block-range messages have fixed or protocol-bounded payloads, but the transport reader trusted the larger stream frame limit until after allocating the declared payload. A mismatched outer type could also hide a smaller inner message discriminator until after allocation.

## Solution

Apply the message-specific cap from the outer frame type immediately after the header, then check the payload discriminator before allocating or reading the remainder. This covers `GetBlocks`, `Block`, `BlocksDone`, and `RangeUnavailable`; messages without a specified cap retain the negotiated stream cap.

## Testing

Real-QUIC regressions reject every block-range kind one byte above its cap before reading the withheld payload. `GB-WF-09` also covers a mismatched outer and inner discriminator and an exact nine-byte request.

## Changelog

Security fragment: `docs/changelog/unreleased/879.md`.
