### PR TITLE
feat(ops): add fork monitoring and alerts

### DIFF
--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -642,7 +642,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-mainnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --state-file /var/lib/zakura-mainnet-dashboard/orphan-pairs.json
+          ExecStart=/usr/bin/python3 /opt/zakura-mainnet-dashboard/zakura-cluster-status.py --config /opt/zakura-mainnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network mainnet --interval 10 --stale-after 300 --fork-confirmations 2 --state-file /var/lib/zakura-mainnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/.github/workflows/zakura-mainnet-deploy.yml
+++ b/.github/workflows/zakura-mainnet-deploy.yml
@@ -715,7 +715,9 @@ jobs:
             : > "$tmp_env"
           fi
           if ! grep -qE '^(SLACK_WEB_HOOK|SLACK_WEBHOOK_URL|SLACK_WEBHOOK)=' "$tmp_env"; then
-            echo "::warning::SLACK_WEB_HOOK is not set; fleet watchdog cannot post to Slack"
+            echo "::error::SLACK_WEB_HOOK is not set; fork alerts cannot reach #zakura-alerts" >&2
+            rm -f "$tmp_env"
+            exit 1
           fi
           sudo install -m 600 "$tmp_env" /etc/zakura-fleet-watchdog/env
           rm -f "$tmp_env"

--- a/.github/workflows/zakura-testnet-deploy.yml
+++ b/.github/workflows/zakura-testnet-deploy.yml
@@ -278,7 +278,16 @@ jobs:
           dashboard_dir="/opt/zakura-testnet-dashboard"
           sudo install -d -m 755 "$dashboard_dir"
           sudo install -m 755 deploy/runner/zakura-cluster-status.py "$dashboard_dir/zakura-cluster-status.py"
-          sudo install -m 644 deploy/deployer/nodes.ci.toml "$dashboard_dir/nodes.toml"
+          cp deploy/deployer/nodes.ci.toml "$RUNNER_TEMP/dashboard.nodes.toml"
+          cat >> "$RUNNER_TEMP/dashboard.nodes.toml" <<'EOF'
+
+          # Independent chain observer used by the mining pool. It is dashboard
+          # only and is never passed to deploy.py.
+          [[chain_observers]]
+          name = "testnet-mining-pool"
+          rpc_url = "http://38.190.136.75:18232/"
+          EOF
+          sudo install -m 644 "$RUNNER_TEMP/dashboard.nodes.toml" "$dashboard_dir/nodes.toml"
 
           sudo tee /etc/systemd/system/zakura-testnet-dashboard.service >/dev/null <<'EOF'
           [Unit]
@@ -289,7 +298,7 @@ jobs:
           [Service]
           Type=simple
           WorkingDirectory=/opt/zakura-testnet-dashboard
-          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --state-file /var/lib/zakura-testnet-dashboard/orphan-pairs.json
+          ExecStart=/usr/bin/python3 /opt/zakura-testnet-dashboard/zakura-cluster-status.py --config /opt/zakura-testnet-dashboard/nodes.toml --host 0.0.0.0 --port 8090 --network testnet --interval 10 --stale-after 300 --fork-confirmations 2 --state-file /var/lib/zakura-testnet-dashboard/orphan-pairs.json
           Restart=always
           RestartSec=5
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -9,8 +9,9 @@ The public `sendrawtransaction` broadcast gateway lives under
 
 ## Cluster Status and Public Ironwood API
 
-`zakura-cluster-status.py` polls authenticated node RPC endpoints over SSH and
-serves both the existing fleet dashboard and a narrow public API:
+`zakura-cluster-status.py` polls managed node RPC endpoints over SSH plus any
+configured read-only chain observers, and serves both the fleet dashboard and a
+narrow public API:
 
 - `GET /ironwood-status.json` returns a fresh, verified website response.
 - `OPTIONS /ironwood-status.json` handles the allow-listed CORS preflight.
@@ -53,20 +54,47 @@ the page does not serve it unless the dashboard runs with `--expose-logs`. These
 dashboards are public and unauthenticated, so log text stays off by default even
 though peer addresses are already redacted on the node.
 
-### Tip Agreement and Orphan Pairs
+### Fork / Uncle Studio
 
-Each poll groups the fleet by `(height, tip hash)`. A single group means the
-nodes agree; several groups at the leading height mean a split, and the
-dashboard labels each node `majority`, `fork`, `ahead`, or `behind`. Fork depth
-between two tips at the same height is estimated from best-chain ancestor
-hashes sampled at 1, 2, 5, 10, and 32 blocks back, so an unresolved fork reports
-`> 32 or unknown` rather than a wrong number.
+The fleet page includes a fork / uncle studio for both mainnet and testnet. It
+keeps the live `(height, tip hash)` lanes for propagation and lag diagnosis, but
+fork alerting uses a stronger comparison. On every poll after warmup, each
+source returns the block hash at one shared absolute height two blocks behind
+the slowest healthy source from the prior poll. Different hashes at that settled
+height prove chain divergence even when both branches keep advancing at
+different heights. An unavailable source produces `partial` or `insufficient`,
+not a false recovery.
+
+The studio shows each settled branch, its source membership, the strict quorum
+candidate when one exists, and sources that could not be compared. Managed
+nodes are polled over SSH as before. Independent read-only RPC sources can be
+added without deployment access:
+
+```toml
+[[chain_observers]]
+name = "testnet-mining-pool"
+rpc_url = "http://38.190.136.75:18232/"
+```
+
+The testnet deploy installs that mining-pool backend as an observer, closing the
+gap where fresh block templates could look healthy while the miner followed a
+minority fork. Mainnet already includes the separately operated
+`zcashd-compat` source in its dashboard cohort.
+
+The live tip view still labels each source `majority`, `fork`, `ahead`, or
+`behind`. Fork depth between two tips at the same height is estimated from
+best-chain ancestor hashes sampled at 1, 2, 5, 10, and 32 blocks back, so an
+unresolved fork reports `> 32 or unknown` rather than a wrong number.
 
 A node whose height drops or whose tip hash changes at the same height records
 an orphan pair: the discarded hash, the new canonical hash, and the depth. Pass
 `--state-file` to persist that history across restarts; the deploy workflows
 point it at `/var/lib/zakura-<network>-dashboard/orphan-pairs.json`. Without the
 flag the history is in-memory only and is lost on every restart.
+
+“Uncle” in the studio is operational shorthand for a block or branch that left
+the observed best chain. Zcash does not reward uncles as Ethereum historically
+did.
 
 ## Fleet Slack Watchdog
 
@@ -90,6 +118,10 @@ The default config in `fleet-watchdog.toml` watches:
 
 Alerts fire only after a sustained condition:
 
+- two or more sources return different hashes at the shared settled height for
+  at least 3 minutes
+- a newly recorded reorg/orphan event is at least 2 blocks deep; one-block tip
+  races remain visible in the studio but do not page
 - `health` is `down` or `rpc_error` for at least 10 minutes
 - one node's height has not advanced for at least 10 minutes
 - every observable node shares one height and block hash for at least 30 minutes,
@@ -103,13 +135,19 @@ watchdog therefore uses the same collector snapshot for the stall condition and
 its diagnostics. The diagnostic object contains no per-node history, logs, or
 addresses.
 
+Fork alerts include the comparison height, every branch hash, source membership,
+and the quorum candidate. They remain latched if a source disappears and clear
+only after a complete comparison agrees again. Identical reorg notifications
+are deduped across sources and limited to events first observed in the prior 10
+minutes, so a watchdog restart does not replay old dashboard history.
+
 The watchdog coalesces a verifiable shared tip into one fleet alert. A missing
 or different block hash keeps the individual node alerts. Down alerts take
 precedence over stalled alerts, so each node has at most one active alert. The
 watchdog posts only on transitions: first failure after the threshold, then
 recovery. Persistent failures do not post every poll.
 
-Slack delivery is **webhook-only**. Set:
+Slack delivery to `#zakura-alerts` is **webhook-only**. Set:
 
 - `SLACK_WEB_HOOK`
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -65,10 +65,22 @@ height prove chain divergence even when both branches keep advancing at
 different heights. An unavailable source produces `partial` or `insufficient`,
 not a false recovery.
 
-The studio shows each settled branch, its source membership, the strict quorum
-candidate when one exists, and sources that could not be compared. Managed
-nodes are polled over SSH as before. Independent read-only RPC sources can be
-added without deployment access:
+The chain explorer links directly to the current canonical tip and draws the
+recent canonical block spine beside any live competing branch. Select or hover
+a block to see its full hash, observing sources, mining software evidence, and
+operator tag. The `Live`, `24 hours`, and `7 days` ranges add persisted reorg or
+orphan events to the same view.
+
+Each displayed block carries one mining software symbol. `ZA` means its
+coinbase contains Zakura's built-in flower marker, `ZE` means it contains an
+explicit Zebra tag, and `?` means the coinbase did not prove either. The source
+that reported a block is never treated as its miner. An operator is shown only
+when Zakura's marker includes a printable configured tag; otherwise it remains
+unknown. Recent block metadata is fetched once per distinct observed branch and
+cached by hash, so an advancing chain normally adds only the new tip.
+
+Managed nodes are polled over SSH as before. Independent read-only RPC sources
+can be added without deployment access:
 
 ```toml
 [[chain_observers]]
@@ -81,7 +93,7 @@ gap where fresh block templates could look healthy while the miner followed a
 minority fork. Mainnet already includes the separately operated
 `zcashd-compat` source in its dashboard cohort.
 
-The live tip view still labels each source `majority`, `fork`, `ahead`, or
+The source table still labels each source `majority`, `fork`, `ahead`, or
 `behind`. Fork depth between two tips at the same height is estimated from
 best-chain ancestor hashes sampled at 1, 2, 5, 10, and 32 blocks back, so an
 unresolved fork reports `> 32 or unknown` rather than a wrong number.
@@ -154,7 +166,8 @@ Slack delivery to `#zakura-alerts` is **webhook-only**. Set:
 Do not commit real Slack credentials. Install them on the runner in
 `/etc/zakura-fleet-watchdog/env` with mode `600`, or provide the
 `SLACK_WEB_HOOK` GitHub Actions environment secret so the deploy workflow
-writes the env file.
+writes the env file. The deployment fails rather than install a watchdog that
+cannot deliver to `#zakura-alerts` when neither source contains a webhook.
 
 Manual checks on `us-east-0`:
 

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -109,6 +109,35 @@ class NodeConfigTests(unittest.TestCase):
 
         self.assertEqual(configured.metrics_endpoint, "127.0.0.1:9999")
 
+    def test_chain_observer_is_loaded_as_a_direct_rpc_source(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                '[[chain_observers]]\nname = "pool"\n'
+                'rpc_url = "https://observer.example/rpc"\n'
+            )
+            config.flush()
+
+            configured = status.load_nodes(Path(config.name))
+
+        observer = configured[1]
+        self.assertEqual(observer.name, "pool")
+        self.assertEqual(observer.source_type, "observer")
+        self.assertEqual(observer.observer_rpc_url, "https://observer.example/rpc")
+        self.assertEqual(observer.ssh_string, "")
+
+    def test_chain_observer_rejects_credentials_in_the_url(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".toml") as config:
+            config.write(
+                '[[nodes]]\nname = "node-a"\nssh_string = "root@node-a"\n'
+                '[[chain_observers]]\nname = "pool"\n'
+                'rpc_url = "https://user:secret@observer.example/rpc"\n'
+            )
+            config.flush()
+
+            with self.assertRaises(SystemExit):
+                status.load_nodes(Path(config.name))
+
 
 class RemoteProbeTests(unittest.TestCase):
     """Run the probe the way a node does: as a standalone script over stdin.
@@ -214,6 +243,7 @@ zcash_net_peers_connected{user_agent="/Gone:1.0/",remote_version="170160"} 0
             "health_listen_addr": "",
             "state_cache_dir": tempfile.gettempdir(),
             "want_metrics": "1",
+            "comparison_height": "",
         }
         args.update(overrides)
         with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as handle:
@@ -344,6 +374,25 @@ zcash_net_in_bytes_total 12345
         )
         self.assertNotIn("peer_user_agents", probe)
 
+    def test_settled_comparison_hash_is_read_at_the_requested_height(self):
+        self.rpc_results = {
+            "getblockchaininfo": {
+                "blocks": 100,
+                "headers": 100,
+                "bestblockhash": "a" * 64,
+                "chain": "test",
+            },
+            "getblockhash": "b" * 64,
+        }
+
+        probe = self.run_probe(
+            rpc_url=f"http://{self.endpoint}/",
+            comparison_height="98",
+        )
+
+        self.assertEqual(probe["comparison_height"], 98)
+        self.assertEqual(probe["comparison_hash"], "b" * 64)
+
     def test_metrics_scrape_can_be_skipped(self):
         probe = self.run_probe(metrics_endpoint=self.endpoint, want_metrics="")
 
@@ -423,6 +472,37 @@ zcash_net_in_bytes_total 12345
         self.assertIn("metrics_error", probe)
         self.assertNotIn("metrics", probe)
         self.assertIn("host", probe)
+
+
+class ChainObserverTests(unittest.TestCase):
+    def test_direct_observer_returns_tip_and_settled_hash(self):
+        source = node("pool")
+        source.source_type = "observer"
+        source.probe_kind = "rpc_observer"
+        source.observer_rpc_url = "https://observer.invalid/"
+
+        def rpc(_url, method, params=None):
+            if method == "getblockchaininfo":
+                return {
+                    "blocks": 110,
+                    "headers": 111,
+                    "bestblockhash": "f" * 64,
+                    "chain": "test",
+                }
+            if method == "getblockhash":
+                return f"{params[0]:064x}"
+            if method == "getnetworkinfo":
+                return {"subversion": "/MagicBean:6.2.0/", "version": 6020050}
+            raise AssertionError(method)
+
+        with mock.patch.object(status, "direct_rpc_call", side_effect=rpc):
+            probe = status.probe_node(source, comparison_height=104)
+
+        self.assertEqual(probe["height"], 110)
+        self.assertEqual(probe["comparison_height"], 104)
+        self.assertEqual(probe["comparison_hash"], f"{104:064x}")
+        self.assertEqual(probe["rpc_chain"], "test")
+        self.assertNotIn("rpc_error", probe)
 
 
 class IronwoodStatusTests(unittest.TestCase):
@@ -549,6 +629,161 @@ class IronwoodStatusTests(unittest.TestCase):
 
 
 class TipAgreementTests(unittest.TestCase):
+    def test_comparison_height_uses_the_slowest_healthy_source(self):
+        rows = [
+            {"name": "fast", "height": 110, "health": "healthy"},
+            {"name": "slow", "height": 106, "health": "healthy"},
+            {"name": "stalled", "height": 50, "health": "stale"},
+        ]
+
+        self.assertEqual(status.select_comparison_height(rows, 2), 104)
+
+    def test_settled_hashes_detect_an_advancing_fork_at_different_tips(self):
+        rows = [
+            {
+                "name": "node-a",
+                "source_type": "node",
+                "height": 110,
+                "block_hash": "1" * 64,
+                "comparison_height": 104,
+                "comparison_hash": "a" * 64,
+            },
+            {
+                "name": "node-b",
+                "source_type": "node",
+                "height": 108,
+                "block_hash": "2" * 64,
+                "comparison_height": 104,
+                "comparison_hash": "a" * 64,
+            },
+            {
+                "name": "testnet-mining-pool",
+                "source_type": "observer",
+                "height": 109,
+                "block_hash": "3" * 64,
+                "comparison_height": 104,
+                "comparison_hash": "b" * 64,
+            },
+        ]
+
+        chain = status.compute_chain_summary(rows)
+        status.enrich_chain_roles(rows, chain)
+
+        self.assertEqual(chain["status"], "lagging")
+        self.assertEqual(chain["fork_status"], "diverged")
+        self.assertEqual(chain["comparison_height"], 104)
+        self.assertEqual(chain["quorum_hash"], "a" * 64)
+        self.assertEqual(chain["forked_sources"], ["testnet-mining-pool"])
+        self.assertEqual(
+            {row["name"]: row["settled_role"] for row in rows},
+            {
+                "node-a": "quorum",
+                "node-b": "quorum",
+                "testnet-mining-pool": "fork",
+            },
+        )
+
+    def test_missing_comparison_source_is_partial_not_recovered(self):
+        chain = status.compute_chain_summary(
+            [
+                {
+                    "name": "node-a",
+                    "height": 100,
+                    "block_hash": "1" * 64,
+                    "comparison_height": 98,
+                    "comparison_hash": "a" * 64,
+                },
+                {
+                    "name": "node-b",
+                    "height": 100,
+                    "block_hash": "1" * 64,
+                    "comparison_height": 98,
+                    "comparison_hash": "a" * 64,
+                },
+                {
+                    "name": "pool",
+                    "height": 100,
+                    "block_hash": "1" * 64,
+                    "comparison_height": 98,
+                    "comparison_hash": "",
+                },
+            ]
+        )
+
+        self.assertEqual(chain["fork_status"], "partial")
+        self.assertEqual(chain["unavailable_sources"], ["pool"])
+
+    def test_tied_branches_do_not_claim_a_quorum(self):
+        rows = [
+            {
+                "name": name,
+                "height": 100,
+                "block_hash": "f" * 64,
+                "comparison_height": 98,
+                "comparison_hash": branch * 64,
+            }
+            for name, branch in (
+                ("a", "1"), ("b", "1"), ("c", "2"), ("d", "2")
+            )
+        ]
+
+        chain = status.compute_chain_summary(rows)
+        status.enrich_chain_roles(rows, chain)
+
+        self.assertEqual(chain["fork_status"], "diverged")
+        self.assertEqual(chain["quorum_hash"], "")
+        self.assertEqual({row["settled_role"] for row in rows}, {"candidate"})
+
+    def test_partial_observation_does_not_claim_a_configured_quorum(self):
+        rows = [
+            {
+                "name": name,
+                "height": 100,
+                "block_hash": "f" * 64,
+                "comparison_height": 98,
+                "comparison_hash": branch * 64,
+            }
+            for name, branch in (("a", "1"), ("b", "1"), ("c", "2"))
+        ]
+        rows.append({"name": "unavailable", "rpc_ok": False})
+
+        chain = status.compute_chain_summary(rows)
+        status.enrich_chain_roles(rows, chain)
+
+        self.assertEqual(chain["fork_status"], "diverged")
+        self.assertEqual(chain["comparison_observed"], 3)
+        self.assertEqual(chain["quorum_hash"], "")
+        self.assertEqual(
+            {row["settled_role"] for row in rows if row["name"] != "unavailable"},
+            {"candidate"},
+        )
+
+    def test_invalid_rpc_source_is_not_used_for_settled_agreement(self):
+        chain = status.compute_chain_summary(
+            [
+                {
+                    "name": "node-a",
+                    "height": 100,
+                    "block_hash": "1" * 64,
+                    "comparison_height": 98,
+                    "comparison_hash": "a" * 64,
+                    "rpc_ok": True,
+                },
+                {
+                    "name": "wrong-network",
+                    "height": 100,
+                    "block_hash": "2" * 64,
+                    "comparison_height": 98,
+                    "comparison_hash": "b" * 64,
+                    "rpc_ok": False,
+                },
+            ]
+        )
+
+        self.assertEqual(chain["fork_status"], "insufficient")
+        self.assertEqual(chain["comparison_observed"], 1)
+        self.assertEqual(chain["unavailable_sources"], ["wrong-network"])
+
     def test_classify_tip_event_detects_reorg_signals(self):
         self.assertEqual(
             status.classify_tip_event(None, None, 10, "a" * 64),
@@ -818,6 +1053,12 @@ class ViewSwitchingTests(unittest.TestCase):
 
     def test_page_forces_hidden_elements_to_stay_hidden(self):
         self.assertIn("[hidden] { display: none !important; }", self.page)
+
+    def test_fork_studio_renders_settled_branches_and_orphan_events(self):
+        self.assertIn("Fork / uncle studio", self.page)
+        self.assertIn('id="comparison-groups"', self.page)
+        self.assertIn('id="reorg-list"', self.page)
+        self.assertIn("chain.fork_status", self.page)
 
     def test_every_toggled_section_is_covered_by_the_override(self):
         toggled = re.findall(

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -504,15 +504,92 @@ class ChainObserverTests(unittest.TestCase):
         self.assertEqual(probe["rpc_chain"], "test")
         self.assertNotIn("rpc_error", probe)
 
+    def test_chain_segment_stops_at_cached_parent_and_reads_coinbase_markers(self):
+        hashes = {height: f"{height:064x}" for height in (100, 101, 102)}
+        zakura_data = status.ZAKURA_COINBASE_MARKER + b": valargroup"
+        zakura_coinbase = (
+            b"\x03abc" + bytes([len(zakura_data)]) + zakura_data
+        ).hex()
+        zebra_coinbase = b"\x03abc/Zebra/".hex()
+
+        def rpc(method, params):
+            if method == "getblock":
+                block_hash = params[0]
+                height = next(
+                    height for height, value in hashes.items() if value == block_hash
+                )
+                return {
+                    "height": height,
+                    "hash": block_hash,
+                    "previousblockhash": hashes[height - 1],
+                    "time": 1_000 + height,
+                    "tx": [f"tx-{height}"],
+                }
+            if method == "getrawtransaction":
+                return {
+                    "vin": [{
+                        "coinbase": zakura_coinbase
+                        if params[0] == "tx-102"
+                        else zebra_coinbase
+                    }]
+                }
+            raise AssertionError(method)
+
+        result = status.collect_chain_segment(
+            rpc,
+            hashes[102],
+            {hashes[100]},
+        )
+
+        self.assertEqual(result["error"], "")
+        self.assertEqual([block["height"] for block in result["blocks"]], [102, 101])
+        self.assertEqual(result["blocks"][0]["miner_mark"], "ZA")
+        self.assertEqual(result["blocks"][0]["miner_operator"], "valargroup")
+        self.assertEqual(result["blocks"][1]["miner_mark"], "ZE")
+
+    def test_mining_software_classification_never_uses_observer_identity(self):
+        zakura_data = status.ZAKURA_COINBASE_MARKER + b": pool-a"
+        zakura = status.classify_mining_software(
+            (b"height" + bytes([len(zakura_data)]) + zakura_data).hex()
+        )
+        untagged_data = status.ZAKURA_COINBASE_MARKER
+        untagged = status.classify_mining_software(
+            (
+                b"height"
+                + bytes([len(untagged_data)])
+                + untagged_data
+                + b"/unrelated-pool-data/"
+            ).hex()
+        )
+        zebra = status.classify_mining_software(b"height/Zebra:5.2.0/".hex())
+        unknown = status.classify_mining_software(b"height/pool-a/".hex())
+
+        self.assertEqual(
+            (zakura["software"], zakura["mark"], zakura["operator"]),
+            ("zakura", "ZA", "pool-a"),
+        )
+        self.assertEqual(
+            (untagged["software"], untagged["mark"], untagged["operator"]),
+            ("zakura", "ZA", "unknown"),
+        )
+        self.assertEqual((zebra["software"], zebra["mark"]), ("zebra", "ZE"))
+        self.assertEqual(
+            (unknown["software"], unknown["mark"]),
+            ("unknown", "?"),
+        )
+
 
 class IronwoodStatusTests(unittest.TestCase):
     def test_remote_probe_is_valid_python_and_uses_required_rpcs(self):
         compile(status.REMOTE_PROBE, "<remote-probe>", "exec")
+        compile(status.CHAIN_WINDOW_PROBE, "<chain-window-probe>", "exec")
         self.assertIn('rpc_call("getblockchaininfo")', status.REMOTE_PROBE)
         self.assertIn('rpc_call("getinfo")', status.REMOTE_PROBE)
         self.assertIn('blockchain_info.get("headers")', status.REMOTE_PROBE)
         self.assertIn('"getblockhash"', status.REMOTE_PROBE)
         self.assertIn('rpc_call("getblockheader"', status.REMOTE_PROBE)
+        self.assertIn('rpc_call("getblock"', status.CHAIN_WINDOW_PROBE)
+        self.assertIn('rpc_call("getrawtransaction"', status.CHAIN_WINDOW_PROBE)
 
     def test_peer_version_panel_prefers_rpc_subver(self):
         # When getpeerinfo.subver is present, the live RPC mix wins over the
@@ -835,6 +912,114 @@ class TipAgreementTests(unittest.TestCase):
         self.assertEqual(split["status"], "split")
         self.assertTrue(split["split"])
 
+    def test_explorer_builds_block_marked_canonical_and_competing_branches(self):
+        subject = status.ClusterCollector(
+            [node("a"), node("b")],
+            interval=10,
+            stale_after=300,
+            network="testnet",
+        )
+        canonical_hash = "f" * 64
+        fork_hash = "b" * 64
+        parent_hash = "c" * 64
+        rows = [
+            {
+                "name": "a",
+                "height": 101,
+                "block_hash": canonical_hash,
+                "rpc_ok": True,
+                "source_type": "node",
+            },
+            {
+                "name": "b",
+                "height": 101,
+                "block_hash": fork_hash,
+                "rpc_ok": True,
+                "source_type": "node",
+            },
+        ]
+        chain = status.compute_chain_summary(rows)
+
+        def blocks(_source, tip_hash, _known):
+            software = "zakura" if tip_hash == canonical_hash else "zebra"
+            return {
+                "error": "",
+                "blocks": [{
+                    "height": 101,
+                    "hash": tip_hash,
+                    "previous_hash": parent_hash,
+                    "time": 1_000,
+                    "miner_software": software,
+                    "miner_mark": "ZA" if software == "zakura" else "ZE",
+                    "miner_operator": "unknown",
+                    "miner_evidence": "test marker",
+                }],
+            }
+
+        with mock.patch.object(status, "probe_chain_window", side_effect=blocks):
+            subject.populate_chain_explorer(rows, chain, now=2_000.0)
+
+        self.assertEqual(len(chain["branches"]), 2)
+        canonical = next(
+            branch for branch in chain["branches"] if branch["role"] == "canonical"
+        )
+        competitor = next(
+            branch for branch in chain["branches"] if branch["role"] == "competitor"
+        )
+        self.assertEqual(canonical["blocks"][-1]["miner_mark"], "ZA")
+        self.assertEqual(competitor["blocks"][-1]["miner_mark"], "ZE")
+        self.assertEqual(competitor["first_seen_at"], 2_000.0)
+        self.assertEqual(chain["current_tip"]["hash"], canonical["tip_hash"])
+
+    def test_explorer_does_not_present_a_lagging_canonical_source_as_a_fork(self):
+        subject = status.ClusterCollector(
+            [node("a"), node("b")],
+            interval=10,
+            stale_after=300,
+            network="testnet",
+        )
+        tip_hash = "f" * 64
+        parent_hash = "e" * 64
+        rows = [
+            {"name": "a", "height": 101, "block_hash": tip_hash, "rpc_ok": True},
+            {"name": "b", "height": 100, "block_hash": parent_hash, "rpc_ok": True},
+        ]
+        chain = status.compute_chain_summary(rows)
+        subject.cache_chain_blocks([
+            {
+                "height": 100,
+                "hash": parent_hash,
+                "previous_hash": "d" * 64,
+                "time": 1_000,
+                "miner_software": "unknown",
+                "miner_mark": "?",
+                "miner_operator": "unknown",
+                "miner_evidence": "no recognized coinbase marker",
+            },
+            {
+                "height": 101,
+                "hash": tip_hash,
+                "previous_hash": parent_hash,
+                "time": 1_100,
+                "miner_software": "zakura",
+                "miner_mark": "ZA",
+                "miner_operator": "unknown",
+                "miner_evidence": "Zakura flower coinbase marker",
+            },
+        ])
+
+        with mock.patch.object(
+            status,
+            "probe_chain_window",
+            return_value={"blocks": [], "error": ""},
+        ):
+            subject.populate_chain_explorer(rows, chain, now=2_000.0)
+
+        roles = {branch["tip_hash"]: branch["role"] for branch in chain["branches"]}
+        self.assertEqual(roles[tip_hash], "canonical")
+        self.assertEqual(roles[parent_hash], "lagging")
+        self.assertFalse(subject.fork_first_seen)
+
     def test_enrich_chain_roles(self):
         rows = [
             {"name": "a", "height": 100, "block_hash": "aa"},
@@ -1054,10 +1239,14 @@ class ViewSwitchingTests(unittest.TestCase):
     def test_page_forces_hidden_elements_to_stay_hidden(self):
         self.assertIn("[hidden] { display: none !important; }", self.page)
 
-    def test_fork_studio_renders_settled_branches_and_orphan_events(self):
-        self.assertIn("Fork / uncle studio", self.page)
-        self.assertIn('id="comparison-groups"', self.page)
-        self.assertIn('id="reorg-list"', self.page)
+    def test_chain_explorer_renders_blocks_and_miner_symbols(self):
+        self.assertIn("Canonical chain and competing forks", self.page)
+        self.assertIn('id="current-tip-link"', self.page)
+        self.assertIn('id="chain-svg"', self.page)
+        self.assertIn('data-chain-range="24h"', self.page)
+        self.assertIn('class="miner-mark is-zakura" aria-hidden="true">ZA', self.page)
+        self.assertIn('class="miner-mark is-zebra" aria-hidden="true">ZE', self.page)
+        self.assertIn('class="miner-mark is-unknown" aria-hidden="true">?', self.page)
         self.assertIn("chain.fork_status", self.page)
 
     def test_every_toggled_section_is_covered_by_the_override(self):

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -24,6 +24,9 @@ def make_args(**overrides):
         "down_after": 600.0,
         "stalled_after": 600.0,
         "shared_stalled_after": 1800.0,
+        "fork_after": 180.0,
+        "reorg_depth": 2,
+        "reorg_lookback": 600.0,
         "starting_grace": 120.0,
         "dashboard_down_after": 600.0,
         "request_timeout": 20.0,
@@ -599,6 +602,219 @@ class FleetSnapshotTests(unittest.TestCase):
 
         self.assertEqual(state["fleets"]["testnet"]["condition"], "ok")
         self.assertEqual(state["nodes"]["testnet/node-a"]["condition"], "ok")
+
+
+class ForkAndReorgAlertTests(unittest.TestCase):
+    NOW = 2_000.0
+
+    def setUp(self):
+        self.posted: list[str] = []
+        self.fleet = watchdog.Fleet(
+            name="testnet",
+            url="http://dashboard.invalid/data",
+            dashboard_url="http://dashboard.invalid/",
+        )
+        self.instance = watchdog.Watchdog([self.fleet], make_args())
+        self.state = {
+            "version": watchdog.STATE_VERSION,
+            "nodes": {},
+            "fleets": {},
+            "shared_stalls": {},
+            "forks": {},
+            "reorg_events": {},
+        }
+
+    @staticmethod
+    def row(name, height):
+        return {
+            "name": name,
+            "health": "healthy",
+            "height": height,
+            "block_hash": ("1" if name != "pool" else "2") * 64,
+            "seconds_since_advanced": 1.0,
+        }
+
+    @classmethod
+    def snapshot(cls, groups, *, events=None, expected=3, height=104):
+        names = [name for _block_hash, sources in groups for name in sources]
+        heights = {"node-a": 110, "node-b": 108, "pool": 112}
+        return {
+            "last_poll": cls.NOW,
+            "rows": [cls.row(name, heights.get(name, 110)) for name in names],
+            "chain": {
+                "comparison_height": height,
+                "comparison_observed": len(names),
+                "comparison_expected": expected,
+                "comparison_groups": [
+                    {"block_hash": block_hash, "nodes": sources}
+                    for block_hash, sources in groups
+                ],
+                "recent_reorgs": events or [],
+            },
+        }
+
+    def run_snapshot(self, snapshot, now=None):
+        with (
+            patch.object(watchdog, "fetch_json", return_value=snapshot),
+            patch.object(watchdog.time, "time", return_value=now or self.NOW),
+            patch.object(
+                watchdog,
+                "post_slack",
+                side_effect=lambda text, _args: (self.posted.append(text), True)[1],
+            ),
+        ):
+            self.instance.run_once(self.state)
+
+    def test_advancing_sources_alert_when_settled_hashes_stay_divergent(self):
+        first = self.snapshot(
+            [("a" * 64, ["node-a", "node-b"]), ("b" * 64, ["pool"])]
+        )
+        self.run_snapshot(first)
+        self.assertEqual(self.posted, [])
+
+        second = self.snapshot(
+            [("c" * 64, ["node-a", "node-b"]), ("d" * 64, ["pool"])],
+            height=106,
+        )
+        second["last_poll"] = self.NOW + 180
+        self.run_snapshot(second, now=self.NOW + 180)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fork detected", self.posted[0])
+        self.assertIn("settled height: 106", self.posted[0])
+        self.assertIn("fork (1): pool", self.posted[0])
+        self.assertTrue(self.state["forks"]["testnet"]["alerting"])
+
+    def test_changing_membership_does_not_reset_continuous_divergence(self):
+        first = self.snapshot(
+            [("a" * 64, ["node-a", "node-b"]), ("b" * 64, ["pool"])]
+        )
+        self.run_snapshot(first)
+
+        second = self.snapshot(
+            [("c" * 64, ["node-a"]), ("d" * 64, ["node-b", "pool"])],
+            height=106,
+        )
+        second["last_poll"] = self.NOW + 180
+        self.run_snapshot(second, now=self.NOW + 180)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fork detected", self.posted[0])
+
+    def test_transient_divergence_does_not_alert(self):
+        self.run_snapshot(
+            self.snapshot(
+                [("a" * 64, ["node-a", "node-b"]), ("b" * 64, ["pool"])]
+            )
+        )
+        agreed = self.snapshot(
+            [("c" * 64, ["node-a", "node-b", "pool"])], height=105
+        )
+        agreed["last_poll"] = self.NOW + 60
+        self.run_snapshot(agreed, now=self.NOW + 60)
+
+        self.assertEqual(self.posted, [])
+        self.assertEqual(self.state["forks"]["testnet"]["condition"], "ok")
+
+    def test_missing_source_cannot_clear_a_latched_fork(self):
+        self.instance.args.fork_after = 0
+        self.run_snapshot(
+            self.snapshot(
+                [("a" * 64, ["node-a", "node-b"]), ("b" * 64, ["pool"])]
+            )
+        )
+        self.posted.clear()
+
+        partial = self.snapshot(
+            [("c" * 64, ["node-a", "node-b"])], expected=3, height=105
+        )
+        partial["last_poll"] = self.NOW + 60
+        self.run_snapshot(partial, now=self.NOW + 60)
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["forks"]["testnet"]["alerting"])
+
+        agreed = self.snapshot(
+            [("d" * 64, ["node-a", "node-b", "pool"])], height=106
+        )
+        agreed["last_poll"] = self.NOW + 120
+        self.run_snapshot(agreed, now=self.NOW + 120)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("fork cleared", self.posted[0])
+
+    def test_reported_source_count_cannot_hide_a_missing_observer(self):
+        self.instance.args.fork_after = 0
+        self.run_snapshot(
+            self.snapshot(
+                [("a" * 64, ["node-a", "node-b"]), ("b" * 64, ["pool"])]
+            )
+        )
+        self.posted.clear()
+
+        malformed = self.snapshot(
+            [("c" * 64, ["node-a", "node-b"])], expected=2, height=105
+        )
+        malformed["rows"].append(self.row("pool", 112))
+        malformed["last_poll"] = self.NOW + 60
+        self.run_snapshot(malformed, now=self.NOW + 60)
+
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["forks"]["testnet"]["alerting"])
+        self.assertEqual(self.state["fleets"]["testnet"]["condition"], "unreachable")
+
+    def test_deep_reorg_alerts_once_and_deduplicates_across_sources(self):
+        event = {
+            "node": "node-a",
+            "kind": "reorg_height_drop",
+            "from_height": 110,
+            "from_hash": "a" * 64,
+            "to_height": 105,
+            "to_hash": "b" * 64,
+            "depth": 5,
+            "at": self.NOW - 10,
+        }
+        duplicate = {**event, "node": "node-b", "at": self.NOW - 9}
+        snapshot = self.snapshot(
+            [("c" * 64, ["node-a", "node-b", "pool"])],
+            events=[event, duplicate],
+        )
+
+        self.run_snapshot(snapshot)
+        self.run_snapshot(snapshot, now=self.NOW + 60)
+
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("deep reorg / orphan event", self.posted[0])
+        self.assertIn("depth: 5", self.posted[0])
+
+    def test_one_block_and_old_reorgs_do_not_page(self):
+        events = [
+            {
+                "node": "node-a",
+                "kind": "tip_switch",
+                "from_height": 100,
+                "from_hash": "a" * 64,
+                "to_height": 100,
+                "to_hash": "b" * 64,
+                "depth": 1,
+                "at": self.NOW - 10,
+            },
+            {
+                "node": "node-a",
+                "kind": "reorg_height_drop",
+                "from_height": 100,
+                "from_hash": "c" * 64,
+                "to_height": 90,
+                "to_hash": "d" * 64,
+                "depth": 10,
+                "at": self.NOW - 700,
+            },
+        ]
+        self.run_snapshot(
+            self.snapshot(
+                [("e" * 64, ["node-a", "node-b", "pool"])], events=events
+            )
+        )
+
+        self.assertEqual(self.posted, [])
 
 
 class SharedStallTests(unittest.TestCase):

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -123,6 +123,14 @@ RECENT_REORG_LIMIT = 40
 ANCESTOR_DEPTHS = (1, 2, 5, 10, 32)
 DEFAULT_FORK_CONFIRMATIONS = 2
 MAX_RPC_RESPONSE_BYTES = 2 * 1024 * 1024
+# The explorer follows only the recent edge of each observed branch. Once a
+# block is cached, ordinary advancement fetches just the new tip instead of
+# walking the whole window again.
+CHAIN_EXPLORER_BLOCK_LIMIT = 7
+CHAIN_BLOCK_CACHE_LIMIT = 512
+BLOCK_HASH_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+ZAKURA_COINBASE_MARKER = "🌸".encode("utf-8")
+ZEBRA_COINBASE_TAG_RE = re.compile(r"(?:^|[^a-z0-9])zebra(?:[^a-z0-9]|$)", re.I)
 
 SSH_COMMON_OPTS = [
     "-o", "BatchMode=yes",
@@ -1007,6 +1015,134 @@ print(json.dumps(out, separators=(",", ":")))
 """
 
 
+CHAIN_WINDOW_PROBE = r"""
+import base64
+import json
+import sys
+import urllib.request
+
+(
+    rpc_url,
+    rpc_auth,
+    rpc_user,
+    rpc_password,
+    rpc_config_path,
+    tip_hash,
+    known_hashes_raw,
+    block_limit_raw,
+) = sys.argv[1:9]
+
+MAX_RPC_RESPONSE_BYTES = 2 * 1024 * 1024
+
+def parse_zcash_conf(path):
+    values = {}
+    if not path:
+        return values
+    with open(path, encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip()
+    return values
+
+def rpc_headers():
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    user = rpc_user
+    password = rpc_password
+    if rpc_auth == "zcash_conf":
+        config = parse_zcash_conf(rpc_config_path)
+        user = config.get("rpcuser", user)
+        password = config.get("rpcpassword", password)
+    elif rpc_auth == "cookie":
+        with open(rpc_config_path, encoding="utf-8") as fh:
+            token = fh.read().strip()
+        if ":" in token:
+            user, password = token.split(":", 1)
+        else:
+            user, password = token, ""
+    if rpc_auth in ("basic", "zcash_conf", "cookie") and user and password:
+        token = base64.b64encode(f"{user}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+    return headers
+
+def rpc_call(method, params=None):
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "id": "zakura-chain-window",
+        "method": method,
+        "params": list(params or []),
+    }).encode()
+    request = urllib.request.Request(
+        rpc_url,
+        data=body,
+        headers=rpc_headers(),
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=6) as response:
+        payload = json.loads(response.read(MAX_RPC_RESPONSE_BYTES).decode())
+    if not isinstance(payload, dict):
+        raise RuntimeError("RPC returned a non-object response")
+    if payload.get("error"):
+        raise RuntimeError(str(payload["error"]))
+    return payload.get("result")
+
+def coinbase_script(block_hash, transactions):
+    if not transactions:
+        return "", "block has no transactions"
+    first = transactions[0]
+    txid = first.get("txid") if isinstance(first, dict) else first
+    if not isinstance(txid, str) or not txid:
+        return "", "coinbase transaction id is unavailable"
+    try:
+        transaction = rpc_call("getrawtransaction", [txid, 1, block_hash])
+    except Exception as error:
+        return "", str(error)
+    if not isinstance(transaction, dict):
+        return "", "getrawtransaction returned a non-object response"
+    inputs = transaction.get("vin")
+    if not isinstance(inputs, list) or not inputs or not isinstance(inputs[0], dict):
+        return "", "coinbase input is unavailable"
+    value = inputs[0].get("coinbase")
+    return (str(value), "") if value else ("", "coinbase script is unavailable")
+
+known_hashes = set(filter(None, known_hashes_raw.split(",")))
+block_limit = max(1, min(16, int(block_limit_raw)))
+current_hash = tip_hash
+blocks = []
+error = ""
+for _ in range(block_limit):
+    if current_hash in known_hashes:
+        break
+    try:
+        block = rpc_call("getblock", [current_hash, 1])
+        if not isinstance(block, dict):
+            raise RuntimeError("getblock returned a non-object response")
+        coinbase, attribution_error = coinbase_script(
+            current_hash,
+            block.get("tx") if isinstance(block.get("tx"), list) else [],
+        )
+        blocks.append({
+            "height": block.get("height"),
+            "hash": block.get("hash") or current_hash,
+            "previous_hash": block.get("previousblockhash") or "",
+            "time": block.get("time"),
+            "coinbase": coinbase,
+            "attribution_error": attribution_error,
+        })
+        previous_hash = block.get("previousblockhash")
+        if not isinstance(previous_hash, str) or not previous_hash:
+            break
+        current_hash = previous_hash
+    except Exception as caught:
+        error = str(caught)
+        break
+
+print(json.dumps({"blocks": blocks, "error": error}, separators=(",", ":")))
+"""
+
+
 def ssh_capture_script(node: Node, script: str) -> subprocess.CompletedProcess:
     return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True, capture_output=True)
 
@@ -1035,6 +1171,217 @@ def direct_rpc_call(url: str, method: str, params: list | None = None):
     if payload.get("error"):
         raise RuntimeError(str(payload["error"]))
     return payload.get("result")
+
+
+def safe_coinbase_tag(value: bytes, limit: int = 48) -> str:
+    """Return a short printable miner tag without exposing raw script bytes."""
+    text = value.decode("utf-8", "ignore")
+    text = "".join(character for character in text if character.isprintable())
+    return text.strip(" \t\r\n\x00:/|_-")[:limit]
+
+
+def classify_mining_software(
+    coinbase_hex: object,
+    attribution_error: object = "",
+) -> dict[str, str]:
+    """Classify a block from coinbase evidence, never from its observer."""
+    unknown = {
+        "software": "unknown",
+        "mark": "?",
+        "operator": "unknown",
+        "evidence": (
+            "coinbase data unavailable"
+            if attribution_error
+            else "no recognized coinbase marker"
+        ),
+    }
+    if not isinstance(coinbase_hex, str) or not coinbase_hex:
+        return unknown
+    try:
+        raw = bytes.fromhex(coinbase_hex)
+    except ValueError:
+        return {**unknown, "evidence": "invalid coinbase data"}
+
+    marker_at = raw.find(ZAKURA_COINBASE_MARKER)
+    if marker_at >= 0:
+        # Zakura's marker is the start of a dedicated script push. Bound the
+        # operator tag to that push so bytes a pool appends later cannot be
+        # misreported as the configured operator.
+        marker_end = marker_at + len(ZAKURA_COINBASE_MARKER)
+        push_end = marker_end
+        if marker_at >= 1 and raw[marker_at - 1] <= 75:
+            push_end = marker_at + raw[marker_at - 1]
+        elif marker_at >= 2 and raw[marker_at - 2] == 0x4C:
+            push_end = marker_at + raw[marker_at - 1]
+        push_end = min(max(marker_end, push_end), len(raw))
+        tail = raw[marker_end:push_end]
+        operator = (
+            safe_coinbase_tag(tail[2:])
+            if tail.startswith(b": ")
+            else "unknown"
+        ) or "unknown"
+        return {
+            "software": "zakura",
+            "mark": "ZA",
+            "operator": operator,
+            "evidence": "Zakura flower coinbase marker",
+        }
+
+    printable = safe_coinbase_tag(raw, limit=100)
+    zebra_match = ZEBRA_COINBASE_TAG_RE.search(printable)
+    if zebra_match:
+        return {
+            "software": "zebra",
+            "mark": "ZE",
+            "operator": "unknown",
+            "evidence": "explicit Zebra coinbase tag",
+        }
+    return unknown
+
+
+def normalize_chain_block(value: object) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    block_hash = str(value.get("hash") or "")
+    previous_hash = str(value.get("previous_hash") or "")
+    height = coerce_int(value.get("height"))
+    if height is None or height < 0 or BLOCK_HASH_RE.fullmatch(block_hash) is None:
+        return None
+    if previous_hash and BLOCK_HASH_RE.fullmatch(previous_hash) is None:
+        previous_hash = ""
+    mined = classify_mining_software(
+        value.get("coinbase"),
+        value.get("attribution_error"),
+    )
+    timestamp = finite_number(value.get("time"))
+    return {
+        "height": height,
+        "hash": block_hash.lower(),
+        "previous_hash": previous_hash.lower(),
+        "time": timestamp,
+        "miner_software": mined["software"],
+        "miner_mark": mined["mark"],
+        "miner_operator": mined["operator"],
+        "miner_evidence": mined["evidence"],
+    }
+
+
+def collect_chain_segment(
+    rpc,
+    tip_hash: str,
+    known_hashes: set[str],
+    block_limit: int = CHAIN_EXPLORER_BLOCK_LIMIT,
+) -> dict:
+    """Fetch a bounded, uncached best-chain segment through an RPC callback."""
+    if BLOCK_HASH_RE.fullmatch(tip_hash) is None:
+        return {"blocks": [], "error": "tip hash is invalid"}
+    current_hash = tip_hash.lower()
+    blocks = []
+    error = ""
+    for _ in range(max(1, min(16, block_limit))):
+        if current_hash in known_hashes:
+            break
+        try:
+            block = rpc("getblock", [current_hash, 1])
+            if not isinstance(block, dict):
+                raise RuntimeError("getblock returned a non-object response")
+            transactions = block.get("tx")
+            transactions = transactions if isinstance(transactions, list) else []
+            coinbase = ""
+            attribution_error = ""
+            if transactions:
+                first = transactions[0]
+                txid = first.get("txid") if isinstance(first, dict) else first
+                if isinstance(txid, str) and txid:
+                    try:
+                        transaction = rpc(
+                            "getrawtransaction", [txid, 1, current_hash]
+                        )
+                        inputs = (
+                            transaction.get("vin")
+                            if isinstance(transaction, dict)
+                            else None
+                        )
+                        if (
+                            isinstance(inputs, list)
+                            and inputs
+                            and isinstance(inputs[0], dict)
+                        ):
+                            coinbase = str(inputs[0].get("coinbase") or "")
+                        if not coinbase:
+                            attribution_error = "coinbase script is unavailable"
+                    except Exception as caught:
+                        attribution_error = str(caught)
+                else:
+                    attribution_error = "coinbase transaction id is unavailable"
+            else:
+                attribution_error = "block has no transactions"
+            normalized = normalize_chain_block({
+                "height": block.get("height"),
+                "hash": block.get("hash") or current_hash,
+                "previous_hash": block.get("previousblockhash") or "",
+                "time": block.get("time"),
+                "coinbase": coinbase,
+                "attribution_error": attribution_error,
+            })
+            if normalized is None:
+                raise RuntimeError("getblock returned invalid chain metadata")
+            blocks.append(normalized)
+            current_hash = normalized["previous_hash"]
+            if not current_hash:
+                break
+        except Exception as caught:
+            error = str(caught)
+            break
+    return {"blocks": blocks, "error": error}
+
+
+def probe_chain_window(
+    node: Node,
+    tip_hash: str,
+    known_hashes: set[str],
+) -> dict:
+    """Fetch only the unknown edge of one observed branch."""
+    if node.source_type == "observer":
+        return collect_chain_segment(
+            lambda method, params: direct_rpc_call(
+                node.observer_rpc_url, method, params
+            ),
+            tip_hash,
+            known_hashes,
+        )
+
+    rpc_url = rpc_url_for(node.rpc_listen_addr)
+    if not rpc_url:
+        return {"blocks": [], "error": "RPC disabled in deployer config"}
+    known = ",".join(sorted(known_hashes))
+    script = (
+        "python3 - "
+        f"{shlex.quote(rpc_url)} "
+        f"{shlex.quote(node.rpc_auth)} "
+        f"{shlex.quote(node.rpc_user)} "
+        f"{shlex.quote(node.rpc_password)} "
+        f"{shlex.quote(node.rpc_config_path)} "
+        f"{shlex.quote(tip_hash)} "
+        f"{shlex.quote(known)} "
+        f"{CHAIN_EXPLORER_BLOCK_LIMIT} <<'PY'\n"
+        f"{CHAIN_WINDOW_PROBE}\n"
+        "PY\n"
+    )
+    proc = ssh_capture_script(node, script)
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        return {"blocks": [], "error": detail or f"ssh exited {proc.returncode}"}
+    try:
+        payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError) as error:
+        return {"blocks": [], "error": f"invalid chain probe output: {error}"}
+    blocks = []
+    for value in payload.get("blocks", []):
+        normalized = normalize_chain_block(value)
+        if normalized is not None:
+            blocks.append(normalized)
+    return {"blocks": blocks, "error": str(payload.get("error") or "")}
 
 
 def probe_chain_observer(node: Node, comparison_height: int | None) -> dict:
@@ -1215,6 +1562,8 @@ class ClusterCollector:
         self.history: dict[str, deque[dict]] = {node.name: deque() for node in nodes}
         # Last successful scrape per node, reused on the polls that skip it.
         self.last_metrics: dict[str, dict] = {}
+        self.block_cache: dict[str, dict] = {}
+        self.fork_first_seen: dict[str, float] = {}
         self.ironwood_activation_height = IRONWOOD_ACTIVATION_HEIGHTS[network]
         self.lock = threading.Lock()
         restored_progress = load_progress(state_file)
@@ -1279,10 +1628,11 @@ class ClusterCollector:
 
         rows.sort(key=lambda row: row["name"])
         now = time.time()
+        recent_reorgs = list(self.recent_reorgs)
+        chain = compute_chain_summary(rows, recent_reorgs)
+        enrich_chain_roles(rows, chain)
+        self.populate_chain_explorer(rows, chain, now)
         with self.lock:
-            recent_reorgs = list(self.recent_reorgs)
-            chain = compute_chain_summary(rows, recent_reorgs)
-            enrich_chain_roles(rows, chain)
             self.rows = rows
             self.chain = chain
             self.last_poll = now
@@ -1310,8 +1660,190 @@ class ClusterCollector:
         )
 
     def record_orphan_pair(self, event: dict) -> None:
+        discarded_hash = str(
+            event.get("discarded_hash") or event.get("from_hash") or ""
+        ).lower()
+        cached = self.block_cache.get(discarded_hash)
+        if cached is not None:
+            event["orphan_block"] = dict(cached)
         self.recent_reorgs.appendleft(event)
         self.persist_state()
+
+    def cached_branch(self, tip_hash: str) -> list[dict]:
+        current_hash = str(tip_hash or "").lower()
+        blocks = []
+        seen = set()
+        while (
+            current_hash
+            and current_hash not in seen
+            and len(blocks) < CHAIN_EXPLORER_BLOCK_LIMIT
+        ):
+            seen.add(current_hash)
+            block = self.block_cache.get(current_hash)
+            if block is None:
+                break
+            blocks.append(dict(block))
+            current_hash = str(block.get("previous_hash") or "").lower()
+        blocks.reverse()
+        return blocks
+
+    def uncached_branch_edge(self, tip_hash: str) -> str:
+        """Return the first missing hash needed to complete the explorer window."""
+        current_hash = str(tip_hash or "").lower()
+        seen = set()
+        for _ in range(CHAIN_EXPLORER_BLOCK_LIMIT):
+            if not current_hash or current_hash in seen:
+                return ""
+            seen.add(current_hash)
+            block = self.block_cache.get(current_hash)
+            if block is None:
+                return current_hash
+            current_hash = str(block.get("previous_hash") or "").lower()
+        return ""
+
+    def cache_chain_blocks(self, blocks: list[dict]) -> None:
+        for block in blocks:
+            block_hash = str(block.get("hash") or "").lower()
+            if BLOCK_HASH_RE.fullmatch(block_hash) is None:
+                continue
+            # Refresh insertion order when a source supplies better metadata.
+            self.block_cache.pop(block_hash, None)
+            self.block_cache[block_hash] = dict(block)
+        while len(self.block_cache) > CHAIN_BLOCK_CACHE_LIMIT:
+            oldest = next(iter(self.block_cache))
+            self.block_cache.pop(oldest, None)
+
+    def populate_chain_explorer(
+        self,
+        rows: list[dict],
+        chain: dict,
+        now: float,
+    ) -> None:
+        """Attach recent block paths and honest miner attribution to a snapshot."""
+        rows_by_tip: dict[tuple[int, str], list[dict]] = defaultdict(list)
+        for row in rows:
+            height = coerce_int(row.get("height"))
+            block_hash = str(row.get("block_hash") or "").lower()
+            if height is None or BLOCK_HASH_RE.fullmatch(block_hash) is None:
+                continue
+            rows_by_tip[(height, block_hash)].append(row)
+
+        errors = []
+        for group in chain.get("tip_groups", []):
+            height = coerce_int(group.get("height"))
+            tip_hash = str(group.get("block_hash") or "").lower()
+            if height is None or BLOCK_HASH_RE.fullmatch(tip_hash) is None:
+                continue
+            fetch_hash = self.uncached_branch_edge(tip_hash)
+            if not fetch_hash:
+                continue
+            candidates = sorted(
+                rows_by_tip.get((height, tip_hash), []),
+                key=lambda row: (
+                    row.get("source_type") == "observer",
+                    str(row.get("name") or ""),
+                ),
+            )
+            result = {"blocks": [], "error": "no source can serve this tip"}
+            for row in candidates:
+                source = self.nodes_by_name.get(str(row.get("name") or ""))
+                if source is None or row.get("rpc_ok") is False:
+                    continue
+                result = probe_chain_window(
+                    source,
+                    fetch_hash,
+                    set(self.block_cache),
+                )
+                self.cache_chain_blocks(result.get("blocks") or [])
+                if not self.uncached_branch_edge(tip_hash):
+                    break
+            if result.get("error"):
+                errors.append({
+                    "tip_hash": tip_hash,
+                    "source": str(candidates[0].get("name") or "") if candidates else "",
+                    "error": str(result["error"])[:200],
+                })
+
+        majority_height = coerce_int(chain.get("majority_height"))
+        majority_hash = str(chain.get("majority_hash") or "").lower()
+        canonical_hashes = {
+            block["hash"] for block in self.cached_branch(majority_hash)
+        }
+        live_hashes = set()
+        branches = []
+        for group in chain.get("tip_groups", []):
+            height = coerce_int(group.get("height"))
+            tip_hash = str(group.get("block_hash") or "").lower()
+            if height is None or BLOCK_HASH_RE.fullmatch(tip_hash) is None:
+                continue
+            canonical = height == majority_height and tip_hash == majority_hash
+            blocks = self.cached_branch(tip_hash)
+            branch_hashes = {block["hash"] for block in blocks}
+            if canonical:
+                role = "canonical"
+            elif tip_hash in canonical_hashes:
+                role = "lagging"
+            elif majority_hash and majority_hash in branch_hashes:
+                role = "extension"
+            else:
+                role = "competitor"
+            if role == "competitor":
+                live_hashes.add(tip_hash)
+                self.fork_first_seen.setdefault(tip_hash, now)
+            if not blocks:
+                blocks = [{
+                    "height": height,
+                    "hash": tip_hash,
+                    "previous_hash": "",
+                    "time": None,
+                    "miner_software": "unknown",
+                    "miner_mark": "?",
+                    "miner_operator": "unknown",
+                    "miner_evidence": "coinbase data unavailable",
+                }]
+            branches.append({
+                "role": role,
+                "tip_height": height,
+                "tip_hash": tip_hash,
+                "sources": list(group.get("nodes") or []),
+                "fork_depth": group.get("fork_depth"),
+                "fork_depth_label": group.get("fork_depth_label") or "",
+                "first_seen_at": (
+                    self.fork_first_seen[tip_hash]
+                    if role == "competitor"
+                    else None
+                ),
+                "blocks": blocks,
+            })
+        self.fork_first_seen = {
+            tip_hash: first_seen
+            for tip_hash, first_seen in self.fork_first_seen.items()
+            if tip_hash in live_hashes
+        }
+
+        hydrated_reorgs = []
+        for event in chain.get("recent_reorgs", []):
+            hydrated = dict(event)
+            discarded_hash = str(
+                hydrated.get("discarded_hash")
+                or hydrated.get("from_hash")
+                or ""
+            ).lower()
+            block = hydrated.get("orphan_block") or self.block_cache.get(discarded_hash)
+            if isinstance(block, dict):
+                hydrated["orphan_block"] = dict(block)
+            hydrated_reorgs.append(hydrated)
+
+        canonical_branch = next(
+            (branch for branch in branches if branch["role"] == "canonical"),
+            None,
+        )
+        chain["branches"] = branches
+        chain["current_tip"] = (
+            dict(canonical_branch["blocks"][-1]) if canonical_branch else None
+        )
+        chain["recent_reorgs"] = hydrated_reorgs
+        chain["explorer_errors"] = errors
 
     def should_scrape_metrics(self, name: str, now: float) -> bool:
         """Decide per node, from what its last scrape cost."""
@@ -1608,8 +2140,25 @@ class ClusterCollector:
             chain["comparison_groups"] = [
                 dict(group) for group in chain.get("comparison_groups", [])
             ]
+            chain["branches"] = [
+                {
+                    **dict(branch),
+                    "blocks": [
+                        dict(block) for block in branch.get("blocks", [])
+                    ],
+                }
+                for branch in chain.get("branches", [])
+            ]
             chain["recent_reorgs"] = [
-                dict(event) for event in chain.get("recent_reorgs", [])
+                {
+                    **dict(event),
+                    **(
+                        {"orphan_block": dict(event["orphan_block"])}
+                        if isinstance(event.get("orphan_block"), dict)
+                        else {}
+                    ),
+                }
+                for event in chain.get("recent_reorgs", [])
             ]
         healthy = sum(1 for row in rows if row.get("healthy"))
         return {
@@ -1821,6 +2370,9 @@ def empty_chain_summary() -> dict:
         "forked_sources": [],
         "unavailable_sources": [],
         "recent_reorgs": [],
+        "branches": [],
+        "current_tip": None,
+        "explorer_errors": [],
     }
 
 
@@ -2255,8 +2807,8 @@ PAGE = r"""<!doctype html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="Zakura Ironwood cluster status">
-<title>Zakura cluster status</title>
+<meta name="description" content="Zakura chain fork and miner monitor">
+<title>Zakura chain monitor</title>
 <link rel="icon" href="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" type="image/png">
 <style>
 :root {
@@ -2442,6 +2994,21 @@ button { font: inherit; }
 .ghost-button.is-on { border-color: var(--warn-line); background: var(--warn-soft); color: var(--warn); }
 .freshness { font-size: 0.76rem; color: var(--muted); white-space: nowrap; }
 .freshness b { color: var(--ink-2); font-weight: 600; }
+.tip-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 38px;
+  padding: 6px 12px;
+  border: 1px solid var(--line-hi);
+  border-radius: var(--r-sm);
+  background: var(--base);
+  color: var(--ink-2);
+  font-size: 0.72rem;
+  text-decoration: none;
+}
+.tip-link:hover { border-color: var(--pink); color: var(--ink); }
+.tip-link code { color: var(--pink-hi); font-family: var(--mono); font-size: 0.72rem; }
 
 /* ---------- fleet health card ---------- */
 .card-head {
@@ -2676,6 +3243,187 @@ button { font: inherit; }
   font-size: 0.84rem;
   text-align: center;
 }
+
+/* ---------- chain explorer ---------- */
+.chain-explorer { overflow: hidden; }
+.chain-alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 20px;
+  min-height: 42px;
+  padding: 9px 22px;
+  border-bottom: 1px solid var(--line);
+  background: var(--ok-soft);
+  color: var(--ok);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.chain-alert.is-warn { background: var(--warn-soft); color: var(--warn); }
+.chain-alert.is-bad { background: var(--bad-soft); color: var(--bad); }
+.chain-alert-copy { display: inline-flex; align-items: center; gap: 9px; }
+.chain-alert-copy i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 9px currentColor;
+}
+.chain-alert > span:last-child { color: var(--ink-2); font-weight: 500; }
+.chain-explorer-main { padding: 20px 22px 18px; }
+.chain-explorer-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.chain-explorer-head h2 {
+  margin-top: 3px;
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
+  font-weight: 650;
+  letter-spacing: -0.018em;
+}
+.range-switch {
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--line-hi);
+  border-radius: 999px;
+  background: var(--base);
+}
+.range-switch button {
+  min-height: 30px;
+  padding: 0 11px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.73rem;
+  cursor: pointer;
+}
+.range-switch button:hover { color: var(--ink); }
+.range-switch button[aria-pressed="true"] { background: var(--raised); color: var(--ink); }
+.chain-canvas {
+  position: relative;
+  min-height: 390px;
+  margin-top: 12px;
+  overflow: hidden;
+}
+.chain-canvas svg { display: block; width: 100%; height: 390px; overflow: visible; }
+.chain-spine,
+.chain-branch-path { fill: none; stroke-linecap: round; stroke-linejoin: round; }
+.chain-spine { stroke: var(--ok); stroke-width: 3; }
+.chain-branch-path { stroke: var(--bad); stroke-width: 2.5; }
+.chain-branch-path.is-historical { stroke: var(--warn); stroke-dasharray: 5 7; }
+.chain-node { color: var(--ink); text-decoration: none; outline: none; }
+.chain-node rect {
+  width: 38px;
+  height: 38px;
+  rx: 10px;
+  fill: var(--raised);
+  stroke: var(--line-hi);
+  stroke-width: 1.5;
+}
+.chain-node:hover rect,
+.chain-node:focus rect,
+.chain-node.is-selected rect { stroke: var(--pink-hi); stroke-width: 2.5; }
+.chain-node.is-zakura rect { fill: var(--pink-soft); stroke: rgba(232, 112, 159, 0.58); }
+.chain-node.is-zebra rect { fill: url(#zebra-pattern); }
+.chain-node.is-unknown rect { rx: 19px; }
+.chain-node text {
+  fill: currentColor;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  text-anchor: middle;
+  dominant-baseline: central;
+  pointer-events: none;
+}
+.chain-height-label { fill: var(--muted); font-family: var(--mono); font-size: 10px; text-anchor: middle; }
+.chain-branch-label rect { fill: var(--base); stroke: var(--line-hi); rx: 7px; }
+.chain-branch-label text { fill: var(--ink-2); font-size: 11px; font-weight: 600; }
+.chain-empty { color: var(--muted); font-size: 0.84rem; }
+.chain-tooltip {
+  position: absolute;
+  z-index: 5;
+  width: min(292px, calc(100% - 20px));
+  padding: 11px 12px;
+  border: 1px solid var(--line-hi);
+  border-radius: 10px;
+  background: var(--raised);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.35);
+  color: var(--ink);
+  pointer-events: none;
+}
+.chain-tooltip[hidden] { display: none; }
+.chain-tooltip strong { display: block; margin-bottom: 5px; }
+.chain-tooltip-grid { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 3px 9px; font-size: 0.75rem; }
+.chain-tooltip-grid span:nth-child(odd) { color: var(--muted); }
+.chain-tooltip-grid span:nth-child(even) { overflow-wrap: anywhere; }
+.chain-legend {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 18px;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+.chain-line-legend,
+.miner-legend,
+.miner-legend > span,
+.miner-value { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.chain-line-legend { gap: 8px 16px; }
+.chain-line-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.chain-line-legend i { width: 18px; height: 3px; border-radius: 3px; background: var(--line-hi); }
+.chain-line-legend i.canonical { background: var(--ok); }
+.chain-line-legend i.competitor { background: var(--bad); }
+.chain-line-legend i.historical { background: var(--warn); }
+.miner-legend { gap: 8px 12px; color: var(--ink-2); }
+.miner-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 25px;
+  height: 25px;
+  flex: 0 0 auto;
+  border: 1px solid var(--line-hi);
+  border-radius: 7px;
+  background: var(--raised);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.65rem;
+  font-style: normal;
+  font-weight: 700;
+}
+.miner-mark.is-zakura { border-color: rgba(232, 112, 159, 0.58); background: var(--pink-soft); color: var(--pink-hi); }
+.miner-mark.is-zebra {
+  background: repeating-linear-gradient(135deg, var(--raised) 0, var(--raised) 4px, var(--line-hi) 4px, var(--line-hi) 7px);
+}
+.miner-mark.is-unknown { border-radius: 50%; }
+.chain-selection {
+  display: grid;
+  grid-template-columns: minmax(230px, 1.4fr) repeat(3, minmax(140px, 1fr));
+  gap: 16px 22px;
+  margin-top: 16px;
+  padding: 14px 15px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--base);
+}
+.chain-selection > div { min-width: 0; }
+.chain-selection-primary strong { display: block; font-size: 0.96rem; }
+.chain-selection-top { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; font-size: 0.72rem; }
+.chain-selection-status { padding: 1px 7px; border-radius: 999px; background: var(--ok-soft); color: var(--ok); font-weight: 650; }
+.chain-selection-status.is-competitor { background: var(--bad-soft); color: var(--bad); }
+.chain-selection-status.is-historical { background: var(--warn-soft); color: var(--warn); }
+.selected-hash { display: block; margin-top: 4px; color: var(--pink-hi); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.miner-value { margin-top: 5px; flex-wrap: nowrap; }
+.miner-value strong,
+.chain-selection-value { display: block; margin-top: 5px; font-size: 0.86rem; font-weight: 620; overflow-wrap: anywhere; }
+.chain-selection small { display: block; margin-top: 3px; font-size: 0.7rem; }
+.attribution-note { margin-top: 8px; color: var(--dim); font-size: 0.72rem; }
 
 /* ---------- toolbar ---------- */
 .toolbar { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
@@ -2920,6 +3668,22 @@ footer {
   .pad { padding: 16px; }
   .topbar { align-items: flex-start; }
   .search input { width: 130px; }
+  .tip-link { width: 100%; justify-content: space-between; order: 3; }
+  .chain-alert,
+  .chain-explorer-head,
+  .chain-legend { align-items: flex-start; flex-direction: column; }
+  .chain-alert { padding: 10px 16px; }
+  .chain-explorer-main { padding: 16px; }
+  .chain-selection { grid-template-columns: 1fr 1fr; }
+  .chain-selection-primary { grid-column: 1 / -1; }
+}
+@media (max-width: 460px) {
+  .range-switch { width: 100%; }
+  .range-switch button { flex: 1; padding-inline: 7px; }
+  .chain-canvas { min-height: 430px; }
+  .chain-canvas svg { height: 430px; }
+  .chain-selection { grid-template-columns: 1fr; }
+  .chain-selection-primary { grid-column: auto; }
 }
 </style>
 </head>
@@ -2929,17 +3693,92 @@ footer {
     <div class="brand">
       <img src="https://avatars.githubusercontent.com/u/272444516?s=200&v=4" alt="Valar Group" width="40" height="40">
       <div>
-        <p class="eyebrow"><span id="network-chip" class="chip">mainnet</span> Ironwood observability</p>
-        <h1>Zakura Cluster Status</h1>
+        <p class="eyebrow"><span id="network-chip" class="chip">mainnet</span> Fork history and miner attribution</p>
+        <h1>Zakura chain monitor</h1>
       </div>
     </div>
     <div class="header-right">
+      <a class="tip-link" id="current-tip-link" href="#chain-tip">
+        <span>Canonical tip</span>
+        <code id="current-tip-value">waiting for first poll</code>
+        <span aria-hidden="true">&#8594;</span>
+      </a>
       <span class="freshness" id="freshness">connecting...</span>
       <span class="state-pill" id="state-pill">Connecting</span>
     </div>
   </header>
 
   <div class="banner" id="banner" hidden></div>
+
+  <section class="panel chain-explorer" data-view="fleet" aria-labelledby="chain-explorer-title">
+    <div class="chain-alert" id="chain-alert">
+      <span class="chain-alert-copy"><i aria-hidden="true"></i><span id="chain-alert-text">Waiting for chain observations...</span></span>
+      <span id="slack-policy">Slack policy · alert after 3 minutes · #zakura-alerts</span>
+    </div>
+    <div class="chain-explorer-main">
+      <div class="chain-explorer-head">
+        <div>
+          <p class="eyebrow" id="chain-network-label">mainnet · live</p>
+          <h2 id="chain-explorer-title">Canonical chain and competing forks</h2>
+        </div>
+        <div class="range-switch" role="group" aria-label="Fork history range">
+          <button type="button" data-chain-range="live" aria-pressed="true">Live</button>
+          <button type="button" data-chain-range="24h" aria-pressed="false">24 hours</button>
+          <button type="button" data-chain-range="7d" aria-pressed="false">7 days</button>
+        </div>
+      </div>
+
+      <div class="chain-canvas" id="chain-canvas">
+        <svg id="chain-svg" role="img" aria-labelledby="chain-svg-title chain-svg-desc">
+          <title id="chain-svg-title">Canonical chain and competing fork history</title>
+          <desc id="chain-svg-desc">Recent canonical blocks and current or historical competing blocks. Each block shows ZA for Zakura, ZE for Zebra, or a question mark when its mining software is unknown.</desc>
+        </svg>
+        <div class="chain-tooltip" id="chain-tooltip" role="tooltip" hidden></div>
+      </div>
+
+      <div class="chain-legend">
+        <div class="chain-line-legend">
+          <span><i class="canonical"></i>Canonical majority</span>
+          <span><i class="competitor"></i>Live competitor</span>
+          <span><i class="historical"></i>Historical orphan</span>
+        </div>
+        <div class="miner-legend" aria-label="Mining software symbols">
+          <span class="label">Mining software</span>
+          <span><i class="miner-mark is-zakura" aria-hidden="true">ZA</i>Zakura</span>
+          <span><i class="miner-mark is-zebra" aria-hidden="true">ZE</i>Zebra</span>
+          <span><i class="miner-mark is-unknown" aria-hidden="true">?</i>Unknown</span>
+        </div>
+        <span class="chain-help">Hover for evidence · click to pin</span>
+      </div>
+
+      <section class="chain-selection" id="chain-selection" aria-live="polite" aria-label="Selected block details">
+        <div class="chain-selection-primary">
+          <div class="chain-selection-top">
+            <span class="chain-selection-status" id="selected-status">canonical</span>
+            <span class="muted" id="selected-time">waiting for first poll</span>
+          </div>
+          <strong id="selected-height">Block height —</strong>
+          <span class="mono selected-hash" id="selected-hash">—</span>
+        </div>
+        <div>
+          <span class="label">Mining software</span>
+          <div class="miner-value"><i class="miner-mark is-unknown" id="selected-miner-mark" aria-hidden="true">?</i><strong id="selected-miner">Unknown</strong></div>
+          <small class="muted" id="selected-evidence">No coinbase evidence yet</small>
+        </div>
+        <div>
+          <span class="label">Operator</span>
+          <strong class="chain-selection-value" id="selected-operator">Unknown</strong>
+          <small class="muted" id="selected-sources">No source yet</small>
+        </div>
+        <div>
+          <span class="label">Branch</span>
+          <strong class="chain-selection-value" id="selected-branch">Canonical best chain</strong>
+          <small class="muted" id="selected-seen">—</small>
+        </div>
+      </section>
+      <p class="attribution-note">Software and operator are separate signals. A ? means the block did not expose enough coinbase evidence to identify Zakura or Zebra.</p>
+    </div>
+  </section>
 
   <section class="panel pad" data-view="fleet">
     <div class="card-head">
@@ -3003,24 +3842,6 @@ footer {
       <div class="stat-value" id="last-poll">...</div>
       <small id="stale-window">...</small>
     </div>
-  </section>
-
-  <section class="panel pad" data-view="fleet">
-    <div class="section-head">
-      <div>
-        <p class="eyebrow">Fork / uncle studio</p>
-        <h2>Settled chain agreement</h2>
-      </div>
-      <p class="section-note" id="fork-summary">Waiting for first comparison...</p>
-    </div>
-    <p class="fork-explainer" id="fork-explainer">The studio compares every source at one shared block height behind the live tips, avoiding alerts for ordinary propagation races.</p>
-    <div class="branch-studio" id="comparison-groups"></div>
-    <div class="fork-missing" id="comparison-missing"></div>
-    <div class="subhead"><p class="eyebrow">Live tip lanes</p></div>
-    <p class="section-note" id="chain-summary">Waiting for first poll...</p>
-    <div class="tip-groups" id="tip-groups"></div>
-    <div class="subhead"><p class="eyebrow">Reorg / orphan events</p></div>
-    <div class="reorg-list" id="reorg-list"></div>
   </section>
 
   <section class="panel pad" data-view="fleet">
@@ -3140,6 +3961,9 @@ const state = {
   sortDir: 1,
   expanded: new Set(),
   expandAll: false,
+  chainRange: 'live',
+  selectedBlockKey: '',
+  chainBlockIndex: new Map(),
   fetchedAt: null,
   error: '',
 };
@@ -3314,7 +4138,17 @@ function renderHeader(data) {
   const chain = data.chain || {};
   const network = data.network || 'mainnet';
   el('network-chip').textContent = network;
-  document.title = 'Zakura ' + network + ' cluster status';
+  document.title = 'Zakura ' + network + ' chain monitor';
+  const currentTip = chain.current_tip || {
+    height: chain.majority_height,
+    hash: chain.majority_hash,
+  };
+  el('current-tip-value').textContent = currentTip.height == null
+    ? 'waiting for first poll'
+    : num(currentTip.height) + ' · ' + tinyHash(currentTip.hash);
+  el('current-tip-link').setAttribute('aria-label', currentTip.height == null
+    ? 'Canonical tip is not available yet'
+    : 'Select canonical tip at height ' + num(currentTip.height));
 
   let label = 'Healthy';
   let toneName = 'ok';
@@ -3451,102 +4285,289 @@ function renderStats(data) {
   el('stale-window').textContent =
     'stale after ' + Math.round(data.stale_after) + 's without a new block';
 }
+function miningSoftwareName(value) {
+  return { zakura: 'Zakura', zebra: 'Zebra' }[value] || 'Unknown';
+}
+function miningSoftwareClass(value) {
+  return { zakura: 'is-zakura', zebra: 'is-zebra' }[value] || 'is-unknown';
+}
+function chainBlockKey(role, block, index) {
+  return role + ':' + (block.hash || ('unknown-' + index));
+}
+function chainBlockEntry(block, details) {
+  return {
+    block: block || {},
+    role: details.role,
+    status: details.status,
+    branch: details.branch,
+    sources: details.sources || [],
+    firstSeenAt: details.firstSeenAt || null,
+    eventAt: details.eventAt || null,
+  };
+}
+function chainNodeMarkup(entry, key, x, y, options) {
+  const block = entry.block || {};
+  const software = block.miner_software || 'unknown';
+  const mark = block.miner_mark || (software === 'zakura' ? 'ZA' : (software === 'zebra' ? 'ZE' : '?'));
+  const selected = state.selectedBlockKey === key ? ' is-selected' : '';
+  const tipId = options && options.tip ? ' id="chain-tip"' : '';
+  const label = 'Block ' + num(block.height) + ', ' + miningSoftwareName(software)
+    + ' mining software, ' + entry.status;
+  const heightLabel = options && options.compact
+    ? '…' + String(block.height == null ? '?' : block.height).slice(-3)
+    : num(block.height);
+  return '<g transform="translate(' + (x - 19).toFixed(1) + ' ' + (y - 19).toFixed(1) + ')">'
+    + '<a href="#chain-selection" class="chain-node ' + miningSoftwareClass(software) + selected + '"'
+    + tipId + ' data-chain-block="' + esc(key) + '" aria-label="' + esc(label) + '">'
+    + '<rect width="38" height="38"></rect><text x="19" y="19">' + esc(mark) + '</text></a>'
+    + '<text class="chain-height-label" x="19" y="57">' + esc(heightLabel) + '</text></g>';
+}
+function chainBranchLabel(text, x, y, width) {
+  const boxWidth = Math.max(92, Math.min(width || 210, 10 + text.length * 6.1));
+  return '<g class="chain-branch-label" transform="translate(' + x.toFixed(1) + ' ' + y.toFixed(1) + ')">'
+    + '<rect width="' + boxWidth.toFixed(1) + '" height="25"></rect>'
+    + '<text x="8" y="17">' + esc(text) + '</text></g>';
+}
+function renderSelectedChainBlock(entry, key) {
+  if (!entry) return;
+  const block = entry.block || {};
+  const software = block.miner_software || 'unknown';
+  state.selectedBlockKey = key;
+  el('selected-status').textContent = entry.status;
+  el('selected-status').className = 'chain-selection-status'
+    + (entry.role === 'competitor' ? ' is-competitor' : '')
+    + (entry.role === 'historical' ? ' is-historical' : '');
+  el('selected-time').textContent = block.time
+    ? new Date(block.time * 1000).toLocaleString()
+    : (entry.eventAt ? 'recorded ' + clockTime(entry.eventAt) : 'time unavailable');
+  el('selected-height').textContent = 'Block height ' + num(block.height);
+  el('selected-hash').textContent = block.hash || 'hash unavailable';
+  const mark = el('selected-miner-mark');
+  mark.textContent = block.miner_mark || (software === 'zakura' ? 'ZA' : (software === 'zebra' ? 'ZE' : '?'));
+  mark.className = 'miner-mark ' + miningSoftwareClass(software);
+  el('selected-miner').textContent = miningSoftwareName(software);
+  el('selected-evidence').textContent = block.miner_evidence || 'no recognized coinbase marker';
+  el('selected-operator').textContent = block.miner_operator && block.miner_operator !== 'unknown'
+    ? block.miner_operator
+    : 'Unknown';
+  el('selected-sources').textContent = entry.sources.length
+    ? 'Observed by ' + entry.sources.join(', ')
+    : 'Observer unavailable';
+  el('selected-branch').textContent = entry.branch;
+  el('selected-seen').textContent = entry.firstSeenAt
+    ? 'first seen ' + age(Math.max(0, (Date.now() / 1000) - entry.firstSeenAt)) + ' ago'
+    : (entry.role === 'historical' ? 'left the observed best chain' : 'current best chain');
+}
+function showChainTooltip(trigger, clientX, clientY) {
+  const entry = state.chainBlockIndex.get(trigger.dataset.chainBlock);
+  if (!entry) return;
+  const block = entry.block || {};
+  const tooltip = el('chain-tooltip');
+  tooltip.innerHTML = '<strong>Block ' + esc(num(block.height)) + ' · ' + esc(entry.status) + '</strong>'
+    + '<div class="chain-tooltip-grid">'
+    + '<span>Hash</span><span class="mono">' + esc(tinyHash(block.hash)) + '</span>'
+    + '<span>Software</span><span>' + esc(miningSoftwareName(block.miner_software)) + '</span>'
+    + '<span>Operator</span><span>' + esc(block.miner_operator || 'unknown') + '</span>'
+    + '<span>Evidence</span><span>' + esc(block.miner_evidence || 'no recognized coinbase marker') + '</span>'
+    + '<span>Observed by</span><span>' + esc(entry.sources.join(', ') || 'unknown') + '</span>'
+    + '</div>';
+  tooltip.hidden = false;
+  const canvas = el('chain-canvas').getBoundingClientRect();
+  const triggerBox = trigger.getBoundingClientRect();
+  let left = clientX == null ? triggerBox.left + triggerBox.width / 2 : clientX;
+  let top = clientY == null ? triggerBox.top : clientY;
+  left = Math.max(canvas.left + 10, Math.min(left + 12, canvas.right - tooltip.offsetWidth - 10));
+  top = Math.max(canvas.top + 8, Math.min(top + 12, canvas.bottom - tooltip.offsetHeight - 8));
+  tooltip.style.left = (left - canvas.left) + 'px';
+  tooltip.style.top = (top - canvas.top) + 'px';
+}
 function renderChain(data) {
   const chain = data.chain || {};
-  const status = chain.status || 'unknown';
   const forkStatus = chain.fork_status || 'warming';
   const tipGroups = chain.tip_groups || [];
-  const comparisonGroups = chain.comparison_groups || [];
-  const reorgs = chain.recent_reorgs || [];
+  let branches = chain.branches || [];
+  if (!branches.length) {
+    branches = tipGroups.map((group) => ({
+      role: group.height === chain.majority_height && group.block_hash === chain.majority_hash
+        ? 'canonical' : 'competitor',
+      tip_height: group.height,
+      tip_hash: group.block_hash,
+      sources: group.nodes || [],
+      fork_depth_label: group.fork_depth_label || '',
+      blocks: [{
+        height: group.height,
+        hash: group.block_hash,
+        miner_software: 'unknown',
+        miner_mark: '?',
+        miner_operator: 'unknown',
+        miner_evidence: 'coinbase data unavailable',
+      }],
+    }));
+  }
+  const canonical = branches.find((branch) => branch.role === 'canonical') || null;
+  const competitors = branches.filter((branch) => branch.role === 'competitor');
+  const generatedAt = data.generated_at || Date.now() / 1000;
+  const cutoff = state.chainRange === '7d'
+    ? generatedAt - 7 * 86400
+    : generatedAt - 86400;
+  const historical = state.chainRange === 'live'
+    ? []
+    : (chain.recent_reorgs || []).filter((event) => Number(event.at || 0) >= cutoff).slice(0, 6);
 
-  el('fork-summary').textContent = {
-    agreed: 'All configured sources agree at the settled comparison height.',
-    diverged: 'Sources return different block hashes at the same settled height.',
-    partial: 'Available sources agree, but one or more sources could not be compared.',
-    insufficient: 'Fewer than two sources returned a hash at the comparison height.',
-    warming: 'The first poll establishes tip heights; the next poll compares chains.',
-  }[forkStatus] || 'Waiting for settled chain observations.';
-  el('fork-explainer').textContent = chain.comparison_height == null
-    ? 'The studio compares every source at one shared block height behind the live tips, avoiding alerts for ordinary propagation races.'
-    : 'Height ' + num(chain.comparison_height) + ' is ' + num(data.fork_confirmations || 0)
-      + ' block' + ((data.fork_confirmations || 0) === 1 ? '' : 's')
-      + ' behind the slowest healthy source observed on the prior poll.';
+  el('chain-network-label').textContent = (data.network || 'mainnet') + ' · '
+    + ({ live: 'live', '24h': 'last 24 hours', '7d': 'last 7 days' }[state.chainRange]);
+  const alert = el('chain-alert');
+  alert.className = 'chain-alert';
+  if (forkStatus === 'diverged') {
+    alert.classList.add('is-bad');
+    el('chain-alert-text').textContent = 'Competing fork active at settled height '
+      + num(chain.comparison_height) + ' · ' + (chain.comparison_groups || []).length + ' branches';
+  } else if (forkStatus === 'partial' || forkStatus === 'insufficient') {
+    alert.classList.add('is-warn');
+    el('chain-alert-text').textContent = 'Fork comparison incomplete · '
+      + (chain.comparison_observed || 0) + ' of ' + (chain.comparison_expected || data.total || 0) + ' sources';
+  } else if (forkStatus === 'warming') {
+    alert.classList.add('is-warn');
+    el('chain-alert-text').textContent = 'Establishing the settled comparison height';
+  } else {
+    el('chain-alert-text').textContent = 'No competing settled fork detected';
+  }
 
-  el('comparison-groups').innerHTML = comparisonGroups.length
-    ? comparisonGroups.map((group) => {
-      const role = group.role || 'candidate';
-      const cls = role === 'quorum' ? 'is-majority' : (role === 'fork' ? 'is-fork' : 'is-candidate');
-      const observers = new Set(group.observers || []);
-      const labels = (group.nodes || []).map((name) =>
-        name + (observers.has(name) ? ' (observer)' : ''));
-      return '<div class="tip-group branch-group ' + cls + '">'
-        + '<div class="tip-group-top">'
-        + badge(role, tone(CHAIN_TONE, role))
-        + '<span class="height num">height ' + num(chain.comparison_height) + '</span>'
-        + '<span class="mono muted" style="font-size:0.78rem">'
-        + copyCell(group.block_hash, shortHash(group.block_hash), 'Copy comparison hash') + '</span>'
-        + '</div>'
-        + '<div class="tip-group-count">' + group.count
-        + ' source' + (group.count === 1 ? '' : 's') + '</div>'
-        + '<div class="tip-group-nodes">' + esc(labels.join(', ')) + '</div>'
-        + '</div>';
-    }).join('')
-    : '<div class="empty">No settled hashes observed yet.</div>';
-  const unavailable = chain.unavailable_sources || [];
-  el('comparison-missing').textContent = unavailable.length
-    ? 'Not compared: ' + unavailable.join(', ')
-    : '';
+  const canvas = el('chain-canvas');
+  const svg = el('chain-svg');
+  const width = Math.max(300, canvas.clientWidth || 900);
+  const compact = width < 560;
+  const height = historical.length ? (compact ? 500 : 455) : (compact ? 430 : 390);
+  canvas.style.minHeight = height + 'px';
+  svg.style.height = height + 'px';
+  svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+  const left = compact ? 34 : 54;
+  const right = compact ? width - 34 : width - 54;
+  const canonicalY = historical.length ? 180 : (compact ? 205 : 195);
+  const visibleCanonical = canonical
+    ? (canonical.blocks || []).slice(compact ? -4 : -7)
+    : [];
+  state.chainBlockIndex = new Map();
 
-  el('chain-summary').textContent = {
-    split: 'Sources disagree on the tip hash at the leading height.',
-    lagging: 'One tip hash leads; some sources are behind.',
-    agreed: 'All observed sources share the same tip.',
-  }[status] || 'Waiting for tip observations.';
+  const defs = '<defs><pattern id="zebra-pattern" width="7" height="7" patternUnits="userSpaceOnUse" patternTransform="rotate(135)">'
+    + '<rect width="7" height="7" fill="var(--raised)"></rect>'
+    + '<rect width="3" height="7" fill="var(--line-hi)"></rect></pattern></defs>';
+  if (!visibleCanonical.length) {
+    svg.innerHTML = defs + '<text class="chain-empty" x="' + left + '" y="90">Waiting for recent block data...</text>';
+    return;
+  }
 
-  el('tip-groups').innerHTML = tipGroups.length
-    ? tipGroups.map((group) => {
-      const isMajority = group.height === chain.majority_height
-        && group.block_hash === chain.majority_hash;
-      const depth = group.fork_depth_label && !isMajority
-        ? badge(group.fork_depth_label, 'warn')
-        : '';
-      return '<div class="tip-group ' + (isMajority ? 'is-majority' : 'is-fork') + '">'
-        + '<div class="tip-group-top">'
-        + badge(isMajority ? 'majority' : 'fork', isMajority ? 'ok' : 'bad')
-        + '<span class="height num">height ' + num(group.height) + '</span>'
-        + '<span class="mono muted" style="font-size:0.78rem">'
-        + copyCell(group.block_hash, shortHash(group.block_hash), 'Copy tip hash') + '</span>'
-        + depth
-        + '</div>'
-        + '<div class="tip-group-count">' + group.count
-        + ' source' + (group.count === 1 ? '' : 's') + '</div>'
-        + '<div class="tip-group-nodes">' + esc((group.nodes || []).join(', ')) + '</div>'
-        + '</div>';
-    }).join('')
-    : '<div class="empty">No tip hashes observed yet.</div>';
+  const allLiveBlocks = branches.flatMap((branch) => branch.blocks || []);
+  const heights = allLiveBlocks.map((block) => Number(block.height)).filter(Number.isFinite);
+  let minHeight = Math.min(...visibleCanonical.map((block) => Number(block.height)));
+  let maxHeight = Math.max(...visibleCanonical.map((block) => Number(block.height)));
+  if (heights.length) {
+    minHeight = Math.min(minHeight, ...heights);
+    maxHeight = Math.max(maxHeight, ...heights);
+  }
+  const heightSpan = Math.max(1, maxHeight - minHeight);
+  const xForHeight = (blockHeight) => left + ((Number(blockHeight) - minHeight) / heightSpan) * (right - left);
+  const canonicalPoints = visibleCanonical.map((block, index) => ({
+    block,
+    x: xForHeight(block.height),
+    y: canonicalY,
+    index,
+  }));
+  const canonicalByHash = new Map(canonicalPoints.map((point) => [point.block.hash, point]));
+  let markup = defs;
+  markup += '<path class="chain-spine" d="M ' + canonicalPoints.map((point) =>
+    point.x.toFixed(1) + ' ' + point.y.toFixed(1)).join(' L ') + '"></path>';
 
-  el('reorg-list').innerHTML = reorgs.length
-    ? reorgs.slice(0, 12).map((event) => {
-      const discarded = event.discarded_hash || event.from_hash || '';
-      const canonical = event.canonical_hash || event.to_hash || '';
-      const depth = event.depth_label
-        || (event.depth != null ? 'depth ' + event.depth : 'depth unknown');
-      return '<div class="reorg-item">'
-        + '<div class="reorg-top">'
-        + '<strong>' + esc(event.node) + '</strong>'
-        + badge(tipEventLabel(event.kind) || event.kind, 'warn')
-        + badge(depth, 'neutral')
-        + (event.demo ? badge('demo', 'info') : '')
-        + '<span class="muted num" style="font-size:0.78rem">' + num(event.from_height)
-        + ' → ' + num(event.to_height) + '</span>'
-        + '</div>'
-        + '<div class="reorg-detail mono">orphan ' + esc(tinyHash(discarded))
-        + ' → tip ' + esc(tinyHash(canonical))
-        + '<span class="dim"> · ' + esc(clockTime(event.at)) + '</span></div>'
-        + '</div>';
-    }).join('')
-    : '<div class="empty">No orphan pairs yet. Height drops and tip switches are'
-      + ' recorded here and survive dashboard restarts.</div>';
+  canonicalPoints.forEach((point, index) => {
+    const key = chainBlockKey('canonical', point.block, index);
+    const entry = chainBlockEntry(point.block, {
+      role: 'canonical',
+      status: index === canonicalPoints.length - 1 ? 'canonical tip' : 'canonical',
+      branch: 'Canonical best chain',
+      sources: canonical.sources || [],
+    });
+    state.chainBlockIndex.set(key, entry);
+    markup += chainNodeMarkup(entry, key, point.x, point.y, {
+      tip: index === canonicalPoints.length - 1,
+      compact,
+    });
+  });
+
+  const laneYs = compact ? [92, 318, 52, 366] : [82, 304, 48, 342];
+  competitors.slice(0, 4).forEach((branch, branchIndex) => {
+    const blocks = (branch.blocks || []).filter((block) => !canonicalByHash.has(block.hash));
+    if (!blocks.length) return;
+    const first = blocks[0];
+    const parent = (branch.blocks || []).find((block) => block.hash === first.previous_hash);
+    const join = parent ? canonicalByHash.get(parent.hash) : null;
+    const forkX = join ? join.x : Math.max(left, xForHeight(first.height) - 44);
+    const laneY = laneYs[branchIndex % laneYs.length];
+    const points = blocks.slice(compact ? -3 : -6).map((block) => ({
+      block,
+      x: Math.max(forkX + 42, Math.min(right, xForHeight(block.height))),
+      y: laneY,
+    }));
+    const firstPoint = points[0];
+    let path = 'M ' + forkX.toFixed(1) + ' ' + canonicalY.toFixed(1)
+      + ' C ' + (forkX + 24).toFixed(1) + ' ' + canonicalY.toFixed(1)
+      + ', ' + (firstPoint.x - 24).toFixed(1) + ' ' + laneY.toFixed(1)
+      + ', ' + firstPoint.x.toFixed(1) + ' ' + laneY.toFixed(1);
+    for (const point of points.slice(1)) path += ' L ' + point.x.toFixed(1) + ' ' + point.y.toFixed(1);
+    markup += '<path class="chain-branch-path" d="' + path + '"></path>';
+    points.forEach((point, index) => {
+      const key = chainBlockKey('competitor-' + branchIndex, point.block, index);
+      const entry = chainBlockEntry(point.block, {
+        role: 'competitor',
+        status: 'live fork',
+        branch: branch.fork_depth_label || 'Competing branch',
+        sources: branch.sources || [],
+        firstSeenAt: branch.first_seen_at,
+      });
+      state.chainBlockIndex.set(key, entry);
+      markup += chainNodeMarkup(entry, key, point.x, point.y, { compact });
+    });
+    const branchLabel = 'LIVE · ' + (branch.fork_depth_label || blocks.length + ' competing blocks');
+    markup += chainBranchLabel(branchLabel, Math.min(firstPoint.x, right - 160), laneY - 54, 210);
+  });
+
+  if (historical.length) {
+    const historyY = compact ? 425 : 390;
+    markup += '<path class="chain-branch-path is-historical" d="M ' + left + ' ' + historyY
+      + ' L ' + right + ' ' + historyY + '"></path>';
+    historical.forEach((event, index) => {
+      const block = event.orphan_block || {
+        height: event.from_height,
+        hash: event.discarded_hash || event.from_hash || '',
+        miner_software: 'unknown',
+        miner_mark: '?',
+        miner_operator: 'unknown',
+        miner_evidence: 'coinbase data was not captured',
+      };
+      const x = historical.length === 1
+        ? (left + right) / 2
+        : left + (index / (historical.length - 1)) * (right - left);
+      const key = chainBlockKey('historical', block, index);
+      const entry = chainBlockEntry(block, {
+        role: 'historical',
+        status: 'historical orphan',
+        branch: event.depth_label || 'Recorded reorg',
+        sources: event.node ? [event.node] : [],
+        eventAt: event.at,
+      });
+      state.chainBlockIndex.set(key, entry);
+      markup += chainNodeMarkup(entry, key, x, historyY, { compact });
+    });
+    markup += chainBranchLabel('HISTORY · ' + historical.length + ' orphan event'
+      + (historical.length === 1 ? '' : 's'), left, historyY - 55, 220);
+  }
+
+  svg.innerHTML = markup;
+  let selectedKey = state.selectedBlockKey;
+  if (!state.chainBlockIndex.has(selectedKey)) {
+    const tipBlock = canonicalPoints[canonicalPoints.length - 1].block;
+    selectedKey = chainBlockKey('canonical', tipBlock, canonicalPoints.length - 1);
+  }
+  renderSelectedChainBlock(state.chainBlockIndex.get(selectedKey), selectedKey);
 }
 
 function matchesQuery(row, query) {
@@ -4126,6 +5147,35 @@ async function tick() {
 
 /* ---------- interaction ---------- */
 document.addEventListener('click', (event) => {
+  const range = event.target.closest('[data-chain-range]');
+  if (range) {
+    state.chainRange = range.dataset.chainRange;
+    for (const button of document.querySelectorAll('[data-chain-range]')) {
+      button.setAttribute('aria-pressed', String(button === range));
+    }
+    if (state.data) renderChain(state.data);
+    return;
+  }
+  const chainBlock = event.target.closest('[data-chain-block]');
+  if (chainBlock) {
+    event.preventDefault();
+    const key = chainBlock.dataset.chainBlock;
+    renderSelectedChainBlock(state.chainBlockIndex.get(key), key);
+    if (state.data) renderChain(state.data);
+    return;
+  }
+  const tipLink = event.target.closest('#current-tip-link');
+  if (tipLink) {
+    const tip = Array.from(state.chainBlockIndex.entries()).find((entry) =>
+      entry[1].status === 'canonical tip');
+    if (tip) {
+      event.preventDefault();
+      renderSelectedChainBlock(tip[1], tip[0]);
+      if (state.data) renderChain(state.data);
+      el('chain-selection').scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+    return;
+  }
   const copy = event.target.closest('[data-copy]');
   if (copy) {
     event.stopPropagation();
@@ -4164,6 +5214,21 @@ document.addEventListener('click', (event) => {
     if (state.data) renderTable(state.data);
   }
 });
+document.addEventListener('pointermove', (event) => {
+  const trigger = event.target.closest('[data-chain-block]');
+  if (trigger) showChainTooltip(trigger, event.clientX, event.clientY);
+});
+document.addEventListener('pointerout', (event) => {
+  const trigger = event.target.closest('[data-chain-block]');
+  if (trigger && !trigger.contains(event.relatedTarget)) el('chain-tooltip').hidden = true;
+});
+document.addEventListener('focusin', (event) => {
+  const trigger = event.target.closest('[data-chain-block]');
+  if (trigger) showChainTooltip(trigger, null, null);
+});
+document.addEventListener('focusout', (event) => {
+  if (event.target.closest('[data-chain-block]')) el('chain-tooltip').hidden = true;
+});
 el('filter-input').addEventListener('input', (event) => {
   state.query = event.target.value.trim().toLowerCase();
   if (state.data) renderTable(state.data);
@@ -4179,6 +5244,13 @@ el('expand-toggle').addEventListener('click', (event) => {
   event.currentTarget.classList.toggle('is-on', state.expandAll);
   event.currentTarget.textContent = state.expandAll ? 'Collapse all' : 'Expand all';
   if (state.data) renderTable(state.data);
+});
+let chainResizeTimer = null;
+window.addEventListener('resize', () => {
+  clearTimeout(chainResizeTimer);
+  chainResizeTimer = setTimeout(() => {
+    if (state.data && !NODE_NAME) renderChain(state.data);
+  }, 100);
 });
 tick();
 setInterval(tick, REFRESH_MS);

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Zakura fleet dashboard and narrow public Ironwood status API.
 
-Reads a deploy/deployer nodes TOML, polls each node over SSH, and serves a small
-HTML dashboard showing the running commit, Zakura node ID, restart time, current
-height, latest block hash, tip agreement across the fleet, per-node reorg
-candidates, and whether the node has advanced recently. It also serves a
-deliberately small public Ironwood status response for zakura.com.
+Reads a deploy/deployer nodes TOML, polls managed nodes over SSH and optional
+read-only RPC observers, and serves an HTML dashboard showing process health,
+live tips, settled-height fork agreement, and reorg/orphan candidates. It also
+serves a deliberately small public Ironwood status response for zakura.com.
 
 Only the Python stdlib is used.
 """
@@ -24,6 +23,7 @@ import threading
 import time
 import tomllib
 import urllib.parse
+import urllib.request
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -121,6 +121,8 @@ ALERT_DIAGNOSTIC_METRICS = (
 RECENT_REORG_LIMIT = 40
 # Sampled best-chain ancestor offsets used to estimate fork depth between tips.
 ANCESTOR_DEPTHS = (1, 2, 5, 10, 32)
+DEFAULT_FORK_CONFIRMATIONS = 2
+MAX_RPC_RESPONSE_BYTES = 2 * 1024 * 1024
 
 SSH_COMMON_OPTS = [
     "-o", "BatchMode=yes",
@@ -173,6 +175,8 @@ class Node:
     health_listen_addr: str = ""
     state_cache_dir: str = ""
     port: object = None
+    source_type: str = "node"
+    observer_rpc_url: str = ""
 
     def ssh_cmd(self, *remote: str) -> list[str]:
         cmd = ["ssh", *SSH_COMMON_OPTS]
@@ -225,9 +229,50 @@ def load_nodes(config_path: Path) -> list[Node]:
             )
         )
 
+    for raw in data.get("chain_observers", []):
+        for required in ("name", "rpc_url"):
+            if required not in raw:
+                raise SystemExit(
+                    f"chain observer missing required field '{required}': {raw}"
+                )
+        name = str(raw["name"])
+        if name in seen:
+            raise SystemExit(f"duplicate node or chain observer name: {name}")
+        seen.add(name)
+        observer_rpc_url = validate_observer_rpc_url(str(raw["rpc_url"]))
+        nodes.append(
+            Node(
+                name=name,
+                ssh_string="",
+                probe_kind="rpc_observer",
+                service_name="",
+                bin_path="",
+                log_file="",
+                rpc_listen_addr="",
+                rpc_auth="",
+                rpc_config_path="",
+                rpc_user="",
+                rpc_password="",
+                process_pattern="",
+                container_name="",
+                node_id="",
+                source_type="observer",
+                observer_rpc_url=observer_rpc_url,
+            )
+        )
+
     if not nodes:
         raise SystemExit(f"no [[nodes]] defined in {config_path}")
     return nodes
+
+
+def validate_observer_rpc_url(value: str) -> str:
+    parsed = urllib.parse.urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise SystemExit(f"chain observer rpc_url must be an http(s) URL: {value}")
+    if parsed.username is not None or parsed.password is not None:
+        raise SystemExit("chain observer rpc_url must not contain credentials")
+    return value
 
 
 def ssh_host(ssh_string: str) -> str:
@@ -301,6 +346,7 @@ import urllib.request
     state_cache_dir,
     want_metrics,
 ) = sys.argv[1:16]
+comparison_height = sys.argv[16] if len(sys.argv) > 16 else ""
 
 out = {
     "service": service,
@@ -851,6 +897,20 @@ if rpc_url:
                         pass
         out["ancestor_hashes"] = ancestor_hashes
 
+        if comparison_height:
+            try:
+                requested_height = int(comparison_height)
+                out["comparison_height"] = requested_height
+                if requested_height < 0 or requested_height > tip_height:
+                    raise ValueError(
+                        "comparison height is outside this source's best chain"
+                    )
+                out["comparison_hash"] = rpc_call(
+                    "getblockhash", [requested_height]
+                )
+            except Exception as error:
+                out["comparison_error"] = str(error)
+
         best_hash = out.get("block_hash")
         if best_hash:
             try:
@@ -951,7 +1011,101 @@ def ssh_capture_script(node: Node, script: str) -> subprocess.CompletedProcess:
     return subprocess.run(node.ssh_cmd("bash", "-s"), input=script, text=True, capture_output=True)
 
 
-def probe_node(node: Node, want_metrics: bool = True) -> dict:
+def direct_rpc_call(url: str, method: str, params: list | None = None):
+    body = json.dumps({
+        "jsonrpc": "2.0",
+        "id": "zakura-chain-observer",
+        "method": method,
+        "params": list(params or []),
+    }).encode()
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "zakura-cluster-status",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=6) as response:
+        payload = json.loads(response.read(MAX_RPC_RESPONSE_BYTES).decode())
+    if not isinstance(payload, dict):
+        raise RuntimeError("RPC returned a non-object response")
+    if payload.get("error"):
+        raise RuntimeError(str(payload["error"]))
+    return payload.get("result")
+
+
+def probe_chain_observer(node: Node, comparison_height: int | None) -> dict:
+    """Read the chain identity from a direct, read-only JSON-RPC observer."""
+    out = {
+        "active_state": "active",
+        "process_running": True,
+        "probe_kind": node.probe_kind,
+        "metrics_error": "metrics are not collected for RPC observers",
+        "health_error": "health endpoint is not collected for RPC observers",
+    }
+    try:
+        info = direct_rpc_call(node.observer_rpc_url, "getblockchaininfo")
+        if not isinstance(info, dict):
+            raise RuntimeError("getblockchaininfo returned a non-object result")
+        out.update({
+            "height": info.get("blocks"),
+            "headers": info.get("headers"),
+            "block_hash": info.get("bestblockhash"),
+            "rpc_chain": info.get("chain"),
+            "rpc_testnet": info.get("chain") == "test",
+        })
+        try:
+            tip_height = int(info.get("blocks"))
+        except (TypeError, ValueError):
+            tip_height = None
+
+        if comparison_height is not None:
+            if (
+                comparison_height < 0
+                or tip_height is None
+                or comparison_height > tip_height
+            ):
+                out["comparison_error"] = (
+                    "comparison height is outside this source's best chain"
+                )
+            else:
+                out["comparison_height"] = comparison_height
+                out["comparison_hash"] = direct_rpc_call(
+                    node.observer_rpc_url,
+                    "getblockhash",
+                    [comparison_height],
+                )
+
+    except Exception as error:
+        out["rpc_error"] = str(error)
+        return out
+
+    try:
+        network_info = direct_rpc_call(node.observer_rpc_url, "getnetworkinfo")
+        if isinstance(network_info, dict):
+            out["client_name"] = str(
+                network_info.get("subversion") or "RPC observer"
+            ).strip("/")
+            out["client_version"] = str(network_info.get("version") or "")
+    except Exception as error:
+        out["rpc_metadata_error"] = str(error)
+    return out
+
+
+def probe_node(
+    node: Node,
+    want_metrics: bool = True,
+    comparison_height: int | None = None,
+) -> dict:
+    if node.source_type == "observer":
+        result = probe_chain_observer(node, comparison_height)
+        if comparison_height is not None:
+            result.setdefault("comparison_height", comparison_height)
+        return result
+
     rpc_url = rpc_url_for(node.rpc_listen_addr)
     script = (
         "python3 - "
@@ -969,18 +1123,31 @@ def probe_node(node: Node, want_metrics: bool = True) -> dict:
         f"{shlex.quote(node.metrics_endpoint)} "
         f"{shlex.quote(node.health_listen_addr)} "
         f"{shlex.quote(node.state_cache_dir)} "
-        f"{shlex.quote('1' if want_metrics else '')} <<'PY'\n"
+        f"{shlex.quote('1' if want_metrics else '')} "
+        f"{shlex.quote(str(comparison_height) if comparison_height is not None else '')} <<'PY'\n"
         f"{REMOTE_PROBE}\n"
         "PY\n"
     )
     proc = ssh_capture_script(node, script)
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "").strip()
-        return {"error": detail or f"ssh exited {proc.returncode}"}
+        result = {"error": detail or f"ssh exited {proc.returncode}"}
+        if comparison_height is not None:
+            result["comparison_height"] = comparison_height
+        return result
     try:
-        return json.loads(proc.stdout.strip().splitlines()[-1])
+        result = json.loads(proc.stdout.strip().splitlines()[-1])
+        if comparison_height is not None:
+            result.setdefault("comparison_height", comparison_height)
+        return result
     except (IndexError, json.JSONDecodeError) as error:
-        return {"error": f"invalid probe output: {error}", "raw": proc.stdout.strip()}
+        result = {
+            "error": f"invalid probe output: {error}",
+            "raw": proc.stdout.strip(),
+        }
+        if comparison_height is not None:
+            result["comparison_height"] = comparison_height
+        return result
 
 
 class RateLimiter:
@@ -1032,6 +1199,7 @@ class ClusterCollector:
         history_window: float = DEFAULT_NODE_HISTORY_WINDOW,
         expose_logs: bool = False,
         metrics_min_interval: float | None = None,
+        fork_confirmations: int = DEFAULT_FORK_CONFIRMATIONS,
     ):
         self.nodes = nodes
         self.interval = interval
@@ -1042,6 +1210,7 @@ class ClusterCollector:
         self.expose_logs = expose_logs
         # None selects the adaptive interval; a number pins it.
         self.metrics_min_interval = metrics_min_interval
+        self.fork_confirmations = fork_confirmations
         self.nodes_by_name = {node.name: node for node in nodes}
         self.history: dict[str, deque[dict]] = {node.name: deque() for node in nodes}
         # Last successful scrape per node, reused on the polls that skip it.
@@ -1070,6 +1239,7 @@ class ClusterCollector:
                 "name": node.name,
                 "ssh": node.ssh_string,
                 "node_id": node.node_id,
+                "source_type": node.source_type,
                 "health": "starting",
                 "healthy": False,
             }
@@ -1085,9 +1255,18 @@ class ClusterCollector:
     def poll_once(self) -> None:
         rows = []
         started = time.time()
+        with self.lock:
+            comparison_height = select_comparison_height(
+                self.rows, self.fork_confirmations
+            )
         with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(self.nodes))) as pool:
             futures = {
-                pool.submit(probe_node, node, self.should_scrape_metrics(node.name, started)): node
+                pool.submit(
+                    probe_node,
+                    node,
+                    self.should_scrape_metrics(node.name, started),
+                    comparison_height,
+                ): node
                 for node in self.nodes
             }
             for future in concurrent.futures.as_completed(futures):
@@ -1216,6 +1395,8 @@ class ClusterCollector:
         block_hash = str(probe.get("block_hash") or "")
         ancestor_hashes = normalize_ancestor_hashes(probe.get("ancestor_hashes"))
         previous_block_hash = str(probe.get("previous_hash") or "")
+        comparison_height = coerce_int(probe.get("comparison_height"))
+        comparison_hash = str(probe.get("comparison_hash") or "")
 
         advanced = False
         tip_event = None
@@ -1269,7 +1450,11 @@ class ClusterCollector:
         active_state = probe.get("active_state") or "unknown"
         process_running = probe.get("process_running")
         service_active = active_state == "active" and process_running is not False
-        rpc_ok = height is not None and not probe.get("rpc_error")
+        rpc_chain_ok = (
+            node.source_type != "observer"
+            or probe.get("rpc_chain") == RPC_CHAIN_NAMES[self.network]
+        )
+        rpc_ok = height is not None and not probe.get("rpc_error") and rpc_chain_ok
         recent = (
             seconds_since_advanced is not None
             and seconds_since_advanced <= self.stale_after
@@ -1287,7 +1472,13 @@ class ClusterCollector:
             detail = f"systemd state: {active_state}"
         elif not rpc_ok:
             health = "rpc_error"
-            detail = str(probe.get("rpc_error") or "RPC height unavailable")
+            if not rpc_chain_ok:
+                detail = (
+                    f"RPC chain {probe.get('rpc_chain')!r} does not match "
+                    f"{RPC_CHAIN_NAMES[self.network]!r}"
+                )
+            else:
+                detail = str(probe.get("rpc_error") or "RPC height unavailable")
         elif not recent:
             health = "stale"
             detail = "height has not advanced within stale window"
@@ -1340,6 +1531,7 @@ class ClusterCollector:
         return {
             "name": node.name,
             "ssh": node.ssh_string,
+            "source_type": node.source_type,
             "healthy": healthy,
             "health": health,
             "detail": detail,
@@ -1347,6 +1539,9 @@ class ClusterCollector:
             "block_hash": block_hash,
             "previous_hash": previous_block_hash,
             "ancestor_hashes": ancestor_hashes,
+            "comparison_height": comparison_height,
+            "comparison_hash": comparison_hash,
+            "comparison_error": probe.get("comparison_error"),
             "node_id": node.node_id or probe.get("node_id") or "",
             "version": probe.get("version") or "",
             "last_restarted": probe.get("last_restarted") or "",
@@ -1355,6 +1550,7 @@ class ClusterCollector:
             "header_lag": header_lag,
             "tip_event": tip_event,
             "chain_role": "unknown",
+            "settled_role": "unknown",
             "active_state": active_state,
             "rpc_ok": rpc_ok,
             "last_seen_at": now,
@@ -1409,6 +1605,9 @@ class ClusterCollector:
             last_poll = self.last_poll
             chain = dict(self.chain)
             chain["tip_groups"] = [dict(group) for group in chain.get("tip_groups", [])]
+            chain["comparison_groups"] = [
+                dict(group) for group in chain.get("comparison_groups", [])
+            ]
             chain["recent_reorgs"] = [
                 dict(event) for event in chain.get("recent_reorgs", [])
             ]
@@ -1418,6 +1617,7 @@ class ClusterCollector:
             "last_poll": last_poll,
             "stale_after": self.stale_after,
             "network": self.network,
+            "fork_confirmations": self.fork_confirmations,
             "healthy": healthy,
             "total": len(rows),
             "chain": chain,
@@ -1611,6 +1811,15 @@ def empty_chain_summary() -> dict:
         "max_height": None,
         "observed_tips": 0,
         "tip_groups": [],
+        "fork_status": "warming",
+        "comparison_height": None,
+        "comparison_observed": 0,
+        "comparison_expected": 0,
+        "comparison_groups": [],
+        "quorum_hash": "",
+        "quorum_count": 0,
+        "forked_sources": [],
+        "unavailable_sources": [],
         "recent_reorgs": [],
     }
 
@@ -1786,6 +1995,126 @@ def tipped_rows(rows: list[dict]) -> list[dict]:
     ]
 
 
+def select_comparison_height(rows: list[dict], confirmations: int) -> int | None:
+    """Choose one settled height that every advancing source should have."""
+    heights = [
+        height
+        for row in rows
+        if row.get("health") == "healthy"
+        if (height := coerce_int(row.get("height"))) is not None
+    ]
+    if not heights:
+        return None
+    return max(0, min(heights) - max(0, confirmations))
+
+
+def settled_chain_summary(rows: list[dict]) -> dict:
+    expected_names = sorted(str(row.get("name") or "unknown") for row in rows)
+    heights = [
+        height
+        for row in rows
+        if (height := coerce_int(row.get("comparison_height"))) is not None
+    ]
+    if not heights:
+        return {
+            "fork_status": "warming",
+            "comparison_height": None,
+            "comparison_observed": 0,
+            "comparison_expected": len(rows),
+            "comparison_groups": [],
+            "quorum_hash": "",
+            "quorum_count": 0,
+            "forked_sources": [],
+            "unavailable_sources": expected_names,
+        }
+
+    # A collector poll requests one absolute height from every source. Choosing
+    # the most common value keeps hand-built/test snapshots deterministic and
+    # treats a mismatched response as unavailable instead of comparing unlike
+    # blocks.
+    counts: dict[int, int] = defaultdict(int)
+    for height in heights:
+        counts[height] += 1
+    comparison_height = max(counts, key=lambda height: (counts[height], height))
+
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        if row.get("rpc_ok") is False:
+            continue
+        if coerce_int(row.get("comparison_height")) != comparison_height:
+            continue
+        block_hash = str(row.get("comparison_hash") or "")
+        if not block_hash:
+            continue
+        groups[block_hash].append(row)
+
+    comparison_groups = []
+    for block_hash, group_rows in groups.items():
+        names = sorted(str(row.get("name") or "unknown") for row in group_rows)
+        observers = sorted(
+            str(row.get("name") or "unknown")
+            for row in group_rows
+            if row.get("source_type") == "observer"
+        )
+        comparison_groups.append({
+            "block_hash": block_hash,
+            "nodes": names,
+            "observers": observers,
+            "count": len(names),
+            "role": "candidate",
+        })
+    comparison_groups.sort(
+        key=lambda group: (group["count"], group["block_hash"]),
+        reverse=True,
+    )
+
+    observed = sum(group["count"] for group in comparison_groups)
+    available = {
+        name for group in comparison_groups for name in group.get("nodes", [])
+    }
+    unavailable = sorted(set(expected_names) - available)
+    quorum = (
+        comparison_groups[0]
+        if comparison_groups and comparison_groups[0]["count"] > len(rows) / 2
+        else None
+    )
+    if quorum is not None:
+        quorum["role"] = "quorum"
+        for group in comparison_groups[1:]:
+            group["role"] = "fork"
+
+    if len(comparison_groups) > 1:
+        fork_status = "diverged"
+    elif observed < 2:
+        fork_status = "insufficient"
+    elif unavailable:
+        fork_status = "partial"
+    else:
+        fork_status = "agreed"
+
+    forked_sources = (
+        sorted(
+            name
+            for group in comparison_groups
+            if group.get("role") == "fork"
+            for name in group.get("nodes", [])
+        )
+        if quorum is not None
+        else []
+    )
+    return {
+        "fork_status": fork_status,
+        "comparison_height": comparison_height,
+        "comparison_observed": observed,
+        "comparison_expected": len(rows),
+        "comparison_groups": comparison_groups,
+        "quorum_hash": quorum["block_hash"] if quorum else "",
+        "quorum_count": quorum["count"] if quorum else 0,
+        "forked_sources": forked_sources,
+        "unavailable_sources": unavailable,
+    }
+
+
 def compute_chain_summary(
     rows: list[dict],
     recent_reorgs: list[dict] | None = None,
@@ -1852,7 +2181,7 @@ def compute_chain_summary(
                 group["fork_depth"] = behind
                 group["fork_depth_label"] = f"{behind} behind"
 
-    return {
+    summary = {
         "status": status,
         "split": split,
         "majority_height": majority["height"] if majority else None,
@@ -1862,6 +2191,8 @@ def compute_chain_summary(
         "tip_groups": tip_groups,
         "recent_reorgs": list(recent_reorgs or []),
     }
+    summary.update(settled_chain_summary(rows))
+    return summary
 
 
 def enrich_chain_roles(rows: list[dict], chain: dict) -> None:
@@ -1882,6 +2213,22 @@ def enrich_chain_roles(rows: list[dict], chain: dict) -> None:
             row["chain_role"] = "ahead"
         else:
             row["chain_role"] = "behind"
+
+        comparison_height = chain.get("comparison_height")
+        comparison_hash = row.get("comparison_hash") or ""
+        quorum_hash = chain.get("quorum_hash") or ""
+        if (
+            comparison_height is None
+            or row.get("comparison_height") != comparison_height
+            or not comparison_hash
+        ):
+            row["settled_role"] = "unavailable"
+        elif not quorum_hash:
+            row["settled_role"] = "candidate"
+        elif comparison_hash == quorum_hash:
+            row["settled_role"] = "quorum"
+        else:
+            row["settled_role"] = "fork"
 
 
 def public_error(network: str, code: str) -> dict:
@@ -2255,6 +2602,53 @@ button { font: inherit; }
   line-height: 1.5;
   overflow-wrap: anywhere;
 }
+.fork-explainer {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 0.79rem;
+  line-height: 1.5;
+}
+.branch-studio {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  padding-left: 28px;
+}
+.branch-studio::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--line-hi);
+}
+.branch-group { position: relative; }
+.branch-group::before {
+  content: '';
+  position: absolute;
+  left: -20px;
+  top: 24px;
+  width: 20px;
+  height: 2px;
+  background: var(--line-hi);
+}
+.branch-group::after {
+  content: '';
+  position: absolute;
+  left: -24px;
+  top: 20px;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--dim);
+  border-radius: 50%;
+  background: var(--surface);
+}
+.branch-group.is-majority::after { border-color: var(--ok); }
+.branch-group.is-fork::after { border-color: var(--bad); }
+.branch-group.is-candidate::after { border-color: var(--warn); }
+.fork-missing { margin-top: 10px; color: var(--warn); font-size: 0.78rem; }
 .subhead {
   display: flex;
   align-items: center;
@@ -2551,7 +2945,7 @@ footer {
     <div class="card-head">
       <div>
         <p class="eyebrow">Fleet health</p>
-        <h2>Nodes reporting</h2>
+        <h2>Sources reporting</h2>
       </div>
       <span class="badge" id="client-mix">...</span>
     </div>
@@ -2580,6 +2974,16 @@ footer {
 
   <section class="stats" data-view="fleet">
     <div class="stat">
+      <span class="label">Settled agreement</span>
+      <div class="stat-value" id="fork-agreement">...</div>
+      <small id="fork-agreement-detail">...</small>
+    </div>
+    <div class="stat">
+      <span class="label">Comparison block</span>
+      <div class="stat-value mono" id="comparison-height">...</div>
+      <small id="comparison-hash">...</small>
+    </div>
+    <div class="stat">
       <span class="label">Tip agreement</span>
       <div class="stat-value" id="tip-agreement">...</div>
       <small id="tip-agreement-detail">...</small>
@@ -2604,26 +3008,31 @@ footer {
   <section class="panel pad" data-view="fleet">
     <div class="section-head">
       <div>
-        <p class="eyebrow">Chain tips</p>
-        <h2>Tip agreement across the fleet</h2>
+        <p class="eyebrow">Fork / uncle studio</p>
+        <h2>Settled chain agreement</h2>
       </div>
-      <p class="section-note" id="chain-summary">Waiting for first poll...</p>
+      <p class="section-note" id="fork-summary">Waiting for first comparison...</p>
     </div>
+    <p class="fork-explainer" id="fork-explainer">The studio compares every source at one shared block height behind the live tips, avoiding alerts for ordinary propagation races.</p>
+    <div class="branch-studio" id="comparison-groups"></div>
+    <div class="fork-missing" id="comparison-missing"></div>
+    <div class="subhead"><p class="eyebrow">Live tip lanes</p></div>
+    <p class="section-note" id="chain-summary">Waiting for first poll...</p>
     <div class="tip-groups" id="tip-groups"></div>
-    <div class="subhead"><p class="eyebrow">Orphan pairs</p></div>
+    <div class="subhead"><p class="eyebrow">Reorg / orphan events</p></div>
     <div class="reorg-list" id="reorg-list"></div>
   </section>
 
   <section class="panel pad" data-view="fleet">
     <div class="section-head">
       <div>
-        <p class="eyebrow">Live node status</p>
-        <h2 id="table-title">Fleet</h2>
+        <p class="eyebrow">Live source status</p>
+        <h2 id="table-title">Sources</h2>
       </div>
       <div class="toolbar">
         <label class="search">
           <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.6-3.6"></path></svg>
-          <input id="filter-input" type="search" placeholder="Filter node, commit, hash, detail" autocomplete="off" spellcheck="false">
+          <input id="filter-input" type="search" placeholder="Filter source, commit, hash, detail" autocomplete="off" spellcheck="false">
         </label>
         <button class="ghost-button" id="issues-toggle" type="button">Issues only</button>
         <button class="ghost-button" id="expand-toggle" type="button">Expand all</button>
@@ -2633,7 +3042,7 @@ footer {
       <table>
         <thead>
           <tr>
-            <th class="col-node sortable" data-sort="name">Node<span class="arrow"></span></th>
+            <th class="col-node sortable" data-sort="name">Source<span class="arrow"></span></th>
             <th class="col-health sortable" data-sort="health">Health<span class="arrow"></span></th>
             <th class="col-chain sortable" data-sort="chain_role">Chain<span class="arrow"></span></th>
             <th class="col-height col-num sortable" data-sort="height">Height<span class="arrow"></span></th>
@@ -2833,9 +3242,13 @@ const HEALTH_TONE = {
   healthy: 'ok', stale: 'warn', rpc_error: 'bad', down: 'bad', starting: 'neutral',
 };
 const CHAIN_TONE = {
-  majority: 'ok', behind: 'warn', ahead: 'warn', fork: 'bad', unknown: 'neutral',
+  majority: 'ok', quorum: 'ok', behind: 'warn', ahead: 'warn', candidate: 'warn',
+  unavailable: 'warn', fork: 'bad', unknown: 'neutral',
 };
 const STATUS_TONE = { agreed: 'ok', lagging: 'warn', split: 'bad', unknown: 'neutral' };
+const FORK_STATUS_TONE = {
+  agreed: 'ok', diverged: 'bad', partial: 'warn', insufficient: 'warn', warming: 'neutral',
+};
 const HEALTH_LABEL = { rpc_error: 'rpc error' };
 function tone(map, value) { return map[value] || 'neutral'; }
 function badge(text, toneName) {
@@ -2849,6 +3262,12 @@ function tipEventLabel(event) {
 }
 function chainStatusLabel(status) {
   return { agreed: 'Agreed', lagging: 'Lagging', split: 'Split' }[status] || 'Unknown';
+}
+function forkStatusLabel(status) {
+  return {
+    agreed: 'Agreed', diverged: 'Fork detected', partial: 'Partial',
+    insufficient: 'Insufficient', warming: 'Warming up',
+  }[status] || 'Unknown';
 }
 
 /* ---------- copy to clipboard ---------- */
@@ -2899,7 +3318,10 @@ function renderHeader(data) {
 
   let label = 'Healthy';
   let toneName = 'ok';
-  if (chain.status === 'split') {
+  if (chain.fork_status === 'diverged') {
+    label = 'Fork detected';
+    toneName = 'bad';
+  } else if (chain.status === 'split') {
     label = 'Tip split';
     toneName = 'bad';
   } else if (data.healthy !== data.total) {
@@ -2937,8 +3359,8 @@ function renderFleet(data) {
   el('healthy-count').textContent = data.healthy + ' / ' + data.total;
   const unhealthy = data.total - data.healthy;
   el('healthy-sub').textContent = unhealthy === 0
-    ? 'every node is active, serving RPC, and advancing'
-    : unhealthy + ' node' + (unhealthy === 1 ? '' : 's') + ' need attention';
+    ? 'every source is serving RPC and advancing'
+    : unhealthy + ' source' + (unhealthy === 1 ? '' : 's') + ' need attention';
 
   const order = ['healthy', 'stale', 'rpc_error', 'down', 'starting'];
   const present = order.filter((key) => counts[key]);
@@ -2990,13 +3412,27 @@ function pickWorst(rows, pick) {
 function renderStats(data) {
   const chain = data.chain || {};
   const status = chain.status || 'unknown';
+  const forkStatus = chain.fork_status || 'warming';
   const tipGroups = chain.tip_groups || [];
   const reorgs = chain.recent_reorgs || [];
+
+  el('fork-agreement').innerHTML = badge(
+    forkStatusLabel(forkStatus), tone(FORK_STATUS_TONE, forkStatus));
+  el('fork-agreement-detail').textContent =
+    (chain.comparison_observed || 0) + ' of ' + (chain.comparison_expected || data.total || 0)
+    + ' sources compared';
+  el('comparison-height').textContent = chain.comparison_height == null
+    ? '—'
+    : num(chain.comparison_height);
+  el('comparison-hash').innerHTML = chain.quorum_hash
+    ? copyCell(chain.quorum_hash, tinyHash(chain.quorum_hash), 'Copy settled quorum hash')
+    : 'no strict quorum';
 
   el('tip-agreement').innerHTML = badge(chainStatusLabel(status), tone(STATUS_TONE, status));
   el('tip-agreement-detail').textContent =
     tipGroups.length + ' tip group' + (tipGroups.length === 1 ? '' : 's')
-    + ' · ' + (chain.observed_tips || 0) + ' node' + (chain.observed_tips === 1 ? '' : 's') + ' observed';
+    + ' · ' + (chain.observed_tips || 0) + ' source'
+    + (chain.observed_tips === 1 ? '' : 's') + ' observed';
 
   el('majority-tip').innerHTML = copyCell(
     chain.majority_hash, shortHash(chain.majority_hash), 'Copy majority tip hash');
@@ -3018,13 +3454,53 @@ function renderStats(data) {
 function renderChain(data) {
   const chain = data.chain || {};
   const status = chain.status || 'unknown';
+  const forkStatus = chain.fork_status || 'warming';
   const tipGroups = chain.tip_groups || [];
+  const comparisonGroups = chain.comparison_groups || [];
   const reorgs = chain.recent_reorgs || [];
 
+  el('fork-summary').textContent = {
+    agreed: 'All configured sources agree at the settled comparison height.',
+    diverged: 'Sources return different block hashes at the same settled height.',
+    partial: 'Available sources agree, but one or more sources could not be compared.',
+    insufficient: 'Fewer than two sources returned a hash at the comparison height.',
+    warming: 'The first poll establishes tip heights; the next poll compares chains.',
+  }[forkStatus] || 'Waiting for settled chain observations.';
+  el('fork-explainer').textContent = chain.comparison_height == null
+    ? 'The studio compares every source at one shared block height behind the live tips, avoiding alerts for ordinary propagation races.'
+    : 'Height ' + num(chain.comparison_height) + ' is ' + num(data.fork_confirmations || 0)
+      + ' block' + ((data.fork_confirmations || 0) === 1 ? '' : 's')
+      + ' behind the slowest healthy source observed on the prior poll.';
+
+  el('comparison-groups').innerHTML = comparisonGroups.length
+    ? comparisonGroups.map((group) => {
+      const role = group.role || 'candidate';
+      const cls = role === 'quorum' ? 'is-majority' : (role === 'fork' ? 'is-fork' : 'is-candidate');
+      const observers = new Set(group.observers || []);
+      const labels = (group.nodes || []).map((name) =>
+        name + (observers.has(name) ? ' (observer)' : ''));
+      return '<div class="tip-group branch-group ' + cls + '">'
+        + '<div class="tip-group-top">'
+        + badge(role, tone(CHAIN_TONE, role))
+        + '<span class="height num">height ' + num(chain.comparison_height) + '</span>'
+        + '<span class="mono muted" style="font-size:0.78rem">'
+        + copyCell(group.block_hash, shortHash(group.block_hash), 'Copy comparison hash') + '</span>'
+        + '</div>'
+        + '<div class="tip-group-count">' + group.count
+        + ' source' + (group.count === 1 ? '' : 's') + '</div>'
+        + '<div class="tip-group-nodes">' + esc(labels.join(', ')) + '</div>'
+        + '</div>';
+    }).join('')
+    : '<div class="empty">No settled hashes observed yet.</div>';
+  const unavailable = chain.unavailable_sources || [];
+  el('comparison-missing').textContent = unavailable.length
+    ? 'Not compared: ' + unavailable.join(', ')
+    : '';
+
   el('chain-summary').textContent = {
-    split: 'Nodes disagree on the tip hash at the leading height.',
-    lagging: 'One tip hash leads; some nodes are behind.',
-    agreed: 'All observed nodes share the same tip.',
+    split: 'Sources disagree on the tip hash at the leading height.',
+    lagging: 'One tip hash leads; some sources are behind.',
+    agreed: 'All observed sources share the same tip.',
   }[status] || 'Waiting for tip observations.';
 
   el('tip-groups').innerHTML = tipGroups.length
@@ -3043,7 +3519,7 @@ function renderChain(data) {
         + depth
         + '</div>'
         + '<div class="tip-group-count">' + group.count
-        + ' node' + (group.count === 1 ? '' : 's') + '</div>'
+        + ' source' + (group.count === 1 ? '' : 's') + '</div>'
         + '<div class="tip-group-nodes">' + esc((group.nodes || []).join(', ')) + '</div>'
         + '</div>';
     }).join('')
@@ -3077,7 +3553,8 @@ function matchesQuery(row, query) {
   if (!query) return true;
   return [
     row.name, row.commit, row.node_id, row.block_hash, row.detail,
-    row.ssh, row.version, row.health, row.chain_role, row.client_name,
+    row.ssh, row.version, row.health, row.chain_role, row.settled_role,
+    row.comparison_hash, row.client_name, row.source_type,
   ].some((value) => String(value || '').toLowerCase().includes(query));
 }
 function sortRows(rows) {
@@ -3160,11 +3637,12 @@ function renderTable(data) {
   const majorityHeight = chain.majority_height;
   const all = data.rows || [];
   const visible = sortRows(all.filter((row) =>
-    (!state.issuesOnly || !row.healthy) && matchesQuery(row, state.query)));
+    (!state.issuesOnly || !row.healthy || row.settled_role === 'fork')
+    && matchesQuery(row, state.query)));
 
   el('table-title').textContent = visible.length === all.length
-    ? all.length + ' nodes'
-    : visible.length + ' of ' + all.length + ' nodes';
+    ? all.length + ' sources'
+    : visible.length + ' of ' + all.length + ' sources';
 
   for (const th of document.querySelectorAll('thead th[data-sort]')) {
     const active = th.dataset.sort === state.sortKey;
@@ -3182,6 +3660,7 @@ function renderTable(data) {
   el('rows').innerHTML = visible.map((row) => {
     const healthTone = tone(HEALTH_TONE, row.health);
     const chainTone = tone(CHAIN_TONE, row.chain_role);
+    const settledTone = tone(CHAIN_TONE, row.settled_role);
     const open = state.expandAll || state.expanded.has(row.name);
     const tipLabel = tipEventLabel(row.tip_event);
     const behind = (majorityHeight != null && row.height != null)
@@ -3190,9 +3669,10 @@ function renderTable(data) {
     const deltaHtml = behind
       ? '<span class="delta">' + (behind > 0 ? '+' : '') + behind + ' vs majority</span>'
       : '';
-    const rowTone = healthTone === 'bad' || chainTone === 'bad'
+    const rowTone = healthTone === 'bad' || chainTone === 'bad' || settledTone === 'bad'
       ? 'row-bad'
-      : (healthTone === 'warn' || chainTone === 'warn' ? 'row-warn' : '');
+      : (healthTone === 'warn' || chainTone === 'warn' || settledTone === 'warn'
+        ? 'row-warn' : '');
     const lag = row.header_lag;
     const lagHtml = lag == null
       ? '<span class="dim">—</span>'
@@ -3202,13 +3682,16 @@ function renderTable(data) {
       + ' data-node="' + esc(row.name) + '">'
       + '<td class="col-node"><div class="node-cell"><span class="twisty">&#9654;</span>'
       + '<div class="stack"><a class="node-link node-name" href="/node/'
-      + encodeURIComponent(row.name) + '" title="Open node detail">' + esc(row.name) + '</a>'
+      + encodeURIComponent(row.name) + '" title="Open source detail">' + esc(row.name) + '</a>'
       + '<span class="node-sub" title="' + esc(row.node_id || '') + '">'
-      + esc(row.node_id ? tinyHash(row.node_id) : 'node id unknown') + '</span></div></div></td>'
+      + esc(row.source_type === 'observer'
+        ? 'external RPC observer'
+        : (row.node_id ? tinyHash(row.node_id) : 'node id unknown')) + '</span></div></div></td>'
       + '<td class="col-health"><div class="stack">'
       + badge(HEALTH_LABEL[row.health] || row.health, healthTone) + vitalBadges(row) + '</div></td>'
       + '<td class="col-chain"><div class="stack">'
-      + badge(row.chain_role || 'unknown', chainTone)
+      + badge(row.settled_role || 'unknown', settledTone)
+      + badge('tip ' + (row.chain_role || 'unknown'), chainTone)
       + (tipLabel ? badge(tipLabel, 'bad') : '') + '</div></td>'
       + '<td class="col-height col-num mono"><div class="stack">'
       + '<span>' + num(row.height) + '</span>' + deltaHtml + '</div></td>'
@@ -3295,7 +3778,7 @@ function renderNodeHeader(data) {
   const network = data.network || 'mainnet';
   const name = row.name || NODE_NAME;
   el('node-network-chip').textContent = network;
-  document.title = name + ' - Zakura ' + network + ' node';
+  document.title = name + ' - Zakura ' + network + ' source';
   el('node-title').textContent = name;
   const polledAge = data.last_poll == null ? null : (Date.now() / 1000) - data.last_poll;
   el('node-subtitle').textContent = [
@@ -3307,9 +3790,12 @@ function renderNodeHeader(data) {
 
   const healthTone = tone(HEALTH_TONE, row.health);
   el('node-badges').innerHTML = badge(HEALTH_LABEL[row.health] || row.health || 'unknown', healthTone)
+    + badge(row.settled_role || 'unknown', tone(CHAIN_TONE, row.settled_role))
     + badge(row.chain_role || 'unknown', tone(CHAIN_TONE, row.chain_role))
-    + badge('service ' + (row.active_state || 'unknown'),
-      row.active_state === 'active' ? 'ok' : 'bad')
+    + (row.source_type === 'observer'
+      ? badge('RPC observer', 'info')
+      : badge('service ' + (row.active_state || 'unknown'),
+        row.active_state === 'active' ? 'ok' : 'bad'))
     + (row.tip_event ? badge(tipEventLabel(row.tip_event) || row.tip_event, 'bad') : '');
 
   const pill = el('state-pill');
@@ -3417,6 +3903,11 @@ function renderNodeChain(data) {
       delta ? 'warn' : null),
     kvRow('Advance rate', rate == null ? '—' : decimal(rate, 1) + ' blocks/min'),
     kvRow('Tip last advanced', age(row.seconds_since_advanced) + ' ago'),
+    kvRow('Settled role', String(row.settled_role || 'unknown'),
+      row.settled_role === 'fork' ? 'bad' : null),
+    kvRow('Comparison height', num(row.comparison_height)),
+    kvRowHtml('Comparison hash', copyCell(
+      row.comparison_hash, shortHash(row.comparison_hash), 'Copy comparison hash')),
     kvRowHtml('Tip hash', copyCell(row.block_hash, shortHash(row.block_hash), 'Copy tip hash')),
     kvRowHtml('Parent hash', copyCell(row.previous_hash, shortHash(row.previous_hash), 'Copy parent hash')),
     kvRow('RPC chain', String(row.rpc_chain || 'unknown')),
@@ -3907,7 +4398,16 @@ def main() -> None:
         default=None,
         help="seconds between metric scrapes; omit to adapt to the last scrape's cost",
     )
+    parser.add_argument(
+        "--fork-confirmations",
+        type=int,
+        default=DEFAULT_FORK_CONFIRMATIONS,
+        help="compare source hashes this many blocks behind the slowest healthy tip",
+    )
     args = parser.parse_args()
+
+    if args.fork_confirmations < 0:
+        parser.error("--fork-confirmations must be non-negative")
 
     nodes = load_nodes(Path(args.config))
     state_file = Path(args.state_file) if args.state_file else None
@@ -3920,6 +4420,7 @@ def main() -> None:
         history_window=args.history_window,
         expose_logs=args.expose_logs,
         metrics_min_interval=args.metrics_min_interval,
+        fork_confirmations=args.fork_confirmations,
     )
     threading.Thread(target=COLLECTOR.loop, daemon=True).start()
 

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -2,7 +2,8 @@
 """Slack watchdog for Zakura fleet status dashboards.
 
 Polls one or more `zakura-cluster-status.py` `/data` endpoints, tracks sustained
-node failures in a small JSON state file, and posts transition alerts to Slack.
+node failures and settled chain forks in a small JSON state file, and posts
+transition plus deep reorg/orphan alerts to Slack.
 
 Only the Python stdlib is used.
 """
@@ -10,6 +11,7 @@ Only the Python stdlib is used.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -35,6 +37,9 @@ MAX_BLOCK_HASH_CHARS = 64
 MAX_DASHBOARD_URL_CHARS = 2_048
 MAX_ALERT_ERROR_CHARS = 2_048
 MAX_SLACK_MESSAGE_CHARS = 35_000
+MAX_FORK_GROUPS = 32
+MAX_FORK_SOURCES = 128
+MAX_REORG_EVENTS = 512
 SLACK_ESSENTIAL_PREFIX_LINES = 3
 SLACK_TRUNCATION_MARKER = "[alert truncated]"
 SLACK_PLAIN_TEXT_TRANSLATION = str.maketrans(
@@ -114,6 +119,25 @@ class NodeObservation:
     threshold: float
     height: int | None
     block_hash: str
+
+
+@dataclass(frozen=True)
+class ForkGroup:
+    block_hash: str
+    source_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ForkObservation:
+    status: str
+    height: int | None
+    observed: int
+    expected: int
+    groups: tuple[ForkGroup, ...]
+
+    @property
+    def partition(self) -> tuple[tuple[str, ...], ...]:
+        return tuple(sorted(group.source_names for group in self.groups))
 
 
 @dataclass(frozen=True)
@@ -209,6 +233,8 @@ def load_state(state_path: Path) -> dict[str, Any]:
             "nodes": {},
             "fleets": {},
             "shared_stalls": {},
+            "forks": {},
+            "reorg_events": {},
         }
 
     with state_path.open(encoding="utf-8") as state_file:
@@ -220,12 +246,16 @@ def load_state(state_path: Path) -> dict[str, Any]:
             "nodes": {},
             "fleets": {},
             "shared_stalls": {},
+            "forks": {},
+            "reorg_events": {},
         }
 
     state.setdefault("nodes", {})
     state.setdefault("fleets", {})
     state.setdefault("shared_stalls", {})
     state.setdefault("release_state", {})
+    state.setdefault("forks", {})
+    state.setdefault("reorg_events", {})
     return state
 
 
@@ -891,6 +921,184 @@ def validated_fleet_rows(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
     return rows
 
 
+def settled_fork_observation(
+    snapshot: dict[str, Any], rows: list[dict[str, Any]]
+) -> ForkObservation | None:
+    """Validate and independently classify the dashboard's settled hash groups."""
+    chain = snapshot.get("chain")
+    if not isinstance(chain, dict) or "comparison_groups" not in chain:
+        # Rolling-upgrade compatibility with dashboards that predate fork probes.
+        return None
+
+    raw_groups = chain.get("comparison_groups")
+    if not isinstance(raw_groups, list) or len(raw_groups) > MAX_FORK_GROUPS:
+        raise ValueError("dashboard comparison_groups is invalid")
+
+    groups = []
+    seen_sources = set()
+    seen_hashes = set()
+    for raw_group in raw_groups:
+        if not isinstance(raw_group, dict):
+            raise ValueError("dashboard comparison group is not an object")
+        block_hash = validated_block_hash(raw_group.get("block_hash"))
+        names = raw_group.get("nodes")
+        if (
+            block_hash is None
+            or len(block_hash) != MAX_BLOCK_HASH_CHARS
+            or not isinstance(names, list)
+            or not names
+        ):
+            raise ValueError("dashboard comparison group has invalid hash or sources")
+        if len(names) > MAX_FORK_SOURCES:
+            raise ValueError("dashboard comparison group has too many sources")
+        normalized_names = []
+        for name in names:
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("dashboard comparison group has an invalid source")
+            normalized = name.strip()
+            if normalized in seen_sources:
+                raise ValueError("dashboard comparison source appears in multiple groups")
+            seen_sources.add(normalized)
+            normalized_names.append(normalized)
+        if block_hash in seen_hashes:
+            raise ValueError("dashboard comparison hash appears in multiple groups")
+        seen_hashes.add(block_hash)
+        groups.append(ForkGroup(block_hash, tuple(sorted(normalized_names))))
+
+    groups.sort(key=lambda group: (-len(group.source_names), group.block_hash))
+    observed = sum(len(group.source_names) for group in groups)
+    expected = coerce_height(chain.get("comparison_expected"))
+    configured_sources = {
+        str(row.get("name") or "").strip()
+        for row in rows
+    }
+    if (
+        expected is None
+        or expected != len(configured_sources)
+        or expected < observed
+        or expected > MAX_FORK_SOURCES
+    ):
+        raise ValueError("dashboard comparison_expected is invalid")
+    if not seen_sources.issubset(configured_sources):
+        raise ValueError("dashboard comparison group contains an unknown source")
+    reported_observed = coerce_height(chain.get("comparison_observed"))
+    if reported_observed != observed:
+        raise ValueError("dashboard comparison_observed does not match its groups")
+
+    height = coerce_height(chain.get("comparison_height"))
+    if groups and height is None:
+        raise ValueError("dashboard comparison groups have no valid height")
+
+    if len(groups) > 1:
+        status = "diverged"
+    elif observed < 2:
+        status = "insufficient"
+    elif observed < expected:
+        status = "partial"
+    else:
+        status = "agreed"
+    return ForkObservation(status, height, observed, expected, tuple(groups))
+
+
+def snapshot_reorg_events(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    chain = snapshot.get("chain")
+    if not isinstance(chain, dict):
+        return []
+    events = chain.get("recent_reorgs", [])
+    if not isinstance(events, list) or any(
+        not isinstance(event, dict) for event in events
+    ):
+        raise ValueError("dashboard recent_reorgs is invalid")
+    return events
+
+
+def fork_quorum_group(observation: ForkObservation) -> ForkGroup | None:
+    if not observation.groups:
+        return None
+    candidate = observation.groups[0]
+    return (
+        candidate
+        if len(candidate.source_names) > observation.expected / 2
+        else None
+    )
+
+
+def fork_alert_text(
+    fleet: Fleet,
+    observation: ForkObservation,
+    age: float,
+) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    height = observation.height if observation.height is not None else "-"
+    quorum = fork_quorum_group(observation)
+    lines = [
+        f":rotating_light: *Zakura {fleet_name} fork detected* for "
+        f"{format_duration(age)}",
+        f"settled height: {height} - {len(observation.groups)} competing branches - "
+        f"{observation.observed}/{observation.expected} sources compared",
+    ]
+    for group in observation.groups:
+        if quorum is None:
+            role = "candidate"
+        elif group == quorum:
+            role = "quorum"
+        else:
+            role = "fork"
+        names = ", ".join(
+            slack_identity(name, MAX_ALERT_NAME_CHARS, "unknown")
+            for name in group.source_names
+        )
+        lines.append(
+            f"- {role} ({len(group.source_names)}): {names} - "
+            f"{slack_block_hash(group.block_hash)}"
+        )
+    lines.append(f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}")
+    return "\n".join(lines)
+
+
+def fork_recovery_text(fleet: Fleet, observation: ForkObservation) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    height = observation.height if observation.height is not None else "-"
+    block_hash = observation.groups[0].block_hash if observation.groups else ""
+    return (
+        f":white_check_mark: *Zakura {fleet_name} fork cleared*\n"
+        f"all {observation.observed} sources agree at settled height {height}\n"
+        f"block hash: {slack_block_hash(block_hash)}\n"
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
+    )
+
+
+def reorg_event_id(event: dict[str, Any]) -> str:
+    identity = [
+        event.get("kind"),
+        event.get("from_height"),
+        normalized_block_hash(event.get("from_hash") or event.get("discarded_hash")),
+        event.get("to_height"),
+        normalized_block_hash(event.get("to_hash") or event.get("canonical_hash")),
+    ]
+    return hashlib.sha256(
+        json.dumps(identity, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def reorg_alert_text(fleet: Fleet, event: dict[str, Any]) -> str:
+    fleet_name = slack_identity(fleet.name, MAX_ALERT_NAME_CHARS, "unknown")
+    source = slack_identity(event.get("node"), MAX_ALERT_NAME_CHARS, "unknown")
+    kind = slack_identity(event.get("kind"), MAX_ALERT_STATUS_CHARS, "reorg")
+    depth = coerce_height(event.get("depth"))
+    from_height = coerce_height(event.get("from_height"))
+    to_height = coerce_height(event.get("to_height"))
+    return (
+        f":warning: *Zakura {fleet_name} deep reorg / orphan event*\n"
+        f"source: {source} - kind: {kind} - depth: {depth if depth is not None else '-'}\n"
+        f"height: {from_height if from_height is not None else '-'} -> "
+        f"{to_height if to_height is not None else '-'}\n"
+        f"discarded: {slack_block_hash(event.get('from_hash') or event.get('discarded_hash'))}\n"
+        f"adopted: {slack_block_hash(event.get('to_hash') or event.get('canonical_hash'))}\n"
+        f"dashboard: {slack_dashboard_url(fleet.dashboard_url)}"
+    )
+
+
 def snapshot_last_poll(snapshot: dict[str, Any]) -> float | None:
     if "last_poll" not in snapshot:
         # Dashboards deployed before the atomic diagnostic payload omitted this
@@ -996,6 +1204,8 @@ class Watchdog:
                 snapshot = fetch_json(fleet.url, self.args.request_timeout)
                 node_rows = validated_fleet_rows(snapshot)
                 last_poll = snapshot_last_poll(snapshot)
+                fork_observation = settled_fork_observation(snapshot, node_rows)
+                reorg_events = snapshot_reorg_events(snapshot)
             except Exception as error:
                 self.handle_fleet_error(state, fleet, error, now, suppressed)
                 continue
@@ -1021,6 +1231,13 @@ class Watchdog:
 
             if not self.handle_fleet_recovered(state, fleet, now):
                 continue
+            if fork_observation is not None:
+                self.handle_fork_observation(
+                    state, fleet, fork_observation, now, suppressed
+                )
+            self.handle_reorg_events(
+                state, fleet, reorg_events, now, suppressed
+            )
             grace_since = max(
                 self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
             )
@@ -1061,6 +1278,135 @@ class Watchdog:
 
         for target in self.release_state:
             self.handle_release_state(state, target, now, suppressed)
+
+    def handle_fork_observation(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        observation: ForkObservation,
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        bucket = state.setdefault("forks", {})
+        previous = dict(bucket.get(fleet.name, {}))
+
+        if observation.status == "diverged":
+            partition = [list(names) for names in observation.partition]
+            continuously_diverged = previous.get("condition") == "diverged"
+            previous_bad_since = coerce_float(previous.get("bad_since"))
+            bad_since = (
+                previous_bad_since
+                if continuously_diverged and previous_bad_since is not None
+                else now
+            )
+            alerting = bool(previous.get("alerting"))
+            # Once Slack owns an incident, keep it open across membership changes
+            # until a complete settled comparison proves convergence.
+            if alerting and previous_bad_since is not None:
+                bad_since = previous_bad_since
+            age = now - bad_since
+            next_entry = {
+                "condition": "diverged",
+                "partition": partition,
+                "bad_since": bad_since,
+                "alerting": alerting,
+                "event_height": observation.height,
+                "last_seen": now,
+            }
+            if alerting and "last_alert_at" in previous:
+                next_entry["last_alert_at"] = previous["last_alert_at"]
+            if not alerting and age >= self.args.fork_after:
+                if suppressed:
+                    if not previous.get("suppression_logged"):
+                        print(
+                            f"suppressed alert for {fleet.name}: fork for "
+                            f"{format_duration(age)}"
+                        )
+                    next_entry["suppression_logged"] = True
+                elif post_slack(
+                    fork_alert_text(fleet, observation, age), self.args
+                ):
+                    next_entry["alerting"] = True
+                    next_entry["last_alert_at"] = now
+            bucket[fleet.name] = next_entry
+            return
+
+        if observation.status == "agreed":
+            if previous.get("alerting"):
+                if post_slack(
+                    fork_recovery_text(fleet, observation), self.args
+                ):
+                    bucket[fleet.name] = {
+                        "condition": "ok",
+                        "alerting": False,
+                    }
+                return
+            bucket[fleet.name] = {"condition": "ok", "alerting": False}
+            return
+
+        if previous.get("alerting"):
+            # Missing sources are not proof that the fork healed. The separate
+            # source health path will alert if the blind spot persists.
+            previous["last_seen"] = now
+            previous["inconclusive"] = observation.status
+            bucket[fleet.name] = previous
+        else:
+            bucket[fleet.name] = {
+                "condition": observation.status,
+                "alerting": False,
+                "last_seen": now,
+            }
+
+    def handle_reorg_events(
+        self,
+        state: dict[str, Any],
+        fleet: Fleet,
+        events: list[dict[str, Any]],
+        now: float,
+        suppressed: bool,
+    ) -> None:
+        bucket = state.setdefault("reorg_events", {})
+        entry = bucket.setdefault(fleet.name, {"seen": {}})
+        seen = entry.get("seen")
+        if not isinstance(seen, dict):
+            seen = {}
+
+        retention = max(86_400.0, self.args.reorg_lookback * 10)
+        seen = {
+            key: timestamp
+            for key, timestamp in seen.items()
+            if (value := coerce_float(timestamp)) is not None
+            if now - value <= retention
+        }
+        for event in sorted(
+            events,
+            key=lambda candidate: coerce_float(candidate.get("at")) or 0,
+        ):
+            identity = reorg_event_id(event)
+            if identity in seen:
+                continue
+            observed_at = coerce_float(event.get("at"))
+            depth = coerce_height(event.get("depth"))
+            if (
+                observed_at is None
+                or observed_at > now + 300
+                or now - observed_at > self.args.reorg_lookback
+                or depth is None
+                or depth < self.args.reorg_depth
+                or bool(event.get("demo"))
+            ):
+                seen[identity] = observed_at if observed_at is not None else now
+                continue
+            if suppressed or post_slack(reorg_alert_text(fleet, event), self.args):
+                seen[identity] = observed_at
+
+        if len(seen) > MAX_REORG_EVENTS:
+            seen = dict(
+                sorted(seen.items(), key=lambda item: item[1], reverse=True)[
+                    :MAX_REORG_EVENTS
+                ]
+            )
+        entry["seen"] = seen
 
     def handle_release_state(
         self,
@@ -1603,6 +1949,24 @@ def parse_args() -> argparse.Namespace:
         help="alert after a dashboard fetch failure persists this many seconds",
     )
     parser.add_argument(
+        "--fork-after",
+        type=float,
+        default=180.0,
+        help="alert after settled chain divergence persists this many seconds",
+    )
+    parser.add_argument(
+        "--reorg-depth",
+        type=int,
+        default=2,
+        help="alert immediately for new reorg/orphan events at least this deep",
+    )
+    parser.add_argument(
+        "--reorg-lookback",
+        type=float,
+        default=600.0,
+        help="maximum age of a reorg/orphan event eligible for a new alert",
+    )
+    parser.add_argument(
         "--starting-grace",
         type=float,
         default=120.0,
@@ -1628,7 +1992,14 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--once", action="store_true", help="poll once, update state, and exit")
     parser.add_argument("--dry-run", action="store_true", help="log Slack messages instead")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.fork_after < 0:
+        parser.error("--fork-after must be non-negative")
+    if args.reorg_depth < 1:
+        parser.error("--reorg-depth must be at least 1")
+    if args.reorg_lookback < 0:
+        parser.error("--reorg-lookback must be non-negative")
+    return args
 
 
 def main() -> int:

--- a/deploy/runner/zakura-fleet-watchdog.service
+++ b/deploy/runner/zakura-fleet-watchdog.service
@@ -9,7 +9,7 @@ WorkingDirectory=/opt/zakura-fleet-watchdog
 EnvironmentFile=-/etc/zakura-fleet-watchdog/env
 StateDirectory=zakura-fleet-watchdog
 RuntimeDirectory=zakura-fleet-watchdog
-ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zakura-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --shared-stalled-after 1800 --dashboard-down-after 600
+ExecStart=/usr/bin/python3 /opt/zakura-fleet-watchdog/zakura-cluster-watchdog.py --config /opt/zakura-fleet-watchdog/fleets.toml --state-file /var/lib/zakura-fleet-watchdog/state.json --interval 60 --down-after 600 --stalled-after 600 --shared-stalled-after 1800 --dashboard-down-after 600 --fork-after 180 --reorg-depth 2 --reorg-lookback 600
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Before, the fleet dashboard could show node health while an advancing miner remained on a competing chain without an automated signal.

After, the mainnet and testnet dashboards compare independent sources at a settled height, show the current and historical branches block by block, and label each block from coinbase evidence as ZA, ZE, or unknown. Sustained forks and depth-2 or greater reorgs alert #zakura-alerts, and deployment now fails if no Slack webhook is available.
