### PR TITLE
fix(continuous-sync): require stopped service before wipe

### DIFF
--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -412,7 +412,11 @@ def start_service(config: Config) -> None:
 
 
 def stop_service(config: Config) -> None:
-    run(["systemctl", "stop", config.policy.service_name], check=False)
+    run(["systemctl", "stop", config.policy.service_name])
+    if service_active(config):
+        raise ControllerError(
+            f"service remained active after stop: {config.policy.service_name}"
+        )
 
 
 def service_active(config: Config) -> bool:

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -147,6 +147,27 @@ class ContinuousSyncTests(unittest.TestCase):
             self.assertTrue((network / "marker").exists())
         os.environ.pop("ZAKURA_CONTINUOUS_SYNC_TESTING", None)
 
+    def test_stop_service_requires_a_completed_stop(self):
+        config = make_config(Path.cwd())
+
+        with (
+            patch.object(sync, "run") as run,
+            patch.object(sync, "service_active", return_value=False),
+        ):
+            sync.stop_service(config)
+
+        run.assert_called_once_with(["systemctl", "stop", config.policy.service_name])
+
+    def test_stop_service_rejects_an_active_service(self):
+        config = make_config(Path.cwd())
+
+        with (
+            patch.object(sync, "run"),
+            patch.object(sync, "service_active", return_value=True),
+            self.assertRaisesRegex(sync.ControllerError, "service remained active after stop"),
+        ):
+            sync.stop_service(config)
+
     def test_cleanup_retention_keeps_active_and_two_newest_runs(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)


### PR DESCRIPTION
## Motivation

Continuous sync test 1 failed while removing its mainnet state directory. Two overlapping controller deployments canceled a systemd stop job. The controller ignored that failure, and a node process reopened the state directory while the controller removed it.

## Solution

Require systemd to complete each stop command. Refuse to continue when the service remains active. These checks prevent the controller from wiping state after a canceled or incomplete stop.

## Testing

- `python3 -m unittest deploy/continuous-sync/tests/test_continuous_sync.py` (51 passed)
- `git diff --check`

The new tests verify that stop failures propagate and that an active service blocks the wipe sequence.

## Changelog

No changelog fragment is required because this PR changes only deployment code.

### Specifications & References

- Continuous sync test 1 incident on 2026-09-02 at 06:26 UTC.

### Follow-up Work

- Redeploy the controller and resume test 1 after review.