### PR TITLE
fix(sync): retry timed-out parked-block refreshes

### DIFF
--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -1681,10 +1681,7 @@ where
 
                         let refreshed =
                             timeout(SYNC_RESTART_DELAY, self.obtain_tips(checkpoint_bootstrap))
-                                .await
-                                .map_err(Into::into)
-                                // TODO: replace with flatten() when it stabilises (#70142)
-                                .and_then(convert::identity)?;
+                                .await;
 
                         // A refresh is not progress, even when it returns hashes.
                         //
@@ -1696,7 +1693,16 @@ where
                         // would refresh every `TIP_REFRESH_INTERVAL` instead of restarting the round
                         // and re-downloading. Only a completed block or a finished extension counts,
                         // which is what the arms below record.
-                        reserve.extend(refreshed);
+                        match refreshed {
+                            Ok(Ok(hashes)) => reserve.extend(hashes),
+                            Ok(Err(error)) => info!(
+                                ?error,
+                                "tip refresh failed while blocks remain in flight; retrying"
+                            ),
+                            Err(_) => info!(
+                                "tip refresh timed out while blocks remain in flight; retrying"
+                            ),
+                        }
                         self.update_metrics();
                     }
                 }

--- a/crates/zakurad/src/components/sync.rs
+++ b/crates/zakurad/src/components/sync.rs
@@ -1694,11 +1694,7 @@ where
                         // and re-downloading. Only a completed block or a finished extension counts,
                         // which is what the arms below record.
                         match refreshed {
-                            Ok(Ok(hashes)) => reserve.extend(hashes),
-                            Ok(Err(error)) => info!(
-                                ?error,
-                                "tip refresh failed while blocks remain in flight; retrying"
-                            ),
+                            Ok(hashes) => reserve.extend(hashes?),
                             Err(_) => info!(
                                 "tip refresh timed out while blocks remain in flight; retrying"
                             ),

--- a/crates/zakurad/src/components/sync/tests/vectors.rs
+++ b/crates/zakurad/src/components/sync/tests/vectors.rs
@@ -699,7 +699,7 @@ async fn sync_singleton_extend_tips_ok() -> Result<(), crate::BoxError> {
 /// Time is paused, so a syncer that instead waits out [`sync::BLOCK_VERIFY_TIMEOUT`] and restarts
 /// fails here in milliseconds of wall-clock time.
 #[tokio::test(start_paused = true)]
-async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
+async fn incomplete_checkpoint_range_retries_refresh_timeout_without_verifier_timeout(
 ) -> Result<(), crate::BoxError> {
     let (
         chain_sync,
@@ -826,17 +826,19 @@ async fn incomplete_checkpoint_range_refreshes_tips_without_verifier_timeout(
     );
 
     // Nothing is left to discover, but blocks 1-3 are parked in the verifier and can only be
-    // verified once the rest of the range arrives. The syncer must run a fresh fanout to find it,
-    // rather than waiting for its in-flight downloads to drain: that wait cannot terminate.
+    // verified once the rest of the range arrives. The first refresh stalls while obtaining the
+    // state locator. The syncer must preserve the parked blocks and retry the refresh.
     let refresh_requested_at = tokio::time::Instant::now();
+    let _stalled_refresh = state_service
+        .expect_request(zs::Request::BlockLocator)
+        .await;
     let refreshed_locator = tokio::time::timeout(
         sync::BLOCK_VERIFY_TIMEOUT,
         state_service.expect_request(zs::Request::BlockLocator),
     )
     .await
     .expect(
-        "syncer must discover the rest of the checkpoint range while its blocks are parked in the \
-         verifier: waiting out BLOCK_VERIFY_TIMEOUT and restarting discards the partial range",
+        "syncer must retry a timed-out tip refresh while its blocks are parked in the verifier",
     );
 
     // The chain has grown to block 5, so the refreshed fanout covers the rest of the range. Blocks

--- a/docs/changelog/unreleased/884.md
+++ b/docs/changelog/unreleased/884.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Legacy synchronization now preserves checkpoint work across temporary tip refresh timeouts
+  ([#884](https://github.com/zakura-core/zakura/pull/884)).


### PR DESCRIPTION
## Motivation

Continuous sync test 5 repeatedly downloaded the same partial checkpoint range. The verifier parked those blocks until the range completed. A 45-second tip refresh timeout then ended the sync round and canceled every parked block.

PR #137 added tip refreshes for partial checkpoint ranges. Closed PR #141 explored preserving the checked frontier after empty extensions. Neither change preserved a live sync round when the refresh itself timed out.

## Solution

Keep the sync round alive after a tip refresh timeout. Retry discovery while the existing verifier work remains parked. Preserve the existing verifier timeout as the final bound for a genuinely stalled round. Propagate state-service and other refresh errors so they still restart the sync round.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p zakura --lib -- -D warnings`
- `cargo test -p zakura --lib components::sync::tests::vectors::` (48 passed)
- `cargo test -p zakura --lib incomplete_checkpoint_range_retries_refresh_timeout_without_verifier_timeout`
- `./scripts/changelog.py check`
- `git diff --check`

The regression test parks a partial checkpoint range, stalls the first refresh for the production 45-second timeout, and verifies that the next refresh completes the range before the verifier timeout.

## Changelog

Added `docs/changelog/unreleased/884.md`.

### Specifications & References

- Continuous sync test 5 incident on 2026-09-03 at height 3,453,371.
- Prior fixes: #137 and closed draft #141.

### Follow-up Work

- Deploy this branch to continuous sync test 5 after review and confirm that later refresh attempts complete the parked checkpoint range.
