### PR TITLE
build(deps): bump Zakura Common crates to 1.1.0 and cascade the header-chain 2.0.0 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "blake2b_simd",
  "chrono",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bitflags",
  "blake2b_simd",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "jsonrpsee-types",
  "reqwest 0.12.28",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "7.1.0"
+version = "7.1.1"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,9 +7696,9 @@ checksum = "cdad84f915d23f50eeb7389fd1ffc2385b35c57c68ceb2df20c73b7724621a30"
 
 [[package]]
 name = "zakura-bellman"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c72c84165959b2578cbf8800ff491e74d819397b53658bbf1b2b170b3ee9fc"
+checksum = "1a6b7239d41621cc0c39349882001442d49bbc8dc46390c4826feb85a55a8d47"
 dependencies = [
  "bitvec",
  "blake2s_simd",
@@ -7713,9 +7713,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-bls12-381"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9c833a85b5ba3303a5f14ed760d613bee8a9769923da5a1e7f51851849e7f5"
+checksum = "1d2c114620056f8c97ecc17d7333add6c818ff376434943c7ff4974320426887"
 dependencies = [
  "ff",
  "group",
@@ -7844,9 +7844,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-gadgets"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c601160505e513507664516f16a38b8e875a31b48155a93964b6e97c1e07d315"
+checksum = "af79f971003d67f4a198985469834c083f37354d604bf93f892c9c9f5a129ae0"
 dependencies = [
  "arrayvec",
  "ff",
@@ -7860,15 +7860,15 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-legacy-pdqsort"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2ecc4b9f643499164caceb5fe3339d1cdd9088dac084dd14314d6f6a75b0e"
+checksum = "2c91d2f5fd4fc95a9c42d43744fa9512b2d7d996ea454f3b21faac6fb36a9806"
 
 [[package]]
 name = "zakura-halo2-poseidon"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ec02070913e40067ae2df9aab21139a55b239f289140d116af5d5e25e5240"
+checksum = "cdac6fc73528451edc4ee8cff55946ff2c75359c47937eb42e6d31b83b542d39"
 dependencies = [
  "bitvec",
  "ff",
@@ -7878,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-proofs"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c39132f1dae675ef4105321da11dee1d70c2b07bbc7d78a31c4044ed381fd74"
+checksum = "5875a590a7d9175fdb47286ca0e5073a1e9ee78775b70ca4309353cf19a6b6ed"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7922,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-jubjub"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b10077e35b311a780366567771c4730245a4df7bd23b1f3414444b0e5c3a9cd"
+checksum = "d9915c2c7f2c021379453608c91548f2811d1ba59b7e8505bb8ba32f51e494db"
 dependencies = [
  "bitvec",
  "ff",
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-keys"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac02340ce2b8eecc13047a936efe6545cc6de3761e2eda11eb5ab30cde8a6bed"
+checksum = "df47ed252741a6fcefc2b92aa773034c602eca361c5f974ffbb4f67a49fe2c78"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -8021,9 +8021,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-orchard"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f40234883ea702da695f1cbf470a0ba3b9fe0ac51d24af588a058afc383d68"
+checksum = "fd7edaa754f9bafb4965559e38af6d337eb001f76de666fe20e510fb8e1cf631"
 dependencies = [
  "aes",
  "bitvec",
@@ -8035,6 +8035,7 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
+ "maybe-rayon",
  "memuse",
  "nonempty",
  "once_cell",
@@ -8057,18 +8058,18 @@ dependencies = [
 
 [[package]]
 name = "zakura-pairing"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d3f4e77bb286c0f1770c90e721edcd99bd493acce6199734fa1eaeb4037f12"
+checksum = "59445f1cb78bef29da023f8ecdba607ed00f2df51c245e1d50964af2a3e7b800"
 dependencies = [
  "group",
 ]
 
 [[package]]
 name = "zakura-pasta-curves"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c906d3541e9e6b71aaa77af25c229a0c1ed38df58930fa75f2fd569632989dd"
+checksum = "e878bab2110a70ed4496e377b4b3f3039d6a227c5d79e171b316f334857531b9"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -8083,9 +8084,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-primitives"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268f6d451f4870f763b5ba51e5f84fd2843d86b103cc01b8fbf9cae84115c36c"
+checksum = "799de508ecd41846dd0dfd06490e30ec6ee918008ceba19155e09f2545f3df73"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8114,9 +8115,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-proofs"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce73755c38fa3d0de97d420d547855b0111083b0f1270ab7d4e53896cb16a7c"
+checksum = "506fc870df35b86053fa50a24f3f02c50189a3a609c62478bbd1b7c94943d188"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8134,9 +8135,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-reddsa"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecd8e46ef79bd3675733cee6741c432ccd259b9e060e4838d2cc311a654744f"
+checksum = "3391ff6c3e6222f5176c046e1d3645748be5b211880747e279d0f17860d51526"
 dependencies = [
  "blake2b_simd",
  "frost-rerandomized",
@@ -8152,9 +8153,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-redjubjub"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa0ca5f5747caad4527ee92ad538271e7124949bc799cdc30b09c631b447fe"
+checksum = "174ffd325c22f5dbb4c4dfe6f825bd82c3ca88a91bbe603b5cdf0dd7590d0a9c"
 dependencies = [
  "rand_core 0.10.1",
  "serde",
@@ -8234,9 +8235,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sapling-crypto"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcd5a8073598e33ffaa2694ca59d7c522a60dd349a3d74d239e6eb929733107"
+checksum = "eadf81594078e0e18f6c1744d978a9ee418fce988c293567131bc4870247ee85"
 dependencies = [
  "aes",
  "bitvec",
@@ -8286,9 +8287,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sinsemilla"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043da1b236d2b976b2046112811dc1be3f734c566a6edb1a0a52b5379231e212"
+checksum = "582ec66fe58b717034b8f5c8b54834d93abd515fc20a0ce2ab769d522432b8ca"
 dependencies = [
  "group",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,26 +49,26 @@ edition = "2021"
 # gate refers to `zakura-assets` and nothing else.
 zakura-assets = { version = "=0.3466571.0" }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = { version = "1.0.1", package = "zakura-orchard" }
-sapling-crypto = { version = "1.0.1", package = "zakura-sapling-crypto" }
+orchard = { version = "1.1.0", package = "zakura-orchard" }
+sapling-crypto = { version = "1.1.0", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
 zcash_history = "0.5.0"
-zcash_keys = { version = "1.0.1", package = "zakura-keys" }
-zcash_primitives = { version = "1.0.1", package = "zakura-primitives" }
-zcash_proofs = { version = "1.0.1", package = "zakura-proofs" }
+zcash_keys = { version = "1.1.0", package = "zakura-keys" }
+zcash_primitives = { version = "1.1.0", package = "zakura-primitives" }
+zcash_proofs = { version = "1.1.0", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
 abscissa_core = { version = "0.7", default-features = false }
 base64 = "0.22.1"
 bech32 = "0.11.0"
-bellman = { version = "1.0.1", package = "zakura-bellman" }
+bellman = { version = "1.1.0", package = "zakura-bellman" }
 bincode = "1.3"
 bitflags = "2.9"
 bitflags-serde-legacy = "0.1.1"
 bitvec = "1.0"
 blake2b_simd = "1.0"
 blake2s_simd = "1.0"
-bls12_381 = { version = "1.0.1", package = "zakura-bls12-381" }
+bls12_381 = { version = "1.1.0", package = "zakura-bls12-381" }
 bs58 = "0.5"
 byteorder = "1.5"
 bytes = "1.10"
@@ -87,7 +87,7 @@ futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 group = "0.14"
-halo2 = { version = "1.0.1", package = "zakura-halo2-proofs" }
+halo2 = { version = "1.1.0", package = "zakura-halo2-proofs" }
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -106,7 +106,7 @@ itertools = "0.14"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
-jubjub = { version = "1.0.1", package = "zakura-jubjub" }
+jubjub = { version = "1.1.0", package = "zakura-jubjub" }
 lazy_static = "1.4"
 libzcash_script = "0.1"
 log = "0.4.27"
@@ -129,8 +129,8 @@ rand_10 = { package = "rand", version = "0.10" }
 rand_chacha_10 = { package = "rand_chacha", version = "0.10" }
 rand_core_10 = { package = "rand_core", version = "0.10" }
 rayon = "1.10"
-reddsa = { version = "1.0.1", package = "zakura-reddsa" }
-redjubjub = { version = "1.0.1", package = "zakura-redjubjub" }
+reddsa = { version = "1.1.0", package = "zakura-reddsa" }
+redjubjub = { version = "1.1.0", package = "zakura-redjubjub" }
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false }
 ripemd = "0.1"
@@ -145,7 +145,7 @@ serde_json = "1.0.140"
 serde_with = "3.12"
 sha2 = "0.10"
 schemars = "1"
-sinsemilla = { version = "1.0.1", package = "zakura-sinsemilla" }
+sinsemilla = { version = "1.1.0", package = "zakura-sinsemilla" }
 spandoc = "0.2"
 anyhow = "1.0"
 strum = "0.27"

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "3.2.1"
+version = "3.2.2"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "7.1.0"
+version = "7.1.1"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/docs/changelog/unreleased/885.md
+++ b/docs/changelog/unreleased/885.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Updated the Zakura Common (`zakura-core/common`) crates from `1.0.1` to
+  `1.1.0`
+  ([#885](https://github.com/zakura-core/zakura/pull/885)).

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -392,87 +392,87 @@ version = "0.52.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zakura-bellman]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-bls12-381]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-gadgets]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-legacy-pdqsort]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-poseidon]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-proofs]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-jubjub]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-keys]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-orchard]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pairing]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pasta-curves]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-primitives]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-proofs]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-reddsa]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-redjubjub]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sapling-crypto]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sinsemilla]]
-version = "1.0.1"
+version = "1.1.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 


### PR DESCRIPTION
## Motivation

The Zakura Common libraries (`zakura-core/common`) released `v1.1.0`, a coordinated minor release of all 17 `zakura-*` crates. Zakura still pins the `1.0.1` release.

## Solution

- Bumps the 12 direct `zakura-*` workspace dependencies in `Cargo.toml` from `1.0.1` to `1.1.0`.
- Moves the 17 exact-version cargo-vet exemptions in `qa/supply-chain/config.toml` in lockstep, matching the approach of #844.
- Patch-bumps the four published crates whose crates.io manifests still require `zakura-header-chain ^1.0.0` after #847 moved it to `2.0.0`: `zakura-consensus` 7.0.0 → 7.0.1, `zakura-node-services` 3.2.1 → 3.2.2, `zakura-state` 7.1.0 → 7.1.1, `zakura-network` 7.0.0 → 7.0.1. Without this, a packaged `zakura-rpc 9.0.0` resolves `zakura-header-chain 1.1.0` from the index next to the workspace's `2.0.0`, and the `crates.io publish graph` job fails (it fails on `main` at 321d7c95f the same way). Bumped with `cargo release version patch`; `dependent-version = "fix"` left every dependent requirement untouched because the existing caret requirements already match the new patch versions.
- `cargo update` moved exactly the 17 `zakura-*` packages; no other lockfile entry changed. `zakura-orchard 1.1.0` now lists `maybe-rayon` under its `multicore` feature, but `maybe-rayon 0.1.1` was already in the graph via `zakura-pasta-curves`, so no new crate or source enters the closure.

## Testing

Local, on this branch (release profile, as the repo's tests are normally run):

- `cargo vet check --store-path ./qa/supply-chain/`: Vetting Succeeded.
- `cargo deny --workspace check bans licenses sources --allow unmatched-skip-root`: bans, licenses, and sources ok.
- `cargo clippy --workspace --all-targets --release --locked -- -D warnings`: clean.
- `cargo test --release --locked -p zakura-chain -p zakura-consensus -p zakura-state -p zakura-rpc`: 11 test binaries, 1326 passed, 0 failed, 4 ignored. These are the crates that call into the Zakura Common stack (Sapling/Orchard verification, batch verifiers, note commitment trees, the RPC coinbase builder).

- `./scripts/check-crate-publish-graph.sh` (the `crates.io publish graph` CI job): dry-run publishes the six-crate publish set against the live index and reports `Publish graph resolves at workspace versions: zakura-consensus@7.0.1 zakura-header-chain@2.0.0 zakura-node-services@3.2.2 zakura-state@7.1.1 zakura-network@7.0.1 zakura-rpc@9.0.0`. The remaining divergence warning is for the already-published `zakura 1.3.1` node crate, which nothing depends on and which the release bumps by construction.

CI on the first two commits: lint, MSRV, supply chain, semver checks, all three unit-test shards, test crate build, changelog fragment, and docs passed; only `crates.io publish graph` failed, for the pre-existing reason fixed by the cascade commit.

## Changelog

`docs/changelog/unreleased/885.md` records the bump under `Changed`, matching #844. `./scripts/changelog.py check` and markdownlint (repo config) pass.

### Specifications & References

- Zakura Common `v1.1.0` tag and per-crate changelogs: https://github.com/zakura-core/common/tree/v1.1.0
- Previous bump: #844
