### PR TITLE
feat(network): add reusable P2P regulation mechanics

### DIFF
--- a/crates/zakura-network/src/zakura.rs
+++ b/crates/zakura-network/src/zakura.rs
@@ -22,6 +22,7 @@ mod handshake;
 mod header_sync;
 mod ip;
 mod legacy_gossip;
+mod regulation;
 #[cfg(any(test, feature = "zakura-testkit"))]
 pub mod testkit;
 mod trace;

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -44,6 +44,7 @@ use zakura_chain::{
 use self::trace::ZakuraConnTrace;
 use super::discovery::{self, native_dial_supervised, spawn_native_bootstrap_dialer, RedialPolicy};
 use super::trace::{reject_reason_label, ZakuraTrace};
+use super::transport::{worker_framed_channel, FramedWorkerRecv, QueuedFrame};
 #[cfg(any(test, feature = "zakura-testkit"))]
 use crate::zakura::drive_header_sync_actions;
 #[cfg(any(test, feature = "zakura-testkit"))]
@@ -3980,13 +3981,13 @@ fn spawn_persistent_stream_worker(
     ordered_session_exit_tx: mpsc::UnboundedSender<OrderedSessionExit>,
 ) -> AdmittedOrderedSession {
     let (to_service_tx, to_service_rx) = mpsc::channel(queue_depth);
-    let (from_service_tx, from_service_rx) = mpsc::channel(queue_depth);
+    let (from_service_tx, from_service_rx) = worker_framed_channel(queue_depth);
     let admitted = AdmittedOrderedSession {
         kind: prelude.stream_kind,
         version: prelude.stream_version,
         session_id: context.stream_id,
         recv: FramedRecv::new(to_service_rx),
-        send: FramedSend::new(from_service_tx),
+        send: from_service_tx,
         cancel_token: context.stream_token.clone(),
     };
 
@@ -4018,7 +4019,7 @@ async fn persistent_stream_worker(
     prelude: StreamPrelude,
     context: StreamWorkerContext,
     inbound_tx: mpsc::Sender<Frame>,
-    outbound_rx: mpsc::Receiver<Frame>,
+    outbound_rx: FramedWorkerRecv,
     queue_depth_limit: usize,
 ) {
     let context = Arc::new(context);
@@ -4124,10 +4125,10 @@ async fn persistent_stream_worker(
                 }
             } => {
                 match outbound {
-                    Some(frame) => {
-                        if let Err(error) = write_ordered_frame(
+                    Some(queued_frame) => {
+                        if let Err(error) = write_queued_ordered_frame(
                             &mut send,
-                            frame,
+                            queued_frame,
                             context.limits,
                             context.outbound_frame_cap,
                         ).await {
@@ -4522,6 +4523,21 @@ async fn write_ordered_frame(
         .await
         .map_err(|_| -> BoxError { "Zakura outbound frame write timed out".into() })??;
     Ok(())
+}
+
+/// Write one queued frame while retaining its byte-accounting lease.
+///
+/// The lease remains owned until the QUIC write succeeds, fails, times out, or
+/// this future is dropped with the worker.
+async fn write_queued_ordered_frame(
+    send: &mut SendStream,
+    queued_frame: QueuedFrame,
+    limits: ZakuraConnectionLimits,
+    max_frame_bytes: u32,
+) -> Result<(), BoxError> {
+    queued_frame
+        .write_with(|frame| write_ordered_frame(send, frame, limits, max_frame_bytes))
+        .await
 }
 
 async fn write_outbound_request_frame(
@@ -8070,7 +8086,7 @@ mod tests {
             // read frame to a full service channel (which would itself stop the
             // reader and confound the test). The outbound side is unused here.
             let (inbound_tx, mut inbound_rx) = mpsc::channel(16);
-            let (_outbound_tx, outbound_rx) = mpsc::channel(1);
+            let (_outbound_tx, outbound_rx) = worker_framed_channel(1);
             tokio::spawn(async move { while inbound_rx.recv().await.is_some() {} });
             tokio::spawn(persistent_stream_worker(
                 send,

--- a/crates/zakura-network/src/zakura/regulation/mod.rs
+++ b/crates/zakura-network/src/zakura/regulation/mod.rs
@@ -1,0 +1,27 @@
+//! Reusable resource accounting for native Zakura services.
+//!
+//! This facade provides the ownership mechanics shared by message-specific
+//! policies. It does not decide what a message costs or what should happen
+//! when capacity is unavailable. Those decisions stay with each service.
+
+#[allow(dead_code)] // used by the first message policy in the stacked PR
+mod outstanding_bytes;
+#[allow(dead_code)] // used by the first message policy in the stacked PR
+mod rate;
+#[allow(dead_code)] // used by the first message policy in the stacked PR
+mod slots;
+
+#[allow(unused_imports)] // used by the first message policy in the stacked PR
+pub(crate) use outstanding_bytes::{
+    FrameLease, OutstandingByteBudget, OutstandingByteReservation, OutstandingCapacityError,
+};
+#[allow(unused_imports)] // used by the first message policy in the stacked PR
+pub(crate) use rate::{
+    CommittedRateReservation, RateBudget, RateBudgetConfigError, RateReservation,
+    RateReservationError, RateReservationSpendError,
+};
+#[allow(unused_imports)] // used by the first message policy in the stacked PR
+pub(crate) use slots::{SlotBudget, SlotBudgetCapacityError, SlotPermit};
+
+#[cfg(test)]
+mod tests;

--- a/crates/zakura-network/src/zakura/regulation/outstanding_bytes.rs
+++ b/crates/zakura-network/src/zakura/regulation/outstanding_bytes.rs
@@ -1,0 +1,255 @@
+//! Linear accounting for response bytes until their transport owner drops them.
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use thiserror::Error;
+use tokio::sync::{futures::Notified, Notify};
+
+/// A reservation exceeded an outstanding-byte budget's total capacity.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("requested {requested} outstanding bytes exceeds capacity {capacity}")]
+pub(crate) struct OutstandingCapacityError {
+    /// Requested byte count.
+    pub(crate) requested: u64,
+    /// Configured byte capacity.
+    pub(crate) capacity: u64,
+}
+
+/// Shared capacity returned only when outstanding byte ownership ends.
+///
+/// Unlike [`RateBudget`](super::RateBudget), this balance does not refill with
+/// time. Clones reserve and release against the same atomic counter, allowing a
+/// node budget and a peer budget to be held by different tasks.
+#[derive(Clone, Debug)]
+pub(crate) struct OutstandingByteBudget {
+    inner: Arc<OutstandingByteBudgetInner>,
+}
+
+#[derive(Debug)]
+struct OutstandingByteBudgetInner {
+    capacity: u64,
+    reserved: AtomicU64,
+    capacity_released: Notify,
+}
+
+impl OutstandingByteBudget {
+    /// Create an empty budget with `capacity` bytes.
+    pub(crate) fn new(capacity: u64) -> Self {
+        Self {
+            inner: Arc::new(OutstandingByteBudgetInner {
+                capacity,
+                reserved: AtomicU64::new(0),
+                capacity_released: Notify::new(),
+            }),
+        }
+    }
+
+    /// Return the configured byte capacity.
+    pub(crate) fn capacity(&self) -> u64 {
+        self.inner.capacity
+    }
+
+    /// Return the bytes currently available for reservation.
+    pub(crate) fn available(&self) -> u64 {
+        self.capacity().saturating_sub(self.reserved())
+    }
+
+    /// Return the bytes currently owned by reservations and frame leases.
+    pub(crate) fn reserved(&self) -> u64 {
+        self.inner.reserved.load(Ordering::Acquire)
+    }
+
+    /// Reserve bytes and return their linear owner.
+    ///
+    /// `Err` means the request can never fit. `Ok(None)` means it can fit after
+    /// another owner releases capacity.
+    pub(crate) fn try_reserve(
+        &self,
+        bytes: u64,
+    ) -> Result<Option<OutstandingByteReservation>, OutstandingCapacityError> {
+        self.ensure_request_fits(bytes)?;
+
+        if !self.reserve_bytes(bytes) {
+            return Ok(None);
+        }
+
+        Ok(Some(OutstandingByteReservation {
+            budget: self.clone(),
+            remaining: bytes,
+        }))
+    }
+
+    /// Wait until `bytes` could fit, without reserving them.
+    ///
+    /// The notification is registered before capacity is rechecked, so a
+    /// concurrent release cannot be missed.
+    pub(crate) async fn wait_for(&self, bytes: u64) -> Result<(), OutstandingCapacityError> {
+        self.ensure_request_fits(bytes)?;
+
+        loop {
+            let released = self.inner.capacity_released.notified();
+            tokio::pin!(released);
+            Notified::enable(released.as_mut());
+
+            if self.available() >= bytes {
+                return Ok(());
+            }
+
+            released.await;
+        }
+    }
+
+    fn ensure_request_fits(&self, bytes: u64) -> Result<(), OutstandingCapacityError> {
+        if bytes > self.capacity() {
+            return Err(OutstandingCapacityError {
+                requested: bytes,
+                capacity: self.capacity(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn reserve_bytes(&self, bytes: u64) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+
+        let mut reserved = self.reserved();
+        loop {
+            if bytes > self.capacity().saturating_sub(reserved) {
+                return false;
+            }
+
+            let next = reserved.saturating_add(bytes);
+            match self.inner.reserved.compare_exchange_weak(
+                reserved,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => reserved = observed,
+            }
+        }
+    }
+
+    fn release_bytes(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+
+        let mut reserved = self.reserved();
+        loop {
+            let next = reserved.saturating_sub(bytes);
+            match self.inner.reserved.compare_exchange_weak(
+                reserved,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(observed) => reserved = observed,
+            }
+        }
+        self.inner.capacity_released.notify_waiters();
+    }
+}
+
+/// Linear ownership of bytes reserved but not yet handed to a frame.
+#[derive(Debug)]
+#[must_use = "dropping an outstanding-byte reservation releases it"]
+pub(crate) struct OutstandingByteReservation {
+    budget: OutstandingByteBudget,
+    remaining: u64,
+}
+
+impl OutstandingByteReservation {
+    /// Return the bytes this reservation still owns directly.
+    pub(crate) fn remaining(&self) -> u64 {
+        self.remaining
+    }
+
+    /// Transfer equal bytes from every reservation into one frame lease.
+    ///
+    /// This operation validates every reservation before changing any of them.
+    /// It is intended for the peer and node response-byte reservations attached
+    /// to the same outbound frame.
+    pub(crate) fn transfer_to_frame<const N: usize>(
+        reservations: [&mut OutstandingByteReservation; N],
+        bytes: u64,
+    ) -> Option<FrameLease> {
+        if reservations
+            .iter()
+            .any(|reservation| reservation.remaining < bytes)
+        {
+            return None;
+        }
+
+        let mut releases = Vec::with_capacity(N);
+        for reservation in reservations {
+            reservation.remaining -= bytes;
+            releases.push(FrameLeaseRelease {
+                budget: reservation.budget.clone(),
+                bytes,
+            });
+        }
+
+        Some(FrameLease {
+            accounted_bytes: bytes,
+            releases,
+        })
+    }
+
+    /// Release all remaining bytes now.
+    pub(crate) fn release(self) {
+        drop(self);
+    }
+}
+
+impl Drop for OutstandingByteReservation {
+    fn drop(&mut self) {
+        self.budget.release_bytes(self.remaining);
+        self.remaining = 0;
+    }
+}
+
+/// Linear ownership of one queued frame's outstanding-byte charges.
+#[derive(Debug)]
+#[must_use = "the transport must retain a frame lease until write completion or drop"]
+pub(crate) struct FrameLease {
+    accounted_bytes: u64,
+    releases: Vec<FrameLeaseRelease>,
+}
+
+#[derive(Debug)]
+struct FrameLeaseRelease {
+    budget: OutstandingByteBudget,
+    bytes: u64,
+}
+
+impl FrameLease {
+    /// Return the response bytes represented by this lease.
+    pub(crate) fn accounted_bytes(&self) -> u64 {
+        self.accounted_bytes
+    }
+
+    #[cfg(test)]
+    pub(crate) fn empty_for_test() -> Self {
+        Self {
+            accounted_bytes: 0,
+            releases: Vec::new(),
+        }
+    }
+}
+
+impl Drop for FrameLease {
+    fn drop(&mut self) {
+        for release in self.releases.drain(..) {
+            release.budget.release_bytes(release.bytes);
+        }
+    }
+}

--- a/crates/zakura-network/src/zakura/regulation/rate.rs
+++ b/crates/zakura-network/src/zakura/regulation/rate.rs
@@ -1,0 +1,356 @@
+//! Refundable reservations from a monotonic rate budget.
+
+use std::{
+    sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
+};
+
+use thiserror::Error;
+use tokio::{
+    sync::{futures::Notified, Notify},
+    time::sleep,
+};
+
+use crate::zakura::transport::{Clock, RealClock};
+
+const NANOS_PER_SECOND: u128 = 1_000_000_000;
+
+/// Invalid local configuration for a rate budget.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub(crate) enum RateBudgetConfigError {
+    /// A zero capacity cannot admit any positive work.
+    #[error("rate budget capacity must be greater than zero")]
+    ZeroCapacity,
+    /// A zero refill would make spent capacity unavailable forever.
+    #[error("rate budget refill must be greater than zero")]
+    ZeroRefill,
+}
+
+/// A rate reservation could not be admitted.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+pub(crate) enum RateReservationError {
+    /// The requested amount can never fit in this budget.
+    #[error("requested rate reservation {requested} exceeds capacity {capacity}")]
+    ExceedsCapacity {
+        /// Requested units.
+        requested: u64,
+        /// Configured burst capacity.
+        capacity: u64,
+    },
+    /// The request can fit after refill or an earlier reservation is returned.
+    #[error("rate reservation is temporarily unavailable for {retry_after:?}")]
+    TemporarilyUnavailable {
+        /// Refill time assuming no earlier return.
+        retry_after: Duration,
+    },
+}
+
+impl RateReservationError {
+    /// Return the refill delay for a temporary rejection.
+    pub(crate) fn retry_after(self) -> Option<Duration> {
+        match self {
+            Self::TemporarilyUnavailable { retry_after } => Some(retry_after),
+            Self::ExceedsCapacity { .. } => None,
+        }
+    }
+}
+
+/// A caller tried to spend more than its refundable reservation.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("rate spend {spent} exceeds refundable reservation {refundable}")]
+pub(crate) struct RateReservationSpendError {
+    /// Units the caller tried to spend.
+    pub(crate) spent: u64,
+    /// Units that were still refundable.
+    pub(crate) refundable: u64,
+}
+
+/// Shared tokens that bound a burst and sustained work rate.
+///
+/// Each instance has one caller-defined unit, such as response bytes or a
+/// measured work unit. Incomparable resources use separate budgets. Time
+/// replenishes spent tokens; dropping an uncommitted reservation returns its
+/// tokens immediately.
+#[derive(Clone, Debug)]
+pub(crate) struct RateBudget<C: Clock = RealClock> {
+    inner: Arc<RateBudgetInner<C>>,
+}
+
+#[derive(Debug)]
+struct RateBudgetInner<C: Clock> {
+    capacity: u64,
+    refill_per_second: u64,
+    clock: C,
+    state: Mutex<RateState>,
+    tokens_returned: Notify,
+}
+
+#[derive(Debug)]
+struct RateState {
+    available: u64,
+    /// Fractional unit numerator in unit-nanoseconds.
+    refill_remainder: u128,
+    last_refill: tokio::time::Instant,
+}
+
+impl RateBudget<RealClock> {
+    /// Create a production budget initialized at full capacity.
+    pub(crate) fn new(
+        capacity: u64,
+        refill_per_second: u64,
+    ) -> Result<Self, RateBudgetConfigError> {
+        Self::with_clock(capacity, refill_per_second, RealClock)
+    }
+
+    /// Wait until `units` could be reserved, without consuming them.
+    ///
+    /// The notification is registered before the balance is rechecked, so a
+    /// concurrent return cannot be missed.
+    pub(crate) async fn wait_for(&self, units: u64) -> Result<(), RateReservationError> {
+        self.ensure_reservation_fits(units)?;
+
+        loop {
+            let returned = self.inner.tokens_returned.notified();
+            tokio::pin!(returned);
+            Notified::enable(returned.as_mut());
+
+            let Some(retry_after) = self.time_until_available(units) else {
+                return Ok(());
+            };
+
+            tokio::select! {
+                _ = &mut returned => {}
+                _ = sleep(retry_after) => {}
+            }
+        }
+    }
+}
+
+impl<C: Clock> RateBudget<C> {
+    /// Create a budget with an injected monotonic clock.
+    pub(crate) fn with_clock(
+        capacity: u64,
+        refill_per_second: u64,
+        clock: C,
+    ) -> Result<Self, RateBudgetConfigError> {
+        if capacity == 0 {
+            return Err(RateBudgetConfigError::ZeroCapacity);
+        }
+        if refill_per_second == 0 {
+            return Err(RateBudgetConfigError::ZeroRefill);
+        }
+
+        let now = clock.now();
+        Ok(Self {
+            inner: Arc::new(RateBudgetInner {
+                capacity,
+                refill_per_second,
+                clock,
+                state: Mutex::new(RateState {
+                    available: capacity,
+                    refill_remainder: 0,
+                    last_refill: now,
+                }),
+                tokens_returned: Notify::new(),
+            }),
+        })
+    }
+
+    /// Return the configured burst capacity.
+    pub(crate) fn capacity(&self) -> u64 {
+        self.inner.capacity
+    }
+
+    /// Return the configured refill rate in units per second.
+    pub(crate) fn refill_per_second(&self) -> u64 {
+        self.inner.refill_per_second
+    }
+
+    /// Return the currently available units after applying elapsed refill.
+    pub(crate) fn available(&self) -> u64 {
+        let mut state = self.lock_state();
+        self.refill(&mut state);
+        state.available
+    }
+
+    /// Reserve units now or return why they are unavailable.
+    pub(crate) fn try_reserve(
+        &self,
+        units: u64,
+    ) -> Result<RateReservation<C>, RateReservationError> {
+        self.ensure_reservation_fits(units)?;
+
+        let mut state = self.lock_state();
+        self.refill(&mut state);
+        if state.available < units {
+            return Err(RateReservationError::TemporarilyUnavailable {
+                retry_after: self.retry_after(&state, units),
+            });
+        }
+
+        state.available -= units;
+        Ok(RateReservation {
+            budget: self.clone(),
+            refundable: units,
+        })
+    }
+
+    fn ensure_reservation_fits(&self, units: u64) -> Result<(), RateReservationError> {
+        if units > self.capacity() {
+            return Err(RateReservationError::ExceedsCapacity {
+                requested: units,
+                capacity: self.capacity(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn time_until_available(&self, units: u64) -> Option<Duration> {
+        let mut state = self.lock_state();
+        self.refill(&mut state);
+        (state.available < units).then(|| self.retry_after(&state, units))
+    }
+
+    fn retry_after(&self, state: &RateState, units: u64) -> Duration {
+        let deficit = units.saturating_sub(state.available);
+        let scaled_deficit = u128::from(deficit)
+            .saturating_mul(NANOS_PER_SECOND)
+            .saturating_sub(state.refill_remainder);
+        let refill = u128::from(self.refill_per_second().max(1));
+        let nanos = scaled_deficit.saturating_add(refill - 1) / refill;
+        Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+    }
+
+    fn refill(&self, state: &mut RateState) {
+        let now = self.inner.clock.now();
+        let elapsed = now.saturating_duration_since(state.last_refill);
+        if elapsed.is_zero() || state.available == self.capacity() {
+            state.last_refill = now;
+            if state.available == self.capacity() {
+                state.refill_remainder = 0;
+            }
+            return;
+        }
+
+        let produced = elapsed
+            .as_nanos()
+            .saturating_mul(u128::from(self.refill_per_second()))
+            .saturating_add(state.refill_remainder);
+        let whole_units = u64::try_from(produced / NANOS_PER_SECOND).unwrap_or(u64::MAX);
+        state.available = self
+            .capacity()
+            .min(state.available.saturating_add(whole_units));
+        state.refill_remainder = if state.available == self.capacity() {
+            0
+        } else {
+            produced % NANOS_PER_SECOND
+        };
+        state.last_refill = now;
+    }
+
+    fn return_units(&self, units: u64) {
+        if units == 0 {
+            return;
+        }
+
+        let mut state = self.lock_state();
+        self.refill(&mut state);
+        state.available = self.capacity().min(state.available.saturating_add(units));
+        if state.available == self.capacity() {
+            state.refill_remainder = 0;
+        }
+        drop(state);
+        self.inner.tokens_returned.notify_waiters();
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, RateState> {
+        self.inner
+            .state
+            .lock()
+            .expect("rate budget mutex should not be poisoned")
+    }
+}
+
+/// Provisional ownership of a fully refundable rate reservation.
+#[derive(Debug)]
+#[must_use = "dropping a provisional rate reservation returns it"]
+pub(crate) struct RateReservation<C: Clock = RealClock> {
+    budget: RateBudget<C>,
+    refundable: u64,
+}
+
+impl<C: Clock> RateReservation<C> {
+    /// Commit the reservation and permanently spend `initial_spend` units.
+    pub(crate) fn commit(
+        mut self,
+        initial_spend: u64,
+    ) -> Result<CommittedRateReservation<C>, RateReservationSpendError> {
+        if initial_spend > self.refundable {
+            return Err(RateReservationSpendError {
+                spent: initial_spend,
+                refundable: self.refundable,
+            });
+        }
+
+        self.refundable -= initial_spend;
+        let refundable = self.refundable;
+        self.refundable = 0;
+        Ok(CommittedRateReservation {
+            budget: self.budget.clone(),
+            refundable,
+        })
+    }
+
+    /// Return the units held by this provisional reservation.
+    pub(crate) fn reserved(&self) -> u64 {
+        self.refundable
+    }
+}
+
+impl<C: Clock> Drop for RateReservation<C> {
+    fn drop(&mut self) {
+        self.budget.return_units(self.refundable);
+        self.refundable = 0;
+    }
+}
+
+/// A committed rate reservation whose unused units remain refundable.
+#[derive(Debug)]
+#[must_use = "dropping a committed rate reservation returns its unused units"]
+pub(crate) struct CommittedRateReservation<C: Clock = RealClock> {
+    budget: RateBudget<C>,
+    refundable: u64,
+}
+
+impl<C: Clock> CommittedRateReservation<C> {
+    /// Permanently spend units consumed by completed work.
+    pub(crate) fn spend(&mut self, units: u64) -> Result<(), RateReservationSpendError> {
+        if units > self.refundable {
+            return Err(RateReservationSpendError {
+                spent: units,
+                refundable: self.refundable,
+            });
+        }
+
+        self.refundable -= units;
+        Ok(())
+    }
+
+    /// Return the units that will be returned when this owner is dropped.
+    pub(crate) fn refundable(&self) -> u64 {
+        self.refundable
+    }
+
+    /// Finish this reservation and return its unused units now.
+    pub(crate) fn finish(self) {
+        drop(self);
+    }
+}
+
+impl<C: Clock> Drop for CommittedRateReservation<C> {
+    fn drop(&mut self) {
+        self.budget.return_units(self.refundable);
+        self.refundable = 0;
+    }
+}

--- a/crates/zakura-network/src/zakura/regulation/slots.rs
+++ b/crates/zakura-network/src/zakura/regulation/slots.rs
@@ -1,0 +1,70 @@
+//! Owned permits for bounded collections of retained or active work.
+
+use std::sync::Arc;
+
+use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// A slot capacity cannot be represented by Tokio's semaphore.
+#[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
+#[error("slot capacity {requested} exceeds maximum {maximum}")]
+pub(crate) struct SlotBudgetCapacityError {
+    /// Requested slot count.
+    pub(crate) requested: usize,
+    /// Largest supported slot count.
+    pub(crate) maximum: usize,
+}
+
+/// Shared ownership bound for retained or active work items.
+///
+/// Each successful admission returns one linear permit. Moving it with the
+/// admitted item makes ordinary drop and cancellation release capacity.
+#[derive(Clone, Debug)]
+pub(crate) struct SlotBudget {
+    capacity: usize,
+    permits: Arc<Semaphore>,
+}
+
+impl SlotBudget {
+    /// Create a budget with `capacity` independently owned slots.
+    pub(crate) fn new(capacity: usize) -> Result<Self, SlotBudgetCapacityError> {
+        if capacity > Semaphore::MAX_PERMITS {
+            return Err(SlotBudgetCapacityError {
+                requested: capacity,
+                maximum: Semaphore::MAX_PERMITS,
+            });
+        }
+
+        Ok(Self {
+            capacity,
+            permits: Arc::new(Semaphore::new(capacity)),
+        })
+    }
+
+    /// Return the maximum number of owned slots.
+    pub(crate) fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Return the number of currently owned slots.
+    pub(crate) fn reserved(&self) -> usize {
+        self.capacity
+            .saturating_sub(self.permits.available_permits())
+    }
+
+    /// Reserve one slot without waiting.
+    pub(crate) fn try_reserve(&self) -> Option<SlotPermit> {
+        self.permits
+            .clone()
+            .try_acquire_owned()
+            .ok()
+            .map(|permit| SlotPermit { _permit: permit })
+    }
+}
+
+/// Linear ownership of one slot.
+#[derive(Debug)]
+#[must_use = "dropping a slot permit releases its capacity"]
+pub(crate) struct SlotPermit {
+    _permit: OwnedSemaphorePermit,
+}

--- a/crates/zakura-network/src/zakura/regulation/slots.rs
+++ b/crates/zakura-network/src/zakura/regulation/slots.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// A slot capacity cannot be represented by Tokio's semaphore.
+/// A slot capacity cannot provide usable, representable permits.
 #[derive(Copy, Clone, Debug, Eq, Error, PartialEq)]
-#[error("slot capacity {requested} exceeds maximum {maximum}")]
+#[error("slot capacity {requested} must be in 1..={maximum}")]
 pub(crate) struct SlotBudgetCapacityError {
     /// Requested slot count.
     pub(crate) requested: usize,
@@ -28,7 +28,7 @@ pub(crate) struct SlotBudget {
 impl SlotBudget {
     /// Create a budget with `capacity` independently owned slots.
     pub(crate) fn new(capacity: usize) -> Result<Self, SlotBudgetCapacityError> {
-        if capacity > Semaphore::MAX_PERMITS {
+        if capacity == 0 || capacity > Semaphore::MAX_PERMITS {
             return Err(SlotBudgetCapacityError {
                 requested: capacity,
                 maximum: Semaphore::MAX_PERMITS,
@@ -61,19 +61,19 @@ impl SlotBudget {
             .map(|permit| SlotPermit { _permit: permit })
     }
 
-    /// Wait until one slot could be reserved, without retaining it.
+    /// Wait for a slot and return its ownership in semaphore queue order.
     ///
-    /// Acquiring and immediately releasing the semaphore permit makes the wait
-    /// race-free. A caller retries its complete multi-resource admission after
-    /// this method returns.
-    pub(crate) async fn wait_for(&self) {
+    /// Keep the returned permit through admission. If another resource cannot
+    /// be reserved, drop it before waiting for that resource. Cancelling this
+    /// future removes its waiter without consuming a slot.
+    pub(crate) async fn reserve(&self) -> SlotPermit {
         let permit = self
             .permits
             .clone()
             .acquire_owned()
             .await
             .expect("slot budget semaphore stays open because this type never closes it");
-        drop(permit);
+        SlotPermit { _permit: permit }
     }
 }
 

--- a/crates/zakura-network/src/zakura/regulation/slots.rs
+++ b/crates/zakura-network/src/zakura/regulation/slots.rs
@@ -60,6 +60,21 @@ impl SlotBudget {
             .ok()
             .map(|permit| SlotPermit { _permit: permit })
     }
+
+    /// Wait until one slot could be reserved, without retaining it.
+    ///
+    /// Acquiring and immediately releasing the semaphore permit makes the wait
+    /// race-free. A caller retries its complete multi-resource admission after
+    /// this method returns.
+    pub(crate) async fn wait_for(&self) {
+        let permit = self
+            .permits
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("slot budget semaphore stays open because this type never closes it");
+        drop(permit);
+    }
 }
 
 /// Linear ownership of one slot.

--- a/crates/zakura-network/src/zakura/regulation/tests.rs
+++ b/crates/zakura-network/src/zakura/regulation/tests.rs
@@ -240,19 +240,57 @@ fn slot_permits_bound_and_release_owned_items() {
     assert_eq!(budget.reserved(), 0);
 }
 
+#[test]
+fn slot_budget_rejects_unusable_capacities() {
+    assert!(SlotBudget::new(0).is_err());
+    assert!(SlotBudget::new(tokio::sync::Semaphore::MAX_PERMITS + 1).is_err());
+}
+
 #[tokio::test]
-async fn slot_wait_wakes_after_an_owner_releases_capacity() {
+async fn slot_waiters_receive_and_retain_owned_capacity() {
+    use futures::poll;
+
     let budget = SlotBudget::new(1).expect("one slot fits the semaphore");
     let reservation = budget.try_reserve().expect("the slot is initially free");
-    let waiting_budget = budget.clone();
-    let waiter = tokio::spawn(async move { waiting_budget.wait_for().await });
-    tokio::task::yield_now().await;
-    assert!(!waiter.is_finished());
+    let first = budget.reserve();
+    let second = budget.reserve();
+    tokio::pin!(first, second);
+    assert!(poll!(&mut first).is_pending());
+    assert!(poll!(&mut second).is_pending());
 
     drop(reservation);
-
-    tokio::time::timeout(Duration::from_secs(1), waiter)
+    let first_permit = tokio::time::timeout(Duration::from_secs(1), &mut first)
         .await
-        .expect("the release must wake the slot waiter")
-        .expect("the waiter task should not panic");
+        .expect("the first waiter receives the released slot");
+    assert_eq!(budget.reserved(), 1);
+    assert!(budget.try_reserve().is_none());
+    assert!(poll!(&mut second).is_pending());
+
+    drop(first_permit);
+    let second_permit = tokio::time::timeout(Duration::from_secs(1), &mut second)
+        .await
+        .expect("the second waiter receives the next released slot");
+    assert_eq!(budget.reserved(), 1);
+    drop(second_permit);
+    assert_eq!(budget.reserved(), 0);
+}
+
+#[tokio::test]
+async fn cancelled_slot_waiter_leaves_capacity_for_its_successor() {
+    use futures::poll;
+
+    let budget = SlotBudget::new(1).expect("one slot fits the semaphore");
+    let owner = budget.try_reserve().expect("the slot is initially free");
+    let mut cancelled = Box::pin(budget.reserve());
+    let mut successor = Box::pin(budget.reserve());
+    assert!(poll!(&mut cancelled).is_pending());
+    assert!(poll!(&mut successor).is_pending());
+    drop(cancelled);
+    drop(owner);
+    let permit = tokio::time::timeout(Duration::from_secs(1), successor)
+        .await
+        .expect("cancelling the first waiter does not strand the next one");
+    assert_eq!(budget.reserved(), 1);
+    drop(permit);
+    assert_eq!(budget.reserved(), 0);
 }

--- a/crates/zakura-network/src/zakura/regulation/tests.rs
+++ b/crates/zakura-network/src/zakura/regulation/tests.rs
@@ -239,3 +239,20 @@ fn slot_permits_bound_and_release_owned_items() {
     drop((second, replacement));
     assert_eq!(budget.reserved(), 0);
 }
+
+#[tokio::test]
+async fn slot_wait_wakes_after_an_owner_releases_capacity() {
+    let budget = SlotBudget::new(1).expect("one slot fits the semaphore");
+    let reservation = budget.try_reserve().expect("the slot is initially free");
+    let waiting_budget = budget.clone();
+    let waiter = tokio::spawn(async move { waiting_budget.wait_for().await });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    drop(reservation);
+
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("the release must wake the slot waiter")
+        .expect("the waiter task should not panic");
+}

--- a/crates/zakura-network/src/zakura/regulation/tests.rs
+++ b/crates/zakura-network/src/zakura/regulation/tests.rs
@@ -1,0 +1,241 @@
+use std::time::Duration;
+
+use super::*;
+use crate::zakura::testkit::TestClock;
+
+#[test]
+fn rate_budget_rejects_configuration_that_cannot_refill() {
+    assert_eq!(
+        RateBudget::with_clock(0, 1, TestClock::new()).unwrap_err(),
+        RateBudgetConfigError::ZeroCapacity,
+    );
+    assert_eq!(
+        RateBudget::with_clock(1, 0, TestClock::new()).unwrap_err(),
+        RateBudgetConfigError::ZeroRefill,
+    );
+}
+
+#[test]
+fn provisional_rate_reservation_returns_all_units_on_drop() {
+    let budget = RateBudget::with_clock(100, 10, TestClock::new())
+        .expect("the rate budget configuration is valid");
+    let reservation = budget
+        .try_reserve(80)
+        .expect("the full budget covers eighty units");
+
+    assert_eq!(budget.available(), 20);
+    drop(reservation);
+    assert_eq!(budget.available(), 100);
+}
+
+#[test]
+fn committed_rate_reservation_keeps_consumed_units_spent() {
+    let budget = RateBudget::with_clock(100, 10, TestClock::new())
+        .expect("the rate budget configuration is valid");
+    let reservation = budget
+        .try_reserve(80)
+        .expect("the full budget covers eighty units");
+    let mut committed = reservation
+        .commit(20)
+        .expect("the initial spend fits the reservation");
+    committed
+        .spend(30)
+        .expect("completed work fits the refundable remainder");
+
+    committed.finish();
+
+    assert_eq!(budget.available(), 50);
+}
+
+#[test]
+fn rate_refill_preserves_fractional_time() {
+    let clock = TestClock::new();
+    let budget = RateBudget::with_clock(10, 3, clock.clone())
+        .expect("the rate budget configuration is valid");
+    budget
+        .try_reserve(10)
+        .expect("the full budget covers its capacity")
+        .commit(10)
+        .expect("the full reservation can be spent")
+        .finish();
+
+    clock.advance(Duration::from_millis(333));
+    assert_eq!(budget.available(), 0);
+    clock.advance(Duration::from_millis(1));
+    assert_eq!(budget.available(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn rate_wait_wakes_when_a_reservation_is_returned() {
+    let budget = RateBudget::new(100, 1).expect("the rate budget configuration is valid");
+    let reservation = budget
+        .try_reserve(100)
+        .expect("the full budget covers its capacity");
+    let waiting_budget = budget.clone();
+    let waiter = tokio::spawn(async move { waiting_budget.wait_for(50).await });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    drop(reservation);
+
+    tokio::task::yield_now().await;
+    waiter
+        .await
+        .expect("the waiter task should not panic")
+        .expect("the returned reservation fits the budget");
+}
+
+#[tokio::test(start_paused = true)]
+async fn rate_wait_wakes_at_the_refill_deadline() {
+    let budget = RateBudget::new(100, 10).expect("the rate budget configuration is valid");
+    budget
+        .try_reserve(100)
+        .expect("the full budget covers its capacity")
+        .commit(100)
+        .expect("the full reservation can be spent")
+        .finish();
+    let waiting_budget = budget.clone();
+    let waiter = tokio::spawn(async move { waiting_budget.wait_for(50).await });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    waiter
+        .await
+        .expect("the waiter task should not panic")
+        .expect("five seconds refill fifty units");
+}
+
+#[tokio::test]
+async fn impossible_waits_return_capacity_errors() {
+    let outstanding = OutstandingByteBudget::new(10);
+    assert_eq!(
+        outstanding.wait_for(11).await,
+        Err(OutstandingCapacityError {
+            requested: 11,
+            capacity: 10,
+        })
+    );
+
+    let rate = RateBudget::new(10, 1).expect("the rate budget configuration is valid");
+    assert_eq!(
+        rate.wait_for(11).await,
+        Err(RateReservationError::ExceedsCapacity {
+            requested: 11,
+            capacity: 10,
+        })
+    );
+}
+
+#[tokio::test]
+async fn outstanding_wait_does_not_miss_a_concurrent_release() {
+    let budget = OutstandingByteBudget::new(10);
+    let reservation = budget
+        .try_reserve(10)
+        .expect("the request fits the budget")
+        .expect("the empty budget admits the reservation");
+    let waiting_budget = budget.clone();
+    let waiter = tokio::spawn(async move { waiting_budget.wait_for(1).await });
+    tokio::task::yield_now().await;
+
+    drop(reservation);
+
+    tokio::time::timeout(Duration::from_secs(1), waiter)
+        .await
+        .expect("the release must wake the waiter")
+        .expect("the waiter task should not panic")
+        .expect("one byte fits after release");
+}
+
+#[tokio::test(start_paused = true)]
+async fn outstanding_budget_does_not_refill_with_time() {
+    let budget = OutstandingByteBudget::new(10);
+    let reservation = budget
+        .try_reserve(10)
+        .expect("the request fits the budget")
+        .expect("the empty budget admits the reservation");
+
+    tokio::time::advance(Duration::from_secs(24 * 60 * 60)).await;
+
+    assert_eq!(budget.available(), 0);
+    reservation.release();
+    assert_eq!(budget.available(), 10);
+}
+
+#[test]
+fn frame_lease_holds_peer_and_node_bytes() {
+    let node = OutstandingByteBudget::new(100);
+    let peer = OutstandingByteBudget::new(100);
+    let mut node_reservation = node
+        .try_reserve(100)
+        .expect("the request fits the node budget")
+        .expect("the node budget is empty");
+    let mut peer_reservation = peer
+        .try_reserve(100)
+        .expect("the request fits the peer budget")
+        .expect("the peer budget is empty");
+
+    let lease = OutstandingByteReservation::transfer_to_frame(
+        [&mut node_reservation, &mut peer_reservation],
+        60,
+    )
+    .expect("both reservations cover the frame");
+    assert_eq!(lease.accounted_bytes(), 60);
+
+    drop(node_reservation);
+    drop(peer_reservation);
+    assert_eq!(node.reserved(), 60);
+    assert_eq!(peer.reserved(), 60);
+
+    drop(lease);
+    assert_eq!(node.reserved(), 0);
+    assert_eq!(peer.reserved(), 0);
+}
+
+#[test]
+fn failed_multi_budget_transfer_changes_nothing() {
+    let first = OutstandingByteBudget::new(100);
+    let second = OutstandingByteBudget::new(50);
+    let mut first_reservation = first
+        .try_reserve(100)
+        .expect("the request fits the first budget")
+        .expect("the first budget is empty");
+    let mut second_reservation = second
+        .try_reserve(50)
+        .expect("the request fits the second budget")
+        .expect("the second budget is empty");
+
+    assert!(OutstandingByteReservation::transfer_to_frame(
+        [&mut first_reservation, &mut second_reservation],
+        60,
+    )
+    .is_none());
+    assert_eq!(first_reservation.remaining(), 100);
+    assert_eq!(second_reservation.remaining(), 50);
+    assert_eq!(first.reserved(), 100);
+    assert_eq!(second.reserved(), 50);
+}
+
+#[test]
+fn slot_permits_bound_and_release_owned_items() {
+    let budget = SlotBudget::new(2).expect("two slots fit the semaphore");
+    let first = budget.try_reserve().expect("the first slot is available");
+    let second = budget.try_reserve().expect("the second slot is available");
+    assert_eq!(budget.capacity(), 2);
+    assert_eq!(budget.reserved(), 2);
+    assert!(budget.try_reserve().is_none());
+
+    drop(first);
+    let replacement = budget
+        .try_reserve()
+        .expect("dropping an owner releases its slot");
+    assert_eq!(budget.reserved(), 2);
+
+    drop((second, replacement));
+    assert_eq!(budget.reserved(), 0);
+}

--- a/crates/zakura-network/src/zakura/transport/io.rs
+++ b/crates/zakura-network/src/zakura/transport/io.rs
@@ -99,6 +99,7 @@ impl FramedSend {
     /// `make_lease` is called only after the transport owns a queue slot. This
     /// prevents accounting from moving to the transport when the queue is full
     /// or closed.
+    #[allow(dead_code)] // consumed by the GetBlocks policy in the stacked PR
     pub(crate) fn try_send_leased(
         &self,
         frame: Frame,
@@ -179,6 +180,7 @@ impl QueuedFrame {
         Self { frame, lease: None }
     }
 
+    #[allow(dead_code)] // consumed through `try_send_leased` in the stacked PR
     fn leased(frame: Frame, lease: FrameLease) -> Self {
         Self {
             frame,

--- a/crates/zakura-network/src/zakura/transport/io.rs
+++ b/crates/zakura-network/src/zakura/transport/io.rs
@@ -8,60 +8,448 @@
 use tokio::sync::mpsc;
 
 use super::Frame;
+use crate::zakura::regulation::FrameLease;
 
 /// Receive half for bounded, rate-admitted Zakura frames.
 #[derive(Debug)]
 pub struct FramedRecv {
-    receiver: mpsc::Receiver<Frame>,
+    receiver: FramedReceiver,
+}
+
+#[derive(Debug)]
+enum FramedReceiver {
+    Plain(mpsc::Receiver<Frame>),
+    Queued(mpsc::Receiver<QueuedFrame>),
 }
 
 impl FramedRecv {
     /// Wrap a bounded frame receiver.
     pub fn new(receiver: mpsc::Receiver<Frame>) -> Self {
-        Self { receiver }
+        Self {
+            receiver: FramedReceiver::Plain(receiver),
+        }
+    }
+
+    fn queued(receiver: mpsc::Receiver<QueuedFrame>) -> Self {
+        Self {
+            receiver: FramedReceiver::Queued(receiver),
+        }
     }
 
     /// Receive the next admitted frame, or `None` after the transport closes the stream.
     pub async fn recv(&mut self) -> Option<Frame> {
-        self.receiver.recv().await
+        match &mut self.receiver {
+            FramedReceiver::Plain(receiver) => receiver.recv().await,
+            FramedReceiver::Queued(receiver) => {
+                receiver.recv().await.map(|queued| queued.into_parts().0)
+            }
+        }
     }
 }
 
 /// Send half for bounded Zakura frames.
 #[derive(Clone, Debug)]
 pub struct FramedSend {
-    sender: mpsc::Sender<Frame>,
+    sender: FramedSender,
+}
+
+#[derive(Clone, Debug)]
+enum FramedSender {
+    Plain(mpsc::Sender<Frame>),
+    Queued(mpsc::Sender<QueuedFrame>),
 }
 
 impl FramedSend {
     /// Wrap a bounded frame sender.
     pub fn new(sender: mpsc::Sender<Frame>) -> Self {
-        Self { sender }
+        Self {
+            sender: FramedSender::Plain(sender),
+        }
+    }
+
+    fn queued(sender: mpsc::Sender<QueuedFrame>) -> Self {
+        Self {
+            sender: FramedSender::Queued(sender),
+        }
     }
 
     /// Queue a frame for transport-owned encoding and writing.
     pub async fn send(&self, frame: Frame) -> Result<(), mpsc::error::SendError<Frame>> {
-        self.sender.send(frame).await
+        match &self.sender {
+            FramedSender::Plain(sender) => sender.send(frame).await,
+            FramedSender::Queued(sender) => sender
+                .send(QueuedFrame::plain(frame))
+                .await
+                .map_err(|error| mpsc::error::SendError(error.0.into_parts().0)),
+        }
     }
 
     /// Try to queue a frame without waiting for capacity.
     pub fn try_send(&self, frame: Frame) -> Result<(), mpsc::error::TrySendError<Frame>> {
-        self.sender.try_send(frame)
+        match &self.sender {
+            FramedSender::Plain(sender) => sender.try_send(frame),
+            FramedSender::Queued(sender) => sender
+                .try_send(QueuedFrame::plain(frame))
+                .map_err(map_queued_try_send_error),
+        }
+    }
+
+    /// Reserve a queue slot before attaching an outstanding-byte lease.
+    ///
+    /// `make_lease` is called only after the transport owns a queue slot. This
+    /// prevents accounting from moving to the transport when the queue is full
+    /// or closed.
+    pub(crate) fn try_send_leased(
+        &self,
+        frame: Frame,
+        make_lease: impl FnOnce() -> FrameLease,
+    ) -> Result<(), LeasedSendError> {
+        let FramedSender::Queued(sender) = &self.sender else {
+            return Err(LeasedSendError::Unsupported(frame));
+        };
+
+        match sender.try_reserve() {
+            Ok(slot) => {
+                slot.send(QueuedFrame::leased(frame, make_lease()));
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Full(())) => Err(LeasedSendError::Full(frame)),
+            Err(mpsc::error::TrySendError::Closed(())) => Err(LeasedSendError::Closed(frame)),
+        }
     }
 
     /// Current free slots in the bounded transport queue.
     pub fn capacity(&self) -> usize {
-        self.sender.capacity()
+        match &self.sender {
+            FramedSender::Plain(sender) => sender.capacity(),
+            FramedSender::Queued(sender) => sender.capacity(),
+        }
     }
 
     /// Total slots in the bounded transport queue.
     pub fn max_capacity(&self) -> usize {
-        self.sender.max_capacity()
+        match &self.sender {
+            FramedSender::Plain(sender) => sender.max_capacity(),
+            FramedSender::Queued(sender) => sender.max_capacity(),
+        }
     }
+}
+
+/// Failure to queue a leased frame.
+#[derive(Debug)]
+#[allow(dead_code)] // consumed by the GetBlocks policy in the stacked PR
+pub(crate) enum LeasedSendError {
+    /// The bounded transport queue has no free slot.
+    Full(Frame),
+    /// The transport worker has closed its receive half.
+    Closed(Frame),
+    /// This handle wraps a compatibility channel without lease support.
+    Unsupported(Frame),
+}
+
+#[allow(dead_code)] // consumed by the GetBlocks policy in the stacked PR
+impl LeasedSendError {
+    /// Recover the frame that was not queued.
+    pub(crate) fn into_frame(self) -> Frame {
+        match self {
+            Self::Full(frame) | Self::Closed(frame) | Self::Unsupported(frame) => frame,
+        }
+    }
+
+    /// Return whether the queue was temporarily full.
+    pub(crate) fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Return whether the worker permanently closed the queue.
+    pub(crate) fn is_closed(&self) -> bool {
+        matches!(self, Self::Closed(_))
+    }
+}
+
+/// Frame plus optional byte ownership retained through its transport write.
+#[derive(Debug)]
+pub(crate) struct QueuedFrame {
+    frame: Frame,
+    lease: Option<FrameLease>,
+}
+
+impl QueuedFrame {
+    fn plain(frame: Frame) -> Self {
+        Self { frame, lease: None }
+    }
+
+    fn leased(frame: Frame, lease: FrameLease) -> Self {
+        Self {
+            frame,
+            lease: Some(lease),
+        }
+    }
+
+    /// Split the frame from its lease while retaining both in the caller.
+    pub(crate) fn into_parts(self) -> (Frame, Option<FrameLease>) {
+        (self.frame, self.lease)
+    }
+
+    /// Run the transport write while retaining this frame's lease.
+    pub(crate) async fn write_with<T, F, Fut>(self, write: F) -> T
+    where
+        F: FnOnce(Frame) -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let (frame, _lease) = self.into_parts();
+        write(frame).await
+    }
+}
+
+/// Transport-worker receive half for outbound queued frames.
+#[derive(Debug)]
+pub(crate) struct FramedWorkerRecv {
+    receiver: mpsc::Receiver<QueuedFrame>,
+}
+
+impl FramedWorkerRecv {
+    /// Receive the next outbound queued frame.
+    pub(crate) async fn recv(&mut self) -> Option<QueuedFrame> {
+        self.receiver.recv().await
+    }
+}
+
+/// Build the queue between a service and its transport worker.
+pub(crate) fn worker_framed_channel(depth: usize) -> (FramedSend, FramedWorkerRecv) {
+    let (sender, receiver) = mpsc::channel(depth);
+    (FramedSend::queued(sender), FramedWorkerRecv { receiver })
 }
 
 /// Build a bounded in-memory framed channel for scaffolding and tests.
 pub fn framed_channel(depth: usize) -> (FramedSend, FramedRecv) {
     let (sender, receiver) = mpsc::channel(depth);
-    (FramedSend::new(sender), FramedRecv::new(receiver))
+    (FramedSend::queued(sender), FramedRecv::queued(receiver))
+}
+
+fn map_queued_try_send_error(
+    error: mpsc::error::TrySendError<QueuedFrame>,
+) -> mpsc::error::TrySendError<Frame> {
+    match error {
+        mpsc::error::TrySendError::Full(queued) => {
+            mpsc::error::TrySendError::Full(queued.into_parts().0)
+        }
+        mpsc::error::TrySendError::Closed(queued) => {
+            mpsc::error::TrySendError::Closed(queued.into_parts().0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    use super::*;
+    use crate::zakura::regulation::{OutstandingByteBudget, OutstandingByteReservation};
+
+    fn frame(message_type: u16) -> Frame {
+        Frame {
+            message_type,
+            flags: 0,
+            payload: vec![u8::try_from(message_type).unwrap_or(u8::MAX)],
+        }
+    }
+
+    #[tokio::test]
+    async fn public_channel_preserves_order_capacity_and_errors() {
+        let (sender, mut receiver) = framed_channel(2);
+        assert_eq!(sender.capacity(), 2);
+        assert_eq!(sender.max_capacity(), 2);
+
+        sender.try_send(frame(1)).expect("first slot is free");
+        sender.try_send(frame(2)).expect("second slot is free");
+        assert!(matches!(
+            sender.try_send(frame(3)),
+            Err(mpsc::error::TrySendError::Full(Frame {
+                message_type: 3,
+                ..
+            }))
+        ));
+        assert_eq!(receiver.recv().await, Some(frame(1)));
+        assert_eq!(receiver.recv().await, Some(frame(2)));
+
+        drop(receiver);
+        assert!(matches!(
+            sender.try_send(frame(4)),
+            Err(mpsc::error::TrySendError::Closed(Frame {
+                message_type: 4,
+                ..
+            }))
+        ));
+    }
+
+    #[tokio::test]
+    async fn public_constructors_keep_plain_channel_compatibility() {
+        let (raw_sender, mut raw_receiver) = mpsc::channel(1);
+        let sender = FramedSend::new(raw_sender);
+        sender.send(frame(7)).await.expect("plain channel is open");
+        assert_eq!(raw_receiver.recv().await, Some(frame(7)));
+
+        let (raw_sender, raw_receiver) = mpsc::channel(1);
+        let mut receiver = FramedRecv::new(raw_receiver);
+        raw_sender
+            .send(frame(8))
+            .await
+            .expect("plain channel is open");
+        assert_eq!(receiver.recv().await, Some(frame(8)));
+    }
+
+    #[tokio::test]
+    async fn queued_frame_holds_lease_until_transport_consumes_it() {
+        let (sender, mut receiver) = worker_framed_channel(1);
+        let budget = OutstandingByteBudget::new(10);
+        let mut reservation = budget
+            .try_reserve(10)
+            .expect("the frame fits the budget")
+            .expect("the budget has capacity");
+
+        sender
+            .try_send_leased(frame(1), || {
+                OutstandingByteReservation::transfer_to_frame([&mut reservation], 10)
+                    .expect("the reservation covers the frame")
+            })
+            .expect("the worker queue has a slot");
+        drop(reservation);
+        assert_eq!(budget.reserved(), 10);
+
+        let queued = receiver.recv().await.expect("worker receives the frame");
+        let (received, lease) = queued.into_parts();
+        assert_eq!(received, frame(1));
+        assert_eq!(budget.reserved(), 10);
+
+        drop(lease);
+        assert_eq!(budget.reserved(), 0);
+    }
+
+    #[tokio::test]
+    async fn queued_frame_holds_lease_while_write_is_pending() {
+        let (sender, mut receiver) = worker_framed_channel(1);
+        let budget = OutstandingByteBudget::new(10);
+        let mut reservation = budget
+            .try_reserve(10)
+            .expect("the frame fits the budget")
+            .expect("the budget has capacity");
+        sender
+            .try_send_leased(frame(1), || {
+                OutstandingByteReservation::transfer_to_frame([&mut reservation], 10)
+                    .expect("the reservation covers the frame")
+            })
+            .expect("the worker queue has a slot");
+        drop(reservation);
+        let queued = receiver.recv().await.expect("worker receives the frame");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+
+        let write = tokio::spawn(queued.write_with(move |_frame| async move {
+            let _ = started_tx.send(());
+            let _ = finish_rx.await;
+        }));
+        started_rx.await.expect("the write reaches its wait point");
+        assert_eq!(budget.reserved(), 10);
+
+        let _ = finish_tx.send(());
+        write.await.expect("the write task should not panic");
+        assert_eq!(budget.reserved(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelling_pending_write_releases_lease() {
+        let (sender, mut receiver) = worker_framed_channel(1);
+        let budget = OutstandingByteBudget::new(10);
+        let mut reservation = budget
+            .try_reserve(10)
+            .expect("the frame fits the budget")
+            .expect("the budget has capacity");
+        sender
+            .try_send_leased(frame(1), || {
+                OutstandingByteReservation::transfer_to_frame([&mut reservation], 10)
+                    .expect("the reservation covers the frame")
+            })
+            .expect("the worker queue has a slot");
+        drop(reservation);
+        let queued = receiver.recv().await.expect("worker receives the frame");
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let write = tokio::spawn(queued.write_with(move |_frame| async move {
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        }));
+        started_rx.await.expect("the write reaches its wait point");
+        assert_eq!(budget.reserved(), 10);
+
+        write.abort();
+        assert!(write
+            .await
+            .expect_err("the write should be cancelled")
+            .is_cancelled());
+        assert_eq!(budget.reserved(), 0);
+    }
+
+    #[test]
+    fn failed_leased_send_does_not_create_a_lease() {
+        let (sender, _receiver) = worker_framed_channel(1);
+        sender.try_send(frame(1)).expect("the queue slot is free");
+        let full_called = Arc::new(AtomicBool::new(false));
+        let called_by_factory = full_called.clone();
+
+        let result = sender.try_send_leased(frame(2), move || {
+            called_by_factory.store(true, Ordering::SeqCst);
+            FrameLease::empty_for_test()
+        });
+
+        assert!(matches!(result, Err(LeasedSendError::Full(_))));
+        assert!(!full_called.load(Ordering::SeqCst));
+
+        let (sender, receiver) = worker_framed_channel(1);
+        drop(receiver);
+        let closed_called = Arc::new(AtomicBool::new(false));
+        let called_by_factory = closed_called.clone();
+        let result = sender.try_send_leased(frame(3), move || {
+            called_by_factory.store(true, Ordering::SeqCst);
+            FrameLease::empty_for_test()
+        });
+        assert!(matches!(result, Err(LeasedSendError::Closed(_))));
+        assert!(!closed_called.load(Ordering::SeqCst));
+
+        let (raw_sender, _raw_receiver) = mpsc::channel(1);
+        let sender = FramedSend::new(raw_sender);
+        let unsupported_called = Arc::new(AtomicBool::new(false));
+        let called_by_factory = unsupported_called.clone();
+        let result = sender.try_send_leased(frame(4), move || {
+            called_by_factory.store(true, Ordering::SeqCst);
+            FrameLease::empty_for_test()
+        });
+        assert!(matches!(result, Err(LeasedSendError::Unsupported(_))));
+        assert!(!unsupported_called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn dropping_worker_queue_releases_queued_lease() {
+        let (sender, receiver) = worker_framed_channel(1);
+        let budget = OutstandingByteBudget::new(10);
+        let mut reservation = budget
+            .try_reserve(10)
+            .expect("the frame fits the budget")
+            .expect("the budget has capacity");
+        sender
+            .try_send_leased(frame(1), || {
+                OutstandingByteReservation::transfer_to_frame([&mut reservation], 10)
+                    .expect("the reservation covers the frame")
+            })
+            .expect("the worker queue has a slot");
+        drop(reservation);
+        assert_eq!(budget.reserved(), 10);
+
+        drop(receiver);
+
+        assert_eq!(budget.reserved(), 0);
+    }
 }

--- a/crates/zakura-network/src/zakura/transport/mod.rs
+++ b/crates/zakura-network/src/zakura/transport/mod.rs
@@ -20,6 +20,8 @@ pub use frame::{Frame, StreamPrelude, ZakuraTrace};
 #[allow(unused_imports)]
 pub(crate) use guard::{Admit, ByteBudget, PeerMeters, SessionGuard};
 pub use io::{framed_channel, FramedRecv, FramedSend};
+#[allow(unused_imports)] // used by the first message policy in the stacked PR
+pub(crate) use io::{worker_framed_channel, FramedWorkerRecv, LeasedSendError, QueuedFrame};
 pub(crate) use pipe::{
     handle_pipe_exit, spawn_supervised_peer_task, spawn_supervised_pipe, CloseCause, Edge, Flow,
     Node, NodeKind, Pipe, PipeCx, PipeShape,

--- a/docs/changelog/unreleased/888.md
+++ b/docs/changelog/unreleased/888.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR adds internal regulation mechanics without enabling a message policy or
+changing operator-visible behavior.


### PR DESCRIPTION
## Motivation

GetBlocks regulation needs reusable resource accounting that can later support other P2P exchanges.

## Solution

Add crate-private rate, outstanding-byte, and slot budgets with owned, refundable reservations. Slot waits return the acquired permit, and outbound frame leases retain capacity through the application transport write. Message policy and defaults belong in the stacked GetBlocks change; generated property/load tests remain deferred until that policy settles.

## Testing

All 15 regulation tests and 7 transport I/O tests pass, including queued slot ownership and waiter cancellation. Formatting and network Clippy with all targets pass.

## Changelog

The no-changelog fragment records internal infrastructure with no operator-visible behavior.

Used Codex for implementation and validation.
