### PR TITLE
fix(deploy): distinguish lagging tips from forks

### DIFF
--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -590,6 +590,11 @@ class TipAgreementTests(unittest.TestCase):
         )
         self.assertEqual(lagging["status"], "lagging")
         self.assertFalse(lagging["split"])
+        lagging_group = next(
+            group for group in lagging["tip_groups"] if group["height"] == 99
+        )
+        self.assertEqual(lagging_group["fork_depth"], 1)
+        self.assertEqual(lagging_group["fork_depth_label"], "1 behind")
 
         split = status.compute_chain_summary(
             [
@@ -634,6 +639,7 @@ class TipAgreementTests(unittest.TestCase):
         ahead_group = next(
             group for group in ahead_chain["tip_groups"] if group["height"] == 101
         )
+        self.assertEqual(ahead_group["fork_depth"], 1)
         self.assertEqual(ahead_group["fork_depth_label"], "1 ahead")
 
     def test_row_for_records_reorg_and_headers(self):
@@ -860,6 +866,7 @@ class ViewSwitchingTests(unittest.TestCase):
         self.assertIn("return 'behind';", self.page)
         self.assertIn("badge(role, tone(CHAIN_TONE, role))", self.page)
         self.assertNotIn("badge(isMajority ? 'majority' : 'fork'", self.page)
+        self.assertIn("lagging: 'Nodes report different tip heights.'", self.page)
 
 
 class NodeDetailTests(unittest.TestCase):

--- a/deploy/runner/test_zakura_cluster_status.py
+++ b/deploy/runner/test_zakura_cluster_status.py
@@ -631,6 +631,10 @@ class TipAgreementTests(unittest.TestCase):
             {row["name"]: row["chain_role"] for row in ahead_rows},
             {"a": "majority", "b": "majority", "c": "ahead"},
         )
+        ahead_group = next(
+            group for group in ahead_chain["tip_groups"] if group["height"] == 101
+        )
+        self.assertEqual(ahead_group["fork_depth_label"], "1 ahead")
 
     def test_row_for_records_reorg_and_headers(self):
         subject = collector()
@@ -844,6 +848,18 @@ class ViewSwitchingTests(unittest.TestCase):
     def test_both_views_are_present_in_one_template(self):
         self.assertIn('data-view="fleet"', self.markup)
         self.assertIn('data-view="node"', self.markup)
+
+    def test_tip_group_badges_use_the_height_relationship(self):
+        self.assertIn(
+            "if (group.height === chain.majority_height) return 'fork';",
+            self.page,
+        )
+        self.assertIn(
+            "if (group.height > chain.majority_height) return 'ahead';", self.page
+        )
+        self.assertIn("return 'behind';", self.page)
+        self.assertIn("badge(role, tone(CHAIN_TONE, role))", self.page)
+        self.assertNotIn("badge(isMajority ? 'majority' : 'fork'", self.page)
 
 
 class NodeDetailTests(unittest.TestCase):

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -1848,10 +1848,12 @@ def compute_chain_summary(
                 group["fork_depth"] = depth_info.get("depth")
                 group["fork_depth_label"] = depth_info.get("label") or "unknown"
             else:
-                behind = majority["height"] - group["height"]
-                group["fork_depth"] = behind
+                height_delta = majority["height"] - group["height"]
+                group["fork_depth"] = abs(height_delta)
                 group["fork_depth_label"] = (
-                    f"{behind} behind" if behind > 0 else f"{-behind} ahead"
+                    f"{height_delta} behind"
+                    if height_delta > 0
+                    else f"{-height_delta} ahead"
                 )
 
     return {
@@ -3034,7 +3036,7 @@ function renderChain(data) {
 
   el('chain-summary').textContent = {
     split: 'Nodes disagree on the tip hash at the leading height.',
-    lagging: 'One tip hash leads; some nodes are behind.',
+    lagging: 'Nodes report different tip heights.',
     agreed: 'All observed nodes share the same tip.',
   }[status] || 'Waiting for tip observations.';
 

--- a/deploy/runner/zakura-cluster-status.py
+++ b/deploy/runner/zakura-cluster-status.py
@@ -1850,7 +1850,9 @@ def compute_chain_summary(
             else:
                 behind = majority["height"] - group["height"]
                 group["fork_depth"] = behind
-                group["fork_depth_label"] = f"{behind} behind"
+                group["fork_depth_label"] = (
+                    f"{behind} behind" if behind > 0 else f"{-behind} ahead"
+                )
 
     return {
         "status": status,
@@ -2244,6 +2246,7 @@ button { font: inherit; }
   border-radius: var(--r-md);
 }
 .tip-group.is-majority { border-left-color: var(--ok); }
+.tip-group.is-behind, .tip-group.is-ahead { border-left-color: var(--warn); }
 .tip-group.is-fork { border-left-color: var(--bad); }
 .tip-group-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .tip-group-top .height { font-weight: 640; font-variant-numeric: tabular-nums; }
@@ -3015,6 +3018,14 @@ function renderStats(data) {
   el('stale-window').textContent =
     'stale after ' + Math.round(data.stale_after) + 's without a new block';
 }
+function tipGroupRole(group, chain) {
+  const isMajority = group.height === chain.majority_height
+    && group.block_hash === chain.majority_hash;
+  if (isMajority) return 'majority';
+  if (group.height === chain.majority_height) return 'fork';
+  if (group.height > chain.majority_height) return 'ahead';
+  return 'behind';
+}
 function renderChain(data) {
   const chain = data.chain || {};
   const status = chain.status || 'unknown';
@@ -3029,14 +3040,14 @@ function renderChain(data) {
 
   el('tip-groups').innerHTML = tipGroups.length
     ? tipGroups.map((group) => {
-      const isMajority = group.height === chain.majority_height
-        && group.block_hash === chain.majority_hash;
+      const role = tipGroupRole(group, chain);
+      const isMajority = role === 'majority';
       const depth = group.fork_depth_label && !isMajority
         ? badge(group.fork_depth_label, 'warn')
         : '';
-      return '<div class="tip-group ' + (isMajority ? 'is-majority' : 'is-fork') + '">'
+      return '<div class="tip-group is-' + role + '">'
         + '<div class="tip-group-top">'
-        + badge(isMajority ? 'majority' : 'fork', isMajority ? 'ok' : 'bad')
+        + badge(role, tone(CHAIN_TONE, role))
         + '<span class="height num">height ' + num(group.height) + '</span>'
         + '<span class="mono muted" style="font-size:0.78rem">'
         + copyCell(group.block_hash, shortHash(group.block_hash), 'Copy tip hash') + '</span>'


### PR DESCRIPTION
## Motivation

The cluster dashboard rendered every non-majority tip group as a red `fork`. Nodes that were still syncing therefore appeared forked even when their lower tip was on the leading chain.

## Solution

Classify each tip group from its height and hash relationship to the majority tip. The dashboard now renders lower groups as `behind`, higher groups as `ahead`, and only same-height hash disagreements as `fork`.

Use warning colors for behind and ahead groups. Keep the error color for forks. Also render a positive `ahead` distance when a higher group outnumbers the leading group.

## Testing

- `python3 -m unittest deploy/runner/test_zakura_cluster_status.py` — 58 tests passed
- `python3 deploy/runner/test_zakura_cluster_watchdog.py` — 67 tests passed
- Extracted the embedded JavaScript and checked its syntax with `node --check`

The regression test verifies that the dashboard selects each badge from the height relationship and no longer defaults every non-majority group to `fork`. The chain summary test verifies the corrected ahead-distance label.

## Changelog

No changelog entry: this change only corrects an internal deployment dashboard.