### PR TITLE
chore(release): allow v1.3.2 patch release

### DIFF
--- a/docs/changelog/unreleased/867.md
+++ b/docs/changelog/unreleased/867.md
@@ -3,3 +3,5 @@
 - Added metrics, dashboard visibility, and alerts for the existing Mainnet
   end-of-support schedule
   ([#867](https://github.com/zakura-core/zakura/pull/867)).
+
+<!-- release-readiness: allow-patch; reason: The added metrics are backwards compatible, and the Changed entry is an internal dependency update with no operator-facing behavior change. -->


### PR DESCRIPTION
## Motivation

The automated v1.3.2 release preparation rejected the patch version because the pending changelog contains Added and Changed entries. For this release, those entries describe backwards-compatible metrics and an internal dependency update, so they do not require a minor Zakura node release.

## Solution

Record the supported release-readiness allow-patch waiver with a concrete reason. This changes only the Zakura node release floor; library crates still receive independently required SemVer bumps.

## Testing

- python3 scripts/release-readiness.py version --repo-root . --base-version 1.3.1 --release-tag v1.3.2
- ./scripts/changelog.py check
- npm exec --yes markdownlint-cli -- docs/changelog/unreleased/867.md --config .github/.markdownlint.yaml
- git diff --check

The readiness report now selects patch with minimum version 1.3.2.

## Changelog

This PR updates release metadata in an existing pending fragment and has no separate operator-visible effect.

### Specifications & References

- Failed preparation run: https://github.com/zakura-core/zakura/actions/runs/33930899496

### Follow-up Work

After this PR merges, rerun Prepare release PR for v1.3.2 from v1.3.1.

### AI Disclosure

This focused release-policy annotation and PR description were prepared with Codex and verified with the repository release-readiness tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only release tooling metadata with no runtime or operator behavior change.
> 
> **Overview**
> Adds a **release-readiness** HTML comment to the pending changelog fragment for [#867](https://github.com/zakura-core/zakura/pull/867), waiving the usual rule that **Added**/**Changed** entries force a minor bump so automated prepare can target **v1.3.2** as a patch.
> 
> The waiver reason documents that the metrics work is backwards compatible and any **Changed** item is an internal dependency update with no operator-facing behavior change. No operator-visible changelog text is altered beyond this metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9084f4c565dfcb7279b969d12c599096578186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->