### PR TITLE
fix(ci): resolve volume snapshot IDs from the catalog

### DIFF
--- a/.github/workflows/scripts/do_snapshot.py
+++ b/.github/workflows/scripts/do_snapshot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Create a volume snapshot and resolve its ID from the snapshot catalog."""
+
+import argparse
+import subprocess
+import sys
+import time
+
+from do_provision import doctl
+
+
+def matching_snapshots(volume_id, name, region):
+    return [
+        snapshot
+        for snapshot in doctl("snapshot", "list", "--resource", "volume")
+        if snapshot["name"] == name
+        and snapshot["resource_id"] == volume_id
+        and region in snapshot["regions"]
+    ]
+
+
+def create_snapshot(volume_id, name, region, timeout=300):
+    """Create once, then wait for the exact volume/name/region to be listed."""
+    if matching_snapshots(volume_id, name, region):
+        raise RuntimeError(f"snapshot already exists for volume {volume_id}: {name}")
+    # doctl 1.120.0 discards the create response, even with --output json.
+    doctl("volume", "snapshot", volume_id, "--snapshot-name", name)
+    deadline = time.monotonic() + timeout
+    while True:
+        matches = matching_snapshots(volume_id, name, region)
+        if len(matches) > 1:
+            raise RuntimeError(f"multiple snapshots match volume {volume_id}: {name}")
+        if matches:
+            return str(matches[0]["id"])
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"created snapshot not listed for volume {volume_id}: {name}"
+            )
+        time.sleep(min(5, remaining))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--volume-id", required=True)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--region", required=True)
+    args = parser.parse_args()
+    print(create_snapshot(args.volume_id, args.name, args.region))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        print(error.stderr, file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/scripts/test_do_provision.py
+++ b/.github/workflows/scripts/test_do_provision.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import do_artifact_retention as retention
 import do_provision as p
 import do_seed_approach as seed
+import do_snapshot as snapshots
 
 
 def size(slug, regions=("nyc1",), disk=100, price=0.25, cpu=8, memory=16384):
@@ -329,6 +330,73 @@ class Lifecycle(unittest.TestCase):
             args("--policy", "bake", "--regions", "sfo3"),
         )
         self.assertFalse(p.volume_names(first) & p.volume_names(second))
+
+
+class SnapshotCreation(unittest.TestCase):
+    def snapshot(self, **changes):
+        return (
+            dict(
+                id="snapshot-id",
+                name="fixture",
+                resource_id="volume-id",
+                regions=["nyc1"],
+            )
+            | changes
+        )
+
+    @patch.object(snapshots.time, "sleep")
+    @patch.object(p.subprocess, "run")
+    def test_empty_create_output_and_delayed_listing(self, run, sleep):
+        other_volume = self.snapshot(resource_id="other-volume")
+        other_region = self.snapshot(regions=["sfo3"])
+        other_name = self.snapshot(name="other-name")
+        run.side_effect = [
+            subprocess.CompletedProcess("doctl", 0, stdout=output, stderr="")
+            for output in (
+                "[]",
+                "",
+                json.dumps([other_volume, other_region, other_name]),
+                json.dumps([self.snapshot()]),
+            )
+        ]
+        self.assertEqual(
+            snapshots.create_snapshot("volume-id", "fixture", "nyc1"), "snapshot-id"
+        )
+        creates = [
+            call.args[0]
+            for call in run.call_args_list
+            if call.args[0][2:4] == ["volume", "snapshot"]
+        ]
+        self.assertEqual(len(creates), 1)
+        self.assertEqual(creates[0][-1], "0")
+        sleep.assert_called_once()
+
+    @patch.object(snapshots, "doctl")
+    def test_existing_snapshot_does_not_create_another(self, api):
+        api.return_value = [self.snapshot()]
+        with self.assertRaisesRegex(RuntimeError, "already exists"):
+            snapshots.create_snapshot("volume-id", "fixture", "nyc1")
+        api.assert_called_once()
+
+    @patch.object(snapshots, "doctl")
+    def test_duplicate_matches_are_not_arbitrarily_selected(self, api):
+        api.side_effect = [[], None, [self.snapshot(), self.snapshot(id="second")]]
+        with self.assertRaisesRegex(RuntimeError, "multiple snapshots"):
+            snapshots.create_snapshot("volume-id", "fixture", "nyc1")
+
+    @patch.object(snapshots, "doctl")
+    def test_missing_snapshot_times_out_without_recreating(self, api):
+        api.side_effect = [[], None, []]
+        with self.assertRaisesRegex(TimeoutError, "not listed"):
+            snapshots.create_snapshot("volume-id", "fixture", "nyc1", timeout=0)
+        self.assertEqual(api.call_count, 3)
+
+    @patch.object(snapshots, "doctl")
+    def test_ambiguous_create_is_not_retried(self, api):
+        api.side_effect = [[], subprocess.TimeoutExpired("doctl", 180)]
+        with self.assertRaises(subprocess.TimeoutExpired):
+            snapshots.create_snapshot("volume-id", "fixture", "nyc1")
+        self.assertEqual(api.call_count, 2)
 
 
 class Retention(unittest.TestCase):

--- a/.github/workflows/zakura-pr-node-bake.yml
+++ b/.github/workflows/zakura-pr-node-bake.yml
@@ -17,6 +17,7 @@ on:
       - .github/workflows/zakura-pr-node-bake.yml
       - .github/workflows/scripts/do_provision.py
       - .github/workflows/scripts/do_seed_approach.py
+      - .github/workflows/scripts/do_snapshot.py
       - .github/workflows/scripts/pr-node-bake.sh
   workflow_dispatch:
     inputs:
@@ -188,16 +189,19 @@ jobs:
           if [ "$REBUILD_APPROACH_FROM_SANDBLAST" != "true" ]; then
             MAINNET_H=$(fetch_height /root/mainnet-state-height)
             TESTNET_H=$(fetch_height /root/testnet-state-height)
-            MAINNET_ID=$(doctl compute volume snapshot "${MAINNET_VOL_ID}" \
-              --snapshot-name "${STATE_PREFIX}-mainnet-${STAMP}-${REGION}-h${MAINNET_H}" --output json | jq -er 'if type == "array" then .[0].id else .id end')
+            MAINNET_ID=$(python3 .github/workflows/scripts/do_snapshot.py \
+              --volume-id "${MAINNET_VOL_ID}" --region "$REGION" \
+              --name "${STATE_PREFIX}-mainnet-${STAMP}-${REGION}-h${MAINNET_H}")
             echo "mainnet_id=$MAINNET_ID" >> "$GITHUB_OUTPUT"
-            TESTNET_ID=$(doctl compute volume snapshot "${TESTNET_VOL_ID}" \
-              --snapshot-name "${STATE_PREFIX}-testnet-${STAMP}-${REGION}-h${TESTNET_H}" --output json | jq -er 'if type == "array" then .[0].id else .id end')
+            TESTNET_ID=$(python3 .github/workflows/scripts/do_snapshot.py \
+              --volume-id "${TESTNET_VOL_ID}" --region "$REGION" \
+              --name "${STATE_PREFIX}-testnet-${STAMP}-${REGION}-h${TESTNET_H}")
             echo "testnet_id=$TESTNET_ID" >> "$GITHUB_OUTPUT"
           fi
           if [ -n "$APPROACH_H" ]; then
-            APPROACH_ID=$(doctl compute volume snapshot "${APPROACH_VOL_ID}" \
-              --snapshot-name "${APPROACH_PREFIX}-mainnet-${STAMP}-${REGION}-h${APPROACH_H}" --output json | jq -er 'if type == "array" then .[0].id else .id end')
+            APPROACH_ID=$(python3 .github/workflows/scripts/do_snapshot.py \
+              --volume-id "${APPROACH_VOL_ID}" --region "$REGION" \
+              --name "${APPROACH_PREFIX}-mainnet-${STAMP}-${REGION}-h${APPROACH_H}")
             echo "approach_id=$APPROACH_ID" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::approach state was not refreshed; retaining the existing pinned snapshot"


### PR DESCRIPTION
## Motivation
Both regional bakes create a Mainnet volume snapshot and then fail because doctl's snapshot command prints no JSON, even when JSON output is requested. The remaining snapshots and image are never published.

## Solution
Create each volume snapshot once, then resolve its ID from the catalog using its exact name, source volume, and region. Bound catalog polling and reject ambiguous matches without repeating creation.

## Testing
All 29 provisioning tests and PR CI pass. The [branch bake](https://github.com/zakura-core/zakura/actions/runs/33939105967) succeeded in NYC1 and SFO3, each producing a verified 100 GB image and three state snapshots. The [NYC1 canary](https://github.com/zakura-core/zakura/actions/runs/33942273945) and [SFO3 canary](https://github.com/zakura-core/zakura/actions/runs/33943099686) passed against their exact new artifacts, finalized checkpoint 3,470,171, and reached heights 3,470,691 and 3,470,713. Both recorded VCT activity with no errors or restarts. Temporary droplets, cloned volumes, and all eight isolated validation artifacts were removed after retaining the logs and metadata.

Used Codex for implementation and validation.





