### PR TITLE
test: add native sync resource reports

### DIFF
--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -8236,6 +8236,120 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn ordered_write_keeps_capacity_until_transport_completion() -> Result<(), BoxError> {
+        use crate::zakura::regulation::{OutstandingByteBudget, OutstandingByteReservation};
+
+        const ALPN: &[u8] = b"/zakura/testkit/ordered-write-lifetime/0";
+        const FRAME_CAP: u32 = 64 * 1024;
+        let _guard = zakura_test::init();
+
+        for resume_reader in [true, false] {
+            // Small transport windows block a single ordinary frame without a large transfer.
+            let transport = || {
+                let mut config = TransportConfig::default();
+                config
+                    .send_window(1024)
+                    .receive_window(VarInt::from_u32(1024))
+                    .stream_receive_window(VarInt::from_u32(1024));
+                config
+            };
+            let server = LocalEndpointFactory::with_transport_config(transport())
+                .endpoint(176)
+                .await?;
+            let (conn_tx, _conn_rx) = mpsc::channel(1);
+            let (stream_tx, mut stream_rx) = mpsc::channel(2);
+            let router = Router::builder(server)
+                .accept(
+                    ALPN,
+                    CaptureConnection {
+                        connection_tx: conn_tx,
+                        stream_tx,
+                    },
+                )
+                .spawn();
+            let client = LocalEndpointFactory::with_transport_config(transport())
+                .endpoint(177)
+                .await?;
+            let address = router.endpoint().node_addr().initialized().await;
+            client.add_node_addr(address.clone())?;
+            let connection =
+                timeout(Duration::from_secs(10), client.connect(address, ALPN)).await??;
+            let (mut send, _recv) = timeout(Duration::from_secs(5), connection.open_bi()).await??;
+            let payload = vec![0x5a; 16 * 1024];
+            let charged = u64::try_from(payload.len()).expect("the small test payload fits in u64");
+            let budget = OutstandingByteBudget::new(charged);
+            let mut reservation = budget.try_reserve(charged)?.expect("the budget is empty");
+            let (sender, mut receiver) = worker_framed_channel(1);
+            sender
+                .try_send_leased(
+                    Frame {
+                        message_type: 1,
+                        flags: 0,
+                        payload: payload.clone(),
+                    },
+                    || {
+                        OutstandingByteReservation::transfer_to_frame([&mut reservation], charged)
+                            .expect("the reservation covers the frame")
+                    },
+                )
+                .expect("the worker queue is empty");
+            drop(reservation);
+            let queued = receiver.recv().await.expect("the frame is queued");
+            let mut limits = test_connection_limits();
+            limits.max_message_bytes = FRAME_CAP;
+            let writing = tokio::spawn(async move {
+                let result = write_queued_ordered_frame(&mut send, queued, limits, FRAME_CAP).await;
+                (send, result)
+            });
+            let (_server_send, mut server_recv) = timeout(Duration::from_secs(5), stream_rx.recv())
+                .await?
+                .expect("the first frame bytes make the stream visible");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            assert!(
+                !writing.is_finished(),
+                "the unread stream must block the write"
+            );
+            assert_eq!(budget.reserved(), charged);
+
+            if resume_reader {
+                let received = read_frame(
+                    &mut server_recv,
+                    FRAME_CAP,
+                    Duration::from_secs(5),
+                    Some(Duration::from_secs(5)),
+                )
+                .await?;
+                assert_eq!(received.payload, payload);
+            }
+            let (mut send, result) = timeout(
+                OUTBOUND_STREAM_WRITE_TIMEOUT + Duration::from_secs(5),
+                writing,
+            )
+            .await??;
+            if resume_reader {
+                result?;
+            } else {
+                assert_eq!(
+                    result
+                        .expect_err("the unread frame must time out")
+                        .to_string(),
+                    "Zakura outbound frame write timed out"
+                );
+            }
+            assert_eq!(
+                budget.reserved(),
+                0,
+                "completion must release the frame charge"
+            );
+            let _ = send.reset(VarInt::from_u32(0));
+            connection.close(0u32.into(), b"done");
+            client.close().await;
+            router.shutdown().await?;
+        }
+        Ok(())
+    }
+
     // Regression for `claude-control-payload-late-hard-cap`: the native control
     // hello/ack reads passed the configured `max_control_frame_bytes` (1 MiB
     // default) to `read_control_payload`, so a peer could force allocation/read

--- a/docs/changelog/unreleased/908.md
+++ b/docs/changelog/unreleased/908.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+Adds native sync observation tools and a transport ownership test. Serving policy
+and production defaults are unchanged.

--- a/docs/testing/getblocks-workloads.md
+++ b/docs/testing/getblocks-workloads.md
@@ -25,6 +25,10 @@ indices. The artifact records the source file's SHA-256.
 
 ## Evidence boundary
 
+Pair captures with [native sync observations](native-sync-observations.md) when
+assessing hardware fit. Ownership replay does not measure process memory,
+kernel cache reclaim or committed sync throughput.
+
 This first import contains decoded arrivals. The artifact explicitly sets
 `service_lifecycles_complete` and `capture_loss_verified` to false. Per-session
 continuity cannot detect a session whose entire trace disappeared. Process-wide

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -64,6 +64,12 @@ diagnostic report with `recording_complete=false`; it does not accept a corrupt
 or truncated gzip stream. A recording with no selected active-node samples has
 null pressure and available-memory observations, not a zero-pressure pass.
 
+The separate `whole_recording` section includes all recorded active-node samples,
+including startup and the period after the last client finishes. Keep it beside
+the selected workload results: a server can reach a memory limit during capture
+drain or shutdown even when its sync-phase counters were zero. This summary uses
+the same streaming analysis and does not change the chosen phase boundaries.
+
 ## Interpret the measurements
 
 PSI totals count microseconds of stalls. The analyzer excludes counter resets,
@@ -108,6 +114,11 @@ valid interval was observed, while zero means valid intervals showed no change.
 These changes are not the unit's absolute lifetime event counts. Keep the raw
 recording and the controller's full-run outcome alongside the selected-phase
 report, particularly when the node reaches a memory limit.
+
+`event_observations` separately preserves the maximum absolute counter value
+read, including the first sample. Numeric and unavailable sample counts keep a
+missing counter distinct from observed zero. The maximum is not a sum across
+counter resets or a count of events after the final successful read.
 
 Do not align timestamps from different native trace emitters merely because
 their process identities match. Explain received-body gaps with events from the

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -86,6 +86,14 @@ dirty-page and kernel subcategories overlap. The report preserves their values
 without treating them as guaranteed reclaimable memory or calculating a headroom
 pass from subtraction.
 
+`value_observations` reports numeric ranges and counts for usage, swap usage,
+and the applied high and hard memory limits across all selected active-node
+samples. It counts unlimited (`max`) and unavailable reads separately. A limit
+seen only at peak usage cannot hide a different or missing limit in other
+samples. Matching limits throughout the recording still do not prove the value
+between samples, and zero observed swap usage requires numeric observations;
+missing swap counters cannot establish it.
+
 Limit-event changes are differences between valid adjacent samples of the same
 unit and boot. Initial counter values, missing reads, resets and sampling gaps
 do not contribute; excluded intervals remain explicit. A null change means no

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -167,6 +167,13 @@ written. A recorded supervision failure or audited unsuccessful outcome is
 completion timing. Changed evidence fails reporting instead of silently dropping
 the trial. `all_pairs_complete` requires every planned pair to be complete.
 
+Capture imports are reported separately in each pair's `captures` and the series'
+`capture_counts`. A native sync can complete even when its trace lost rows and
+cannot be replayed. `all_required_captures_imported` is false if any requested
+capture failed or is unavailable, and null when none were requested. Successful
+imports are bound to the saved workload's digest. This checks the existing import
+record, not the raw trace again, and does not establish that replay passed.
+
 A preparation failure may later have a completed outcome only with a bound
 resumption record showing that no native trial had started and no process needed
 stopping. The failure and its resumption remain visible in the completed run,

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -1,0 +1,84 @@
+# Native sync observations
+
+The recorder captures a test node's chain progress, process statistics, Linux
+cgroup counters, host pressure and local metrics. The pressure report separates
+reclaimable file cache from the time spent waiting for memory. These observations
+complement the [GetBlocks ownership replay](getblocks-workloads.md); neither
+establishes native sync success or a supported hardware envelope by itself.
+
+## Record an existing test node
+
+Run on the Linux test host after its node service starts. Use Python 3.11 or later
+and a cgroup v2 system. The recorder only reads the service and local endpoints;
+it does not start, stop or reconfigure the node.
+
+```sh
+python3 scripts/record-native-sync.py \
+  --unit native-sync-test.service \
+  --out /var/tmp/native-sync-samples.jsonl.gz \
+  --seconds 900
+```
+
+The default exporter is `http://127.0.0.1:19999/metrics`, and the default RPC is
+`http://127.0.0.1:18232`. Override them with `--metrics-url` and `--rpc-url` for
+the test configuration. Only literal loopback HTTP endpoints without URL
+credentials are accepted; proxies and redirects are disabled. The test node
+must expose the read-only chain RPC without authentication on that local port.
+
+The observer aims for one sample every two seconds. It brackets all reads with
+same-host monotonic timestamps and also records wall time. RPC/exporter reads
+have two-second timeouts and bounded responses. Missing files and endpoint
+failures remain error objects rather than zero values. A missing systemd unit
+fails the recording instead of resembling a successful stopped node.
+
+Recording stops when the unit is inactive or failed, or the duration expires.
+An existing output is never replaced. Preserve a failed or interrupted recording;
+it can still be useful as explicitly incomplete diagnostic evidence.
+
+## Read pressure without loading the whole recording
+
+Use the measured workload phase from the experiment controller. Replace
+`START_NS` and `END_NS` below with its inclusive Unix-nanosecond boundaries.
+Those boundaries need recorded clock uncertainty when derived across hosts.
+
+```sh
+python3 scripts/report-native-sync-pressure.py \
+  /var/tmp/native-sync-samples.jsonl.gz pressure.json \
+  --start-utc-ns START_NS --end-utc-ns END_NS
+python3 -m unittest discover -s scripts/tests -p 'test_native_sync_pressure.py'
+```
+
+The report streams through the entire gzip recording, including its footer and
+rows outside the selected phase, and records its SHA-256. Memory use does not
+grow with the number of samples. The output is created exclusively.
+
+`recording_complete` means the recording ended with a stopped unit. A failed
+unit can have a complete recording. `unit_success_observed` separately reports
+whether the final systemd properties show success; it is null for older
+recordings that did not include the unit result. Neither field proves the node
+reached the intended chain hash. Keep the controller's exact-target and cleanup
+evidence with this report.
+
+An active final unit is rejected by default. `--allow-incomplete` produces a
+diagnostic report with `recording_complete=false`; it does not accept a corrupt
+or truncated gzip stream. A recording with no selected active-node samples has
+null pressure and available-memory observations, not a zero-pressure pass.
+
+## Interpret the measurements
+
+PSI totals count microseconds of stalls. The analyzer excludes counter resets,
+long sampling gaps and cgroup identity changes. It retains sample-read uncertainty
+in the covered-time bounds and maximum interval percentage. These percentages
+are bounds on observed intervals, not exact instantaneous utilization. Missing
+counters remain null and excluded intervals are counted.
+
+The host's estimated available memory includes reclaimable cache. Cgroup file
+memory may be charged to the group that first created those pages, including a
+fixture-preparation group. Neither high cache occupancy nor high estimated
+availability alone establishes safe memory headroom. Inspect both host and node
+pressure, memory-limit/OOM events, process memory and actual committed progress.
+The recorder includes the underlying counters for those separate checks.
+
+Do not align timestamps from different native trace emitters merely because
+their process identities match. Explain received-body gaps with events from the
+same block-sync emitter or an independently synchronized observer.

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -79,6 +79,21 @@ availability alone establishes safe memory headroom. Inspect both host and node
 pressure, memory-limit/OOM events, process memory and actual committed progress.
 The recorder includes the underlying counters for those separate checks.
 
+The `cgroup_memory` section retains the memory composition at the highest sampled
+total usage and, separately, at the highest sampled anonymous usage. Each is one
+bracketed read, not an atomic snapshot or a sum of independent peaks. File, LRU,
+dirty-page and kernel subcategories overlap. The report preserves their values
+without treating them as guaranteed reclaimable memory or calculating a headroom
+pass from subtraction.
+
+Limit-event changes are differences between valid adjacent samples of the same
+unit and boot. Initial counter values, missing reads, resets and sampling gaps
+do not contribute; excluded intervals remain explicit. A null change means no
+valid interval was observed, while zero means valid intervals showed no change.
+These changes are not the unit's absolute lifetime event counts. Keep the raw
+recording and the controller's full-run outcome alongside the selected-phase
+report, particularly when the node reaches a memory limit.
+
 Do not align timestamps from different native trace emitters merely because
 their process identities match. Explain received-body gaps with events from the
 same block-sync emitter or an independently synchronized observer.

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -78,6 +78,16 @@ in the covered-time bounds and maximum interval percentage. These percentages
 are bounds on observed intervals, not exact instantaneous utilization. Missing
 counters remain null and excluded intervals are counted.
 
+`host_pressure` separately summarizes the recorded CPU and I/O PSI counters,
+using the same interval rules as memory pressure. These cover the entire host,
+including activity outside the node's cgroup. They can identify contention worth
+investigating, but do not attribute a node stall to a particular operation or
+measure CPU utilization, disk latency or disk throughput. CPU, I/O and memory
+stall intervals can overlap; their totals must not be added into one stall time.
+Only CPU `some` is reported. System-wide CPU `full` is undefined even when the
+kernel exports zero for compatibility; see the
+[Linux PSI documentation](https://docs.kernel.org/accounting/psi.html).
+
 The host's estimated available memory includes reclaimable cache. Cgroup file
 memory may be charged to the group that first created those pages, including a
 fixture-preparation group. Neither high cache occupancy nor high estimated

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -126,9 +126,16 @@ the raw trace audit or independently attest what ran on the remote hosts.
 
 Every planned pair remains in the report. A missing completion audit is
 `unavailable`, which can mean an active run or a failure before an audit was
-written. An audited unsuccessful outcome is `failed`. Neither contributes a
+written. A recorded supervision failure or audited unsuccessful outcome is
+`failed`. Neither contributes a
 completion timing. Changed evidence fails reporting instead of silently dropping
 the trial. `all_pairs_complete` requires every planned pair to be complete.
+
+A preparation failure may later have a completed outcome only with a bound
+resumption record showing that no native trial had started and no process needed
+stopping. The failure and its resumption remain visible in the completed run,
+and `runs_with_supervision_failures` still counts it. Repeating a timed trial
+under the same run identifier is not accepted by this exception.
 
 Individual client changes, medians and ranges describe the completed pairs.
 Clients share a server and are not independent repetitions. A partial series,

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -82,3 +82,41 @@ The recorder includes the underlying counters for those separate checks.
 Do not align timestamps from different native trace emitters merely because
 their process identities match. Explain received-body gaps with events from the
 same block-sync emitter or an independently synchronized observer.
+
+## Compare a planned series
+
+After the native experiment controller writes its outcome audits, compare the
+whole frozen plan, including trials whose evidence is not yet available:
+
+```sh
+python3 scripts/report-native-sync-series.py series-plan.json series-report.json
+python3 -m unittest discover -s scripts/tests -p 'test_native_sync_series.py'
+```
+
+This reporter consumes the native lab's existing schema-1 plan and evidence
+layout. The plan lists `first_pair` and indexed `pairs`, with a filename and
+SHA-256 for each baseline and candidate specification. Each completed run needs
+its controller, resources, outcome audit, and per-host archives with their
+audited extracted metadata alongside the plan. It does not launch experiments
+or recreate missing audits. Output is created exclusively.
+
+The reporter checks specification, configuration, resource and archive digests,
+audit/outcome agreement, and matching runtime helpers and host environments.
+Within a pair, only the serving binary, its regulation overrides and capture
+enablement may differ. Across repetitions, each side's conditions must remain
+the same. Companion binaries, targets, resource limits and other settings remain
+part of that comparison. Finite-pause recovery trials are rejected as ordinary
+timing trials. These checks bind existing audited evidence; they do not repeat
+the raw trace audit or independently attest what ran on the remote hosts.
+
+Every planned pair remains in the report. A missing completion audit is
+`unavailable`, which can mean an active run or a failure before an audit was
+written. An audited unsuccessful outcome is `failed`. Neither contributes a
+completion timing. Changed evidence fails reporting instead of silently dropping
+the trial. `all_pairs_complete` requires every planned pair to be complete.
+
+Individual client changes, medians and ranges describe the completed pairs.
+Clients share a server and are not independent repetitions. A partial series,
+or five completed pairs, does not establish p95 performance or production
+readiness. Keep resource pressure, recovery and exact-target evidence with the
+timing report when deciding whether the serving policy is acceptable.

--- a/docs/testing/native-sync-observations.md
+++ b/docs/testing/native-sync-observations.md
@@ -94,6 +94,13 @@ samples. Matching limits throughout the recording still do not prove the value
 between samples, and zero observed swap usage requires numeric observations;
 missing swap counters cannot establish it.
 
+The recorded `memory.peak` counter also preserves kernel-observed spikes between
+usage samples. It is a cgroup lifetime maximum, so a value read during the workload
+may include an earlier startup peak; it is not an exact peak for that phase.
+Keep it separate from the largest sampled `memory.current` value. A missing peak
+counter cannot rule out spikes, and the recording cannot capture a later peak
+after its final successful read.
+
 Limit-event changes are differences between valid adjacent samples of the same
 unit and boot. Initial counter values, missing reads, resets and sampling gaps
 do not contribute; excluded intervals remain explicit. A null change means no

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -32,6 +32,93 @@ def pressure_total(text, kind):
     return int(totals[0]) if len(totals) == 1 and totals[0].isdigit() else None
 
 
+def unsigned_counters(text):
+    """Preserve missing reads; reject malformed or duplicate cgroup counters."""
+    if not isinstance(text, str):
+        return None
+    result = {}
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) != 2 or not fields[1].isdigit() or fields[0] in result:
+            raise ValueError("invalid cgroup counter row")
+        result[fields[0]] = int(fields[1])
+    return result or None
+
+
+class MemoryFootprint:
+    """Keep peak compositions and event changes without inferring reclaimability."""
+
+    EVENTS = ("low", "high", "max", "oom", "oom_kill", "oom_group_kill")
+
+    def __init__(self):
+        self.peak_usage = None
+        self.peak_anon = None
+        self.valid_usage_samples = 0
+        self.missing_stat_samples = 0
+        self.previous = None
+        self.changes = {name: 0 for name in self.EVENTS}
+        self.intervals = {name: 0 for name in self.EVENTS}
+        self.excluded = {name: Counter() for name in self.EVENTS}
+
+    def add(self, row, identity):
+        group = row.get("cgroup", {})
+        stat = unsigned_counters(group.get("memory.stat"))
+        raw_usage = group.get("memory.current")
+        usage = (int(raw_usage) if isinstance(raw_usage, str)
+                 and raw_usage.strip().isdigit() else None)
+        sample = {"utc_ns": row.get("utc_ns"), "sample_start_ns": row["sample_start_ns"],
+                  "sample_end_ns": row["sample_end_ns"], "unit_identity": identity,
+                  "boot_id": row.get("boot_id"), "memory_current_bytes": usage,
+                  "memory_max": group.get("memory.max"), "memory_high": group.get("memory.high"),
+                  "memory_stat": stat}
+        if usage is not None:
+            self.valid_usage_samples += 1
+            if self.peak_usage is None or usage > self.peak_usage["memory_current_bytes"]:
+                self.peak_usage = sample
+        if stat is None:
+            self.missing_stat_samples += 1
+        elif "anon" in stat and (self.peak_anon is None
+                                  or stat["anon"] > self.peak_anon["memory_stat"]["anon"]):
+            self.peak_anon = sample
+        events = unsigned_counters(group.get("memory.events")) or {}
+        if self.previous is not None:
+            before, old_events = self.previous
+            for name in self.EVENTS:
+                reason = None
+                if not identity or before["unit_identity"] != identity:
+                    reason = "unit_changed"
+                elif before["boot_id"] != sample["boot_id"]:
+                    reason = "host_changed"
+                elif (sample["sample_start_ns"] <= before["sample_end_ns"]
+                      or before["sample_end_ns"] < before["sample_start_ns"]
+                      or sample["sample_end_ns"] < sample["sample_start_ns"]
+                      or sample["sample_end_ns"] - before["sample_start_ns"] > 10_000_000_000):
+                    reason = "clock_or_sampling_gap"
+                elif name not in events or name not in old_events:
+                    reason = "missing_counter"
+                elif events[name] < old_events[name]:
+                    reason = "counter_reset"
+                if reason:
+                    self.excluded[name][reason] += 1
+                else:
+                    self.changes[name] += events[name] - old_events[name]
+                    self.intervals[name] += 1
+        self.previous = sample, events
+
+    def report(self):
+        return {"valid_usage_samples": self.valid_usage_samples,
+                "missing_stat_samples": self.missing_stat_samples,
+                "peak_usage_sample": self.peak_usage, "peak_anon_sample": self.peak_anon,
+                "event_changes": {name: {"observed_change": self.changes[name] if self.intervals[name] else None,
+                                         "valid_intervals": self.intervals[name],
+                                         "excluded_intervals": dict(self.excluded[name])}
+                                  for name in self.EVENTS},
+                "scope": "Peak fields come from the same bracketed read, not an atomic snapshot. "
+                         "Memory categories overlap; do not sum file and LRU fields. "
+                         "Event changes exclude the initial count and unobserved intervals; "
+                         "they are not absolute lifetime totals or a headroom pass."}
+
+
 class PressureIntervals:
     """Accumulate adjacent observations without retaining the recording."""
 
@@ -88,6 +175,7 @@ class MemoryPressure:
 
     def __init__(self):
         self.previous = None
+        self.footprint = MemoryFootprint()
         self.samples = 0
         self.memory_samples = 0
         self.minimum_available = None
@@ -114,6 +202,7 @@ class MemoryPressure:
         identity = (unit.get("MainPID"), unit.get("ControlGroup"))
         if not identity[0] or identity[0] == "0" or not identity[1]:
             identity = None
+        self.footprint.add(row, identity)
         current = {"start": row["sample_start_ns"], "end": row["sample_end_ns"],
                    "unit_identity": identity, "boot_id": row.get("boot_id")}
         for scope, field in (("host", "pressure/memory"), ("cgroup", "memory.pressure")):
@@ -131,6 +220,7 @@ class MemoryPressure:
             "host_memory_samples": self.memory_samples,
             "host_minimum_available_percent": self.minimum_available,
             "host_peak_cached_bytes": self.peak_cached,
+            "cgroup_memory": self.footprint.report(),
             "memory_pressure": {scope: {kind: counter.report() for kind, counter in counters.items()}
                                 for scope, counters in self.pressure.items()},
         }

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -1,4 +1,4 @@
-"""Streaming memory-pressure analysis for native node recordings.
+"""Streaming resource-pressure analysis for native node recordings.
 
 PSI totals are microseconds. Sample timestamps bracket several reads, so elapsed
 time and pressure percentages are intervals, not exact instantaneous values.
@@ -7,6 +7,16 @@ Missing counters, restarts and long sampling gaps cannot establish zero pressure
 from collections import Counter
 
 MAX_SAMPLE_BYTES = 4 * 1024 * 1024
+PRESSURE_FIELDS = {
+    "memory": {"host": "pressure/memory", "cgroup": "memory.pressure"},
+    "cpu": {"host": "pressure/cpu"},
+    "io": {"host": "pressure/io"},
+}
+
+
+def pressure_kinds(resource):
+    """System-wide CPU full pressure is undefined; do not interpret its zero."""
+    return ("some",) if resource == "cpu" else ("some", "full")
 
 
 def memory_fields(text):
@@ -177,7 +187,7 @@ class PressureIntervals:
         self.maximum_ns = 0
         self.maximum_percent_upper = None
 
-    def add(self, before, after, scope, kind):
+    def add(self, before, after, resource, scope, kind):
         if scope == "cgroup" and (not before["unit_identity"]
                                   or before["unit_identity"] != after["unit_identity"]):
             self.excluded["unit_changed"] += 1
@@ -185,7 +195,7 @@ class PressureIntervals:
         if before["boot_id"] != after["boot_id"]:
             self.excluded["host_changed"] += 1
             return
-        first, last = before[scope][kind], after[scope][kind]
+        first, last = before[resource][scope][kind], after[resource][scope][kind]
         if first is None or last is None:
             self.excluded["missing_counter"] += 1
             return
@@ -227,8 +237,11 @@ class MemoryPressure:
         self.memory_samples = 0
         self.minimum_available = None
         self.peak_cached = None
-        self.pressure = {scope: {kind: PressureIntervals() for kind in ("some", "full")}
-                         for scope in ("host", "cgroup")}
+        self.pressure = {
+            resource: {scope: {kind: PressureIntervals() for kind in pressure_kinds(resource)}
+                       for scope in fields}
+            for resource, fields in PRESSURE_FIELDS.items()
+        }
 
     def add(self, row):
         for field in ("sample_start_ns", "sample_end_ns"):
@@ -252,13 +265,17 @@ class MemoryPressure:
         self.footprint.add(row, identity)
         current = {"start": row["sample_start_ns"], "end": row["sample_end_ns"],
                    "unit_identity": identity, "boot_id": row.get("boot_id")}
-        for scope, field in (("host", "pressure/memory"), ("cgroup", "memory.pressure")):
-            current[scope] = {kind: pressure_total(row.get(scope, {}).get(field), kind)
-                              for kind in ("some", "full")}
+        for resource, fields in PRESSURE_FIELDS.items():
+            current[resource] = {
+                scope: {kind: pressure_total(row.get(scope, {}).get(field), kind)
+                        for kind in pressure_kinds(resource)}
+                for scope, field in fields.items()
+            }
         if self.previous is not None:
-            for scope, counters in self.pressure.items():
-                for kind, counter in counters.items():
-                    counter.add(self.previous, current, scope, kind)
+            for resource, scopes in self.pressure.items():
+                for scope, counters in scopes.items():
+                    for kind, counter in counters.items():
+                        counter.add(self.previous, current, resource, scope, kind)
         self.previous = current
 
     def report(self):
@@ -269,5 +286,9 @@ class MemoryPressure:
             "host_peak_cached_bytes": self.peak_cached,
             "cgroup_memory": self.footprint.report(),
             "memory_pressure": {scope: {kind: counter.report() for kind, counter in counters.items()}
-                                for scope, counters in self.pressure.items()},
+                                for scope, counters in self.pressure["memory"].items()},
+            "host_pressure": {
+                resource: {kind: counter.report() for kind, counter in self.pressure[resource]["host"].items()}
+                for resource in ("cpu", "io")
+            },
         }

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -94,6 +94,8 @@ class MemoryFootprint:
         self.changes = {name: 0 for name in self.EVENTS}
         self.intervals = {name: 0 for name in self.EVENTS}
         self.excluded = {name: Counter() for name in self.EVENTS}
+        self.event_observations = {name: {"numeric_samples": 0, "unavailable_samples": 0,
+                                          "maximum_count": None} for name in self.EVENTS}
 
     def add(self, row, identity):
         group = row.get("cgroup", {})
@@ -116,6 +118,12 @@ class MemoryFootprint:
                                   or stat["anon"] > self.peak_anon["memory_stat"]["anon"]):
             self.peak_anon = sample
         events = unsigned_counters(group.get("memory.events")) or {}
+        for name, observation in self.event_observations.items():
+            if name in events:
+                observation["numeric_samples"] += 1
+                observation["maximum_count"] = max(observation["maximum_count"] or 0, events[name])
+            else:
+                observation["unavailable_samples"] += 1
         if self.previous is not None:
             before, old_events = self.previous
             for name in self.EVENTS:
@@ -145,6 +153,7 @@ class MemoryFootprint:
                 "missing_stat_samples": self.missing_stat_samples,
                 "value_observations": {name: values.report() for name, values in self.values.items()},
                 "peak_usage_sample": self.peak_usage, "peak_anon_sample": self.peak_anon,
+                "event_observations": {name: dict(value) for name, value in self.event_observations.items()},
                 "event_changes": {name: {"observed_change": self.changes[name] if self.intervals[name] else None,
                                          "valid_intervals": self.intervals[name],
                                          "excluded_intervals": dict(self.excluded[name])}
@@ -152,7 +161,9 @@ class MemoryFootprint:
                 "scope": "Peak fields come from the same bracketed read, not an atomic snapshot. "
                          "Memory categories overlap; do not sum file and LRU fields. "
                          "Event changes exclude the initial count and unobserved intervals; "
-                         "they are not absolute lifetime totals or a headroom pass."}
+                         "they are not absolute lifetime totals or a headroom pass. "
+                         "Event observations retain absolute counter maxima, including initial counts; "
+                         "they cannot count events after the last read or sum across counter resets."}
 
 
 class PressureIntervals:

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -85,7 +85,7 @@ class MemoryFootprint:
 
     def __init__(self):
         self.values = {name: MemoryValues() for name in
-                       ("memory.current", "memory.high", "memory.max", "memory.swap.current")}
+                       ("memory.current", "memory.peak", "memory.high", "memory.max", "memory.swap.current")}
         self.peak_usage = None
         self.peak_anon = None
         self.valid_usage_samples = 0
@@ -99,8 +99,8 @@ class MemoryFootprint:
         group = row.get("cgroup", {})
         stat = unsigned_counters(group.get("memory.stat"))
         usage = self.values["memory.current"].add(group.get("memory.current"))
-        for name in ("memory.high", "memory.max", "memory.swap.current"):
-            self.values[name].add(group.get(name), allow_unlimited=name != "memory.swap.current")
+        for name in ("memory.peak", "memory.high", "memory.max", "memory.swap.current"):
+            self.values[name].add(group.get(name), allow_unlimited=name in ("memory.high", "memory.max"))
         sample = {"utc_ns": row.get("utc_ns"), "sample_start_ns": row["sample_start_ns"],
                   "sample_end_ns": row["sample_end_ns"], "unit_identity": identity,
                   "boot_id": row.get("boot_id"), "memory_current_bytes": usage,

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -1,0 +1,136 @@
+"""Streaming memory-pressure analysis for native node recordings.
+
+PSI totals are microseconds. Sample timestamps bracket several reads, so elapsed
+time and pressure percentages are intervals, not exact instantaneous values.
+Missing counters, restarts and long sampling gaps cannot establish zero pressure.
+"""
+from collections import Counter
+
+MAX_SAMPLE_BYTES = 4 * 1024 * 1024
+
+
+def memory_fields(text):
+    """Return the byte-valued fields in a Linux meminfo sample."""
+    fields = {}
+    if isinstance(text, str):
+        for line in text.splitlines():
+            parts = line.split()
+            if len(parts) == 3 and parts[2] == "kB" and parts[1].isdigit():
+                fields[parts[0].rstrip(":")] = int(parts[1]) * 1024
+    return fields
+
+
+def pressure_total(text, kind):
+    """Return one valid cumulative PSI total, or None if it is unavailable."""
+    totals = []
+    if isinstance(text, str):
+        for line in text.splitlines():
+            parts = line.split()
+            if parts and parts[0] == kind:
+                totals.extend(part.removeprefix("total=") for part in parts[1:]
+                              if part.startswith("total="))
+    return int(totals[0]) if len(totals) == 1 and totals[0].isdigit() else None
+
+
+class PressureIntervals:
+    """Accumulate adjacent observations without retaining the recording."""
+
+    def __init__(self):
+        self.intervals = 0
+        self.excluded = Counter()
+        self.stall_us = 0
+        self.minimum_ns = 0
+        self.maximum_ns = 0
+        self.maximum_percent_upper = None
+
+    def add(self, before, after, scope, kind):
+        if scope == "cgroup" and (not before["unit_identity"]
+                                  or before["unit_identity"] != after["unit_identity"]):
+            self.excluded["unit_changed"] += 1
+            return
+        if before["boot_id"] != after["boot_id"]:
+            self.excluded["host_changed"] += 1
+            return
+        first, last = before[scope][kind], after[scope][kind]
+        if first is None or last is None:
+            self.excluded["missing_counter"] += 1
+            return
+        shortest = after["start"] - before["end"]
+        longest = after["end"] - before["start"]
+        if (shortest <= 0 or longest > 10_000_000_000
+                or before["end"] < before["start"] or after["end"] < after["start"]):
+            self.excluded["clock_or_sampling_gap"] += 1
+            return
+        if last < first:
+            self.excluded["counter_reset"] += 1
+            return
+        delta = last - first
+        upper = delta * 100_000 / shortest
+        self.intervals += 1
+        self.stall_us += delta
+        self.minimum_ns += shortest
+        self.maximum_ns += longest
+        self.maximum_percent_upper = max(self.maximum_percent_upper or 0, upper)
+
+    def report(self):
+        return {
+            "intervals": self.intervals,
+            "excluded_intervals": dict(self.excluded),
+            "observed_stall_us": self.stall_us if self.intervals else None,
+            "maximum_interval_percent_upper": self.maximum_percent_upper,
+            "minimum_observed_seconds": self.minimum_ns / 1e9,
+            "maximum_observed_seconds": self.maximum_ns / 1e9,
+        }
+
+
+class MemoryPressure:
+    """Summarize one host and unit; memory use is independent of trace length."""
+
+    def __init__(self):
+        self.previous = None
+        self.samples = 0
+        self.memory_samples = 0
+        self.minimum_available = None
+        self.peak_cached = None
+        self.pressure = {scope: {kind: PressureIntervals() for kind in ("some", "full")}
+                         for scope in ("host", "cgroup")}
+
+    def add(self, row):
+        for field in ("sample_start_ns", "sample_end_ns"):
+            if type(row.get(field)) is not int or row[field] < 0:
+                raise ValueError(f"invalid sample timestamp: {field}")
+        self.samples += 1
+        memory = memory_fields(row.get("host", {}).get("meminfo"))
+        if memory.get("MemTotal", 0) > 0 and "MemAvailable" in memory:
+            if memory["MemAvailable"] > memory["MemTotal"]:
+                raise ValueError("available memory exceeds total memory")
+            available = 100 * memory["MemAvailable"] / memory["MemTotal"]
+            self.minimum_available = (available if self.minimum_available is None
+                                      else min(self.minimum_available, available))
+            self.memory_samples += 1
+        if "Cached" in memory:
+            self.peak_cached = max(self.peak_cached or 0, memory["Cached"])
+        unit = row.get("unit", {})
+        identity = (unit.get("MainPID"), unit.get("ControlGroup"))
+        if not identity[0] or identity[0] == "0" or not identity[1]:
+            identity = None
+        current = {"start": row["sample_start_ns"], "end": row["sample_end_ns"],
+                   "unit_identity": identity, "boot_id": row.get("boot_id")}
+        for scope, field in (("host", "pressure/memory"), ("cgroup", "memory.pressure")):
+            current[scope] = {kind: pressure_total(row.get(scope, {}).get(field), kind)
+                              for kind in ("some", "full")}
+        if self.previous is not None:
+            for scope, counters in self.pressure.items():
+                for kind, counter in counters.items():
+                    counter.add(self.previous, current, scope, kind)
+        self.previous = current
+
+    def report(self):
+        return {
+            "samples": self.samples,
+            "host_memory_samples": self.memory_samples,
+            "host_minimum_available_percent": self.minimum_available,
+            "host_peak_cached_bytes": self.peak_cached,
+            "memory_pressure": {scope: {kind: counter.report() for kind, counter in counters.items()}
+                                for scope, counters in self.pressure.items()},
+        }

--- a/scripts/native_sync_pressure.py
+++ b/scripts/native_sync_pressure.py
@@ -45,12 +45,47 @@ def unsigned_counters(text):
     return result or None
 
 
+class MemoryValues:
+    """Summarize scalar reads without treating unlimited or missing as zero."""
+
+    def __init__(self):
+        self.numeric_samples = 0
+        self.unlimited_samples = 0
+        self.unavailable_samples = 0
+        self.minimum = None
+        self.maximum = None
+
+    def add(self, value, *, allow_unlimited=False):
+        if not isinstance(value, str):
+            self.unavailable_samples += 1
+            return None
+        value = value.strip()
+        if allow_unlimited and value == "max":
+            self.unlimited_samples += 1
+            return None
+        if not value.isdigit():
+            raise ValueError("invalid cgroup memory value")
+        value = int(value)
+        self.numeric_samples += 1
+        self.minimum = value if self.minimum is None else min(self.minimum, value)
+        self.maximum = value if self.maximum is None else max(self.maximum, value)
+        return value
+
+    def report(self):
+        return {"numeric_samples": self.numeric_samples,
+                "unlimited_samples": self.unlimited_samples,
+                "unavailable_samples": self.unavailable_samples,
+                "minimum_bytes": self.minimum, "maximum_bytes": self.maximum}
+
+
 class MemoryFootprint:
     """Keep peak compositions and event changes without inferring reclaimability."""
 
     EVENTS = ("low", "high", "max", "oom", "oom_kill", "oom_group_kill")
 
     def __init__(self):
+        self.values = {name: MemoryValues() for name in
+                       ("memory.current", "memory.high", "memory.max", "memory.swap.current")}
         self.peak_usage = None
         self.peak_anon = None
         self.valid_usage_samples = 0
@@ -63,9 +98,9 @@ class MemoryFootprint:
     def add(self, row, identity):
         group = row.get("cgroup", {})
         stat = unsigned_counters(group.get("memory.stat"))
-        raw_usage = group.get("memory.current")
-        usage = (int(raw_usage) if isinstance(raw_usage, str)
-                 and raw_usage.strip().isdigit() else None)
+        usage = self.values["memory.current"].add(group.get("memory.current"))
+        for name in ("memory.high", "memory.max", "memory.swap.current"):
+            self.values[name].add(group.get(name), allow_unlimited=name != "memory.swap.current")
         sample = {"utc_ns": row.get("utc_ns"), "sample_start_ns": row["sample_start_ns"],
                   "sample_end_ns": row["sample_end_ns"], "unit_identity": identity,
                   "boot_id": row.get("boot_id"), "memory_current_bytes": usage,
@@ -108,6 +143,7 @@ class MemoryFootprint:
     def report(self):
         return {"valid_usage_samples": self.valid_usage_samples,
                 "missing_stat_samples": self.missing_stat_samples,
+                "value_observations": {name: values.report() for name, values in self.values.items()},
                 "peak_usage_sample": self.peak_usage, "peak_anon_sample": self.peak_anon,
                 "event_changes": {name: {"observed_change": self.changes[name] if self.intervals[name] else None,
                                          "valid_intervals": self.intervals[name],

--- a/scripts/native_sync_series.py
+++ b/scripts/native_sync_series.py
@@ -87,9 +87,33 @@ vary within one pair. Across repetitions each side's full conditions must match.
 def run_evidence(root, spec):
     """Bind completed outcomes to their audited resources and archived bytes."""
     run = spec["run"]
+    attempt = {}
+    failure_path = root / (run + "-supervision-failure.json")
+    if failure_path.exists():
+        failure = read(failure_path)
+        if failure.get("run") != run:
+            raise ValueError("supervision failure names another run")
+        attempt["supervision_failure"] = {"sha256": digest(failure_path), "record": failure}
     audit_path = root / (run + "-outcome-audit.json")
     if not audit_path.exists():
-        return {"status": "unavailable", "reason": "completion audit is missing"}
+        return attempt | {"status": "failed" if attempt else "unavailable",
+                          "reason": "completion audit is missing"}
+    if attempt:
+        resumed_path = root / (run + "-resumption.json")
+        resumed = read(resumed_path)
+        hosts = resumed.get("prepared_hosts", {})
+        cleanup = failure.get("cleanup", {})
+        if (failure.get("step") != "prepare-native-run.py"
+                or resumed.get("run") != run
+                or resumed.get("failure_sha256") != digest(failure_path)
+                or resumed.get("original_controller_absent") is not True
+                or set(hosts) != set(spec["hosts"]) or set(cleanup) != set(hosts)
+                or any(value.get("copy_complete") is not True
+                       or value.get("native_start_absent") is not True for value in hosts.values())
+                or any(value.get("all_run_units_stopped") is not True or value.get("stops") != []
+                       or value.get("recorder_forced_stop") is not False for value in cleanup.values())):
+            raise ValueError("completed run does not prove resumption before native startup")
+        attempt["resumption"] = {"sha256": digest(resumed_path), "record": resumed}
     audit = read(audit_path)
     resources_path = root / (run + "-resources.json")
     resources = read(resources_path)
@@ -118,7 +142,7 @@ def run_evidence(root, spec):
                 or observation["resources"].get("recording_complete") is not True):
             failed.append(host)
     if failed:
-        return {"status": "failed", "hosts": failed, "audit_sha256": digest(audit_path)}
+        return attempt | {"status": "failed", "hosts": failed, "audit_sha256": digest(audit_path)}
     controller_path = root / (run + "-controller.json")
     controller = read(controller_path)
     if controller["run"] != run:
@@ -130,7 +154,7 @@ def run_evidence(root, spec):
             if type(seconds) not in (int, float) or not math.isfinite(seconds) or seconds <= 0:
                 raise ValueError("invalid completion duration: " + host)
             clients[host] = seconds
-    return {"status": "complete", "clients": clients,
+    return attempt | {"status": "complete", "clients": clients,
             "resources": resources["hosts"],
             "provenance": {key: controller[key] for key in ("host_environments", "remote_tool_hashes")},
             "sha256": {"audit": digest(audit_path), "resources": digest(resources_path),
@@ -191,6 +215,9 @@ def report_series(plan_path):
     result["pair_counts"] = {status: sum(pair["status"] == status for pair in result["pairs"])
                              for status in ("complete", "failed", "unavailable")}
     result["all_pairs_complete"] = result["pair_counts"]["complete"] == len(planned)
+    result["runs_with_supervision_failures"] = sum(
+        "supervision_failure" in observation for pair in result["pairs"]
+        for observation in pair["observations"].values())
     result["conditions_sha256"] = {label: hashlib.sha256(json.dumps(value, sort_keys=True).encode()).hexdigest()
                                    for label, value in reference.items()}
     for host, values in changes.items():

--- a/scripts/native_sync_series.py
+++ b/scripts/native_sync_series.py
@@ -161,6 +161,27 @@ def run_evidence(root, spec):
                        "controller": digest(controller_path), "archives": archive_hashes}}
 
 
+def capture_evidence(root, spec):
+    """Keep capture import separate from native completion and replay success."""
+    if spec.get("capture_application_lifetimes") is not True:
+        return {"status": "not_requested"}
+    path = root / (spec["run"] + "-capture-import.json")
+    if not path.exists():
+        return {"status": "unavailable"}
+    record = read(path)
+    if (record.get("run") != spec["run"] or type(record.get("capture_import_ok")) is not bool
+            or type(record.get("returncode")) is not int
+            or record["capture_import_ok"] != (record["returncode"] == 0)):
+        raise ValueError("capture import outcome differs from its run or exit status")
+    result = {"status": "complete" if record["capture_import_ok"] else "failed",
+              "import_sha256": digest(path), "import_record": record}
+    if record["capture_import_ok"]:
+        profile = root / (spec["run"] + "-workload.json")
+        if digest(profile) != record.get("profile_sha256"):
+            raise ValueError("imported workload differs from its recorded digest")
+    return result
+
+
 def report_series(plan_path):
     """Assess the whole frozen plan; completed subsets remain explicitly partial."""
     root, plan = plan_path.parent, read(plan_path)
@@ -194,7 +215,8 @@ def report_series(plan_path):
         observations = {label: run_evidence(root, spec) for label, spec in specs.items()}
         entry = {"index": pair["index"], "planned_order": pair["order"],
                  "runs": {label: spec["run"] for label, spec in specs.items()},
-                 "observations": observations}
+                 "observations": observations,
+                 "captures": {label: capture_evidence(root, spec) for label, spec in specs.items()}}
         complete = all(item["status"] == "complete" for item in observations.values())
         entry["status"] = "complete" if complete else "failed" if any(
             item["status"] == "failed" for item in observations.values()) else "unavailable"
@@ -215,6 +237,12 @@ def report_series(plan_path):
     result["pair_counts"] = {status: sum(pair["status"] == status for pair in result["pairs"])
                              for status in ("complete", "failed", "unavailable")}
     result["all_pairs_complete"] = result["pair_counts"]["complete"] == len(planned)
+    result["capture_counts"] = {
+        status: sum(capture["status"] == status for pair in result["pairs"] for capture in pair["captures"].values())
+        for status in ("complete", "failed", "unavailable", "not_requested")
+    }
+    required = sum(result["capture_counts"][status] for status in ("complete", "failed", "unavailable"))
+    result["all_required_captures_imported"] = result["capture_counts"]["complete"] == required if required else None
     result["runs_with_supervision_failures"] = sum(
         "supervision_failure" in observation for pair in result["pairs"]
         for observation in pair["observations"].values())

--- a/scripts/native_sync_series.py
+++ b/scripts/native_sync_series.py
@@ -1,0 +1,200 @@
+"""Assess every planned native pair, retaining unavailable or failed trials."""
+import copy
+import hashlib
+import json
+import math
+from pathlib import Path
+import re
+import statistics
+import tomllib
+
+
+def digest(path):
+    with path.open("rb") as source:
+        return hashlib.file_digest(source, "sha256").hexdigest()
+
+
+def read(path):
+    return json.loads(path.read_text())
+
+
+def identifier(value):
+    if not isinstance(value, str) or not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}", value):
+        raise ValueError("invalid run or host identifier")
+    return value
+
+
+def load_spec(root, witness):
+    name = witness["file"]
+    if Path(name).name != name or not name.endswith(".json"):
+        raise ValueError("specification must be a local JSON basename")
+    path = root / name
+    if digest(path) != witness["sha256"]:
+        raise ValueError("planned specification changed: " + name)
+    spec = read(path)
+    if type(spec.get("schema")) is not int or spec["schema"] != 1:
+        raise ValueError("unsupported run specification schema")
+    if name != identifier(spec["run"]) + ".json":
+        raise ValueError("specification name differs from its run")
+    for host in spec["hosts"]:
+        identifier(host)
+    roles = [host["role"] for host in spec["hosts"].values()]
+    if (type(spec.get("client_count")) is not int or roles.count("server") != 1
+            or roles.count("downloader") != spec["client_count"]
+            or spec["client_count"] < 1 or set(roles) - {"server", "downloader", "source"}):
+        raise ValueError("invalid native cohort")
+    if "finite_client_pause" in spec:
+        raise ValueError("recovery trials cannot be ordinary timing comparisons")
+    return spec
+
+
+def conditions(spec, *, allow_server_change=False):
+    """Ignore provenance labels and three output paths, retaining unknown settings.
+
+Only the serving binary, its regulation overrides and capture enablement may
+vary within one pair. Across repetitions each side's full conditions must match.
+"""
+    result = copy.deepcopy(spec)
+    for key in ("run", "claim", "acceptance", "derived_from", "repetition"):
+        result.pop(key, None)
+    if allow_server_change:
+        result.pop("server_revision")
+        result.pop("capture_application_lifetimes", None)
+    for host in result["hosts"].values():
+        raw = host.pop("config")
+        if hashlib.sha256(raw.encode()).hexdigest() != host.pop("config_sha256"):
+            raise ValueError("configuration differs from its recorded digest")
+        config = tomllib.loads(raw)
+        for path in (("network", "cache_dir"), ("network", "zakura", "trace_dir"),
+                     ("state", "cache_dir")):
+            section = config
+            for key in path[:-1]:
+                section = section.get(key, {})
+            if path[-1] in section:
+                section[path[-1]] = section[path[-1]].replace("/" + spec["run"] + "/", "/RUN/")
+        if allow_server_change and host["role"] == "server":
+            host.pop("binary")
+            host.pop("binary_sha256")
+            network = config["network"]["zakura"]
+            block_sync = network.get("block_sync", {})
+            block_sync.pop("get_blocks_regulation", None)
+            if not block_sync:
+                network.pop("block_sync", None)
+        host["config"] = config
+    return result
+
+
+def run_evidence(root, spec):
+    """Bind completed outcomes to their audited resources and archived bytes."""
+    run = spec["run"]
+    audit_path = root / (run + "-outcome-audit.json")
+    if not audit_path.exists():
+        return {"status": "unavailable", "reason": "completion audit is missing"}
+    audit = read(audit_path)
+    resources_path = root / (run + "-resources.json")
+    resources = read(resources_path)
+    if (audit["run"] != run or resources["run"] != run
+            or set(audit["hosts"]) != set(spec["hosts"])
+            or set(resources["hosts"]) != set(spec["hosts"])
+            or audit["resources_sha256"] != digest(resources_path)):
+        raise ValueError("audit/resource binding differs: " + run)
+    failed = []
+    archive_hashes = {}
+    for host, observation in audit["hosts"].items():
+        directory = root / "evidence" / run / host
+        extracted = directory / "extracted"
+        if (read(extracted / "run-spec.json") != spec
+                or read(extracted / "run-outcome.json") != observation["run_outcome"]
+                or observation["resources"] != resources["hosts"][host]
+                or observation["role"] != spec["hosts"][host]["role"]):
+            raise ValueError("archived metadata differs from audit: " + host)
+        archive_hashes[host] = digest(directory / (run + ".tar.zst"))
+        if archive_hashes[host] != observation["archive_sha256"]:
+            raise ValueError("archived bytes differ from audit: " + host)
+        outcome = observation["run_outcome"]
+        if (outcome.get("run") != run or outcome.get("host") != host
+                or outcome.get("native_completed") is not True
+                or outcome.get("all_clients_reached_target") is not True
+                or observation["resources"].get("recording_complete") is not True):
+            failed.append(host)
+    if failed:
+        return {"status": "failed", "hosts": failed, "audit_sha256": digest(audit_path)}
+    controller_path = root / (run + "-controller.json")
+    controller = read(controller_path)
+    if controller["run"] != run:
+        raise ValueError("controller run differs")
+    clients = {}
+    for host, config in spec["hosts"].items():
+        if config["role"] == "downloader":
+            seconds = resources["hosts"][host]["completion_seconds"]
+            if type(seconds) not in (int, float) or not math.isfinite(seconds) or seconds <= 0:
+                raise ValueError("invalid completion duration: " + host)
+            clients[host] = seconds
+    return {"status": "complete", "clients": clients,
+            "resources": resources["hosts"],
+            "provenance": {key: controller[key] for key in ("host_environments", "remote_tool_hashes")},
+            "sha256": {"audit": digest(audit_path), "resources": digest(resources_path),
+                       "controller": digest(controller_path), "archives": archive_hashes}}
+
+
+def report_series(plan_path):
+    """Assess the whole frozen plan; completed subsets remain explicitly partial."""
+    root, plan = plan_path.parent, read(plan_path)
+    if type(plan.get("schema")) is not int or plan["schema"] != 1:
+        raise ValueError("unsupported series schema")
+    planned = [{"index": 1, "order": plan.get("first_pair_order"), "runs": plan["first_pair"]}, *plan["pairs"]]
+    indices = [pair["index"] for pair in planned]
+    if indices != list(range(1, len(planned) + 1)):
+        raise ValueError("planned pairs must have consecutive unique indices")
+    result = {"schema_version": 1, "plan_sha256": digest(plan_path), "pairs": [], "clients": {},
+              "scope": "Descriptive paired sync timings. Clients share a server; neither p95 nor production qualification."}
+    reference = {}
+    reference_provenance = None
+    seen_runs = set()
+    changes = {}
+    for pair in planned:
+        if (set(pair["runs"]) != {"baseline", "candidate"}
+                or pair["order"] is not None and sorted(pair["order"]) != ["baseline", "candidate"]):
+            raise ValueError("each pair must contain both policies exactly once")
+        specs = {label: load_spec(root, witness) for label, witness in pair["runs"].items()}
+        if conditions(specs["baseline"], allow_server_change=True) != conditions(specs["candidate"], allow_server_change=True):
+            raise ValueError("paired conditions differ beyond the serving policy")
+        for label, spec in specs.items():
+            if spec["run"] in seen_runs:
+                raise ValueError("a run cannot supply multiple trials")
+            seen_runs.add(spec["run"])
+            current = conditions(spec)
+            if label in reference and current != reference[label]:
+                raise ValueError("repetition conditions changed: " + spec["run"])
+            reference[label] = current
+        observations = {label: run_evidence(root, spec) for label, spec in specs.items()}
+        entry = {"index": pair["index"], "planned_order": pair["order"],
+                 "runs": {label: spec["run"] for label, spec in specs.items()},
+                 "observations": observations}
+        complete = all(item["status"] == "complete" for item in observations.values())
+        entry["status"] = "complete" if complete else "failed" if any(
+            item["status"] == "failed" for item in observations.values()) else "unavailable"
+        if complete:
+            for observation in observations.values():
+                provenance = observation["provenance"]
+                if reference_provenance is not None and provenance != reference_provenance:
+                    raise ValueError("runtime helpers or host environment changed between trials")
+                reference_provenance = provenance
+            entry["clients"] = {}
+            for host, baseline in observations["baseline"]["clients"].items():
+                candidate = observations["candidate"]["clients"][host]
+                change = 100 * (candidate / baseline - 1)
+                entry["clients"][host] = {"baseline_seconds": baseline, "candidate_seconds": candidate,
+                                         "change_percent": change}
+                changes.setdefault(host, []).append(change)
+        result["pairs"].append(entry)
+    result["pair_counts"] = {status: sum(pair["status"] == status for pair in result["pairs"])
+                             for status in ("complete", "failed", "unavailable")}
+    result["all_pairs_complete"] = result["pair_counts"]["complete"] == len(planned)
+    result["conditions_sha256"] = {label: hashlib.sha256(json.dumps(value, sort_keys=True).encode()).hexdigest()
+                                   for label, value in reference.items()}
+    for host, values in changes.items():
+        result["clients"][host] = {"completed_pairs": len(values), "paired_changes_percent": values,
+                                   "median_change_percent": statistics.median(values),
+                                   "minimum_change_percent": min(values), "maximum_change_percent": max(values)}
+    return result

--- a/scripts/record-native-sync.py
+++ b/scripts/record-native-sync.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Record a local test node's progress and resource pressure without controlling it."""
+import argparse
+import gzip
+import json
+from pathlib import Path
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from native_sync_pressure import MAX_SAMPLE_BYTES
+
+CGROUP_FIELDS = (
+    "memory.current", "memory.peak", "memory.max", "memory.high", "memory.pressure",
+    "memory.stat", "memory.events", "memory.swap.current", "pids.current", "pids.peak",
+    "pids.events", "cpu.stat", "io.stat",
+)
+HOST_FIELDS = ("stat", "meminfo", "diskstats", "net/dev", "pressure/cpu", "pressure/io", "pressure/memory")
+UNIT_FIELDS = ("MainPID", "ControlGroup", "ActiveState", "ExecMainStatus", "Result", "LoadState")
+MAX_HTTP_BYTES = 2 * 1024 * 1024
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, message, headers, new_url):
+        raise urllib.error.URLError("local observation endpoint redirected")
+
+
+def local_url(value):
+    """The observer reads this host's test-node endpoints only."""
+    parsed = urllib.parse.urlsplit(value)
+    if (parsed.scheme != "http" or parsed.hostname not in ("127.0.0.1", "::1")
+            or parsed.username is not None or parsed.password is not None or parsed.fragment):
+        raise argparse.ArgumentTypeError("use an HTTP URL on 127.0.0.1 or [::1], without credentials")
+    return value
+
+
+def file_text(path):
+    try:
+        return Path(path).read_text()
+    except OSError as error:
+        return {"error": str(error)}
+
+
+def read_url(url, payload=None):
+    try:
+        request = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+        # Do not forward local observations through ambient HTTP proxy settings.
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect())
+        with opener.open(request, timeout=2) as response:
+            body = response.read(MAX_HTTP_BYTES + 1)
+        if len(body) > MAX_HTTP_BYTES:
+            return {"error": "response exceeds observation byte limit"}
+        return {"body": body.decode()}
+    except Exception as error:
+        return {"error": str(error)}
+
+
+def observe(unit, metrics_url, rpc_url):
+    """Bracket all reads so later analysis can retain timestamp uncertainty."""
+    row = {"schema": 1, "clock": "monotonic_ns", "unit_name": unit,
+           "sample_start_ns": time.monotonic_ns(), "utc_ns": time.time_ns()}
+    raw = subprocess.check_output(
+        ["systemctl", "show", "--property=" + ",".join(UNIT_FIELDS), "--", unit],
+        text=True, timeout=5,
+    )
+    properties = dict(line.split("=", 1) for line in raw.splitlines() if "=" in line)
+    if not all(field in properties for field in UNIT_FIELDS):
+        raise ValueError("systemd did not return the required node unit properties")
+    if properties["LoadState"] != "loaded":
+        raise ValueError("the selected node unit is not loaded")
+    row["unit"] = properties
+    pid = properties["MainPID"]
+    row["process"] = {name: file_text(f"/proc/{pid}/{name}") for name in ("stat", "status", "io")}
+    try:
+        row["open_file_descriptors"] = sum(1 for _ in Path(f"/proc/{pid}/fd").iterdir())
+    except OSError as error:
+        row["open_file_descriptors"] = {"error": str(error)}
+    group = properties["ControlGroup"]
+    row["cgroup"] = {name: file_text("/sys/fs/cgroup" + group + "/" + name)
+                     for name in CGROUP_FIELDS} if group else {}
+    row["host"] = {name: file_text("/proc/" + name) for name in HOST_FIELDS}
+    row["boot_id"] = file_text("/proc/sys/kernel/random/boot_id")
+    row["metrics"] = read_url(metrics_url)
+    row["chain"] = read_url(rpc_url, b'{"jsonrpc":"2.0","id":1,"method":"getblockchaininfo","params":[]}')
+    row["sample_end_ns"] = time.monotonic_ns()
+    return row
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--unit", required=True, help="Existing test-node systemd service.")
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--seconds", type=int, default=10800)
+    parser.add_argument("--metrics-url", type=local_url, default="http://127.0.0.1:19999/metrics")
+    parser.add_argument("--rpc-url", type=local_url, default="http://127.0.0.1:18232")
+    args = parser.parse_args()
+    if not 1 <= args.seconds <= 172800:
+        parser.error("recording duration must be between one second and two days")
+    if not args.unit.endswith(".service"):
+        parser.error("the observed unit must be a systemd service")
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + args.seconds
+    with gzip.open(args.out, "xt") as output:
+        while time.monotonic() < deadline:
+            started = time.monotonic()
+            row = observe(args.unit, args.metrics_url, args.rpc_url)
+            encoded = json.dumps(row) + "\n"
+            if len(encoded) > MAX_SAMPLE_BYTES:
+                raise ValueError("combined sample exceeds the recording row limit")
+            output.write(encoded)
+            output.flush()
+            if row["unit"]["ActiveState"] in ("inactive", "failed"):
+                break
+            time.sleep(max(0, min(2 - (time.monotonic() - started), deadline - time.monotonic())))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/report-native-sync-pressure.py
+++ b/scripts/report-native-sync-pressure.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Report memory pressure from one closed native sync recording."""
+import argparse
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from native_sync_pressure import MAX_SAMPLE_BYTES, MemoryPressure
+
+
+def report_recording(path, start_utc_ns, end_utc_ns, *, allow_incomplete=False):
+    """Read through the gzip footer, including rows outside the selected phase."""
+    if not 0 <= start_utc_ns <= end_utc_ns:
+        raise ValueError("invalid workload interval")
+    pressure = MemoryPressure()
+    last = None
+    rows = 0
+    unit_name = None
+    with path.open("rb") as source:
+        before = os.fstat(source.fileno())
+        with gzip.GzipFile(fileobj=source) as stream:
+            while line := stream.readline(MAX_SAMPLE_BYTES + 1):
+                if len(line) > MAX_SAMPLE_BYTES:
+                    raise ValueError("sample exceeds the recording row limit")
+                row = json.loads(line)
+                if (type(row.get("schema")) is not int or row["schema"] != 1
+                        or row.get("clock") != "monotonic_ns"
+                        or type(row.get("utc_ns")) is not int):
+                    raise ValueError("unsupported recording schema or clock")
+                name = row.get("unit_name")
+                if rows and name != unit_name:
+                    raise ValueError("recording mixes different unit names")
+                unit_name = name
+                rows += 1
+                if (start_utc_ns <= row["utc_ns"] <= end_utc_ns
+                        and row["unit"].get("MainPID", "0") != "0"
+                        and row["unit"].get("ControlGroup")):
+                    pressure.add(row)
+                last = row
+        source.seek(0)
+        checksum = hashlib.file_digest(source, "sha256").hexdigest()
+        after = path.stat()
+        if (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns) != (
+                after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns):
+            raise ValueError("recording changed while being read")
+    unit = last.get("unit", {}) if last else {}
+    complete = unit.get("ActiveState") in ("inactive", "failed")
+    success = None
+    if all(key in unit for key in ("ActiveState", "ExecMainStatus", "Result")):
+        success = (unit["ActiveState"] == "inactive" and unit["ExecMainStatus"] == "0"
+                   and unit["Result"] == "success")
+    if not complete and not allow_incomplete:
+        raise ValueError("recording does not end with a stopped node unit")
+    return {
+        "schema_version": 1,
+        "samples_sha256": checksum,
+        "recording_complete": complete,
+        "unit_success_observed": success,
+        "recorded_rows": rows,
+        "unit_name": unit_name,
+        "phase_start_unix_ns": start_utc_ns,
+        "phase_end_unix_ns": end_utc_ns,
+        "scope": "Selected workload phase, adjacent same-host sample bounds. "
+                 "Missing counters are unknown. Complete recording does not establish sync success.",
+        **pressure.report(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("recording", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--start-utc-ns", type=int, required=True)
+    parser.add_argument("--end-utc-ns", type=int, required=True)
+    parser.add_argument("--allow-incomplete", action="store_true",
+                        help="Write a diagnostic report with recording_complete=false.")
+    args = parser.parse_args()
+    result = report_recording(args.recording, args.start_utc_ns, args.end_utc_ns,
+                              allow_incomplete=args.allow_incomplete)
+    with args.output.open("x") as output:
+        json.dump(result, output, indent=2)
+        output.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/report-native-sync-pressure.py
+++ b/scripts/report-native-sync-pressure.py
@@ -15,6 +15,7 @@ def report_recording(path, start_utc_ns, end_utc_ns, *, allow_incomplete=False):
     if not 0 <= start_utc_ns <= end_utc_ns:
         raise ValueError("invalid workload interval")
     pressure = MemoryPressure()
+    whole_recording = MemoryPressure()
     last = None
     rows = 0
     unit_name = None
@@ -34,10 +35,11 @@ def report_recording(path, start_utc_ns, end_utc_ns, *, allow_incomplete=False):
                     raise ValueError("recording mixes different unit names")
                 unit_name = name
                 rows += 1
-                if (start_utc_ns <= row["utc_ns"] <= end_utc_ns
-                        and row["unit"].get("MainPID", "0") != "0"
+                if (row["unit"].get("MainPID", "0") != "0"
                         and row["unit"].get("ControlGroup")):
-                    pressure.add(row)
+                    whole_recording.add(row)
+                    if start_utc_ns <= row["utc_ns"] <= end_utc_ns:
+                        pressure.add(row)
                 last = row
         source.seek(0)
         checksum = hashlib.file_digest(source, "sha256").hexdigest()
@@ -64,6 +66,11 @@ def report_recording(path, start_utc_ns, end_utc_ns, *, allow_incomplete=False):
         "phase_end_unix_ns": end_utc_ns,
         "scope": "Selected workload phase, adjacent same-host sample bounds. "
                  "Missing counters are unknown. Complete recording does not establish sync success.",
+        "whole_recording": {
+            "scope": "All recorded active-node samples, including startup and drain/shutdown. "
+                     "This interval differs from the selected workload phase and ends at the last successful read.",
+            **whole_recording.report(),
+        },
         **pressure.report(),
     }
 

--- a/scripts/report-native-sync-series.py
+++ b/scripts/report-native-sync-series.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Report all native sync pairs in a frozen experiment plan."""
+import argparse
+import json
+from pathlib import Path
+
+from native_sync_series import report_series
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("plan", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    report = report_series(args.plan)
+    with args.output.open("x") as output:
+        json.dump(report, output, indent=2)
+        output.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -44,6 +44,40 @@ def summary(rows):
 
 
 class PressureTests(unittest.TestCase):
+    def test_host_cpu_and_io_stalls_stay_separate_from_memory(self):
+        rows = [sample(0, 0), sample(2_000_000_000, 100_000)]
+        for row, cpu, io in zip(rows, [20, 200_020], [40, 300_040]):
+            row["host"]["pressure/cpu"] = f"some total={cpu}\nfull total=0\n"
+            row["host"]["pressure/io"] = f"some total={io}\nfull total={io // 2}\n"
+        result = summary(rows)
+        host = result["host_pressure"]
+        self.assertEqual(host["cpu"]["some"]["observed_stall_us"], 200_000)
+        self.assertNotIn("full", host["cpu"])
+        self.assertEqual(host["io"]["some"]["observed_stall_us"], 300_000)
+        self.assertEqual(host["io"]["full"]["observed_stall_us"], 150_000)
+        self.assertAlmostEqual(host["io"]["full"]["maximum_interval_percent_upper"], 150 / 19)
+        self.assertEqual(result["memory_pressure"]["host"]["some"]["observed_stall_us"], 100_000)
+
+    def test_host_contention_preserves_missing_resets_boot_changes_and_gaps(self):
+        for resource in ("cpu", "io"):
+            for reason in ("missing_counter", "counter_reset", "host_changed", "clock_or_sampling_gap"):
+                rows = [sample(0, 0), sample(2_000_000_000, 0)]
+                rows[0]["host"]["pressure/" + resource] = "some total=100\n"
+                rows[1]["host"]["pressure/" + resource] = "some total=200\n"
+                if reason == "missing_counter":
+                    rows[1]["host"]["pressure/" + resource] = {"error": "unavailable"}
+                elif reason == "counter_reset":
+                    rows[1]["host"]["pressure/" + resource] = "some total=99\n"
+                elif reason == "host_changed":
+                    rows[1]["boot_id"] = "new-boot"
+                else:
+                    rows[1]["sample_start_ns"] = 20_000_000_000
+                    rows[1]["sample_end_ns"] = 20_100_000_000
+                result = summary(rows)["host_pressure"][resource]["some"]
+                with self.subTest(resource=resource, reason=reason):
+                    self.assertIsNone(result["observed_stall_us"])
+                    self.assertEqual(result["excluded_intervals"], {reason: 1})
+
     def test_absolute_event_counts_preserve_initial_counts_resets_and_missing_reads(self):
         rows = [sample(i * 2_000_000_000, 0) for i in range(4)]
         for row, count in zip(rows, [50, None, 0, 3]):
@@ -264,6 +298,16 @@ class RecordingTests(unittest.TestCase):
         empty_phase = self.reporter.report_recording(self.path, 1, 1)
         self.assertIsNone(empty_phase["cgroup_memory"]["event_observations"]["max"]["maximum_count"])
         self.assertEqual(empty_phase["whole_recording"], result["whole_recording"])
+
+    def test_host_io_pressure_after_workload_remains_in_whole_recording(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(4)]
+        for row, total in zip(rows, [0, 0, 500_000, 900_000]):
+            row["host"]["pressure/io"] = f"some total={total}\nfull total={total}\n"
+        rows[-1]["unit"].update(MainPID="0", ActiveState="inactive")
+        self.write(rows)
+        result = self.reporter.report_recording(self.path, 0, 2_000_000_000)
+        self.assertEqual(result["host_pressure"]["io"]["full"]["observed_stall_us"], 0)
+        self.assertEqual(result["whole_recording"]["host_pressure"]["io"]["full"]["observed_stall_us"], 500_000)
 
     def test_deadline_or_truncated_gzip_cannot_be_a_complete_recording(self):
         self.write([sample(0, 0)])

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -44,6 +44,60 @@ def summary(rows):
 
 
 class PressureTests(unittest.TestCase):
+    def test_peak_composition_does_not_combine_different_samples(self):
+        rows = [sample(0, 0), sample(2_000_000_000, 1)]
+        rows[0]["cgroup"].update({"memory.current": "1000", "memory.stat": "anon 100\nfile 900\ninactive_file 800\n"})
+        rows[1]["cgroup"].update({"memory.current": "700", "memory.stat": "anon 200\nfile 500\ninactive_file 400\n"})
+        result = summary(rows)["cgroup_memory"]
+        self.assertEqual(result["peak_usage_sample"]["memory_current_bytes"], 1000)
+        self.assertEqual(result["peak_usage_sample"]["memory_stat"]["anon"], 100)
+        self.assertEqual(result["peak_anon_sample"]["memory_current_bytes"], 700)
+        self.assertEqual(result["peak_anon_sample"]["memory_stat"]["anon"], 200)
+
+    def test_limit_events_report_changes_not_initial_counts(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(3)]
+        for row, count in zip(rows, [50, 54, 61]):
+            row["cgroup"]["memory.events"] = f"max {count}\noom 0\n"
+        result = summary(rows)["cgroup_memory"]["event_changes"]
+        self.assertEqual(result["max"]["observed_change"], 11)
+        self.assertEqual(result["max"]["valid_intervals"], 2)
+        self.assertEqual(result["oom"]["observed_change"], 0)
+        self.assertIsNone(result["high"]["observed_change"])
+        self.assertIsNone(summary(rows[:1])["cgroup_memory"]["event_changes"]["max"]["observed_change"])
+
+    def test_missing_and_reset_memory_counters_remain_explicit(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(4)]
+        for row, count in zip(rows, [50, None, 52, 0]):
+            row["cgroup"]["memory.events"] = {"error": "unavailable"} if count is None else f"max {count}\n"
+        result = summary(rows)["cgroup_memory"]
+        self.assertIsNone(result["peak_usage_sample"])
+        self.assertEqual(result["missing_stat_samples"], 4)
+        self.assertIsNone(result["event_changes"]["max"]["observed_change"])
+        self.assertEqual(result["event_changes"]["max"]["excluded_intervals"],
+                         {"missing_counter": 2, "counter_reset": 1})
+        rows[1]["unit"]["MainPID"] = "456"
+        self.assertEqual(summary(rows)["cgroup_memory"]["event_changes"]["max"]["excluded_intervals"],
+                         {"unit_changed": 2, "counter_reset": 1})
+
+    def test_malformed_memory_counter_cannot_be_a_zero(self):
+        for value in ("anon -1\n", "anon 1\nanon 2\n", "anon unavailable\n"):
+            row = sample(0, 0)
+            row["cgroup"]["memory.stat"] = value
+            with self.assertRaises(ValueError):
+                summary([row])
+
+    def test_limit_event_changes_exclude_boot_changes_and_sampling_gaps(self):
+        for after, reason in [(sample(20_000_000_000, 0), "clock_or_sampling_gap"),
+                              (sample(2_000_000_000, 0), "host_changed")]:
+            before = sample(0, 0)
+            if reason == "host_changed":
+                after["boot_id"] = "new-boot"
+            before["cgroup"]["memory.events"] = "max 1\n"
+            after["cgroup"]["memory.events"] = "max 2\n"
+            result = summary([before, after])["cgroup_memory"]["event_changes"]["max"]
+            self.assertIsNone(result["observed_change"])
+            self.assertEqual(result["excluded_intervals"], {reason: 1})
+
     def test_microsecond_counter_and_clock_uncertainty(self):
         report = summary([sample(0, 0), sample(2_000_000_000, 100_000)])
         value = report["memory_pressure"]["host"]["some"]

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -44,6 +44,47 @@ def summary(rows):
 
 
 class PressureTests(unittest.TestCase):
+    def test_memory_limits_are_observed_beyond_the_peak_usage_sample(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(3)]
+        for row, usage, high, swap in zip(rows, [900, 800, 700], ["1000", "1100", "max"], [0, 10, 5]):
+            row["cgroup"].update({"memory.current": str(usage), "memory.high": high,
+                                  "memory.max": "1400", "memory.swap.current": str(swap)})
+        result = summary(rows)["cgroup_memory"]
+        self.assertEqual(result["peak_usage_sample"]["memory_high"], "1000")
+        values = result["value_observations"]
+        self.assertEqual(values["memory.high"], {"numeric_samples": 2, "unlimited_samples": 1,
+                         "unavailable_samples": 0, "minimum_bytes": 1000, "maximum_bytes": 1100})
+        self.assertEqual(values["memory.max"]["numeric_samples"], 3)
+        self.assertEqual(values["memory.max"]["minimum_bytes"], 1400)
+        self.assertEqual(values["memory.max"]["maximum_bytes"], 1400)
+        self.assertEqual(values["memory.swap.current"]["maximum_bytes"], 10)
+
+    def test_missing_memory_values_cannot_establish_an_applied_limit(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(3)]
+        rows[0]["cgroup"]["memory.high"] = "1000"
+        rows[1]["cgroup"]["memory.high"] = {"error": "unavailable"}
+        values = summary(rows)["cgroup_memory"]["value_observations"]
+        self.assertEqual(values["memory.high"]["numeric_samples"], 1)
+        self.assertEqual(values["memory.high"]["unavailable_samples"], 2)
+        self.assertIsNone(values["memory.swap.current"]["maximum_bytes"])
+        self.assertEqual(values["memory.swap.current"]["unavailable_samples"], 3)
+        empty = summary([])["cgroup_memory"]["value_observations"]["memory.max"]
+        self.assertIsNone(empty["maximum_bytes"])
+        self.assertEqual(empty["numeric_samples"], 0)
+
+    def test_malformed_scalar_memory_values_are_rejected(self):
+        for name in ("memory.current", "memory.high", "memory.max", "memory.swap.current"):
+            for value in ("-1", "1.5", "", "unavailable", "100 200"):
+                row = sample(0, 0)
+                row["cgroup"][name] = value
+                with self.subTest(name=name, value=value), self.assertRaises(ValueError):
+                    summary([row])
+        for name in ("memory.current", "memory.swap.current"):
+            row = sample(0, 0)
+            row["cgroup"][name] = "max"
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                summary([row])
+
     def test_peak_composition_does_not_combine_different_samples(self):
         rows = [sample(0, 0), sample(2_000_000_000, 1)]
         rows[0]["cgroup"].update({"memory.current": "1000", "memory.stat": "anon 100\nfile 900\ninactive_file 800\n"})

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -44,6 +44,17 @@ def summary(rows):
 
 
 class PressureTests(unittest.TestCase):
+    def test_absolute_event_counts_preserve_initial_counts_resets_and_missing_reads(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(4)]
+        for row, count in zip(rows, [50, None, 0, 3]):
+            if count is not None:
+                row["cgroup"]["memory.events"] = f"max {count}\n"
+        result = summary(rows)["cgroup_memory"]
+        self.assertEqual(result["event_observations"]["max"],
+                         {"numeric_samples": 3, "unavailable_samples": 1, "maximum_count": 50})
+        self.assertEqual(result["event_changes"]["max"]["observed_change"], 3)
+        self.assertIsNone(result["event_observations"]["oom"]["maximum_count"])
+
     def test_kernel_peak_is_distinct_from_sampled_current_usage(self):
         rows = [sample(0, 0), sample(2_000_000_000, 0)]
         rows[0]["cgroup"].update({"memory.current": "100", "memory.peak": "150"})
@@ -235,6 +246,24 @@ class RecordingTests(unittest.TestCase):
         row["unit"].pop("Result")
         self.write([row])
         self.assertIsNone(self.reporter.report_recording(self.path, 0, 0)["unit_success_observed"])
+
+    def test_clean_workload_cannot_hide_later_memory_pressure(self):
+        rows = [sample(i * 2_000_000_000, 0) for i in range(4)]
+        for row, events, usage in zip(rows, [0, 0, 7, 9], [100, 100, 140, 150]):
+            row["cgroup"].update({"memory.events": f"max {events}\noom 0\n",
+                                  "memory.current": str(usage)})
+        rows[-1]["unit"].update(MainPID="0", ActiveState="inactive")
+        self.write(rows)
+        result = self.reporter.report_recording(self.path, 0, 2_000_000_000)
+        phase = result["cgroup_memory"]
+        whole = result["whole_recording"]["cgroup_memory"]
+        self.assertEqual(phase["event_observations"]["max"]["maximum_count"], 0)
+        self.assertEqual(whole["event_observations"]["max"]["maximum_count"], 7)
+        self.assertEqual(whole["peak_usage_sample"]["memory_current_bytes"], 140)
+        self.assertEqual(result["whole_recording"]["samples"], 3)
+        empty_phase = self.reporter.report_recording(self.path, 1, 1)
+        self.assertIsNone(empty_phase["cgroup_memory"]["event_observations"]["max"]["maximum_count"])
+        self.assertEqual(empty_phase["whole_recording"], result["whole_recording"])
 
     def test_deadline_or_truncated_gzip_cannot_be_a_complete_recording(self):
         self.write([sample(0, 0)])

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -44,6 +44,18 @@ def summary(rows):
 
 
 class PressureTests(unittest.TestCase):
+    def test_kernel_peak_is_distinct_from_sampled_current_usage(self):
+        rows = [sample(0, 0), sample(2_000_000_000, 0)]
+        rows[0]["cgroup"].update({"memory.current": "100", "memory.peak": "150"})
+        rows[1]["cgroup"].update({"memory.current": "110", "memory.peak": "200"})
+        result = summary(rows)["cgroup_memory"]
+        self.assertEqual(result["peak_usage_sample"]["memory_current_bytes"], 110)
+        self.assertEqual(result["value_observations"]["memory.peak"]["maximum_bytes"], 200)
+        rows[1]["cgroup"].pop("memory.peak")
+        values = summary(rows)["cgroup_memory"]["value_observations"]["memory.peak"]
+        self.assertEqual(values["maximum_bytes"], 150)
+        self.assertEqual(values["unavailable_samples"], 1)
+
     def test_memory_limits_are_observed_beyond_the_peak_usage_sample(self):
         rows = [sample(i * 2_000_000_000, 0) for i in range(3)]
         for row, usage, high, swap in zip(rows, [900, 800, 700], ["1000", "1100", "max"], [0, 10, 5]):
@@ -73,13 +85,13 @@ class PressureTests(unittest.TestCase):
         self.assertEqual(empty["numeric_samples"], 0)
 
     def test_malformed_scalar_memory_values_are_rejected(self):
-        for name in ("memory.current", "memory.high", "memory.max", "memory.swap.current"):
+        for name in ("memory.current", "memory.peak", "memory.high", "memory.max", "memory.swap.current"):
             for value in ("-1", "1.5", "", "unavailable", "100 200"):
                 row = sample(0, 0)
                 row["cgroup"][name] = value
                 with self.subTest(name=name, value=value), self.assertRaises(ValueError):
                     summary([row])
-        for name in ("memory.current", "memory.swap.current"):
+        for name in ("memory.current", "memory.peak", "memory.swap.current"):
             row = sample(0, 0)
             row["cgroup"][name] = "max"
             with self.subTest(name=name), self.assertRaises(ValueError):

--- a/scripts/tests/test_native_sync_pressure.py
+++ b/scripts/tests/test_native_sync_pressure.py
@@ -1,0 +1,165 @@
+"""Pressure evidence must preserve missing data, bounded memory use and failures."""
+import argparse
+import copy
+import gc
+import gzip
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+import weakref
+
+SCRIPTS = Path(__file__).parents[1]
+sys.path.insert(0, str(SCRIPTS))
+from native_sync_pressure import MemoryPressure, pressure_total
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / (name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def sample(start, total):
+    pressure = f"some avg10=0 total={total}\nfull avg10=0 total=0\n"
+    return {"schema": 1, "clock": "monotonic_ns", "unit_name": "test-node.service",
+            "utc_ns": start, "sample_start_ns": start, "sample_end_ns": start + 100_000_000,
+            "unit": {"MainPID": "123", "ControlGroup": "/test", "ActiveState": "active",
+                     "Result": "success", "ExecMainStatus": "0"},
+            "host": {"pressure/memory": pressure,
+                     "meminfo": "MemTotal: 1024 kB\nMemAvailable: 128 kB\nCached: 512 kB\n"},
+            "cgroup": {"memory.pressure": pressure}}
+
+
+def summary(rows):
+    accumulator = MemoryPressure()
+    for row in rows:
+        accumulator.add(row)
+    return accumulator.report()
+
+
+class PressureTests(unittest.TestCase):
+    def test_microsecond_counter_and_clock_uncertainty(self):
+        report = summary([sample(0, 0), sample(2_000_000_000, 100_000)])
+        value = report["memory_pressure"]["host"]["some"]
+        self.assertEqual(value["observed_stall_us"], 100_000)
+        self.assertAlmostEqual(value["maximum_interval_percent_upper"], 100 / 19)
+        self.assertAlmostEqual(value["minimum_observed_seconds"], 1.9)
+        self.assertAlmostEqual(value["maximum_observed_seconds"], 2.1)
+        self.assertEqual(report["host_minimum_available_percent"], 12.5)
+        self.assertEqual(report["host_peak_cached_bytes"], 512 * 1024)
+
+    def test_missing_is_unknown_and_observed_zero_is_zero(self):
+        rows = [sample(0, 0), sample(2_000_000_000, 0)]
+        self.assertEqual(summary(rows)["memory_pressure"]["host"]["some"]["observed_stall_us"], 0)
+        rows[1]["host"]["pressure/memory"] = {"error": "unavailable"}
+        result = summary(rows)["memory_pressure"]["host"]["some"]
+        self.assertIsNone(result["observed_stall_us"])
+        self.assertEqual(result["excluded_intervals"], {"missing_counter": 1})
+        self.assertIsNone(summary([])["host_minimum_available_percent"])
+        self.assertIsNone(pressure_total("some total=1 total=2", "some"))
+
+    def test_restarts_resets_and_long_gaps_do_not_bridge_observations(self):
+        original = [sample(0, 100), sample(2_000_000_000, 200)]
+        rows = copy.deepcopy(original)
+        rows[1]["unit"]["MainPID"] = "456"
+        self.assertEqual(summary(rows)["memory_pressure"]["cgroup"]["some"]["excluded_intervals"], {"unit_changed": 1})
+        self.assertEqual(summary(rows)["memory_pressure"]["host"]["some"]["intervals"], 1)
+        rows = copy.deepcopy(original)
+        rows[1]["boot_id"] = "different-host"
+        self.assertEqual(summary(rows)["memory_pressure"]["host"]["some"]["excluded_intervals"], {"host_changed": 1})
+        for after, reason in [(sample(2_000_000_000, 99), "counter_reset"),
+                              (sample(20_000_000_000, 101), "clock_or_sampling_gap")]:
+            result = summary([original[0], after])["memory_pressure"]["host"]["some"]
+            self.assertEqual(result["excluded_intervals"], {reason: 1})
+
+    def test_large_unrelated_sample_fields_are_not_retained(self):
+        class Payload:
+            pass
+        row = sample(0, 0)
+        row["metrics"] = Payload()
+        observed = weakref.ref(row["metrics"])
+        accumulator = MemoryPressure()
+        accumulator.add(row)
+        del row
+        gc.collect()
+        self.assertIsNone(observed())
+        for index in range(1, 10_000):
+            accumulator.add(sample(index * 2_000_000_000, index))
+        self.assertEqual(accumulator.report()["memory_pressure"]["host"]["some"]["intervals"], 9999)
+
+
+class RecordingTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.path = Path(temporary.name) / "samples.jsonl.gz"
+        self.reporter = load("report-native-sync-pressure")
+
+    def write(self, rows):
+        with gzip.open(self.path, "wt") as output:
+            for row in rows:
+                output.write(json.dumps(row) + "\n")
+
+    def test_complete_recording_hash_and_selected_interval(self):
+        rows = [sample(i * 2_000_000_000, i * 100) for i in range(4)]
+        rows[-1]["unit"].update(MainPID="0", ActiveState="inactive")
+        self.write(rows)
+        report = self.reporter.report_recording(self.path, 0, 2_000_000_000)
+        self.assertEqual(report["samples"], 2)
+        self.assertEqual(report["recorded_rows"], 4)
+        self.assertEqual(report["samples_sha256"], hashlib.sha256(self.path.read_bytes()).hexdigest())
+        self.assertTrue(report["recording_complete"])
+        self.assertTrue(report["unit_success_observed"])
+
+    def test_failed_or_unknown_unit_result_is_not_success(self):
+        row = sample(0, 0)
+        row["unit"].update(ActiveState="failed", Result="oom-kill", ExecMainStatus="9")
+        self.write([row])
+        report = self.reporter.report_recording(self.path, 0, 0)
+        self.assertTrue(report["recording_complete"])
+        self.assertFalse(report["unit_success_observed"])
+        row["unit"].update(ActiveState="inactive", ExecMainStatus="0")
+        row["unit"].pop("Result")
+        self.write([row])
+        self.assertIsNone(self.reporter.report_recording(self.path, 0, 0)["unit_success_observed"])
+
+    def test_deadline_or_truncated_gzip_cannot_be_a_complete_recording(self):
+        self.write([sample(0, 0)])
+        with self.assertRaises(ValueError):
+            self.reporter.report_recording(self.path, 0, 0)
+        result = self.reporter.report_recording(self.path, 0, 0, allow_incomplete=True)
+        self.assertFalse(result["recording_complete"])
+        self.path.write_bytes(self.path.read_bytes()[:-4])
+        with self.assertRaises(EOFError):
+            self.reporter.report_recording(self.path, 0, 0, allow_incomplete=True)
+
+    def test_corruption_outside_selected_phase_is_not_ignored(self):
+        rows = [sample(0, 0), sample(2_000_000_000, 1)]
+        rows[1]["clock"] = "unrelated-clock"
+        self.write(rows)
+        with self.assertRaises(ValueError):
+            self.reporter.report_recording(self.path, 0, 0, allow_incomplete=True)
+
+    def test_observer_uses_only_explicit_local_endpoints(self):
+        recorder = load("record-native-sync")
+        self.assertEqual(recorder.local_url("http://[::1]:19999/metrics"), "http://[::1]:19999/metrics")
+        for url in ["https://127.0.0.1", "http://example.com", "http://name:secret@127.0.0.1"]:
+            with self.assertRaises(argparse.ArgumentTypeError):
+                recorder.local_url(url)
+
+    def test_missing_service_is_not_a_successfully_stopped_node(self):
+        recorder = load("record-native-sync")
+        properties = "MainPID=0\nControlGroup=\nActiveState=inactive\nExecMainStatus=0\nResult=success\nLoadState=not-found\n"
+        with patch.object(recorder.subprocess, "check_output", return_value=properties):
+            with self.assertRaises(ValueError):
+                recorder.observe("missing.service", "http://127.0.0.1", "http://127.0.0.1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_native_sync_series.py
+++ b/scripts/tests/test_native_sync_series.py
@@ -100,6 +100,41 @@ class SeriesTests(unittest.TestCase):
         self.assertEqual(result["pair_counts"], {"complete": 1, "failed": 0, "unavailable": 1})
         self.assertEqual(result["clients"]["client"]["completed_pairs"], 1)
 
+    def test_successful_native_pairs_preserve_failed_and_unavailable_captures(self):
+        write(self.root / "candidate-01-capture-import.json", {
+            "run": "candidate-01", "capture_import_ok": False, "returncode": 1,
+            "stderr": "missing decoded messages"})
+        result = report_series(self.path)
+        self.assertTrue(result["all_pairs_complete"])
+        self.assertFalse(result["all_required_captures_imported"])
+        self.assertEqual(result["capture_counts"],
+                         {"complete": 0, "failed": 1, "unavailable": 1, "not_requested": 2})
+        failed = result["pairs"][0]["captures"]["candidate"]
+        self.assertEqual(failed["import_record"]["stderr"], "missing decoded messages")
+
+    def test_successful_capture_requires_unchanged_workload_bytes(self):
+        for run in ("candidate-01", "candidate-02"):
+            profile = self.root / (run + "-workload.json")
+            write(profile, {"fixture": run})
+            write(self.root / (run + "-capture-import.json"), {
+                "run": run, "capture_import_ok": True, "returncode": 0,
+                "profile_sha256": digest(profile)})
+        self.assertTrue(report_series(self.path)["all_required_captures_imported"])
+        profile.write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "workload differs"):
+            report_series(self.path)
+
+    def test_capture_claim_cannot_override_its_run_or_exit_status(self):
+        for record in (
+            {"run": "another-run", "capture_import_ok": False, "returncode": 1},
+            {"run": "candidate-01", "capture_import_ok": True, "returncode": 1},
+            {"run": "candidate-01", "capture_import_ok": False, "returncode": 0},
+            {"run": "candidate-01", "capture_import_ok": "true", "returncode": 0},
+        ):
+            write(self.root / "candidate-01-capture-import.json", record)
+            with self.subTest(record=record), self.assertRaises(ValueError):
+                report_series(self.path)
+
     def test_failed_trial_is_not_a_fast_success(self):
         path = self.root / "candidate-02-outcome-audit.json"
         audit = json.loads(path.read_text())

--- a/scripts/tests/test_native_sync_series.py
+++ b/scripts/tests/test_native_sync_series.py
@@ -111,6 +111,36 @@ class SeriesTests(unittest.TestCase):
         self.assertEqual(result["pair_counts"], {"complete": 1, "failed": 1, "unavailable": 0})
         self.assertEqual(result["clients"]["client"]["completed_pairs"], 1)
 
+    def test_preparation_failure_remains_visible_after_verified_resumption(self):
+        run = "candidate-02"
+        audit_path = self.root / (run + "-outcome-audit.json")
+        saved_audit = audit_path.read_bytes()
+        audit_path.unlink()
+        failure_path = self.root / (run + "-supervision-failure.json")
+        write(failure_path, {"run": run, "step": "prepare-native-run.py", "cleanup": {
+            host: {"all_run_units_stopped": True, "stops": [], "recorder_forced_stop": False}
+            for host in self.specs[run]["hosts"]}})
+        report = report_series(self.path)
+        self.assertEqual(report["pair_counts"]["failed"], 1)
+        self.assertEqual(report["runs_with_supervision_failures"], 1)
+        audit_path.write_bytes(saved_audit)
+        with self.assertRaises(FileNotFoundError):
+            report_series(self.path)
+        resumed = {"run": run, "failure_sha256": digest(failure_path),
+                   "original_controller_absent": True, "prepared_hosts": {
+                       host: {"copy_complete": True, "native_start_absent": True}
+                       for host in self.specs[run]["hosts"]}}
+        resumed_path = self.root / (run + "-resumption.json")
+        write(resumed_path, resumed)
+        report = report_series(self.path)
+        self.assertTrue(report["all_pairs_complete"])
+        self.assertEqual(report["runs_with_supervision_failures"], 1)
+        self.assertIn("supervision_failure", report["pairs"][1]["observations"]["candidate"])
+        resumed["prepared_hosts"]["client"]["native_start_absent"] = False
+        write(resumed_path, resumed)
+        with self.assertRaisesRegex(ValueError, "resumption before native startup"):
+            report_series(self.path)
+
     def test_changed_companion_or_unknown_condition_is_rejected(self):
         original = copy.deepcopy(self.specs["candidate-02"])
         for change in ("companion", "network_profile"):

--- a/scripts/tests/test_native_sync_series.py
+++ b/scripts/tests/test_native_sync_series.py
@@ -1,0 +1,163 @@
+"""Synthetic metadata fixtures exercise reporting, never native node execution."""
+import copy
+import hashlib
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+from native_sync_series import digest, report_series
+
+
+def write(path, value):
+    path.write_text(json.dumps(value))
+
+
+class SeriesTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.plan = {"schema": 1, "first_pair": {}, "pairs": []}
+        self.specs = {}
+        for index in (1, 2):
+            pair = {"index": index, "order": ["candidate", "baseline"], "runs": {}}
+            for policy in ("baseline", "candidate"):
+                run = f"{policy}-{index:02}"
+                config = f'[network]\ncache_dir = "/runs/{run}/network"\n[network.zakura]\ntrace_dir = "/runs/{run}/traces"\n[state]\ncache_dir = "/runs/{run}/state"\n'
+                spec = {"schema": 1, "run": run, "client_count": 1, "server_revision": policy,
+                        "capture_application_lifetimes": policy == "candidate", "hosts": {}}
+                for host, role in (("server", "server"), ("client", "downloader")):
+                    spec["hosts"][host] = {"role": role, "binary": policy if host == "server" else "fixed-client",
+                                           "binary_sha256": policy if host == "server" else "fixed-client-hash",
+                                           "config": config, "config_sha256": hashlib.sha256(config.encode()).hexdigest()}
+                self.specs[run] = spec
+                witness = self.save_spec(run)
+                if index == 1:
+                    self.plan["first_pair"][policy] = witness
+                else:
+                    pair["runs"][policy] = witness
+                self.complete(run, 100 if policy == "baseline" else 90 if index == 1 else 105)
+            if index == 2:
+                self.plan["pairs"].append(pair)
+        self.path = self.root / "series.json"
+        write(self.path, self.plan)
+
+    def save_spec(self, run):
+        path = self.root / (run + ".json")
+        write(path, self.specs[run])
+        return {"file": path.name, "sha256": digest(path)}
+
+    def update_planned_spec(self, run):
+        witness = self.save_spec(run)
+        policy = run.split("-", 1)[0]
+        if run.endswith("01"):
+            self.plan["first_pair"][policy] = witness
+        else:
+            self.plan["pairs"][0]["runs"][policy] = witness
+        write(self.path, self.plan)
+
+    def complete(self, run, seconds):
+        spec = self.specs[run]
+        resources = {"run": run, "hosts": {host: {"recording_complete": True,
+                                                    "completion_seconds": seconds if host == "client" else None}
+                                             for host in spec["hosts"]}}
+        resources_path = self.root / (run + "-resources.json")
+        write(resources_path, resources)
+        audit = {"run": run, "resources_sha256": digest(resources_path), "hosts": {}}
+        for host, config in spec["hosts"].items():
+            directory = self.root / "evidence" / run / host
+            extracted = directory / "extracted"
+            extracted.mkdir(parents=True)
+            write(extracted / "run-spec.json", spec)
+            outcome = {"run": run, "host": host, "native_completed": True, "all_clients_reached_target": True}
+            write(extracted / "run-outcome.json", outcome)
+            archive = directory / (run + ".tar.zst")
+            archive.write_bytes(b"metadata-only test fixture, not a node archive")
+            audit["hosts"][host] = {"role": config["role"], "resources": resources["hosts"][host],
+                                    "run_outcome": outcome, "archive_sha256": digest(archive)}
+        write(self.root / (run + "-outcome-audit.json"), audit)
+        write(self.root / (run + "-controller.json"),
+              {"run": run, "host_environments": {"server": "fixed environment"},
+               "remote_tool_hashes": {"server": "fixed helper hashes"}})
+
+    def test_complete_pairs_keep_individual_changes_and_spread(self):
+        result = report_series(self.path)
+        self.assertTrue(result["all_pairs_complete"])
+        self.assertEqual(result["pair_counts"], {"complete": 2, "failed": 0, "unavailable": 0})
+        self.assertIsNone(result["pairs"][0]["planned_order"])
+        client = result["clients"]["client"]
+        self.assertAlmostEqual(client["minimum_change_percent"], -10)
+        self.assertAlmostEqual(client["maximum_change_percent"], 5)
+        self.assertAlmostEqual(client["median_change_percent"], -2.5)
+
+    def test_missing_trial_stays_in_the_planned_denominator(self):
+        (self.root / "candidate-02-outcome-audit.json").unlink()
+        result = report_series(self.path)
+        self.assertFalse(result["all_pairs_complete"])
+        self.assertEqual(result["pair_counts"], {"complete": 1, "failed": 0, "unavailable": 1})
+        self.assertEqual(result["clients"]["client"]["completed_pairs"], 1)
+
+    def test_failed_trial_is_not_a_fast_success(self):
+        path = self.root / "candidate-02-outcome-audit.json"
+        audit = json.loads(path.read_text())
+        outcome = audit["hosts"]["client"]["run_outcome"]
+        outcome.update(native_completed=False, all_clients_reached_target=False)
+        write(self.root / "evidence/candidate-02/client/extracted/run-outcome.json", outcome)
+        write(path, audit)
+        result = report_series(self.path)
+        self.assertEqual(result["pair_counts"], {"complete": 1, "failed": 1, "unavailable": 0})
+        self.assertEqual(result["clients"]["client"]["completed_pairs"], 1)
+
+    def test_changed_companion_or_unknown_condition_is_rejected(self):
+        original = copy.deepcopy(self.specs["candidate-02"])
+        for change in ("companion", "network_profile"):
+            self.specs["candidate-02"] = copy.deepcopy(original)
+            if change == "companion":
+                self.specs["candidate-02"]["hosts"]["client"]["binary_sha256"] = "different"
+            else:
+                self.specs["candidate-02"]["network_profile"] = {"rtt_ms": 80}
+            self.update_planned_spec("candidate-02")
+            with self.assertRaisesRegex(ValueError, "paired conditions differ"):
+                report_series(self.path)
+
+    def test_server_rate_tuning_cannot_mix_repetitions(self):
+        host = self.specs["candidate-02"]["hosts"]["server"]
+        host["config"] += "\n[network.zakura.block_sync.get_blocks_regulation]\npeer_rate_bytes_per_second = 7\n"
+        host["config_sha256"] = hashlib.sha256(host["config"].encode()).hexdigest()
+        self.update_planned_spec("candidate-02")
+        with self.assertRaisesRegex(ValueError, "repetition conditions changed"):
+            report_series(self.path)
+
+    def test_mutated_archive_and_spec_are_rejected(self):
+        path = self.root / "candidate-02.json"
+        path.write_text(path.read_text() + " ")
+        with self.assertRaisesRegex(ValueError, "planned specification changed"):
+            report_series(self.path)
+        self.update_planned_spec("candidate-02")
+        (self.root / "evidence/candidate-02/client/candidate-02.tar.zst").write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "archived bytes differ"):
+            report_series(self.path)
+
+    def test_runtime_change_cannot_mix_trials(self):
+        path = self.root / "candidate-02-controller.json"
+        original = json.loads(path.read_text())
+        for field in ("host_environments", "remote_tool_hashes"):
+            with self.subTest(field=field):
+                controller = copy.deepcopy(original)
+                controller[field]["server"] = "changed"
+                write(path, controller)
+                with self.assertRaisesRegex(ValueError, "runtime helpers or host environment changed"):
+                    report_series(self.path)
+
+    def test_recovery_run_is_not_an_ordinary_timing_trial(self):
+        self.specs["candidate-02"]["finite_client_pause"] = {"seconds": 30}
+        self.update_planned_spec("candidate-02")
+        with self.assertRaisesRegex(ValueError, "recovery trials"):
+            report_series(self.path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

A completed sync can still have an unusable capture, and a report limited to the sync phase can miss memory pressure during startup or shutdown. Those distinctions matter when choosing GetBlocks defaults.

## Solution

Add a read-only Linux recorder and reports that retain whole-run memory observations, CPU and I/O pressure, failed trials, capture outcomes, and source hashes. The recorder observes an existing test node; it does not manage nodes or provision a lab. A bounded QUIC test checks that queued payload capacity remains held through an unfinished write.

## Testing

All 102 Python script tests passed. Formatting and Markdown lint pass. The real QUIC writer test passes on this exact branch (one test, including completion and timeout). Scoped Clippy also passes on this branch. These tools report evidence and do not certify production readiness.

Used Codex for implementation and validation.
