### PR TITLE
fix(ops): retain sync failure traces and recover disk space

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -20,17 +20,16 @@ v2 stack.
 `zakura-continuous-sync.service` runs
 `/usr/local/sbin/zakura-continuous-sync.py` on each host:
 
-1. Fetch `origin/main` in `/root/zakura` and pin the full commit SHA.
+1. Stop the node, prune old artifacts, check disk space, then fetch `origin/main` in `/root/zakura` and pin the full commit SHA.
 2. Build `zakurad` from a detached worktree and cache the binary by SHA.
 3. Atomically install the binary at `/usr/local/bin/zakurad`.
 4. Stop `zakura.service`.
 5. Verify `/var/lib/zakura/.continuous-sync-wipe-ok` exists.
 6. Delete only the configured disposable state entries:
    `/var/lib/zakura/state` and `/var/lib/zakura/non_finalized_state`.
-7. Preserve `/var/lib/zakura/network`, controller state, logs, traces, and build
-   cache.
-8. Render `/etc/zakura/zebrad.toml` with the node's assigned `p2p_stack` and a
-   run-specific trace directory.
+7. Preserve `/var/lib/zakura/network` and controller state.
+8. Render `/etc/zakura/zebrad.toml` with the node's assigned `p2p_stack`.
+   Detailed JSONL traces are enabled for every sync.
 9. Start `zakura.service` with `Restart=no`.
 10. Poll metrics and `/ready` until the node is stably near tip.
 11. Stop the node, record the completion for the daily audit digest, and start
@@ -41,8 +40,9 @@ continuous sync canary, not a once-per-SHA CI job.
 
 ## Failure Semantics
 
-Any build, install, cleanup, startup, sync, stall, timeout, disk, metrics, or
-readiness failure halts the affected node:
+Build, install, cleanup, startup, sync, stall, timeout, metrics, and readiness
+failures halt the affected node. Disk pressure follows the automatic recovery
+policy below. Other failures behave as follows:
 
 - `zakura-continuous-sync.service` exits non-zero.
 - `/var/lib/zakura-continuous-sync/state.json` records `failed = true`.
@@ -50,8 +50,7 @@ readiness failure halts the affected node:
 - a Slack alert is posted with the node mode, SHA, height, SSH target, log path,
   trace path, and monitor log path.
 
-The controller does not automatically retry after failure. Resume is an explicit
-operator action:
+For failures other than disk pressure, resume is an explicit operator action:
 
 ```bash
 python3 deploy/continuous-sync/deploy.py --node temp-zakura-sync-test-2 resume
@@ -238,8 +237,8 @@ a cycle complete. `/ready` checks that the node has live peers, is near the
 estimated network tip, and has a fresh tip. The controller also records
 Prometheus samples in `samples.jsonl` so a completed or failed run has evidence
 for height movement, readiness, legacy pipeline depth, and each active download
-or verification phase. The controller copies the current node log into the run
-directory on both completion and failure.
+or verification phase. The controller saves up to the last 64 MiB of the node
+log in the run directory on completion and failure.
 
 The relevant loopback endpoints are only bound locally:
 
@@ -249,15 +248,45 @@ The relevant loopback endpoints are only bound locally:
 
 ## Retention
 
-Detailed run artifacts live under `/var/log/zakura/runs/`. The controller keeps
-the active run and the two newest prior runs (`retention_runs = 3`), deleting
-older completed or failed run directories when each cycle starts.
+Detailed traces stay enabled so a failure can be investigated without reproducing
+it. The controller keeps up to 10 runs within a 20 GiB retention target, deleting
+successful runs first, oldest first. The current run and the most recent failed
+run are protected, including their traces, metadata, samples, and log tail.
+Protected runs may exceed the target; cleanup never discards them to meet it.
 
-`templates/logrotate` also rotates `/var/log/zakura/zebrad.log` and
-`/var/log/zakura/monitor.log` daily, keeping five compressed rotations.
+During sync, the controller checks trace files with logrotate every polling
+interval (normally 30 seconds). Each stream rotates at 128 MiB and keeps two older
+segments beside the current file. Files can exceed that size between checks.
+This preserves recent detailed history, not necessarily the entire sync.
+`copytruncate` keeps the existing append-only writer working without a restart;
+a small number of records can be lost at the copy/truncate boundary. Only the
+controller rotates traces, so retention cannot race a separate trace cleaner.
 
-The controller checks disk free space before and during sync. If free space falls
-below `min_free_bytes`, it halts and alerts instead of filling the host.
+For example, read `block_sync.jsonl.2`, then `.1`, then `block_sync.jsonl` for
+chronological history. To use tools that expect one file, concatenate those
+segments into a separate analysis directory. The stopped failure's files remain
+unchanged until a newer failure replaces its protected status.
+
+The controller also retains two cached binaries and removes interrupted
+controller build worktrees and temporary binary copies. The cache is reserved
+for controller builds. Unknown names and symlinked child directories are left
+alone; the runs directory itself may point to another volume.
+
+The existing minute monitor rotates node and monitor logs at 64 MiB or daily,
+retaining seven rotations. Each archived run log keeps its final 64 MiB.
+
+Cleanup runs before the initial disk check. During sync the controller checks
+the state, run, and build-cache filesystems. Below 10 GiB free it stops the node,
+records and alerts on the failed attempt, and prunes unprotected history. Once
+all three filesystems have 15 GiB free, it automatically starts a fresh sync.
+Until then it stays failed and rechecks once a minute. If protected evidence or
+unrelated files occupy the remaining space, it waits rather than deleting them.
+Other sync failures remain halted for investigation.
+
+Cleanup never touches chain state or network identity. A fresh attempt uses the
+existing sentinel-protected reset of disposable chain state. Stopping the
+controller also stops automatic recovery. Deployment removes the earlier
+standalone storage timer; `--no-start` does not start the controller.
 
 ## Replacement Node Bootstrap
 
@@ -274,7 +303,7 @@ For a fresh Ubuntu x86_64 host:
    apt-get update
    apt-get install -y \
      build-essential clang cmake git libclang-dev pkg-config \
-     protobuf-compiler python3
+     protobuf-compiler python3 logrotate
    ```
 
 5. Install the Rust toolchain specified by `rust-toolchain.toml`.

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -237,8 +237,8 @@ a cycle complete. `/ready` checks that the node has live peers, is near the
 estimated network tip, and has a fresh tip. The controller also records
 Prometheus samples in `samples.jsonl` so a completed or failed run has evidence
 for height movement, readiness, legacy pipeline depth, and each active download
-or verification phase. The controller saves up to the last 64 MiB of the node
-log in the run directory on completion and failure.
+or verification phase. Node logs are written directly into the run directory,
+so a failure keeps both the current log and its preceding rotated segment.
 
 The relevant loopback endpoints are only bound locally:
 
@@ -272,19 +272,24 @@ controller build worktrees and temporary binary copies. The cache is reserved
 for controller builds. Unknown names and symlinked child directories are left
 alone; the runs directory itself may point to another volume.
 
-The existing minute monitor rotates node and monitor logs at 64 MiB or daily,
-retaining seven rotations. Each archived run log keeps its final 64 MiB.
+The controller also rotates each run's node log at 64 MiB, keeping the current
+file and one prior segment. `/var/log/zakura/zebrad.log` points to the current
+run's log. The minute monitor retains seven rotations of its own log and handles
+legacy node logs until they are replaced by this symlink.
 
 Cleanup runs before the initial disk check. During sync the controller checks
 the state, run, and build-cache filesystems. Below 10 GiB free it stops the node,
-records and alerts on the failed attempt, and prunes unprotected history. Once
-all three filesystems have 15 GiB free, it automatically starts a fresh sync.
+records and alerts on the failed attempt, and prunes unprotected history. Recovery
+resets the stopped, disposable chain database before checking for 15 GiB free on
+all three filesystems. It then starts a fresh sync and sends a recovery alert
+identifying the failed attempt once the new node service is active.
 Until then it stays failed and rechecks once a minute. If protected evidence or
 unrelated files occupy the remaining space, it waits rather than deleting them.
 Other sync failures remain halted for investigation.
 
-Cleanup never touches chain state or network identity. A fresh attempt uses the
-existing sentinel-protected reset of disposable chain state. Stopping the
+Artifact cleanup preserves chain state. Disk recovery and fresh attempts use the
+existing sentinel-protected reset of disposable chain state, preserving network
+identity and the failed run's diagnostics. Stopping the
 controller also stops automatic recovery. Deployment removes the earlier
 standalone storage timer; `--no-start` does not start the controller.
 

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -282,7 +282,9 @@ the state, run, and build-cache filesystems. Below 10 GiB free it stops the node
 records and alerts on the failed attempt, and prunes unprotected history. Recovery
 resets the stopped, disposable chain database before checking for 15 GiB free on
 all three filesystems. It then starts a fresh sync and sends a recovery alert
-identifying the failed attempt once the new node service is active.
+identifying the failed attempt once the new node service is active. Failed
+delivery remains pending across controller restarts and retries during sync
+polling; a new sync failure supersedes that pending recovery.
 Until then it stays failed and rechecks once a minute. If protected evidence or
 unrelated files occupy the remaining space, it waits rather than deleting them.
 Other sync failures remain halted for investigation.

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -542,7 +542,9 @@ def rotate_run_logs(config: Config, run_dir: Path) -> None:
          str(rotation_config)], timeout=60)
 
 
-def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
+def wait_for_completion(
+    config: Config, run_dir: Path, run_state: dict[str, Any], state: dict[str, Any]
+) -> None:
     started = now()
     last_height: int | None = None
     last_progress = started
@@ -557,6 +559,10 @@ def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]
         if not service_active(config):
             raise ControllerError(f"{config.policy.service_name} exited before sync completion")
 
+        recovered_run = state.get("disk_recovery_run")
+        if recovered_run and post_slack(config, f"{resumed_text(config)} | recovered run: {recovered_run}"):
+            state.pop("disk_recovery_run")
+            save_state(config.paths.state_dir / "state.json", state)
         rotate_run_logs(config, run_dir)
         sample = sample_status(config)
         sample["time"] = utc_stamp(ts)
@@ -744,13 +750,7 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
     save_state(state_path, state)
     try:
         start_service(config)
-        recovered_run = state.pop("disk_recovery_run", None)
-        if recovered_run:
-            if not service_active(config):
-                raise ControllerError(f"{config.policy.service_name} failed to start")
-            post_slack(config, f"{resumed_text(config)} | recovered run: {recovered_run}")
-            save_state(state_path, state)
-        wait_for_completion(config, run_dir, run_state)
+        wait_for_completion(config, run_dir, run_state, state)
     finally:
         state["phase"] = "stopping"
         try:

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -383,7 +383,7 @@ def render_config(config: Config, run_dir: Path) -> None:
     trace_dir.mkdir(parents=True, exist_ok=True)
     substitutions = {
         "TRACE_DIR": str(trace_dir),
-        "LOG_FILE": str(config.paths.log_file),
+        "LOG_FILE": str(run_dir / "zebrad.log"),
         "STATE_CACHE_DIR": str(config.paths.chain_state_dir),
         "P2P_STACK": config.policy.p2p_stack,
         "TRACING_FILTER": config.policy.tracing_filter,
@@ -396,6 +396,8 @@ def render_config(config: Config, run_dir: Path) -> None:
     tmp.write_text(rendered, encoding="utf-8")
     tmp.replace(config.paths.zakurad_config)
     relink(config.paths.trace_link, trace_dir)
+    (run_dir / "zebrad.log").touch()
+    relink(config.paths.log_file, run_dir / "zebrad.log")
 
 
 def relink(link: Path, target: Path) -> None:
@@ -525,13 +527,15 @@ def sample_status(config: Config) -> dict[str, Any]:
     return status
 
 
-def rotate_traces(config: Config, run_dir: Path) -> None:
-    """Bound each append-only trace stream using the host's existing logrotate."""
+def rotate_run_logs(config: Config, run_dir: Path) -> None:
+    """Keep trace and node-log rotations inside the run that produced them."""
     rotation_config = run_dir / ".trace-logrotate.conf"
     rotation_config.write_text(
         f'{json.dumps(str(run_dir / "traces" / "*.jsonl"))} {{\n'
         f"    size {config.policy.trace_file_bytes}\n"
-        "    rotate 2\n    missingok\n    notifempty\n    copytruncate\n    nocompress\n}\n",
+        "    rotate 2\n    missingok\n    notifempty\n    copytruncate\n    nocompress\n}\n"
+        f'{json.dumps(str(run_dir / "zebrad.log"))} {{\n'
+        "    size 64M\n    rotate 1\n    missingok\n    notifempty\n    copytruncate\n    nocompress\n}\n",
         encoding="utf-8",
     )
     run(["logrotate", "--state", str(run_dir / ".trace-logrotate.state"),
@@ -553,7 +557,7 @@ def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]
         if not service_active(config):
             raise ControllerError(f"{config.policy.service_name} exited before sync completion")
 
-        rotate_traces(config, run_dir)
+        rotate_run_logs(config, run_dir)
         sample = sample_status(config)
         sample["time"] = utc_stamp(ts)
         with samples_path.open("a", encoding="utf-8") as samples:
@@ -588,17 +592,6 @@ def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]
         else:
             ready_samples = 0
             time.sleep(config.policy.poll_interval_seconds)
-
-
-def archive_run_log(config: Config, run_dir: Path) -> None:
-    if not config.paths.log_file.exists():
-        return
-    dest = run_dir / "zebrad.log"
-    # Keep a useful tail even if an old installation missed log rotation.
-    with config.paths.log_file.open("rb") as source, dest.open("wb") as target:
-        source.seek(max(0, source.seek(0, 2) - 64 * 1024**2))
-        shutil.copyfileobj(source, target)
-    config.paths.log_file.write_text("", encoding="utf-8")
 
 
 def cleanup_retention(
@@ -700,10 +693,11 @@ def short_reason(reason: str, limit: int = 96) -> str:
 
 
 def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[str, Any]:
-    stop_service(config)
-    cleanup_retention(config)
     state.pop("current_run", None)
     state["phase"] = "preflight"
+    save_state(state_path, state)
+    stop_service(config)
+    cleanup_retention(config)
     preflight(config)
     sha = resolve_sha(config)
     started_at = now()
@@ -736,7 +730,6 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
     stop_service(config)
     safe_wipe_state(config)
     render_config(config, run_dir)
-    config.paths.log_file.write_text("", encoding="utf-8")
 
     sync_started_at = now()
     run_state.update(
@@ -751,11 +744,20 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
     save_state(state_path, state)
     try:
         start_service(config)
+        recovered_run = state.pop("disk_recovery_run", None)
+        if recovered_run:
+            if not service_active(config):
+                raise ControllerError(f"{config.policy.service_name} failed to start")
+            post_slack(config, f"{resumed_text(config)} | recovered run: {recovered_run}")
+            save_state(state_path, state)
         wait_for_completion(config, run_dir, run_state)
     finally:
-        stop_service(config)
-    rotate_traces(config, run_dir)
-    archive_run_log(config, run_dir)
+        state["phase"] = "stopping"
+        try:
+            save_state(state_path, state)
+        finally:
+            stop_service(config)
+    rotate_run_logs(config, run_dir)
 
     completed_at_epoch = now()
     completed_at = utc_stamp(completed_at_epoch)
@@ -813,9 +815,10 @@ def halt(config: Config, state_path: Path, state: dict[str, Any], run_state: dic
             "failed_at": failed_at,
             "phase": "failed",
             "last_failed_sha": run_state.get("sha"),
-            "last_failed_run": run_state.get("run_id"),
+            "last_failed_run": run_state.get("run_id") or f"preflight-{time.time_ns()}",
         }
     )
+    state.pop("disk_recovery_run", None)
     state.pop("failure_notification", None)
     save_state(state_path, state)
     if post_slack(config, failure_text(config, run_state, reason)):
@@ -844,13 +847,15 @@ def run_loop(config: Config, config_path: Path) -> int:
                 print(f"controller halted: {reason}", file=sys.stderr)
                 return 2
             stop_service(config)
+            safe_wipe_state(config)
             cleanup_retention(config, recovery=True)
             try:
                 check_free_space(config, recovery=True)
             except DiskPressure:
                 time.sleep(max(60, config.policy.cooldown_seconds))
                 continue
-            state.update({"failed": False, "phase": "resumed", "resumed_at": utc_stamp()})
+            state.update({"failed": False, "phase": "resumed", "resumed_at": utc_stamp(),
+                          "disk_recovery_run": state.get("last_failed_run") or "unknown"})
             state.pop("failure", None)
             save_state(state_path, state)
             log(config, "disk-pressure-recovered; starting a fresh sync")
@@ -874,11 +879,6 @@ def run_loop(config: Config, config_path: Path) -> int:
             if isinstance(error, DiskPressure):
                 cleanup_retention(config, active_run=run_dir, recovery=True)
             halt(config, state_path, state, run_state or state, reason)
-            if run_dir is not None:
-                try:
-                    archive_run_log(config, run_dir)
-                except OSError as archive_error:
-                    log(config, f"failure-log-archive-failed error={archive_error}")
             if not isinstance(error, DiskPressure):
                 return 1
         time.sleep(config.policy.cooldown_seconds)

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -4,12 +4,13 @@
 The controller repeatedly builds the configured ref, starts `zakurad` from an
 empty allowlisted state directory, waits until the node is stably ready at tip,
 records a completion for the audit digest, and starts over. Any failure writes a
-durable halt marker and exits non-zero; operators must explicitly run `resume`.
+durable halt marker. Disk pressure retries after cleanup; other failures require `resume`.
 """
 
 from __future__ import annotations
 
 import argparse
+import errno
 import hashlib
 import json
 import os
@@ -30,6 +31,10 @@ STATE_VERSION = 1
 
 class ControllerError(Exception):
     """Operator-facing failure that should halt the sync loop."""
+
+
+class DiskPressure(ControllerError):
+    """Disposable artifacts may be reclaimed before retrying a fresh sync."""
 
 
 @dataclass(frozen=True)
@@ -69,7 +74,9 @@ class Policy:
     ready_samples: int = 6
     ready_sample_interval_seconds: int = 30
     min_free_bytes: int = 10 * 1024 * 1024 * 1024
-    retention_runs: int = 3
+    retention_runs: int = 10
+    retention_bytes: int = 20 * 1024**3
+    trace_file_bytes: int = 128 * 1024**2
     cooldown_seconds: int = 60
     wipe_entries: tuple[str, ...] = ("state", "non_finalized_state")
     preserve_entries: tuple[str, ...] = ("network",)
@@ -275,8 +282,8 @@ def build_binary(config: Config, sha: str) -> Path:
     if worktree.exists():
         run(["git", "worktree", "remove", "--force", str(worktree)], cwd=config.paths.repo_dir, check=False)
         shutil.rmtree(worktree, ignore_errors=True)
-    run(["git", "worktree", "add", "--detach", str(worktree), sha], cwd=config.paths.repo_dir)
     try:
+        run(["git", "worktree", "add", "--detach", str(worktree), sha], cwd=config.paths.repo_dir)
         run(["cargo", "build", "--release", "--locked", "-p", "zakura"], cwd=worktree)
         built = worktree / "target" / "release" / "zakurad"
         if not built.is_file():
@@ -300,7 +307,12 @@ def build_binary(config: Config, sha: str) -> Path:
             encoding="utf-8",
         )
         meta_tmp.replace(meta)
+    except ControllerError:
+        # Classify an exhausted build volume before finally removes its worktree.
+        check_free_space(config)
+        raise
     finally:
+        target.with_suffix(".tmp").unlink(missing_ok=True)
         run(["git", "worktree", "remove", "--force", str(worktree)], cwd=config.paths.repo_dir, check=False)
         shutil.rmtree(worktree, ignore_errors=True)
     return target
@@ -317,16 +329,19 @@ def install_binary(config: Config, binary: Path) -> None:
     tmp.replace(target)
 
 
-def check_free_space(config: Config) -> None:
-    usage = shutil.disk_usage(config.paths.chain_state_dir)
-    if usage.free < config.policy.min_free_bytes:
-        raise ControllerError(
-            f"free disk {usage.free} bytes below minimum {config.policy.min_free_bytes}"
-        )
+def check_free_space(config: Config, *, recovery: bool = False) -> None:
+    minimum = config.policy.min_free_bytes + (5 * 1024**3 if recovery else 0)
+    for path in (config.paths.chain_state_dir, config.paths.runs_dir, config.paths.build_cache_dir):
+        # A fresh installation may not have created the cache yet.
+        while not path.exists():
+            path = path.parent
+        free = shutil.disk_usage(path).free
+        if free < minimum:
+            raise DiskPressure(f"free disk {free} bytes below minimum {minimum} at {path}")
 
 
 def preflight(config: Config) -> None:
-    for command in ("cargo", "git", "systemctl"):
+    for command in ("cargo", "git", "systemctl", "logrotate"):
         if shutil.which(command) is None:
             raise ControllerError(f"required command is unavailable: {command}")
     for path, description in (
@@ -510,6 +525,19 @@ def sample_status(config: Config) -> dict[str, Any]:
     return status
 
 
+def rotate_traces(config: Config, run_dir: Path) -> None:
+    """Bound each append-only trace stream using the host's existing logrotate."""
+    rotation_config = run_dir / ".trace-logrotate.conf"
+    rotation_config.write_text(
+        f'{json.dumps(str(run_dir / "traces" / "*.jsonl"))} {{\n'
+        f"    size {config.policy.trace_file_bytes}\n"
+        "    rotate 2\n    missingok\n    notifempty\n    copytruncate\n    nocompress\n}\n",
+        encoding="utf-8",
+    )
+    run(["logrotate", "--state", str(run_dir / ".trace-logrotate.state"),
+         str(rotation_config)], timeout=60)
+
+
 def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
     started = now()
     last_height: int | None = None
@@ -521,10 +549,11 @@ def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]
         ts = now()
         if ts - started > config.policy.max_run_seconds:
             raise ControllerError(f"run exceeded max duration {config.policy.max_run_seconds}s")
+        check_free_space(config)
         if not service_active(config):
             raise ControllerError(f"{config.policy.service_name} exited before sync completion")
-        check_free_space(config)
 
+        rotate_traces(config, run_dir)
         sample = sample_status(config)
         sample["time"] = utc_stamp(ts)
         with samples_path.open("a", encoding="utf-8") as samples:
@@ -565,36 +594,69 @@ def archive_run_log(config: Config, run_dir: Path) -> None:
     if not config.paths.log_file.exists():
         return
     dest = run_dir / "zebrad.log"
-    shutil.copy2(config.paths.log_file, dest)
+    # Keep a useful tail even if an old installation missed log rotation.
+    with config.paths.log_file.open("rb") as source, dest.open("wb") as target:
+        source.seek(max(0, source.seek(0, 2) - 64 * 1024**2))
+        shutil.copyfileobj(source, target)
     config.paths.log_file.write_text("", encoding="utf-8")
 
 
-def cleanup_retention(config: Config, active_run: Path | None = None) -> None:
+def cleanup_retention(
+    config: Config, active_run: Path | None = None, *, recovery: bool = False
+) -> None:
+    """Call with the node/build stopped. Preserve the active and latest failed runs."""
+    cache = config.paths.build_cache_dir
+    binaries = []
+    for child in cache.iterdir() if cache.exists() else []:
+        if child.is_symlink():
+            continue
+        if re.fullmatch(r"worktree-[0-9a-f]{12}", child.name) and child.is_dir():
+            run(["git", "worktree", "remove", "--force", str(child)],
+                cwd=config.paths.repo_dir, check=False)
+            if child.exists():
+                shutil.rmtree(child)
+        elif re.fullmatch(r"zakurad-[0-9a-f]{40}\.tmp", child.name) and child.is_file():
+            child.unlink()
+        elif re.fullmatch(r"zakurad-[0-9a-f]{40}", child.name) and child.is_file():
+            binaries.append(child)
+    for binary in sorted(binaries, key=lambda path: path.stat().st_mtime, reverse=True)[2:]:
+        binary.unlink()
+        binary.with_suffix(".json").unlink(missing_ok=True)
+
     runs = []
     for child in config.paths.runs_dir.iterdir() if config.paths.runs_dir.exists() else []:
-        if not child.is_dir():
-            continue
-        run_json = child / "run.json"
-        if not run_json.exists():
+        if (child.is_symlink() or not child.is_dir()
+                or not re.fullmatch(r"\d{8}T\d{6}Z-[0-9a-f]{12}", child.name)):
             continue
         try:
-            data = json.loads(run_json.read_text(encoding="utf-8"))
-        except Exception:
+            data = json.loads((child / "run.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
             continue
-        runs.append((str(data.get("started_at", "")), child))
+        if not isinstance(data, dict):
+            continue
+        size = sum(path.stat().st_size for path in child.rglob("*")
+                   if not path.is_symlink() and path.is_file())
+        runs.append((data.get("phase"), str(data.get("started_at", "")), child, size))
 
-    runs.sort(key=lambda run: (run[0], run[1].name), reverse=True)
-    keep_count = max(config.policy.retention_runs, 1 if active_run else 0)
-    keep = {child for _, child in runs[:keep_count]}
-    if active_run is not None and active_run not in keep:
-        keep.add(active_run)
-        if len(keep) > keep_count:
-            oldest_kept = next(child for _, child in reversed(runs) if child in keep and child != active_run)
-            keep.remove(oldest_kept)
-
-    for _, child in runs:
-        if child not in keep:
-            shutil.rmtree(child, ignore_errors=True)
+    failed = [entry for entry in runs if entry[0] == "failed"]
+    protected = {active_run}
+    if failed:
+        protected.add(max(failed, key=lambda entry: (entry[1], entry[2]))[2])
+    total, count = sum(entry[3] for entry in runs), len(runs)
+    # Successful runs are expendable first; discard the oldest within each group.
+    for _, _, child, size in sorted(runs, key=lambda entry: (entry[0] != "complete", entry[1], entry[2])):
+        if child in protected:
+            continue
+        needs_space = False
+        if recovery:
+            try:
+                check_free_space(config, recovery=True)
+            except DiskPressure:
+                needs_space = True
+        if count > config.policy.retention_runs or total > config.policy.retention_bytes or needs_space:
+            shutil.rmtree(child)
+            total -= size
+            count -= 1
 
 
 def failure_text(config: Config, run_state: dict[str, Any], reason: str) -> str:
@@ -638,6 +700,10 @@ def short_reason(reason: str, limit: int = 96) -> str:
 
 
 def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[str, Any]:
+    stop_service(config)
+    cleanup_retention(config)
+    state.pop("current_run", None)
+    state["phase"] = "preflight"
     preflight(config)
     sha = resolve_sha(config)
     started_at = now()
@@ -688,7 +754,8 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
         wait_for_completion(config, run_dir, run_state)
     finally:
         stop_service(config)
-        archive_run_log(config, run_dir)
+    rotate_traces(config, run_dir)
+    archive_run_log(config, run_dir)
 
     completed_at_epoch = now()
     completed_at = utc_stamp(completed_at_epoch)
@@ -769,15 +836,30 @@ def run_loop(config: Config, config_path: Path) -> int:
     config.paths.state_dir.mkdir(parents=True, exist_ok=True)
     config.paths.runs_dir.mkdir(parents=True, exist_ok=True)
     state = load_state(state_path)
-    if state.get("failed"):
-        print(f"controller halted: {state.get('failure')}", file=sys.stderr)
-        return 2
-
     while True:
+        if state.get("failed"):
+            reason = str(state.get("failure", ""))
+            # Also recover the exact disk-space halt emitted by older controllers.
+            if not reason.startswith(("DiskPressure:", "ControllerError: free disk ")):
+                print(f"controller halted: {reason}", file=sys.stderr)
+                return 2
+            stop_service(config)
+            cleanup_retention(config, recovery=True)
+            try:
+                check_free_space(config, recovery=True)
+            except DiskPressure:
+                time.sleep(max(60, config.policy.cooldown_seconds))
+                continue
+            state.update({"failed": False, "phase": "resumed", "resumed_at": utc_stamp()})
+            state.pop("failure", None)
+            save_state(state_path, state)
+            log(config, "disk-pressure-recovered; starting a fresh sync")
         run_state: dict[str, Any] = {}
         try:
             state = one_cycle(config, state_path, state)
         except Exception as error:
+            if isinstance(error, OSError) and error.errno == errno.ENOSPC:
+                error = DiskPressure(str(error))
             reason = f"{type(error).__name__}: {error}"
             current_run = state.get("current_run")
             if current_run:
@@ -787,8 +869,18 @@ def run_loop(config: Config, config_path: Path) -> int:
                         run_state = json.loads(run_json.read_text(encoding="utf-8"))
                     except json.JSONDecodeError:
                         run_state = {}
+            stop_service(config)
+            run_dir = config.paths.runs_dir / str(current_run) if current_run else None
+            if isinstance(error, DiskPressure):
+                cleanup_retention(config, active_run=run_dir, recovery=True)
             halt(config, state_path, state, run_state or state, reason)
-            return 1
+            if run_dir is not None:
+                try:
+                    archive_run_log(config, run_dir)
+                except OSError as archive_error:
+                    log(config, f"failure-log-archive-failed error={archive_error}")
+            if not isinstance(error, DiskPressure):
+                return 1
         time.sleep(config.policy.cooldown_seconds)
 
 

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -246,6 +246,14 @@ controller_service={controller_service}
 node_service={node_service}
 start_controller={start_controller}
 
+# Retire the earlier standalone cleaner before replacing its controller/config.
+if [ -f /etc/systemd/system/zakura-storage.timer ]; then
+  systemctl disable --now zakura-storage.timer
+  systemctl stop zakura-storage.service
+  rm -f /etc/systemd/system/zakura-storage.timer /etc/systemd/system/zakura-storage.service
+fi
+rm -f /usr/local/sbin/zakura_sync_storage.py
+
 install -d -m 755 /usr/local/sbin
 install -d -m 755 "$(dirname "$controller_config")" "$(dirname "$alert_config")" \
   "$(dirname "$config_template")" "$(dirname "$config_path")" "$chain_state_dir" \

--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -35,11 +35,11 @@ ready_samples = 6
 ready_sample_interval_seconds = 30
 health_min_connected_peers = 1
 min_free_bytes = 10737418240
-retention_runs = 3
+retention_runs = 10
 cooldown_seconds = 60
 wipe_entries = ["state", "non_finalized_state"]
 preserve_entries = ["network"]
-tracing_filter = "info,zakura_network::zakura=debug,zakura_network::zakura::transport::guard=error,zebrad::commands::start::zakura=debug,iroh=error,iroh::magicsock=error,iroh_quinn_udp=error"
+tracing_filter = "info,iroh=error,iroh::magicsock=error,iroh_quinn_udp=error"
 
 # Public mainnet Zakura peers used by today's temporary nodes.
 bootstrap_peers = [

--- a/deploy/continuous-sync/templates/logrotate
+++ b/deploy/continuous-sync/templates/logrotate
@@ -2,7 +2,8 @@
 /var/log/zakura/monitor.log
 {
     daily
-    rotate 5
+    maxsize 64M
+    rotate 7
     compress
     delaycompress
     missingok

--- a/deploy/continuous-sync/templates/zakura-monitor.service
+++ b/deploy/continuous-sync/templates/zakura-monitor.service
@@ -5,4 +5,5 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+ExecStartPre=-/usr/sbin/logrotate /etc/logrotate.d/zakura-continuous-sync
 ExecStart=/usr/local/sbin/zakura-monitor.py --config {{ALERT_CONFIG_PATH}}

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -252,7 +252,7 @@ class ContinuousSyncTests(unittest.TestCase):
                 inode = trace.stat().st_ino
                 for batch in range(3):
                     writer.write((json.dumps({"batch": batch, "detail": "x" * 100}) + "\n").encode())
-                    sync.rotate_traces(config, run_dir)
+                    sync.rotate_run_logs(config, run_dir)
                     self.assertEqual(trace.stat().st_ino, inode)
                     self.assertEqual(trace.stat().st_size, 0)
                 writer.write(b'{"batch": 3}\n')
@@ -300,17 +300,26 @@ class ContinuousSyncTests(unittest.TestCase):
                 with self.assertRaises(sync.DiskPressure):
                     sync.check_free_space(config, recovery=True)
 
-    def test_cycle_stops_and_prunes_before_preflight(self):
-        events = []
-        config = make_config(Path("/tmp"))
-        with (
-            patch.object(sync, "stop_service", side_effect=lambda _: events.append("stop")),
-            patch.object(sync, "cleanup_retention", side_effect=lambda _: events.append("cleanup")),
-            patch.object(sync, "preflight", side_effect=sync.DiskPressure("low disk")),
-            self.assertRaises(sync.DiskPressure),
-        ):
-            sync.one_cycle(config, Path("/unused"), {})
-        self.assertEqual(events, ["stop", "cleanup"])
+    def test_cycle_persists_preflight_before_stopping_an_interrupted_sync(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            path = config.paths.state_dir / "state.json"
+            state = {"phase": "syncing", "current_run": "previous"}
+            sync.save_state(path, state)
+            def check_stopped_phase(_):
+                persisted = sync.load_state(path)
+                self.assertEqual(persisted["phase"], "preflight")
+                self.assertNotIn("current_run", persisted)
+                self.assertIsNone(deploy.audit_problem({"controller_state": persisted,
+                    "service_active": False, "disk_free_bytes": 20 * 1024**3}, 0))
+            with (
+                patch.object(sync, "stop_service", side_effect=check_stopped_phase),
+                patch.object(sync, "cleanup_retention") as cleanup,
+                patch.object(sync, "preflight", side_effect=sync.DiskPressure("low disk")),
+                self.assertRaises(sync.DiskPressure),
+            ):
+                sync.one_cycle(config, path, state)
+            cleanup.assert_called_once()
 
     def test_disk_failure_retries_but_sync_failure_stays_halted(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -329,6 +338,7 @@ class ContinuousSyncTests(unittest.TestCase):
             with (
                 patch.object(sync, "one_cycle", side_effect=cycle_with_disk_failure),
                 patch.object(sync, "stop_service"),
+                patch.object(sync, "safe_wipe_state"),
                 patch.object(sync, "check_free_space"),
                 patch.object(sync, "post_slack", return_value=False),
                 patch.object(sync.time, "sleep"),
@@ -355,6 +365,7 @@ class ContinuousSyncTests(unittest.TestCase):
             sync.save_state(state_path, {"failed": True, "failure": "ControllerError: free disk 1 bytes below minimum 2"})
             with (
                 patch.object(sync, "stop_service"),
+                patch.object(sync, "safe_wipe_state"),
                 patch.object(sync, "check_free_space", side_effect=[sync.DiskPressure("low"), None]),
                 patch.object(sync.time, "sleep") as sleep,
                 patch.object(sync, "one_cycle", side_effect=KeyboardInterrupt) as cycle,
@@ -365,23 +376,27 @@ class ContinuousSyncTests(unittest.TestCase):
             cycle.assert_called_once()
             self.assertFalse(sync.load_state(state_path)["failed"])
 
-    def test_archived_log_keeps_only_bounded_tail(self):
+    @unittest.skipUnless(sync.shutil.which("logrotate"), "logrotate is required on the canaries")
+    def test_rotated_node_log_stays_with_failure_after_next_run_starts(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = make_config(Path(tmp))
-            run_dir = config.paths.runs_dir / "current"
-            run_dir.mkdir(parents=True)
-            with config.paths.log_file.open("wb") as source:
-                source.write(b"old")
-                source.seek(65 * 1024**2)
-                source.write(b"failure details")
-            sync.archive_run_log(config, run_dir)
-            archived = run_dir / "zebrad.log"
-            self.assertEqual(archived.stat().st_size, 64 * 1024**2)
-            with archived.open("rb") as source:
-                self.assertEqual(source.read(3), b"\0\0\0")
-                source.seek(-15, 2)
-                self.assertEqual(source.read(), b"failure details")
-            self.assertEqual(config.paths.log_file.stat().st_size, 0)
+            config.paths.config_template.write_text('[tracing]\nlog_file = "{{LOG_FILE}}"\n')
+            failed = config.paths.runs_dir / "failed"
+            sync.render_config(config, failed)
+            with config.paths.log_file.open("wb") as writer:
+                writer.seek(64 * 1024**2)
+                writer.write(b"failure details")
+            sync.rotate_run_logs(config, failed)
+            self.assertEqual((failed / "zebrad.log").stat().st_size, 0)
+            next_run = config.paths.runs_dir / "next"
+            sync.render_config(config, next_run)
+            config.paths.log_file.write_text("next run")
+            self.assertEqual(config.paths.log_file.resolve(), (next_run / "zebrad.log").resolve())
+            self.assertEqual(tomllib.loads(config.paths.zakurad_config.read_text())["tracing"]["log_file"],
+                             str(next_run / "zebrad.log"))
+            with (failed / "zebrad.log.1").open("rb") as previous:
+                previous.seek(-15, 2)
+                self.assertEqual(previous.read(), b"failure details")
 
     def test_deployment_retires_old_timer_without_starting_controller(self):
         node = deploy.load_nodes(DEPLOY_PATH.with_name("nodes.toml"), None)[0]
@@ -398,22 +413,6 @@ class ContinuousSyncTests(unittest.TestCase):
         self.assertNotIn("zakura-storage.timer", rendered)
         self.assertIn("logrotate", rendered["zakura-monitor.service"])
         self.assertIn("maxsize 64M", rendered["logrotate"])
-
-    def test_archive_run_log_copies_current_log_and_truncates_source(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
-            run_dir = tmp_path / "runs" / "current"
-            run_dir.mkdir(parents=True)
-            config = make_config(tmp_path)
-            config.paths.log_file.write_text("current run log\n", encoding="utf-8")
-
-            sync.archive_run_log(config, run_dir)
-
-            self.assertEqual(
-                (run_dir / "zebrad.log").read_text(encoding="utf-8"),
-                "current run log\n",
-            )
-            self.assertEqual(config.paths.log_file.read_text(encoding="utf-8"), "")
 
     def test_relink_backs_up_existing_trace_directory(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1575,13 +1574,61 @@ class NotificationTests(unittest.TestCase):
             self.assertIn("other", loaded["problems"])
             self.assertEqual(loaded["last_digest_at"], 1)
 
+    def test_disk_recovery_wipes_before_headroom_and_announces_after_start(self):
+        with tempfile.TemporaryDirectory() as tmp, contextlib.ExitStack() as stack:
+            root = Path(tmp)
+            config = make_config(root)
+            path = config.paths.state_dir / "state.json"
+            for directory in (root / "state", root / "network"):
+                directory.mkdir()
+                (directory / "marker").write_text("keep network only")
+            config.paths.wipe_sentinel.touch()
+            config.paths.config_template.write_text('[tracing]\nlog_file = "{{LOG_FILE}}"\n')
+            sync.save_state(path, {"failed": True, "failure": "DiskPressure: low", "last_failed_run": "old-run"})
+            usage = sync.shutil.disk_usage(root)
+            def disk_usage(_):
+                return usage._replace(free=(12 if (root / "state").exists() else 30) * 1024**3)
+            stack.enter_context(patch.dict(os.environ, {"ZAKURA_CONTINUOUS_SYNC_TESTING": "1"}))
+            stack.enter_context(patch.object(sync.shutil, "disk_usage", side_effect=disk_usage))
+            for name in ("preflight", "build_binary", "sha256_file", "install_binary", "stop_service", "rotate_run_logs"):
+                stack.enter_context(patch.object(sync, name, return_value="test"))
+            stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))
+            started = stack.enter_context(patch.object(sync, "start_service"))
+            stack.enter_context(patch.object(sync, "service_active", return_value=True))
+            def observe_message(_, text):
+                started.assert_called_once()
+                self.assertIn("old-run", text)
+                self.assertIn("resumed", text)
+                return True
+            post = stack.enter_context(patch.object(sync, "post_slack", side_effect=observe_message))
+            stack.enter_context(patch.object(sync, "wait_for_completion", side_effect=KeyboardInterrupt))
+            with self.assertRaises(KeyboardInterrupt):
+                sync.run_loop(config, Path("/unused"))
+            post.assert_called_once()
+            self.assertFalse((root / "state").exists())
+            self.assertTrue((root / "network" / "marker").exists())
+            self.assertNotIn("disk_recovery_run", sync.load_state(path))
+            self.assertEqual(sync.load_state(path)["phase"], "stopping")
+
+    def test_preflight_failure_receipt_is_accepted_by_audit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            path = config.paths.state_dir / "state.json"
+            with patch.object(sync, "post_slack", return_value=True):
+                sync.halt(config, path, {}, {}, "DiskPressure: preflight low")
+            state = sync.load_state(path)
+            receipt = state["failure_notification"]
+            self.assertTrue(state["last_failed_run"].startswith("preflight-"))
+            problem = deploy.audit_problem({"controller_state": state}, 0, receipt["destination"])
+            self.assertEqual(problem.delivered_at, receipt["sent_at"])
+
     def test_successful_cycle_records_digest_without_sending_routine_message(self):
         with tempfile.TemporaryDirectory() as tmp, contextlib.ExitStack() as stack:
             config = make_config(Path(tmp))
             for name in (
                 "preflight", "build_binary", "sha256_file", "install_binary", "stop_service",
                 "safe_wipe_state", "render_config", "start_service", "wait_for_completion",
-                "archive_run_log", "cleanup_retention", "rotate_traces",
+                "cleanup_retention", "rotate_run_logs",
             ):
                 stack.enter_context(patch.object(sync, name, return_value="test"))
             stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1601,7 +1601,7 @@ class NotificationTests(unittest.TestCase):
                 self.assertIn("resumed", text)
                 return True
             post = stack.enter_context(patch.object(sync, "post_slack", side_effect=observe_message))
-            stack.enter_context(patch.object(sync, "wait_for_completion", side_effect=KeyboardInterrupt))
+            stack.enter_context(patch.object(sync, "sample_status", side_effect=KeyboardInterrupt))
             with self.assertRaises(KeyboardInterrupt):
                 sync.run_loop(config, Path("/unused"))
             post.assert_called_once()
@@ -1609,6 +1609,28 @@ class NotificationTests(unittest.TestCase):
             self.assertTrue((root / "network" / "marker").exists())
             self.assertNotIn("disk_recovery_run", sync.load_state(path))
             self.assertEqual(sync.load_state(path)["phase"], "stopping")
+
+    def test_recovery_delivery_retries_from_persisted_state_until_confirmed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            run_dir = config.paths.runs_dir / "current"
+            run_dir.mkdir(parents=True)
+            path = config.paths.state_dir / "state.json"
+            sync.save_state(path, {"disk_recovery_run": "failed-run"})
+            with (
+                patch.object(sync, "check_free_space"),
+                patch.object(sync, "service_active", return_value=True),
+                patch.object(sync, "rotate_run_logs"),
+                patch.object(sync, "post_slack", side_effect=[False, True]) as post,
+                patch.object(sync, "sample_status", return_value={"height": 1}),
+                patch.object(sync.time, "sleep", side_effect=KeyboardInterrupt),
+            ):
+                for attempt in range(3):
+                    with self.assertRaises(KeyboardInterrupt):
+                        sync.wait_for_completion(config, run_dir, {}, sync.load_state(path))
+                    self.assertEqual("disk_recovery_run" in sync.load_state(path), attempt == 0)
+            self.assertEqual(post.call_count, 2)
+            self.assertEqual(post.call_args_list[0], post.call_args_list[1])
 
     def test_preflight_failure_receipt_is_accepted_by_audit(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -125,7 +125,7 @@ class ContinuousSyncTests(unittest.TestCase):
 
             self.assertEqual(
                 [call.args[0] for call in which.call_args_list],
-                ["cargo", "git", "systemctl"],
+                ["cargo", "git", "systemctl", "logrotate"],
             )
 
     def test_safe_wipe_state_removes_only_allowlisted_entries(self):
@@ -176,8 +176,8 @@ class ContinuousSyncTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             runs_dir = tmp_path / "runs"
-            active = runs_dir / "active"
-            completed = [runs_dir / f"completed-{index}" for index in range(4)]
+            active = runs_dir / "20260709T000000Z-aaaaaaaaaaaa"
+            completed = [runs_dir / f"2026071{index}T000000Z-aaaaaaaaaaaa" for index in range(4)]
             for path in (*completed, active):
                 path.mkdir(parents=True)
             for index, path in enumerate(completed):
@@ -199,6 +199,205 @@ class ContinuousSyncTests(unittest.TestCase):
             self.assertFalse(completed[1].exists())
             self.assertTrue(completed[2].exists())
             self.assertTrue(completed[3].exists())
+
+    def test_cleanup_preserves_failure_evidence_and_unmanaged_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = make_config(root, policy=sync.Policy(retention_bytes=1))
+            failed = config.paths.runs_dir / "20260709T000000Z-aaaaaaaaaaaa"
+            complete = config.paths.runs_dir / "20260710T000000Z-bbbbbbbbbbbb"
+            unrelated = config.paths.runs_dir / "investigation"
+            for path, phase in ((failed, "failed"), (complete, "complete"), (unrelated, "complete")):
+                (path / "traces").mkdir(parents=True)
+                (path / "traces" / "big.jsonl").write_text("trace")
+                sync.write_run_json(path, {"started_at": path.name, "phase": phase})
+                (path / "samples.jsonl").write_text("height evidence")
+            outside = root / "outside"
+            outside.mkdir()
+            link = config.paths.runs_dir / "20260711T000000Z-cccccccccccc"
+            link.symlink_to(outside)
+            network = root / "network"
+            network.mkdir()
+            (network / "identity").write_text("identity")
+            sync.cleanup_retention(config, recovery=True)
+            self.assertTrue((failed / "run.json").exists())
+            self.assertTrue((failed / "samples.jsonl").exists())
+            self.assertEqual((failed / "traces" / "big.jsonl").read_text(), "trace")
+            self.assertFalse(complete.exists())
+            self.assertTrue((unrelated / "traces" / "big.jsonl").exists())
+            self.assertTrue(link.is_symlink())
+            self.assertTrue((network / "identity").exists())
+
+    def test_retention_discards_successes_before_older_failures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(retention_runs=2))
+            paths = []
+            for day, phase in ((1, "failed"), (2, "failed"), (3, "complete")):
+                path = config.paths.runs_dir / f"2026070{day}T000000Z-aaaaaaaaaaaa"
+                path.mkdir(parents=True)
+                sync.write_run_json(path, {"phase": phase, "started_at": path.name})
+                paths.append(path)
+            sync.cleanup_retention(config)
+            self.assertEqual([path.exists() for path in paths], [True, True, False])
+
+    @unittest.skipUnless(sync.shutil.which("logrotate"), "logrotate is required on the canaries")
+    def test_trace_rotation_preserves_recent_segments_and_open_writer(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(trace_file_bytes=64))
+            run_dir = config.paths.runs_dir / "current"
+            traces = run_dir / "traces"
+            traces.mkdir(parents=True)
+            trace = traces / "block_sync.jsonl"
+            with trace.open("ab", buffering=0) as writer:
+                inode = trace.stat().st_ino
+                for batch in range(3):
+                    writer.write((json.dumps({"batch": batch, "detail": "x" * 100}) + "\n").encode())
+                    sync.rotate_traces(config, run_dir)
+                    self.assertEqual(trace.stat().st_ino, inode)
+                    self.assertEqual(trace.stat().st_size, 0)
+                writer.write(b'{"batch": 3}\n')
+            history = [json.loads(path.read_text())["batch"] for path in (
+                traces / "block_sync.jsonl.2", traces / "block_sync.jsonl.1", trace,
+            )]
+            self.assertEqual(history, [1, 2, 3])
+            self.assertFalse((traces / "block_sync.jsonl.3").exists())
+
+    def test_cleanup_bounds_binary_cache_and_removes_interrupted_builds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            cache = config.paths.build_cache_dir
+            cache.mkdir()
+            binaries = [cache / ("zakurad-" + str(i) * 40) for i in range(4)]
+            for index, binary in enumerate(binaries):
+                binary.write_text("binary")
+                binary.with_suffix(".json").write_text("{}")
+                os.utime(binary, (index, index))
+            partial = binaries[0].with_suffix(".tmp")
+            partial.write_text("partial")
+            worktree = cache / "worktree-aaaaaaaaaaaa"
+            worktree.mkdir()
+            (cache / "manual-build").mkdir()
+            with patch.object(sync, "run"):
+                sync.cleanup_retention(config)
+            self.assertFalse(partial.exists())
+            self.assertFalse(worktree.exists())
+            self.assertTrue((cache / "manual-build").exists())
+            for index, binary in enumerate(binaries):
+                self.assertEqual(binary.exists(), index >= 2)
+                self.assertEqual(binary.with_suffix(".json").exists(), index >= 2)
+
+    def test_disk_check_covers_separate_run_volume_and_recovery_headroom(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            config.paths.runs_dir.mkdir()
+            config.paths.build_cache_dir.mkdir()
+            usage = sync.shutil.disk_usage(Path(tmp))
+            def disk_usage(path):
+                free = (12 if path == config.paths.runs_dir else 100) * 1024**3
+                return usage._replace(free=free)
+            with patch.object(sync.shutil, "disk_usage", side_effect=disk_usage):
+                sync.check_free_space(config)
+                with self.assertRaises(sync.DiskPressure):
+                    sync.check_free_space(config, recovery=True)
+
+    def test_cycle_stops_and_prunes_before_preflight(self):
+        events = []
+        config = make_config(Path("/tmp"))
+        with (
+            patch.object(sync, "stop_service", side_effect=lambda _: events.append("stop")),
+            patch.object(sync, "cleanup_retention", side_effect=lambda _: events.append("cleanup")),
+            patch.object(sync, "preflight", side_effect=sync.DiskPressure("low disk")),
+            self.assertRaises(sync.DiskPressure),
+        ):
+            sync.one_cycle(config, Path("/unused"), {})
+        self.assertEqual(events, ["stop", "cleanup"])
+
+    def test_disk_failure_retries_but_sync_failure_stays_halted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            state_path = config.paths.state_dir / "state.json"
+            failed_run = config.paths.runs_dir / "20260701T000000Z-aaaaaaaaaaaa"
+            def cycle_with_disk_failure(_, __, state):
+                if failed_run.exists():
+                    raise KeyboardInterrupt
+                (failed_run / "traces").mkdir(parents=True)
+                (failed_run / "traces" / "block_sync.jsonl").write_text("failure evidence")
+                sync.write_run_json(failed_run, {"phase": "syncing", "run_id": failed_run.name,
+                                               "run_dir": str(failed_run), "started_at": failed_run.name})
+                state["current_run"] = failed_run.name
+                raise sync.DiskPressure("low disk")
+            with (
+                patch.object(sync, "one_cycle", side_effect=cycle_with_disk_failure),
+                patch.object(sync, "stop_service"),
+                patch.object(sync, "check_free_space"),
+                patch.object(sync, "post_slack", return_value=False),
+                patch.object(sync.time, "sleep"),
+                self.assertRaises(KeyboardInterrupt),
+            ):
+                sync.run_loop(config, Path("/unused"))
+            self.assertFalse(sync.load_state(state_path)["failed"])
+            self.assertEqual((failed_run / "traces" / "block_sync.jsonl").read_text(), "failure evidence")
+            self.assertEqual(json.loads((failed_run / "run.json").read_text())["phase"], "failed")
+            with (
+                patch.object(sync, "one_cycle", side_effect=sync.ControllerError("sync stalled")) as cycle,
+                patch.object(sync, "stop_service"),
+                patch.object(sync, "post_slack", return_value=False),
+            ):
+                self.assertEqual(sync.run_loop(config, Path("/unused")), 1)
+                self.assertEqual(sync.run_loop(config, Path("/unused")), 2)
+                self.assertEqual(cycle.call_count, 1)
+            self.assertTrue(sync.load_state(state_path)["failed"])
+
+    def test_old_disk_halt_waits_for_headroom_before_fresh_cycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            state_path = config.paths.state_dir / "state.json"
+            sync.save_state(state_path, {"failed": True, "failure": "ControllerError: free disk 1 bytes below minimum 2"})
+            with (
+                patch.object(sync, "stop_service"),
+                patch.object(sync, "check_free_space", side_effect=[sync.DiskPressure("low"), None]),
+                patch.object(sync.time, "sleep") as sleep,
+                patch.object(sync, "one_cycle", side_effect=KeyboardInterrupt) as cycle,
+                self.assertRaises(KeyboardInterrupt),
+            ):
+                sync.run_loop(config, Path("/unused"))
+            sleep.assert_called_once_with(60)
+            cycle.assert_called_once()
+            self.assertFalse(sync.load_state(state_path)["failed"])
+
+    def test_archived_log_keeps_only_bounded_tail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp))
+            run_dir = config.paths.runs_dir / "current"
+            run_dir.mkdir(parents=True)
+            with config.paths.log_file.open("wb") as source:
+                source.write(b"old")
+                source.seek(65 * 1024**2)
+                source.write(b"failure details")
+            sync.archive_run_log(config, run_dir)
+            archived = run_dir / "zebrad.log"
+            self.assertEqual(archived.stat().st_size, 64 * 1024**2)
+            with archived.open("rb") as source:
+                self.assertEqual(source.read(3), b"\0\0\0")
+                source.seek(-15, 2)
+                self.assertEqual(source.read(), b"failure details")
+            self.assertEqual(config.paths.log_file.stat().st_size, 0)
+
+    def test_deployment_retires_old_timer_without_starting_controller(self):
+        node = deploy.load_nodes(DEPLOY_PATH.with_name("nodes.toml"), None)[0]
+        with patch.object(deploy, "run"), patch.object(deploy, "ssh_with_script") as ssh:
+            ssh.return_value.returncode = 0
+            result = deploy.deploy_node(node, argparse.Namespace(dry_run=False, no_start=True))
+        self.assertTrue(result[1])
+        script = ssh.call_args.args[1]
+        subprocess.run(["bash", "-n"], input=script, text=True, check=True)
+        self.assertIn("start_controller=0", script)
+        self.assertLess(script.index("systemctl disable --now zakura-storage.timer"),
+                        script.index("install -m 755 /tmp/zakura-continuous-sync.py"))
+        rendered = deploy.render_files(node)
+        self.assertNotIn("zakura-storage.timer", rendered)
+        self.assertIn("logrotate", rendered["zakura-monitor.service"])
+        self.assertIn("maxsize 64M", rendered["logrotate"])
 
     def test_archive_run_log_copies_current_log_and_truncates_source(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -276,6 +475,8 @@ class ContinuousSyncTests(unittest.TestCase):
             with self.subTest(node=node.name):
                 rendered = deploy.render_files(node)
                 config = tomllib.loads(rendered["zakurad.toml.template"])
+                self.assertEqual(config["network"]["zakura"]["trace_dir"], "{{TRACE_DIR}}")
+                self.assertNotIn("debug", config["tracing"]["filter"])
                 self.assertEqual(
                     config["network"]["external_addr"],
                     f"{node.raw['public_ip']}:8233",
@@ -1380,7 +1581,7 @@ class NotificationTests(unittest.TestCase):
             for name in (
                 "preflight", "build_binary", "sha256_file", "install_binary", "stop_service",
                 "safe_wipe_state", "render_config", "start_service", "wait_for_completion",
-                "archive_run_log", "cleanup_retention",
+                "archive_run_log", "cleanup_retention", "rotate_traces",
             ):
                 stack.enter_context(patch.object(sync, name, return_value="test"))
             stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))


### PR DESCRIPTION
## Motivation

Continuous sync canaries accumulated binaries and traces until disk pressure halted a healthy sync. Detailed traces should remain available to investigate failures without rerunning them.

## Solution

Keep tracing enabled and retain up to 10 runs under a 20 GiB target, deleting successful runs first and protecting the current and latest failed runs. Disk recovery resets the stopped, disposable chain database before checking restart headroom. Other failures stay halted for investigation. Controller phases and incident IDs keep intentional stops and delivered failures from generating duplicate alerts; automatic recovery reports the failed attempt it recovered from.

Node logs and their rotations stay inside each run, alongside its traces. Each trace stream rotates at 128 MiB and keeps two prior segments. This preserves recent history; copy/truncate can lose records at a rotation boundary. Protected evidence takes priority over the storage target. This version has not been deployed; deployment retires the earlier cleanup timer.

## Testing

All 85 controller tests pass, including real logrotate, preserved failure diagnostics across runs, chain cleanup before restart, network identity preservation, and alert transitions, including retrying recovery messages after failed delivery. A failed-start probe confirms no false recovery is sent. Python compilation, Markdown lint, changelog validation, and diff checks pass.

Used Codex for implementation, tests, and the PR description.
