### PR TITLE
fix(ops): batch fleet alerts during long blocks

### DIFF
--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -107,19 +107,69 @@ The watchdog coalesces that majority tip into one fleet alert. Nodes at lower
 heights keep their individual stall timers, so a lagging or resyncing node does
 not cause a separate alert for each node at the majority tip. A higher observed
 tip, conflicting hashes at the highest height, a missing height/hash/timer on
-any observable node, or the absence of a strict majority keeps individual alerts.
-Down and starting nodes do not participate in the tip comparison. Down alerts
-take precedence over stalled alerts and retain their own timers.
+any observable node, or the absence of a strict majority keeps individual
+incident tracking. Down and starting nodes do not participate in the tip
+comparison. Down alerts take precedence over stalled alerts and retain their
+own timers.
+
+When a shared tip starts advancing, former tip followers get up to two minutes
+for propagation before their individual stall alerts can fire. This requires a
+shared observation within the preceding two minutes, no existing alert for the
+node, complete tip observations, and reported ancestry linking all higher tips
+to the former shared block. Missing evidence or conflicting hashes cancel the
+grace. The grace timer starts when the newer block is first observed and survives
+restarts; more blocks do not extend it. A node that remains stuck then follows
+the existing stall threshold. A new watchdog with no prior shared observation
+uses the conservative fallback.
 
 This comparison is within the monitored fleet, not an independent verification
 of network health. A correlated sync failure can also produce agreement, so the
-30-minute shared warning remains enabled. Existing 10-minute individual stall,
-RPC/down, and dashboard thresholds are unchanged. Testnet uses the same policy.
+30-minute shared warning remains enabled. The existing 10-minute individual
+stall, RPC/down, and dashboard thresholds remain in place. Only the narrow
+propagation grace can defer an otherwise due node stall. Testnet uses the same
+policy.
 
 The watchdog posts only on transitions. Persistent failures do not post every
 poll. A transition to another unhealthy state is labeled as a condition change,
 not a green recovery. Consolidating alerts or changing shared-tip ownership is
 informational; clearing a shared stall after height progress is a recovery.
+
+### Batched delivery
+
+Each fleet sends at most one Slack payload per poll. Simultaneous transitions
+share a message containing the essential lines for each incident and dashboard
+links. Single incidents retain their detailed diagnostics. Eleven simultaneous
+stall alerts and eleven simultaneous recoveries therefore produce two messages,
+even when tip grouping is unavailable. The messages are grouped at the sender;
+they are not Slack thread replies.
+
+Larger batches split at the message size limit without dropping incident
+summaries. Remaining chunks stay in `pending_delivery` in the state file and
+send one per poll, in order. Each payload includes its observation time (except
+a legacy single message that already fills the size limit), so delayed delivery
+is distinguishable from a fresh observation. Polling and incident tracking
+continue while delivery is pending, including recoveries and new failures.
+Deployment suppression defers queued payloads until the suppression expires.
+
+The watchdog checkpoints queued messages before sending and checkpoints each
+successful acknowledgement. Confirmed alert state changes are committed when
+the fleet's pending messages have all been accepted. Failed payloads retry after
+restart; acknowledged chunks are not retried after their checkpoint. Delivery
+is at least once: a timeout after Slack accepts a message, or a crash before the
+acknowledgement checkpoint, can still repeat that payload. Keep the state file
+when upgrading and allow pending delivery to drain before reverting to a
+watchdog version that does not understand the queue. A prolonged Slack outage
+can grow the queue; the watchdog retains those transitions instead of dropping
+them.
+
+### Decision evidence
+
+The `decisions` state bucket retains the last 16 grouping/tip/grace changes per
+fleet, with at most 64 rows per entry. It records observation time, the grouping
+reason, participant names, heights, hashes, and progress ages. It excludes RPC
+credentials, webhook URLs, and arbitrary diagnostics. Row counts identify a
+truncated fleet snapshot. Pending delivery retains its prospective decision
+history until acknowledged.
 
 Slack delivery is **webhook-only**. Set:
 

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -115,7 +115,8 @@ own timers.
 When a shared tip starts advancing, former tip followers get up to two minutes
 for propagation before their individual stall alerts can fire. This requires a
 shared observation within the preceding two minutes, no existing alert for the
-node, complete tip observations, and reported ancestry linking all higher tips
+node (a shared fleet warning does not disqualify it), complete tip observations,
+and reported ancestry linking all higher tips
 to the former shared block. Missing evidence or conflicting hashes cancel the
 grace. The grace timer starts when the newer block is first observed and survives
 restarts; more blocks do not extend it. A node that remains stuck then follows

--- a/deploy/runner/README.md
+++ b/deploy/runner/README.md
@@ -113,15 +113,25 @@ comparison. Down alerts take precedence over stalled alerts and retain their
 own timers.
 
 When a shared tip starts advancing, former tip followers get up to two minutes
-for propagation before their individual stall alerts can fire. This requires a
-shared observation within the preceding two minutes, no existing alert for the
-node (a shared fleet warning does not disqualify it), complete tip observations,
-and reported ancestry linking all higher tips
-to the former shared block. Missing evidence or conflicting hashes cancel the
-grace. The grace timer starts when the newer block is first observed and survives
+for propagation before their individual stall alerts can fire. Starting this
+grace requires a shared observation within the preceding two minutes, no
+existing individual alert for the node, complete tip observations, and reported
+ancestry linking all higher tips to the former shared block. A shared fleet
+warning does not disqualify its followers.
+
+The watchdog persists each reference's last positively linked tip. Later
+snapshots can link through that tip when the collector does not sample the
+exact distance to the original shared block. If neither distance is sampled,
+an already proven reference retains only the remainder of the original grace;
+its unproven newer tip is not saved as an ancestry witness. Missing node
+height/hash/timer, conflicting hashes or ancestry, a reference rolling back,
+or an unproven new reference cancels the grace. This adds no collector RPCs.
+
+The grace timer starts when the newer block is first observed and survives
 restarts; more blocks do not extend it. A node that remains stuck then follows
-the existing stall threshold. A new watchdog with no prior shared observation
-uses the conservative fallback.
+the existing stall threshold. A new watchdog with no prior shared observation,
+or an initial extension whose ancestry cannot be established, uses the batched
+fallback.
 
 This comparison is within the monitored fleet, not an independent verification
 of network health. A correlated sync failure can also produce agreement, so the

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import importlib.util
 import json
 import sys
 import unittest
+import threading
+import tempfile
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest.mock import patch
 
@@ -601,7 +605,7 @@ class FleetSnapshotTests(unittest.TestCase):
         self.assertEqual(state["nodes"]["testnet/node-a"]["condition"], "ok")
 
 
-class SharedStallTests(unittest.TestCase):
+class WatchdogFixture:
     NOW = 2_000.0
 
     def setUp(self):
@@ -650,6 +654,301 @@ class SharedStallTests(unittest.TestCase):
         ):
             self.instance.run_once(self.state)
 
+
+class FleetBurstTests(WatchdogFixture, unittest.TestCase):
+    NAMES = [
+        "archive-vct-off", "asia-0", "asia-pacific-0", "asia-south-0",
+        "canada-0", "europe-central-0", "europe-west-0", "us-0",
+        "us-east-0", "us-west-0", "zcashd-compat", "zakura-compat",
+    ]
+    HEIGHT = 3_473_559
+
+    def agreed(self, age=542, height=None):
+        health = "healthy" if age < 300 else "stale"
+        return [self.row(name, height or self.HEIGHT, age, health) for name in self.NAMES]
+
+    def arriving(self, elapsed=60, distance=1):
+        rows = self.agreed(542 + elapsed)
+        rows[-1] = self.row("zakura-compat", self.HEIGHT + distance, 5, "healthy", "00bb")
+        rows[-1]["ancestor_hashes"] = {str(distance): "00aa"}
+        if distance == 1:
+            rows[-1]["previous_hash"] = "00aa"
+        return rows
+
+    def test_natural_gap_and_staggered_arrival_send_nothing(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        self.assertEqual(len(self.state["propagation"]["testnet"]), 11)
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 2), now=self.NOW + 120)
+        self.assertEqual(self.posted, [])
+        self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_unclassified_gap_batches_all_eleven_alerts_and_recoveries(self):
+        for missing_hash in (False, True):
+            with self.subTest(missing_hash=missing_hash):
+                self.state = {}
+                self.posted.clear()
+                rows = self.arriving()
+                if missing_hash:
+                    rows[-1] = self.row("zakura-compat", self.HEIGHT, 5, "healthy", "")
+                self.run_snapshot(rows)
+                self.assertEqual(len(self.posted), 1)
+                for name in self.NAMES[:-1]:
+                    self.assertIn(f"`{name}` stalled", self.posted[0])
+                    self.assertTrue(self.state["nodes"][f"testnet/{name}"]["alerting"])
+                self.run_snapshot(self.agreed(5, self.HEIGHT + 2), now=self.NOW + 60)
+                self.assertEqual(len(self.posted), 2)
+                for name in self.NAMES[:-1]:
+                    self.assertIn(f"`{name}` recovered from stalled", self.posted[1])
+
+    def test_persistent_lag_alerts_after_two_minutes_despite_more_blocks_and_restart(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        self.state = json.loads(json.dumps(self.state))
+        self.instance = watchdog.Watchdog([self.fleet], self.args)
+        self.run_snapshot(self.arriving(179, 2), now=self.NOW + 179)
+        self.assertEqual(self.posted, [])
+        self.run_snapshot(self.arriving(180, 2), now=self.NOW + 180)
+        self.assertEqual(len(self.posted), 1)
+        for name in self.NAMES[:-1]:
+            self.assertIn(f"`{name}` stalled", self.posted[0])
+        self.run_snapshot(self.arriving(240, 5), now=self.NOW + 240)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_incomplete_data_or_conflicting_hash_cancels_grace(self):
+        for field, value in (("block_hash", "ffff"), ("height", None), ("seconds_since_advanced", None)):
+            with self.subTest(field=field):
+                self.state = {}
+                self.posted.clear()
+                self.run_snapshot(self.agreed())
+                self.run_snapshot(self.arriving(), now=self.NOW + 60)
+                rows = self.arriving(90)
+                rows[0][field] = value
+                self.run_snapshot(rows, now=self.NOW + 90)
+                self.assertEqual(len(self.posted), 1)
+                self.assertIn("`us-east-0` stalled", self.posted[0])
+                self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_unproven_extension_does_not_grant_grace(self):
+        self.run_snapshot(self.agreed())
+        rows = self.arriving()
+        rows[-1].pop("previous_hash")
+        rows[-1]["ancestor_hashes"] = {"1": "ffff"}
+        self.run_snapshot(rows, now=self.NOW + 60)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_down_deadline_is_preserved_during_propagation(self):
+        down = self.row("offline", None, None, "rpc_error", "")
+        self.run_snapshot(self.agreed() + [down], now=self.NOW - 540)
+        self.run_snapshot(self.agreed() + [down])
+        self.run_snapshot(self.arriving() + [down], now=self.NOW + 60)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`offline` down for 10m", self.posted[0])
+        self.assertNotIn("`us-east-0` stalled", self.posted[0])
+
+    def test_long_shared_gap_still_warns_and_recovers_once(self):
+        self.run_snapshot(self.agreed(1801))
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("12 nodes agree", self.posted[0])
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 1), now=self.NOW + 60)
+        self.assertEqual(len(self.posted), 2)
+        self.assertIn("shared stall cleared", self.posted[1])
+
+    def test_failed_batch_retries_after_reload_without_committing_delivery(self):
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), False)[1]
+        self.run_snapshot(self.arriving())
+        self.assertEqual(self.state["nodes"], {})
+        pending = copy.deepcopy(self.state["pending_delivery"])
+        self.state = json.loads(json.dumps(self.state))
+        self.instance = watchdog.Watchdog([self.fleet], self.args)
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        self.run_snapshot(self.arriving(120), now=self.NOW + 60)
+        self.assertEqual(self.posted[0], self.posted[1])
+        self.assertEqual(self.posted[1], pending["testnet"]["messages"][0])
+        self.assertFalse(self.state["pending_delivery"])
+        self.assertTrue(self.state["nodes"]["testnet/us-east-0"]["alerting"])
+        self.run_snapshot(self.arriving(180), now=self.NOW + 120)
+        self.assertEqual(len(self.posted), 2)
+
+    def test_recovery_and_new_failure_are_observed_while_delivery_is_pending(self):
+        watchdog.post_slack = lambda text, args: False
+        self.run_snapshot(self.arriving())
+        down = self.row("offline", None, None, "rpc_error", "")
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 1) + [down], now=self.NOW + 60)
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 2) + [down], now=self.NOW + 660)
+        pending = self.state["pending_delivery"]["testnet"]
+        self.assertEqual(len(pending["messages"]), 3)
+        self.assertIn("`us-east-0` recovered", pending["messages"][1])
+        self.assertIn("`offline` down for 10m", pending["messages"][2])
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        for elapsed in (720, 780, 840):
+            self.run_snapshot(self.agreed(5, self.HEIGHT + 2) + [down], now=self.NOW + elapsed)
+        self.assertEqual(len(self.posted), 3)
+        self.assertFalse(self.state["pending_delivery"])
+        self.assertTrue(self.state["nodes"]["testnet/offline"]["alerting"])
+        self.assertFalse(self.state["nodes"]["testnet/us-east-0"]["alerting"])
+
+    def test_large_batch_preserves_each_node_and_delivers_one_chunk_per_poll(self):
+        rows = [self.row(f"node-{i:04}-" + "n" * 100, 100 + i, 601) for i in range(250)]
+        self.run_snapshot(rows)
+        self.assertEqual(len(self.posted), 1)
+        self.assertTrue(self.state["pending_delivery"])
+        for i in range(1, 20):
+            if not self.state["pending_delivery"]:
+                break
+            before = len(self.posted)
+            self.run_snapshot(rows, now=self.NOW + i * 60)
+            self.assertEqual(len(self.posted), before + 1)
+        self.assertFalse(self.state["pending_delivery"])
+        for row in rows:
+            self.assertEqual(sum(f"`{row['name']}` stalled" in message for message in self.posted), 1)
+        self.assertTrue(all(len(message) <= watchdog.MAX_SLACK_MESSAGE_CHARS for message in self.posted))
+
+    def test_decision_history_is_bounded_and_explains_rejected_grouping(self):
+        for i in range(40):
+            rows = self.arriving() if i % 2 else self.agreed()
+            self.run_snapshot(rows, now=self.NOW + i * 60)
+        history = self.state["decisions"]["testnet"]
+        self.assertEqual(len(history), watchdog.MAX_DECISION_HISTORY)
+        self.assertEqual(history[-1]["decision"]["reason"], "no strict majority at highest tip")
+        self.assertEqual(history[-1]["rows"][-1]["height"], self.HEIGHT + 1)
+
+    def test_unrelated_higher_tip_cancels_existing_grace(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        rows = self.arriving(90)
+        rows.append(self.row("unrelated", self.HEIGHT + 2, 5, "healthy", "ffff"))
+        self.run_snapshot(rows, now=self.NOW + 90)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`us-east-0` stalled", self.posted[0])
+        self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_stale_shared_observation_does_not_grant_grace(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(180), now=self.NOW + 180)
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("`us-east-0` stalled", self.posted[0])
+
+    def test_partial_batch_failure_and_restart_do_not_repeat_acknowledged_chunk(self):
+        rows = [self.row(f"node-{i:04}-" + "n" * 100, 100 + i, 601) for i in range(250)]
+        self.run_snapshot(rows)
+        acknowledged = self.posted[0]
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), False)[1]
+        self.run_snapshot(rows, now=self.NOW + 60)
+        failed = self.posted[-1]
+        self.assertNotEqual(acknowledged, failed)
+        self.state = json.loads(json.dumps(self.state))
+        self.instance = watchdog.Watchdog([self.fleet], self.args)
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        self.run_snapshot(rows, now=self.NOW + 120)
+        self.assertEqual(self.posted[-1], failed)
+        self.assertEqual(self.posted.count(acknowledged), 1)
+
+    def test_pending_delivery_and_acknowledgement_are_checkpointed(self):
+        saved = []
+        self.instance.checkpoint = lambda state: saved.append(copy.deepcopy(state))
+
+        def accept(text, args):
+            self.assertTrue(saved[-1]["pending_delivery"])
+            self.assertFalse(saved[-1]["nodes"])
+            return True
+
+        watchdog.post_slack = accept
+        self.run_snapshot(self.arriving())
+        self.assertEqual(len(saved), 2)
+        self.assertFalse(saved[-1]["pending_delivery"])
+        self.assertTrue(saved[-1]["nodes"]["testnet/us-east-0"]["alerting"])
+
+    def test_pending_batch_survives_real_state_file_reload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "state.json"
+            checkpoint = lambda state: watchdog.save_state(path, state)
+            self.instance = watchdog.Watchdog([self.fleet], self.args, checkpoint=checkpoint)
+            watchdog.post_slack = lambda text, args: False
+            self.run_snapshot(self.arriving())
+            self.state = watchdog.load_state(path)
+            self.assertTrue(self.state["pending_delivery"])
+            self.assertEqual(self.state["nodes"], {})
+            self.instance = watchdog.Watchdog([self.fleet], self.args, checkpoint=checkpoint)
+            watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+            self.run_snapshot(self.arriving(120), now=self.NOW + 60)
+            restored = watchdog.load_state(path)
+            self.assertFalse(restored["pending_delivery"])
+            self.assertTrue(restored["nodes"]["testnet/us-east-0"]["alerting"])
+            self.assertEqual(len(self.posted), 1)
+
+    def test_checkpoint_failure_prevents_sending(self):
+        def fail(state):
+            raise OSError("disk full")
+
+        self.instance.checkpoint = fail
+        with self.assertRaisesRegex(OSError, "disk full"):
+            self.run_snapshot(self.arriving())
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["pending_delivery"])
+        self.assertEqual(self.state["nodes"], {})
+
+    def test_one_fleets_failure_does_not_block_or_overwrite_another_fleet(self):
+        other = watchdog.Fleet("mainnet", "http://mainnet.invalid/data", "http://mainnet.invalid/")
+        self.instance = watchdog.Watchdog([self.fleet, other], self.args)
+        watchdog.post_slack = lambda text, args: "*Zakura testnet*" not in text
+        self.run_snapshot(self.arriving())
+        self.assertIn("testnet", self.state["pending_delivery"])
+        self.assertNotIn("mainnet", self.state["pending_delivery"])
+        self.assertTrue(self.state["nodes"]["mainnet/us-east-0"]["alerting"])
+        watchdog.post_slack = lambda text, args: True
+        self.run_snapshot(self.arriving(120), now=self.NOW + 60)
+        self.assertTrue(self.state["nodes"]["testnet/us-east-0"]["alerting"])
+        self.assertTrue(self.state["nodes"]["mainnet/us-east-0"]["alerting"])
+        self.assertFalse(self.state["pending_delivery"])
+
+    def test_deployment_suppression_defers_pending_delivery(self):
+        watchdog.post_slack = lambda text, args: False
+        self.run_snapshot(self.arriving())
+        watchdog.post_slack = lambda text, args: (self.posted.append(text), True)[1]
+        with patch.object(watchdog, "suppression_until", return_value=self.NOW + 120):
+            self.run_snapshot(self.arriving(120), now=self.NOW + 60)
+        self.assertEqual(self.posted, [])
+        self.assertTrue(self.state["pending_delivery"])
+        self.run_snapshot(self.arriving(180), now=self.NOW + 120)
+        self.assertEqual(len(self.posted), 1)
+
+    def test_loopback_webhook_receives_one_payload_for_each_eleven_node_transition(self):
+        payloads = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                payloads.append(json.loads(self.rfile.read(int(self.headers["Content-Length"]))))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        watchdog.post_slack = self._real_post
+        self.args.dry_run = False
+        try:
+            with patch.dict(
+                watchdog.os.environ,
+                {"SLACK_WEB_HOOK": f"http://127.0.0.1:{server.server_port}/"},
+            ):
+                self.run_snapshot(self.arriving())
+                self.run_snapshot(self.agreed(5, self.HEIGHT + 2), now=self.NOW + 60)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+        self.assertEqual(len(payloads), 2)
+        self.assertEqual(payloads[0]["text"].count("stalled for 10m 2s"), 11)
+        self.assertEqual(payloads[1]["text"].count("recovered from stalled"), 11)
+        self.assertFalse(self.state["pending_delivery"])
+
+
+class SharedStallTests(WatchdogFixture, unittest.TestCase):
     def test_matching_height_and_hash_posts_one_fleet_alert(self):
         self.run_snapshot(
             [
@@ -798,7 +1097,7 @@ class SharedStallTests(unittest.TestCase):
                 self.row("reference", 101, 5, "healthy"),
             ]
         )
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         for name in ("node-a", "node-b"):
             self.assertTrue(self.state["nodes"][f"testnet/{name}"]["alerting"])
 
@@ -806,7 +1105,7 @@ class SharedStallTests(unittest.TestCase):
         self.run_snapshot(
             [self.row(f"node-{i}", 100 + i // 2, 601) for i in range(4)]
         )
-        self.assertEqual(len(self.posted), 4)
+        self.assertEqual(len(self.posted), 1)
         self.assertTrue(all(entry["alerting"] for entry in self.state["nodes"].values()))
 
     def test_conflicting_highest_hash_prevents_majority_suppression(self):
@@ -817,7 +1116,7 @@ class SharedStallTests(unittest.TestCase):
                 self.row("fork", 100, 601, block_hash="bbbb"),
             ]
         )
-        self.assertEqual(len(self.posted), 3)
+        self.assertEqual(len(self.posted), 1)
         self.assertTrue(all(entry["alerting"] for entry in self.state["nodes"].values()))
 
     def test_incomplete_laggard_observation_prevents_majority_suppression(self):
@@ -869,11 +1168,11 @@ class SharedStallTests(unittest.TestCase):
             self.row("laggard", 90, 601),
         ]
         self.run_snapshot(rows)
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.state = json.loads(json.dumps(self.state))
         self.instance = watchdog.Watchdog([self.fleet], self.args)
         self.run_snapshot(rows, now=self.NOW + 60)
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
         self.assertTrue(self.state["nodes"]["testnet/laggard"]["alerting"])
 
@@ -882,7 +1181,7 @@ class SharedStallTests(unittest.TestCase):
             [self.row(f"node-{i}", 100, 1801) for i in range(3)]
             + [self.row("laggard", 90, 1900, block_hash="bbbb")]
         )
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.posted.clear()
         self.run_snapshot(
             [
@@ -893,7 +1192,7 @@ class SharedStallTests(unittest.TestCase):
             ],
             now=self.NOW + 60,
         )
-        self.assertEqual(len(self.posted), 3)
+        self.assertEqual(len(self.posted), 1)
         self.assertIn("network height advanced", self.posted[0])
         for name in ("node-1", "node-2", "laggard"):
             self.assertTrue(self.state["nodes"][f"testnet/{name}"]["alerting"])
@@ -909,12 +1208,13 @@ class SharedStallTests(unittest.TestCase):
             self.posted.append(text), "observed tip" not in text
         )[1]
         self.run_snapshot(rows)
-        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
-        self.assertTrue(self.state["nodes"]["testnet/laggard"]["alerting"])
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(self.state["shared_stalls"], {})
+        self.assertEqual(self.state["nodes"], {})
+        self.assertIn("`laggard` stalled", self.posted[0])
+        self.assertEqual(len(self.posted), 1)
         watchdog.post_slack = lambda text, _args: (self.posted.append(text), True)[1]
         self.run_snapshot(rows, now=self.NOW + 60)
-        self.assertEqual(len(self.posted), 3)
+        self.assertEqual(len(self.posted), 2)
         self.assertTrue(self.state["shared_stalls"]["testnet"]["alerting"])
 
     def test_stall_to_rpc_failure_is_a_change_and_still_alerts_when_due(self):
@@ -973,9 +1273,9 @@ class SharedStallTests(unittest.TestCase):
         ]
         self.run_snapshot(diverged, now=self.NOW + 60)
 
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.assertIn("network height advanced", self.posted[0])
-        self.assertIn("`node-b` stalled", self.posted[1])
+        self.assertIn("`node-b` stalled", self.posted[0])
 
     def test_matching_height_with_different_hashes_keeps_node_alerts(self):
         self.run_snapshot(
@@ -985,7 +1285,7 @@ class SharedStallTests(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.assertTrue(all("stalled" in post for post in self.posted))
         self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
 
@@ -997,7 +1297,7 @@ class SharedStallTests(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(len(self.posted), 2)
+        self.assertEqual(len(self.posted), 1)
         self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
 
     def test_fork_closes_shared_alert_before_posting_node_alerts(self):
@@ -1017,10 +1317,11 @@ class SharedStallTests(unittest.TestCase):
             now=self.NOW + 60,
         )
 
-        self.assertEqual(len(self.posted), 3)
+        self.assertEqual(len(self.posted), 1)
         self.assertIn("shared stall tracking changed", self.posted[0])
         self.assertNotIn(":white_check_mark:", self.posted[0])
-        self.assertTrue(all("stalled" in post for post in self.posted[1:]))
+        self.assertIn("`node-a` stalled", self.posted[0])
+        self.assertIn("`node-b` stalled", self.posted[0])
         self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
 
     def test_threshold_skew_never_posts_a_constituent_node_alert(self):
@@ -1306,7 +1607,7 @@ class SharedStallTests(unittest.TestCase):
         self.run_snapshot(rows)
 
         self.assertEqual(len(self.posted), 1)
-        self.assertFalse(self.state["shared_stalls"]["testnet"]["alerting"])
+        self.assertEqual(self.state["shared_stalls"], {})
         self.assertTrue(
             all(not entry["alerting"] for entry in self.state["nodes"].values())
         )

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -683,6 +683,24 @@ class FleetBurstTests(WatchdogFixture, unittest.TestCase):
         self.assertEqual(self.posted, [])
         self.assertEqual(self.state["propagation"]["testnet"], {})
 
+    def test_shared_warning_does_not_prevent_propagation_grace(self):
+        self.run_snapshot(self.agreed(1801))
+        self.assertEqual(len(self.posted), 1)
+        self.assertIn("12 nodes agree", self.posted[0])
+        self.run_snapshot(self.arriving(1320), now=self.NOW + 60)
+        self.assertEqual(len(self.posted), 2)
+        self.assertIn("shared stall cleared", self.posted[1])
+        self.assertNotIn("` stalled", self.posted[1])
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 2), now=self.NOW + 120)
+        self.assertEqual(len(self.posted), 2)
+
+    def test_shared_warning_grace_still_expires_for_stuck_followers(self):
+        self.run_snapshot(self.agreed(1801))
+        self.run_snapshot(self.arriving(1320), now=self.NOW + 60)
+        self.run_snapshot(self.arriving(1440, 2), now=self.NOW + 180)
+        self.assertEqual(len(self.posted), 3)
+        self.assertEqual(self.posted[2].count("` stalled"), 11)
+
     def test_unclassified_gap_batches_all_eleven_alerts_and_recoveries(self):
         for missing_hash in (False, True):
             with self.subTest(missing_hash=missing_hash):

--- a/deploy/runner/test_zakura_cluster_watchdog.py
+++ b/deploy/runner/test_zakura_cluster_watchdog.py
@@ -733,6 +733,75 @@ class FleetBurstTests(WatchdogFixture, unittest.TestCase):
         self.run_snapshot(self.arriving(240, 5), now=self.NOW + 240)
         self.assertEqual(len(self.posted), 1)
 
+    def sparse_arriving(self, elapsed, distance):
+        def block_hash(offset):
+            return {0: "00aa", 1: "00bb"}.get(offset, f"{offset + 1_000_000:064x}")
+
+        rows = self.arriving(elapsed, distance)
+        rows[-1]["block_hash"] = block_hash(distance)
+        rows[-1]["previous_hash"] = block_hash(distance - 1)
+        rows[-1]["ancestor_hashes"] = {
+            str(depth): block_hash(distance - depth) for depth in (1, 2, 5, 10, 32)
+        }
+        return rows
+
+    def test_sparse_depths_preserve_established_grace_without_extending_it(self):
+        for distance in (3, 4, 6, 8, 33):
+            with self.subTest(distance=distance):
+                self.state = {}
+                self.posted.clear()
+                self.run_snapshot(self.agreed())
+                self.run_snapshot(self.arriving(), now=self.NOW + 60)
+                self.state = json.loads(json.dumps(self.state))
+                self.instance = watchdog.Watchdog([self.fleet], self.args)
+                self.run_snapshot(self.sparse_arriving(90, distance), now=self.NOW + 90)
+                self.assertEqual(self.posted, [])
+                self.run_snapshot(self.sparse_arriving(180, distance), now=self.NOW + 180)
+                self.assertEqual(len(self.posted), 1)
+                self.assertEqual(self.posted[0].count("` stalled"), 11)
+
+    def test_cached_reference_hash_conflict_cancels_grace_at_unsampled_depth(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        rows = self.sparse_arriving(90, 3)
+        rows[-1]["ancestor_hashes"]["2"] = "ffff"
+        self.run_snapshot(rows, now=self.NOW + 90)
+        self.assertEqual(len(self.posted), 1)
+        self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_only_positively_linked_reference_tips_are_retained(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        for elapsed, distance, retained_distance in ((75, 3, 3), (90, 7, 3), (105, 8, 8)):
+            self.run_snapshot(self.sparse_arriving(elapsed, distance), now=self.NOW + elapsed)
+            entry = self.state["propagation"]["testnet"]["us-east-0"]
+            self.assertEqual(entry["references"]["zakura-compat"]["height"],
+                             self.HEIGHT + retained_distance)
+            self.assertEqual(entry["since"], self.NOW + 60)
+        self.assertEqual(self.posted, [])
+
+    def test_reference_rollback_cancels_grace(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        self.run_snapshot(self.sparse_arriving(75, 3), now=self.NOW + 75)
+        self.run_snapshot(self.sparse_arriving(90, 2), now=self.NOW + 90)
+        self.assertEqual(len(self.posted), 1)
+        self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_unknown_initial_ancestry_uses_batched_fallback(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.sparse_arriving(60, 3), now=self.NOW + 60)
+        self.assertEqual(len(self.posted), 1)
+        self.assertEqual(self.posted[0].count("` stalled"), 11)
+        self.assertEqual(self.state["propagation"]["testnet"], {})
+
+    def test_sparse_catchup_does_not_create_stall_or_recovery_messages(self):
+        self.run_snapshot(self.agreed())
+        self.run_snapshot(self.arriving(), now=self.NOW + 60)
+        self.run_snapshot(self.sparse_arriving(90, 4), now=self.NOW + 90)
+        self.run_snapshot(self.agreed(5, self.HEIGHT + 4), now=self.NOW + 120)
+        self.assertEqual(self.posted, [])
+
     def test_incomplete_data_or_conflicting_hash_cancels_grace(self):
         for field, value in (("block_hash", "ffff"), ("height", None), ("seconds_since_advanced", None)):
             with self.subTest(field=field):

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -1266,7 +1266,9 @@ class Watchdog:
 
         Each timer stays anchored to the first observed extension, even across
         polls, further blocks, and restarts. Existing alerts are never suppressed.
-        Missing tip evidence or a same-height hash conflict cancels the grace.
+        Missing height/hash/timer or conflicting ancestry cancels the grace.
+        An unsampled ancestry depth alone does not cancel a previously proven
+        reference; it can only use the remainder of the original deadline.
         """
         bucket = state.setdefault("propagation", {})
         pending = bucket.setdefault(fleet.name, {})
@@ -1294,30 +1296,65 @@ class Watchdog:
             and height is not None and bool(block_hash)
         )
 
-        def extensions_match(anchor_height: int, anchor_hash: str) -> bool:
+        def ancestor_at(row: dict[str, Any], ancestor_height: int) -> str | None:
+            distance = coerce_height(row["height"]) - ancestor_height
+            if distance == 0:
+                return validated_block_hash(row["block_hash"])
+            ancestors = row.get("ancestor_hashes")
+            value = ancestors.get(str(distance)) if isinstance(ancestors, dict) else None
+            if distance == 1:
+                value = row.get("previous_hash") or value
+            # Distinguish an unsampled depth from a malformed/conflicting hash.
+            return None if value is None else validated_block_hash(value) or ""
+
+        def extension_references(
+            anchor_height: int, anchor_hash: str, known: dict[str, Any]
+        ) -> dict[str, Any] | None:
             higher_rows = [
                 row for row in observable
                 if coerce_height(row["height"]) > anchor_height
             ]
             if not higher_rows:
-                return False
+                return None
+            confirmed = {}
             for row in higher_rows:
-                distance = coerce_height(row["height"]) - anchor_height
-                ancestors = row.get("ancestor_hashes")
-                ancestor = (
-                    ancestors.get(str(distance)) if isinstance(ancestors, dict) else None
-                )
-                if distance == 1:
-                    ancestor = row.get("previous_hash") or ancestor
-                if validated_block_hash(ancestor) != anchor_hash:
-                    return False
-            return True
+                name = row["name"]
+                direct = ancestor_at(row, anchor_height)
+                if direct is not None and direct != anchor_hash:
+                    return None
+                reference = known.get(name)
+                linked = False
+                if reference:
+                    if coerce_height(row["height"]) < reference["height"]:
+                        return None
+                    ancestor = ancestor_at(row, reference["height"])
+                    if ancestor is not None and ancestor != reference["hash"]:
+                        return None
+                    linked = ancestor == reference["hash"]
+                if direct == anchor_hash or linked:
+                    confirmed[name] = {
+                        "height": coerce_height(row["height"]),
+                        "hash": validated_block_hash(row["block_hash"]),
+                    }
+                elif reference:
+                    # Missing a sampled depth does not revoke an established,
+                    # bounded grace. Retain only the last positively linked tip;
+                    # an unproven newer tip must not become an ancestry witness.
+                    confirmed[name] = reference
+                else:
+                    return None
+            return confirmed
 
-        extension = recent_shared and extensions_match(height, block_hash)
+        references = extension_references(height, block_hash, {}) if recent_shared else None
         for name in list(pending):
             entry = pending[name]
-            if not extensions_match(entry["height"], entry["hash"]):
+            updated = extension_references(
+                entry["height"], entry["hash"], entry.get("references", {})
+            )
+            if updated is None:
                 del pending[name]
+            else:
+                entry["references"] = updated
 
         current = {str(row["name"]): row for row in observable}
         for name in list(pending):
@@ -1329,7 +1366,7 @@ class Watchdog:
                 or validated_block_hash(row["block_hash"]) != entry["hash"]
             ):
                 del pending[name]
-        if extension:
+        if references is not None:
             for name in previous.get("node_names", []):
                 row = current.get(name)
                 old_alert = state.get("nodes", {}).get(f"{fleet.name}/{name}", {})
@@ -1339,7 +1376,10 @@ class Watchdog:
                     and validated_block_hash(row["block_hash"]) == block_hash
                 ):
                     pending.setdefault(
-                        name, {"height": height, "hash": block_hash, "since": now}
+                        name, {
+                            "height": height, "hash": block_hash, "since": now,
+                            "references": references,
+                        }
                     )
         return {
             name for name, entry in pending.items()

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -1288,7 +1288,6 @@ class Watchdog:
         last_seen = coerce_float(previous.get("last_seen"))
         recent_shared = (
             previous.get("condition") == "stalled"
-            and not previous.get("alerting")
             and previous.get("owner") == "shared"
             and last_seen is not None
             and 0 <= now - last_seen <= PROPAGATION_GRACE_SECONDS

--- a/deploy/runner/zakura-cluster-watchdog.py
+++ b/deploy/runner/zakura-cluster-watchdog.py
@@ -10,6 +10,7 @@ Only the Python stdlib is used.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import os
@@ -22,11 +23,15 @@ import datetime
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 DOWN_HEALTH = {"down", "rpc_error"}
 STATE_VERSION = 1
+PROPAGATION_GRACE_SECONDS = 120
+MAX_DECISION_HISTORY = 16
+MAX_DECISION_ROWS = 64
+BATCH_SEPARATOR = "\n\n---\n\n"
 MAX_SHARED_DIAGNOSTIC_ROWS = 8
 MAX_NODE_DETAIL_CHARS = 512
 MAX_ALERT_NAME_CHARS = 128
@@ -665,7 +670,14 @@ def update_alert_state(
     args: argparse.Namespace,
     height: float | None = None,
     log_suppressed: bool = True,
+    notify: Callable[[str, argparse.Namespace], bool] | None = None,
 ) -> None:
+    """Advance an incident only when its notifier accepts the transition.
+
+    A planning notifier may accept into prospective state; the caller must then
+    checkpoint and deliver that plan before committing the incident state.
+    """
+    notify = notify or post_slack
     entry = state_bucket.get(key, {"condition": "ok", "alerting": False})
     was_alerting = bool(entry.get("alerting"))
 
@@ -684,7 +696,7 @@ def update_alert_state(
                         entry["event_height"] = height
                 state_bucket[key] = entry
                 return
-            if post_slack(recovery_text, args):
+            if notify(recovery_text, args):
                 state_bucket[key] = {"condition": "ok", "alerting": False}
             return
 
@@ -721,7 +733,7 @@ def update_alert_state(
         if suppressed:
             if log_suppressed:
                 print(f"suppressed alert for {key}: {condition} for {format_duration(age)}")
-        elif post_slack(alert_text, args):
+        elif notify(alert_text, args):
             next_entry["alerting"] = True
             next_entry["last_alert_at"] = now
             if condition == "stalled" and height is not None:
@@ -994,13 +1006,112 @@ def release_state_recovery_text(target: ReleaseState, previous: dict[str, Any]) 
     )
 
 
+def batch_messages(messages: list[str], now: float) -> list[str]:
+    """Pack transitions without dropping incident summaries or exceeding Slack's cap."""
+    if not messages:
+        return []
+    observed_at = datetime.datetime.fromtimestamp(now, datetime.timezone.utc).isoformat()
+    prefix = f"*Fleet status updates* — observed {observed_at}\n\n"
+    # Keep detailed diagnostics for a single incident; a batch shows the essential
+    # lines for every event and links to the dashboard for the full node details.
+    events = []
+    for message in messages:
+        if len(messages) == 1:
+            events.append(message)
+            continue
+        lines = message.splitlines()
+        summary = lines[:SLACK_ESSENTIAL_PREFIX_LINES]
+        link = next(
+            (line for line in reversed(lines) if line.startswith(("dashboard:", "endpoint:"))),
+            "",
+        )
+        if link and link not in summary:
+            summary.append(link)
+        events.append("\n".join(summary))
+    chunks: list[str] = []
+    chunk = prefix
+    for event in events:
+        event = bounded_slack_message(event)
+        # An individual legacy message may already fill the limit. Keep it intact
+        # as a separate payload rather than cutting off another incident.
+        if len(prefix) + len(event) > MAX_SLACK_MESSAGE_CHARS:
+            if chunk != prefix:
+                chunks.append(chunk)
+                chunk = prefix
+            chunks.append(event)
+            continue
+        separator = BATCH_SEPARATOR if chunk != prefix else ""
+        if len(chunk) + len(separator) + len(event) > MAX_SLACK_MESSAGE_CHARS:
+            chunks.append(chunk)
+            chunk = prefix
+            separator = ""
+        chunk += separator + event
+    if chunk != prefix:
+        chunks.append(chunk)
+    return chunks
+
+
+def record_decision(
+    state: dict[str, Any], fleet: Fleet, rows: list[dict[str, Any]],
+    common: SharedTip | None, grace: set[str], now: float,
+) -> None:
+    """Retain bounded, credential-free evidence when grouping or grace changes."""
+    observed = [row for row in rows if tip_is_observable(row)]
+    if any(not tip_is_verifiable(row) for row in observed):
+        reason = "incomplete tip evidence"
+    elif len(observed) < 2:
+        reason = "fewer than two observable nodes"
+    elif common is not None:
+        reason = "shared highest tip"
+    else:
+        highest = max(coerce_height(row["height"]) for row in observed)
+        tips = [row for row in observed if coerce_height(row["height"]) == highest]
+        reason = (
+            "conflicting highest hashes"
+            if len({validated_block_hash(row["block_hash"]) for row in tips}) > 1
+            else "no strict majority at highest tip"
+        )
+    decision = {
+        "reason": reason,
+        "shared_nodes": [
+            bounded_text(name, MAX_ALERT_NAME_CHARS)
+            for name in common.node_names[:MAX_DECISION_ROWS]
+        ] if common else [],
+        "grace_nodes": [
+            bounded_text(name, MAX_ALERT_NAME_CHARS)
+            for name in sorted(grace)[:MAX_DECISION_ROWS]
+        ],
+        "tips": [
+            [coerce_height(row.get("height")), validated_block_hash(row.get("block_hash"))]
+            for row in rows[:MAX_DECISION_ROWS]
+        ],
+    }
+    history = state.setdefault("decisions", {}).setdefault(fleet.name, [])
+    if history and history[-1]["decision"] == decision:
+        return
+    history.append({
+        "at": now, "decision": decision, "total_rows": len(rows),
+        "rows": [{
+            "name": bounded_text(row.get("name"), MAX_ALERT_NAME_CHARS),
+            "health": bounded_text(row.get("health"), MAX_ALERT_STATUS_CHARS),
+            "height": coerce_height(row.get("height")),
+            "block_hash": validated_block_hash(row.get("block_hash")),
+            "seconds_since_advanced": coerce_float(row.get("seconds_since_advanced")),
+        } for row in rows[:MAX_DECISION_ROWS]],
+    })
+    del history[:-MAX_DECISION_HISTORY]
+
+
 class Watchdog:
     def __init__(
         self,
         fleets: list[Fleet],
         args: argparse.Namespace,
         release_state: list[ReleaseState] | None = None,
+        checkpoint: Callable[[dict[str, Any]], None] | None = None,
     ):
+        self.notify = lambda text, args: post_slack(text, args)
+        self.checkpoint = checkpoint or (lambda state: None)
         self.fleets = fleets
         self.release_state = release_state or []
         self.args = args
@@ -1013,75 +1124,228 @@ class Watchdog:
         suppressed = suppressed_until is not None and suppressed_until > now
 
         for fleet in self.fleets:
+            pending = state.setdefault("pending_delivery", {})
+            candidate = (
+                copy.deepcopy(pending[fleet.name]["state"])
+                if fleet.name in pending else self.fleet_state(state, fleet)
+            )
+            messages: list[str] = []
+            self.notify = lambda text, _args: (messages.append(text), True)[1]
             try:
-                snapshot = fetch_json(fleet.url, self.args.request_timeout)
-                node_rows = validated_fleet_rows(snapshot)
-                last_poll = snapshot_last_poll(snapshot)
-            except Exception as error:
-                self.handle_fleet_error(state, fleet, error, now, suppressed)
-                continue
-
-            if (
-                last_poll is not None
-                and now - last_poll >= self.args.dashboard_down_after
-            ):
-                age = now - last_poll
-                error = ValueError(
-                    "dashboard snapshot is stale: last poll was "
-                    f"{format_duration(age)} ago"
-                )
-                self.handle_fleet_error(
-                    state,
-                    fleet,
-                    error,
-                    now,
-                    suppressed,
-                    bad_since=last_poll,
-                )
-                continue
-
-            if not self.handle_fleet_recovered(state, fleet, now):
-                continue
-            grace_since = max(
-                self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
-            )
-            observations = classify_node_observations(
-                node_rows, now, grace_since, self.args
-            )
-            common_stall = shared_stall_candidate(node_rows, now)
-            if not self.reconcile_obsolete_node_alerts(
-                state, fleet, observations
-            ):
-                continue
-            if not self.reconcile_duplicate_owners(
-                state, fleet, observations, common_stall
-            ):
-                continue
-            reconciled, shared_nodes = self.reconcile_shared_stall(
-                state,
-                fleet,
-                node_rows,
-                observations,
-                common_stall,
-                now,
-                suppressed,
-            )
-            if not reconciled:
-                continue
-
-            for observation in observations:
-                self.handle_node_observation(
-                    state,
-                    fleet,
-                    observation,
-                    now,
-                    suppressed,
-                    observation.condition == "stalled"
-                    and observation.name in shared_nodes,
-                )
+                self.observe_fleet(candidate, fleet, now, suppressed)
+            finally:
+                self.notify = lambda text, args: post_slack(text, args)
+            if messages or fleet.name in pending:
+                delivery = pending.setdefault(fleet.name, {"messages": [], "state": {}})
+                delivery["messages"].extend(batch_messages(messages, now))
+                delivery["state"] = candidate
+                if not suppressed:
+                    self.deliver_batch(state, fleet)
+            else:
+                self.commit_fleet_state(state, fleet, candidate)
 
         for target in self.release_state:
             self.handle_release_state(state, target, now, suppressed)
+
+    @staticmethod
+    def fleet_state(state: dict[str, Any], fleet: Fleet) -> dict[str, Any]:
+        """Copy only this fleet's state so delivery cannot overwrite another fleet."""
+        result = {}
+        for bucket in ("nodes", "fleets", "shared_stalls", "propagation", "decisions"):
+            entries = state.get(bucket, {})
+            result[bucket] = copy.deepcopy({
+                key: value for key, value in entries.items()
+                if (key.startswith(f"{fleet.name}/") if bucket == "nodes" else key == fleet.name)
+            })
+        return result
+
+    @staticmethod
+    def commit_fleet_state(
+        state: dict[str, Any], fleet: Fleet, candidate: dict[str, Any]
+    ) -> None:
+        for bucket, entries in candidate.items():
+            target = state.setdefault(bucket, {})
+            for key in list(target):
+                if (key.startswith(f"{fleet.name}/") if bucket == "nodes" else key == fleet.name):
+                    del target[key]
+            target.update(entries)
+
+    def deliver_batch(self, state: dict[str, Any], fleet: Fleet) -> None:
+        """Send at most one payload per fleet per poll; commit after all chunks succeed.
+
+        Checkpoint the pending payload before sending, then checkpoint each
+        acknowledgement. A crash after Slack accepts a message but
+        before that checkpoint can still repeat it (webhooks have no receipt ID).
+        """
+        pending = state["pending_delivery"][fleet.name]
+        self.checkpoint(state)
+        if not post_slack(pending["messages"][0], self.args):
+            return
+        pending["messages"].pop(0)
+        if not pending["messages"]:
+            self.commit_fleet_state(state, fleet, pending["state"])
+            del state["pending_delivery"][fleet.name]
+        self.checkpoint(state)
+
+    def observe_fleet(
+        self, state: dict[str, Any], fleet: Fleet, now: float, suppressed: bool
+    ) -> None:
+        try:
+            snapshot = fetch_json(fleet.url, self.args.request_timeout)
+            node_rows = validated_fleet_rows(snapshot)
+            last_poll = snapshot_last_poll(snapshot)
+        except Exception as error:
+            self.handle_fleet_error(state, fleet, error, now, suppressed)
+            return
+
+        if (
+            last_poll is not None
+            and now - last_poll >= self.args.dashboard_down_after
+        ):
+            age = now - last_poll
+            error = ValueError(
+                "dashboard snapshot is stale: last poll was "
+                f"{format_duration(age)} ago"
+            )
+            self.handle_fleet_error(
+                state,
+                fleet,
+                error,
+                now,
+                suppressed,
+                bad_since=last_poll,
+            )
+            return
+
+        if not self.handle_fleet_recovered(state, fleet, now):
+            return
+        grace_since = max(
+            self.started_at, self.fetch_recovered_at.get(fleet.name, 0)
+        )
+        observations = classify_node_observations(
+            node_rows, now, grace_since, self.args
+        )
+        common_stall = shared_stall_candidate(node_rows, now)
+        propagation_nodes = self.propagation_grace(state, fleet, node_rows, now)
+        record_decision(state, fleet, node_rows, common_stall, propagation_nodes, now)
+        if not self.reconcile_obsolete_node_alerts(
+            state, fleet, observations
+        ):
+            return
+        if not self.reconcile_duplicate_owners(
+            state, fleet, observations, common_stall
+        ):
+            return
+        reconciled, shared_nodes = self.reconcile_shared_stall(
+            state,
+            fleet,
+            node_rows,
+            observations,
+            common_stall,
+            now,
+            suppressed,
+        )
+        if not reconciled:
+            return
+
+        for observation in observations:
+            self.handle_node_observation(
+                state,
+                fleet,
+                observation,
+                now,
+                suppressed,
+                observation.condition == "stalled"
+                and observation.name in (shared_nodes | propagation_nodes),
+            )
+
+    def propagation_grace(
+        self, state: dict[str, Any], fleet: Fleet, rows: list[dict[str, Any]], now: float
+    ) -> set[str]:
+        """Briefly protect unchanged former tip followers during proven tip extension.
+
+        Each timer stays anchored to the first observed extension, even across
+        polls, further blocks, and restarts. Existing alerts are never suppressed.
+        Missing tip evidence or a same-height hash conflict cancels the grace.
+        """
+        bucket = state.setdefault("propagation", {})
+        pending = bucket.setdefault(fleet.name, {})
+        observable = [row for row in rows if tip_is_observable(row)]
+        hashes: dict[int, set[str]] = {}
+        for row in observable:
+            if not tip_is_verifiable(row):
+                pending.clear()
+                return set()
+            hashes.setdefault(coerce_height(row["height"]), set()).add(
+                validated_block_hash(row["block_hash"])
+            )
+        if any(len(values) != 1 for values in hashes.values()):
+            pending.clear()
+            return set()
+
+        previous = state.get("shared_stalls", {}).get(fleet.name, {})
+        height, block_hash = self.shared_event_identity(previous)
+        last_seen = coerce_float(previous.get("last_seen"))
+        recent_shared = (
+            previous.get("condition") == "stalled"
+            and not previous.get("alerting")
+            and previous.get("owner") == "shared"
+            and last_seen is not None
+            and 0 <= now - last_seen <= PROPAGATION_GRACE_SECONDS
+            and height is not None and bool(block_hash)
+        )
+
+        def extensions_match(anchor_height: int, anchor_hash: str) -> bool:
+            higher_rows = [
+                row for row in observable
+                if coerce_height(row["height"]) > anchor_height
+            ]
+            if not higher_rows:
+                return False
+            for row in higher_rows:
+                distance = coerce_height(row["height"]) - anchor_height
+                ancestors = row.get("ancestor_hashes")
+                ancestor = (
+                    ancestors.get(str(distance)) if isinstance(ancestors, dict) else None
+                )
+                if distance == 1:
+                    ancestor = row.get("previous_hash") or ancestor
+                if validated_block_hash(ancestor) != anchor_hash:
+                    return False
+            return True
+
+        extension = recent_shared and extensions_match(height, block_hash)
+        for name in list(pending):
+            entry = pending[name]
+            if not extensions_match(entry["height"], entry["hash"]):
+                del pending[name]
+
+        current = {str(row["name"]): row for row in observable}
+        for name in list(pending):
+            entry = pending[name]
+            row = current.get(name)
+            if (
+                row is None
+                or coerce_height(row["height"]) != entry["height"]
+                or validated_block_hash(row["block_hash"]) != entry["hash"]
+            ):
+                del pending[name]
+        if extension:
+            for name in previous.get("node_names", []):
+                row = current.get(name)
+                old_alert = state.get("nodes", {}).get(f"{fleet.name}/{name}", {})
+                if (
+                    row and not old_alert.get("alerting")
+                    and coerce_height(row["height"]) == height
+                    and validated_block_hash(row["block_hash"]) == block_hash
+                ):
+                    pending.setdefault(
+                        name, {"height": height, "hash": block_hash, "since": now}
+                    )
+        return {
+            name for name, entry in pending.items()
+            if 0 <= now - entry["since"] < PROPAGATION_GRACE_SECONDS
+        }
 
     def handle_release_state(
         self,
@@ -1129,6 +1393,7 @@ class Watchdog:
             now,
             suppressed,
             self.args,
+            notify=self.notify,
         )
         bucket.setdefault(key, {})["height"] = height
 
@@ -1162,6 +1427,7 @@ class Watchdog:
             now,
             suppressed,
             self.args,
+            notify=self.notify,
         )
 
     def handle_fleet_recovered(
@@ -1187,6 +1453,7 @@ class Watchdog:
             now,
             False,
             self.args,
+            notify=self.notify,
         )
         return not (
             previous.get("alerting")
@@ -1230,7 +1497,7 @@ class Watchdog:
                 continue
             if self.node_alert_matches_observation(previous, observation):
                 continue
-            if not post_slack(
+            if not self.notify(
                 node_recovery_text(fleet, observation.row, previous), self.args
             ):
                 return False
@@ -1313,7 +1580,7 @@ class Watchdog:
                 shared_hash,
             )
             if node_owners:
-                if not post_slack(
+                if not self.notify(
                     shared_stall_recovery_text(
                         fleet,
                         shared_height,
@@ -1349,7 +1616,7 @@ class Watchdog:
                 owner.name,
                 common_stall.height,
             )
-            if not post_slack(text, self.args):
+            if not self.notify(text, self.args):
                 return False
             bucket[f"{fleet.name}/{duplicate.name}"] = {
                 "condition": "ok",
@@ -1396,7 +1663,7 @@ class Watchdog:
                 and common_stall.height > previous_height
                 else "shared tip changed"
             )
-            if previous.get("alerting") and not post_slack(
+            if previous.get("alerting") and not self.notify(
                 shared_stall_recovery_text(
                     fleet, common_stall.height, recovery_detail
                 ),
@@ -1475,7 +1742,7 @@ class Watchdog:
                     age,
                     participant_rows,
                 )
-                if post_slack(alert_text, self.args):
+                if self.notify(alert_text, self.args):
                     next_entry["alerting"] = True
                     next_entry["last_alert_at"] = now
                     next_entry["alert_height"] = common_stall.height
@@ -1520,7 +1787,7 @@ class Watchdog:
             }
             return True, owned_nodes
 
-        if not post_slack(
+        if not self.notify(
             shared_stall_recovery_text(fleet, current_height, detail), self.args
         ):
             return False, set()
@@ -1580,6 +1847,7 @@ class Watchdog:
             self.args,
             observation.height,
             log_suppressed=not coalesced,
+            notify=self.notify,
         )
         if observation.condition == "stalled":
             entry = bucket.get(key, {})
@@ -1655,7 +1923,10 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     fleets = load_fleets(args.config)
-    watchdog = Watchdog(fleets, args, load_release_state(args.config))
+    watchdog = Watchdog(
+        fleets, args, load_release_state(args.config),
+        checkpoint=lambda state: save_state(args.state_file, state),
+    )
 
     while True:
         state = load_state(args.state_file)


### PR DESCRIPTION
## Motivation

A natural ten-minute block gap can still produce eleven stall alerts and eleven recoveries when one node observes the next block first, or another row has incomplete tip data. Either case disables shared-tip grouping.

## Solution

Allow two minutes for former tip followers to catch up after a proven shared-tip extension, including after a shared warning. Retain established grace across unsampled ancestry depths without extending its deadline; conflicting evidence still cancels it. Batch due fleet transitions into one message per poll even when grouping fails. Persist delivery retries and compact decision snapshots while continuing to monitor new failures. Webhook delivery remains at least once, so an ambiguous acknowledgement can repeat a message.

## Testing

All 165 watchdog and dashboard tests pass in an isolated Linux container. Regressions cover the shared-warning transition, sparse ancestry across restarts, persistent lag, conflicting references, outages, suppression, and failed delivery. The actual localhost webhook receives two payloads for the eleven-node alert/recovery sequence; the same test receives 22 on unchanged main. Markdown lint passes with the repository configuration.

Used Codex for implementation, tests, and this description.
