### PR TITLE
chore: add monetary-base defense in depth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "7.0.2-rc0"
+version = "7.0.2"
 dependencies = [
  "blake2b_simd",
  "chrono",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-header-chain"
-version = "2.0.1-rc0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "7.1.0-rc0"
+version = "7.1.0"
 dependencies = [
  "bitflags",
  "blake2b_simd",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "3.2.3-rc0"
+version = "3.2.3"
 dependencies = [
  "jsonrpsee-types",
  "reqwest 0.12.28",
@@ -8166,7 +8166,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "9.0.1-rc0"
+version = "9.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "3.2.2-rc0"
+version = "3.2.2"
 dependencies = [
  "hex",
  "lazy_static",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "7.2.0-rc0"
+version = "7.2.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "2.2.3-rc0"
+version = "2.2.3"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "6.3.0-rc0"
+version = "7.0.0"
 dependencies = [
  "bech32",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-chain"
-version = "7.0.0"
+version = "7.0.0-rc0"
 dependencies = [
  "bech32",
  "bitflags",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "7.0.2"
+version = "7.0.2-rc0"
 dependencies = [
  "blake2b_simd",
  "chrono",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-header-chain"
-version = "2.0.1"
+version = "2.0.1-rc0"
 dependencies = [
  "chrono",
  "criterion",
@@ -7961,7 +7961,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-network"
-version = "7.1.0"
+version = "7.1.0-rc0"
 dependencies = [
  "bitflags",
  "blake2b_simd",
@@ -8007,7 +8007,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-node-services"
-version = "3.2.3"
+version = "3.2.3-rc0"
 dependencies = [
  "jsonrpsee-types",
  "reqwest 0.12.28",
@@ -8166,7 +8166,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-rpc"
-version = "9.0.1"
+version = "9.0.1-rc0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -8269,7 +8269,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-script"
-version = "3.2.2"
+version = "3.2.2-rc0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -8299,7 +8299,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "7.2.0"
+version = "7.2.0-rc0"
 dependencies = [
  "bincode",
  "chrono",
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-utils"
-version = "2.2.3"
+version = "2.2.3-rc0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "6.3.0-rc0"
+version = "7.0.0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/Cargo.toml
+++ b/crates/zakura-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-chain"
-version = "7.0.0"
+version = "7.0.0-rc0"
 authors.workspace = true
 description = "Core Zcash data structures for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-chain/src/value_balance.rs
+++ b/crates/zakura-chain/src/value_balance.rs
@@ -328,7 +328,7 @@ impl ValueBalance<NonNegative> {
     ///
     /// We implement the consensus rules above by constraining the returned value balance to
     /// [`ValueBalance<NonNegative>`]. The sum of all returned pool balances must also fit
-    /// within `MAX_MONEY`, matching Zebra's aggregate monetary-base guard.
+    /// within `MAX_MONEY` as an additional accounting safeguard.
     #[allow(clippy::unwrap_in_result)]
     pub fn add_chain_value_pool_change(
         self,
@@ -341,7 +341,7 @@ impl ValueBalance<NonNegative> {
 
         let chain_value_pool = chain_value_pool.constrain::<NonNegative>()?;
 
-        // Match Zebra's cap on the total monetary base across all chain value pools.
+        // Bound the total monetary base as defence in depth.
         chain_value_pool.total().map_err(ValueBalanceError::Total)?;
 
         Ok(chain_value_pool)

--- a/crates/zakura-chain/src/value_balance.rs
+++ b/crates/zakura-chain/src/value_balance.rs
@@ -160,6 +160,26 @@ where
         }
     }
 
+    /// Returns the sum of all value pool balances.
+    ///
+    /// Returns an error if the final sum does not satisfy the amount constraint `C`.
+    /// Signed balances are summed before applying that constraint.
+    pub fn total(self) -> Result<Amount<C>, amount::Error> {
+        let total: i128 = [
+            self.transparent,
+            self.sprout,
+            self.sapling,
+            self.orchard,
+            self.deferred,
+            self.ironwood,
+        ]
+        .into_iter()
+        .map(|amount| i128::from(amount.zatoshis()))
+        .sum();
+
+        Amount::try_from(total)
+    }
+
     /// Convert this value balance to a different ValueBalance type,
     /// if it satisfies the new constraint
     pub fn constrain<C2>(self) -> Result<ValueBalance<C2>, ValueBalanceError>
@@ -307,7 +327,8 @@ impl ValueBalance<NonNegative> {
     /// <https://developer.bitcoin.org/devguide/transactions.html#transaction-fees-and-change>
     ///
     /// We implement the consensus rules above by constraining the returned value balance to
-    /// [`ValueBalance<NonNegative>`].
+    /// [`ValueBalance<NonNegative>`]. The sum of all returned pool balances must also fit
+    /// within `MAX_MONEY`, matching Zebra's aggregate monetary-base guard.
     #[allow(clippy::unwrap_in_result)]
     pub fn add_chain_value_pool_change(
         self,
@@ -318,26 +339,34 @@ impl ValueBalance<NonNegative> {
             .expect("conversion from NonNegative to NegativeAllowed is always valid");
         chain_value_pool = (chain_value_pool + chain_value_pool_change)?;
 
-        chain_value_pool.constrain()
+        let chain_value_pool = chain_value_pool.constrain::<NonNegative>()?;
+
+        // Match Zebra's cap on the total monetary base across all chain value pools.
+        chain_value_pool.total().map_err(ValueBalanceError::Total)?;
+
+        Ok(chain_value_pool)
     }
 
     /// Create a fake value pool for testing purposes.
     ///
-    /// The resulting [`ValueBalance`] will have half of the MAX_MONEY amount on each pool.
+    /// The resulting [`ValueBalance`] has `MAX_MONEY / 8` on the transparent, Sprout, Sapling,
+    /// Orchard, and Ironwood pools; the deferred pool is zero. This keeps the total within the
+    /// valid `Amount` range (see [`ValueBalance::total`]), while leaving headroom for value pool
+    /// changes that tests commit on top of it.
     #[cfg(any(test, feature = "proptest-impl"))]
     pub fn fake_populated_pool() -> ValueBalance<NonNegative> {
         let mut fake_value_pool = ValueBalance::zero();
 
         let fake_transparent_value_balance =
-            ValueBalance::from_transparent_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+            ValueBalance::from_transparent_amount(Amount::try_from(MAX_MONEY / 8).unwrap());
         let fake_sprout_value_balance =
-            ValueBalance::from_sprout_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+            ValueBalance::from_sprout_amount(Amount::try_from(MAX_MONEY / 8).unwrap());
         let fake_sapling_value_balance =
-            ValueBalance::from_sapling_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+            ValueBalance::from_sapling_amount(Amount::try_from(MAX_MONEY / 8).unwrap());
         let fake_orchard_value_balance =
-            ValueBalance::from_orchard_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+            ValueBalance::from_orchard_amount(Amount::try_from(MAX_MONEY / 8).unwrap());
         let fake_ironwood_value_balance =
-            ValueBalance::from_ironwood_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+            ValueBalance::from_ironwood_amount(Amount::try_from(MAX_MONEY / 8).unwrap());
 
         fake_value_pool.set_transparent_value_balance(fake_transparent_value_balance);
         fake_value_pool.set_sprout_value_balance(fake_sprout_value_balance);
@@ -468,6 +497,9 @@ pub enum ValueBalanceError {
     /// ironwood amount error {0}
     Ironwood(amount::Error),
 
+    /// total amount error {0}
+    Total(amount::Error),
+
     /// ValueBalance is unparsable
     Unparsable,
 }
@@ -481,6 +513,7 @@ impl fmt::Display for ValueBalanceError {
             Orchard(e) => format!("orchard amount err: {e}"),
             Deferred(e) => format!("deferred amount err: {e}"),
             Ironwood(e) => format!("ironwood amount err: {e}"),
+            Total(e) => format!("total amount err: {e}"),
             Unparsable => "value balance is unparsable".to_string(),
         })
     }

--- a/crates/zakura-chain/src/value_balance/tests.rs
+++ b/crates/zakura-chain/src/value_balance/tests.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unwrap_in_result)]
 
 use crate::{
-    amount::{Amount, NegativeAllowed, NonNegative},
+    amount::{Amount, NegativeAllowed, NonNegative, MAX_MONEY},
     value_balance::{ValueBalance, ValueBalanceError},
 };
 
@@ -112,4 +112,74 @@ fn value_balance_bytes_report_invalid_tail_pool() {
         ValueBalance::<NonNegative>::from_bytes(&bytes[..47]),
         Err(ValueBalanceError::Unparsable)
     );
+}
+
+#[test]
+fn chain_pool_total_limit_includes_every_pool() {
+    let _init_guard = zakura_test::init();
+
+    // Every pool contributes to a total exactly at the cap.
+    let share = Amount::<NonNegative>::try_from(MAX_MONEY / 6).unwrap();
+    let at_cap = ValueBalance {
+        transparent: share,
+        sprout: share,
+        sapling: share,
+        orchard: share,
+        deferred: share,
+        ironwood: share,
+    };
+    assert_eq!(at_cap.total(), Ok(Amount::try_from(MAX_MONEY).unwrap()));
+    assert_eq!(
+        at_cap.add_chain_value_pool_change(ValueBalance::zero()),
+        Ok(at_cap)
+    );
+
+    let one = Amount::<NegativeAllowed>::try_from(1).unwrap();
+    let mut deferred_change = ValueBalance::zero();
+    deferred_change.set_deferred_amount(one);
+    for change in [
+        ValueBalance::from_transparent_amount(one),
+        ValueBalance::from_sprout_amount(one),
+        ValueBalance::from_sapling_amount(one),
+        ValueBalance::from_orchard_amount(one),
+        deferred_change,
+        ValueBalance::from_ironwood_amount(one),
+    ] {
+        // Every individual pool remains valid, but the combined total is one zatoshi over.
+        assert!(matches!(
+            at_cap.add_chain_value_pool_change(change),
+            Err(ValueBalanceError::Total(_))
+        ));
+        let below_cap = at_cap.add_chain_value_pool_change(-change).unwrap();
+        assert_eq!(
+            below_cap.total(),
+            Ok(Amount::try_from(MAX_MONEY - 1).unwrap())
+        );
+        assert_eq!(below_cap.add_chain_value_pool_change(change), Ok(at_cap));
+    }
+}
+
+#[test]
+fn chain_pool_transfer_at_total_limit_is_valid() {
+    let _init_guard = zakura_test::init();
+
+    let initial =
+        ValueBalance::from_transparent_amount(Amount::<NonNegative>::try_from(MAX_MONEY).unwrap());
+    let one = Amount::<NegativeAllowed>::try_from(1).unwrap();
+    let mut transfer = ValueBalance::from_transparent_amount(-one);
+    transfer.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(one));
+    let updated = initial.add_chain_value_pool_change(transfer).unwrap();
+    assert_eq!(updated.total(), initial.total());
+    assert_eq!(updated.add_chain_value_pool_change(-transfer), Ok(initial));
+}
+
+#[test]
+fn total_sums_signed_balances_before_applying_the_constraint() {
+    let _init_guard = zakura_test::init();
+
+    let max = Amount::<NegativeAllowed>::try_from(MAX_MONEY).unwrap();
+    let mut balance = ValueBalance::from_transparent_amount(max);
+    balance.set_sprout_value_balance(ValueBalance::from_sprout_amount(max));
+    balance.set_ironwood_value_balance(ValueBalance::from_ironwood_amount(-max));
+    assert_eq!(balance.total(), Ok(max));
 }

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "7.0.2-rc0"
+version = "7.0.2"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -67,11 +67,11 @@ zcash_primitives = { workspace = true }
 tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.2.0" }
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.3.0" }
 
-zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
 
 zcash_protocol.workspace = true
 
@@ -93,7 +93,7 @@ toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "7.0.2"
+version = "7.0.2-rc0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -67,11 +67,11 @@ zcash_primitives = { workspace = true }
 tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/", version = "1.2.0" }
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.3.0" }
 
-zakura-script = { path = "../zakura-script", version = "3.2.2" }
-zakura-state = { path = "../zakura-state", version = "7.2.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
+zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 
 zcash_protocol.workspace = true
 
@@ -93,8 +93,8 @@ toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -70,7 +70,7 @@ tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower
 zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
 zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 
 zcash_protocol.workspace = true
@@ -94,7 +94,7 @@ toml = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
 zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = ["proptest-impl"] }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-header-chain"
-version = "2.0.1"
+version = "2.0.1-rc0"
 authors.workspace = true
 description = "Fork-aware header-chain domain types and transition engine for Zakura"
 license.workspace = true
@@ -20,7 +20,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { workspace = true }
 rayon = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/zakura-header-chain/Cargo.toml
+++ b/crates/zakura-header-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-header-chain"
-version = "2.0.1-rc0"
+version = "2.0.1"
 authors.workspace = true
 description = "Fork-aware header-chain domain types and transition engine for Zakura"
 license.workspace = true

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -82,7 +82,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "7.1.0"
+version = "7.1.0-rc0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -82,10 +82,10 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-network/Cargo.toml
+++ b/crates/zakura-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-network"
-version = "7.1.0-rc0"
+version = "7.1.0"
 authors.workspace = true
 description = "Networking code for the Zakura node. Internal crate, published to support cargo install zakura"
 # # Legal
@@ -83,9 +83,9 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "3.2.3"
+version = "3.2.3-rc0"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -34,8 +34,8 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "7.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
+zakura-chain = { path = "../zakura-chain" , version = "7.0.0-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-node-services"
-version = "3.2.3-rc0"
+version = "3.2.3"
 authors.workspace = true
 description = "The interfaces of some Zakura node services. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -35,7 +35,7 @@ rpc-client = [
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain" , version = "7.0.0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/crates/zakura-node-services/Cargo.toml
+++ b/crates/zakura-node-services/Cargo.toml
@@ -34,7 +34,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain" , version = "6.3.0-rc0" }
+zakura-chain = { path = "../zakura-chain" , version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 tower = { workspace = true }
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "9.0.1"
+version = "9.0.1-rc0"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -108,16 +108,16 @@ zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2" }
-zakura-network = { path = "../zakura-network", version = "7.1.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
+zakura-network = { path = "../zakura-network", version = "7.1.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "3.2.2" }
-zakura-state = { path = "../zakura-state", version = "7.2.0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
@@ -136,16 +136,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "7.1.0", features = [
+zakura-network = { path = "../zakura-network", version = "7.1.0-rc0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "7.2.0", features = [
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = [
     "proptest-impl",
 ] }
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-rpc"
-version = "9.0.1-rc0"
+version = "9.0.1"
 authors.workspace = true
 description = "The Zakura node's JSON Remote Procedure Call (JSON-RPC) interface. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -111,13 +111,13 @@ zcash_transparent = { workspace = true }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "json-conversion",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
-zakura-network = { path = "../zakura-network", version = "7.1.0-rc0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2" }
+zakura-network = { path = "../zakura-network", version = "7.1.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", features = [
     "rpc-client",
 ] }
-zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
@@ -139,13 +139,13 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "proptest-impl",
 ] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = [
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2", features = [
     "proptest-impl",
 ] }
-zakura-network = { path = "../zakura-network", version = "7.1.0-rc0", features = [
+zakura-network = { path = "../zakura-network", version = "7.1.0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = [
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = [
     "proptest-impl",
 ] }
 

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -108,7 +108,7 @@ zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
 zcash_transparent = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "json-conversion",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
@@ -136,7 +136,7 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = [
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = [
     "proptest-impl",
 ] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = [

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "3.2.2"
+version = "3.2.2-rc0"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/zakura-script/Cargo.toml
+++ b/crates/zakura-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-script"
-version = "3.2.2-rc0"
+version = "3.2.2"
 authors.workspace = true
 description = "Zakura script verification wrapping zcashd's zcash_script library. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "7.2.0-rc0"
+version = "7.2.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -74,9 +74,9 @@ tracing = { workspace = true }
 sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -88,7 +88,7 @@ derive-getters.workspace = true
 derive-new.workspace = true
 
 [dev-dependencies]
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0", features = ["test-support"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1", features = ["test-support"] }
 color-eyre = { workspace = true }
 
 once_cell = { workspace = true }

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "7.2.0"
+version = "7.2.0-rc0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -74,9 +74,9 @@ tracing = { workspace = true }
 sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3" }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["async-error"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -88,7 +88,7 @@ derive-getters.workspace = true
 derive-new.workspace = true
 
 [dev-dependencies]
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1", features = ["test-support"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0", features = ["test-support"] }
 color-eyre = { workspace = true }
 
 once_cell = { workspace = true }
@@ -108,7 +108,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -75,7 +75,7 @@ sapling-crypto = { workspace = true }
 
 zakura-assets = { workspace = true }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0" }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["async-error"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["async-error"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 
 # prod feature progress-bar
@@ -108,7 +108,7 @@ orchard = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 
 [lints]

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "2.2.3"
+version = "2.2.3-rc0"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -74,14 +74,14 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", optional = true }
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", optional = true }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "7.2.0", optional = true }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -75,7 +75,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", optional = true }
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", optional = true }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-utils"
-version = "2.2.3-rc0"
+version = "2.2.3"
 authors.workspace = true
 description = "Developer tools for Zakura maintenance and testing. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -74,14 +74,14 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true, optional = true }
 
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", optional = true }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", optional = true }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", optional = true }
 
 # These crates are needed for the zakura-checkpoints binary
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", optional = true }
+zakura-state = { path = "../zakura-state", version = "7.2.0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -168,7 +168,7 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
@@ -305,7 +305,7 @@ tonic-prost = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "6.3.0-rc0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = ["proptest-impl"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0", features = ["test-support"] }
 zakura-network = { path = "../zakura-network", version = "7.1.0-rc0", features = ["proptest-impl", "zakura-testkit"] }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -169,21 +169,21 @@ comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
 zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-network = { path = "../zakura-network", version = "7.1.0-rc0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "9.0.1-rc0" }
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
+zakura-network = { path = "../zakura-network", version = "7.1.0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "9.0.1" }
+zakura-state = { path = "../zakura-state", version = "7.2.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
+zakura-script = { path = "../zakura-script", version = "3.2.2" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "2.2.3-rc0", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "2.2.3", optional = true }
 
 abscissa_core = { workspace = true, default-features = false, features = ["application"] }
 clap = { workspace = true, features = ["cargo"] }
@@ -306,10 +306,10 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = ["proptest-impl"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0", features = ["test-support"] }
-zakura-network = { path = "../zakura-network", version = "7.1.0-rc0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2", features = ["proptest-impl"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1", features = ["test-support"] }
+zakura-network = { path = "../zakura-network", version = "7.1.0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }
 
@@ -322,7 +322,7 @@ zakura-test = { path = "../zakura-test", version = "2.1.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "2.2.3-rc0" }
+zakura-utils = { path = "../zakura-utils", version = "2.2.3" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -168,22 +168,22 @@ tokio-console = ["console-subscriber"]
 comparison-interpreter = ["zakura-script/comparison-interpreter"]
 
 [dependencies]
-zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2" }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1" }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0" }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0" }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0" }
 zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
-zakura-network = { path = "../zakura-network", version = "7.1.0" }
-zakura-node-services = { path = "../zakura-node-services", version = "3.2.3", features = ["rpc-client"] }
-zakura-rpc = { path = "../zakura-rpc", version = "9.0.1" }
-zakura-state = { path = "../zakura-state", version = "7.2.0" }
+zakura-network = { path = "../zakura-network", version = "7.1.0-rc0" }
+zakura-node-services = { path = "../zakura-node-services", version = "3.2.3-rc0", features = ["rpc-client"] }
+zakura-rpc = { path = "../zakura-rpc", version = "9.0.1-rc0" }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zakura-script = { path = "../zakura-script", version = "3.2.2" }
+zakura-script = { path = "../zakura-script", version = "3.2.2-rc0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zakura-utils = { path = "../zakura-utils", version = "2.2.3", optional = true }
+zakura-utils = { path = "../zakura-utils", version = "2.2.3-rc0", optional = true }
 
 abscissa_core = { workspace = true, default-features = false, features = ["application"] }
 clap = { workspace = true, features = ["cargo"] }
@@ -305,11 +305,11 @@ tonic-prost = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 
-zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
-zakura-consensus = { path = "../zakura-consensus", version = "7.0.2", features = ["proptest-impl"] }
-zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1", features = ["test-support"] }
-zakura-network = { path = "../zakura-network", version = "7.1.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "7.2.0", features = ["proptest-impl"] }
+zakura-chain = { path = "../zakura-chain", version = "7.0.0-rc0", features = ["proptest-impl"] }
+zakura-consensus = { path = "../zakura-consensus", version = "7.0.2-rc0", features = ["proptest-impl"] }
+zakura-header-chain = { path = "../zakura-header-chain", version = "2.0.1-rc0", features = ["test-support"] }
+zakura-network = { path = "../zakura-network", version = "7.1.0-rc0", features = ["proptest-impl", "zakura-testkit"] }
+zakura-state = { path = "../zakura-state", version = "7.2.0-rc0", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }
 
@@ -322,7 +322,7 @@ zakura-test = { path = "../zakura-test", version = "2.1.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zakura-utils { path = "../zakura-utils", artifact = "bin:zakura-checkpoints" }
-zakura-utils = { path = "../zakura-utils", version = "2.2.3" }
+zakura-utils = { path = "../zakura-utils", version = "2.2.3-rc0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/docs/changelog/unreleased/911.md
+++ b/docs/changelog/unreleased/911.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Added Zebra's monetary-base guard so blocks cannot raise the combined chain
+  value-pool balance above the maximum money supply
+  ([#911](https://github.com/zakura-core/zakura/pull/911)).

--- a/docs/changelog/unreleased/911.md
+++ b/docs/changelog/unreleased/911.md
@@ -1,5 +1,4 @@
 ## Fixed
 
-- Added Zebra's monetary-base guard so blocks cannot raise the combined chain
-  value-pool balance above the maximum money supply
+- Added a check on the combined chain value-pool balance as defence in depth
   ([#911](https://github.com/zakura-core/zakura/pull/911)).


### PR DESCRIPTION
## Motivation

Add an aggregate monetary-base guard as defence in depth alongside the existing per-pool, subsidy, transaction-balance, and proof checks.

## Solution

Check that the combined balance of all six chain value pools stays within `MAX_MONEY`. This provides an additional accounting safeguard while preserving valid transfers and existing per-pool checks. Update the test fixture, bump `zakura-chain` for the new error variant, and patch-bump dependent libraries so their updated requirements can ship. The node release version remains managed by release preparation.

## Testing

Local validation passed 402 chain tests, 33 state/reorg tests, chain/state Clippy with warnings denied, formatting, and Markdown/changelog checks. Boundary tests cover the exact cap, one zatoshi over it in each pool, and transfers and reversals at the cap. These exercise the guard directly and do not demonstrate a way to exceed the cap through otherwise valid blocks. The dry-run publish graph resolves all nine affected libraries at their workspace versions; the existing node package is skipped pending its next release version.

## Changelog

Added `docs/changelog/unreleased/911.md`.

Used Codex for implementation and validation.
