### PR TITLE
fix(ops): clarify sync summaries with per-run timing and throughput

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -159,14 +159,15 @@ successful digest. An unchanged failure appears only in a digest at least 24 hou
 after its last alert or reminder; a recent alert waits for a later digest.
 The summary names each networking mode (dual, Zakura only, or legacy only),
 keeps the host ID for troubleshooting, and includes hosts with zero completions.
-It shows one row per completed run, with duration, block count, and average blocks
+It shows one row per completed run, with duration and average blocks
 per second (BPS), oldest first, plus the currently observed controller phase.
 Sync duration excludes the build and state cleanup; it includes startup, readiness
 confirmation, shutdown, and log archiving. Failures still alert immediately.
 
-Each cycle starts with empty chain state. The block count is the confirmed height
+Each cycle starts with empty chain state. The BPS calculation uses the confirmed height
 from the final readiness sample plus one for genesis, using the committed-block
-height gauge. Average BPS divides that count by the full, unrounded duration in
+height gauge. The block count is retained for calculation but omitted from Slack. Average BPS
+divides that count by the full, unrounded duration in
 seconds. This is overall sync throughput, not instantaneous verifier speed;
 blocks differ in cost and the node may process more blocks during shutdown.
 An estimated tip or an earlier progress sample cannot supply the count. Missing
@@ -176,15 +177,15 @@ For example, a digest can show these illustrative per-run results:
 
 ```text
 Dual networking · 1 completed
-• 6h 40m · 3.47M blocks · 145 blocks/sec
+• 6h 40m · 145 blocks/sec
 
 Zakura networking only · 3 completed
-• 7h 10m · 3.47M blocks · 134 blocks/sec
-• 7h 00m · 3.47M blocks · 138 blocks/sec
-• 7h 20m · 3.47M blocks · 131 blocks/sec
+• 7h 10m · 134 blocks/sec
+• 7h 00m · 138 blocks/sec
+• 7h 20m · 131 blocks/sec
 
 Legacy networking only · 1 completed
-• 8h 00m · 3.47M blocks · 120 blocks/sec
+• 8h 00m · 120 blocks/sec
 ```
 
 The Slack summary also retains host IDs and current status for troubleshooting.
@@ -193,7 +194,7 @@ Controllers retain the latest 256 completion durations and ending heights in the
 state, independently of run-log cleanup. Audits accumulate up to 256 per-run
 records per host until delivery.
 Older controllers and existing audit caches still contribute their completion
-counts and latest timing, with block counts and BPS unavailable for old records.
+counts and latest timing, with BPS unavailable for old records.
 Missing records, including those beyond retention, are explicitly marked unavailable.
 Malformed optional controller history is discarded without failing a successful
 sync; completion counters remain authoritative. Retired hosts leave the summary

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -159,15 +159,45 @@ successful digest. An unchanged failure appears only in a digest at least 24 hou
 after its last alert or reminder; a recent alert waits for a later digest.
 The summary names each networking mode (dual, Zakura only, or legacy only),
 keeps the host ID for troubleshooting, and includes hosts with zero completions.
-It shows each completed run's sync duration in hours and minutes, oldest first,
-and the currently observed controller phase. Sync duration excludes the build
-and includes the readiness confirmation period. Failures still alert immediately.
+It shows one row per completed run, with duration, block count, and average blocks
+per second (BPS), oldest first, plus the currently observed controller phase.
+Sync duration excludes the build and state cleanup; it includes startup, readiness
+confirmation, shutdown, and log archiving. Failures still alert immediately.
 
-Controllers retain the latest 256 completion timings in their state, independently
-of run-log cleanup. Audits accumulate up to 256 timings per host until delivery.
+Each cycle starts with empty chain state. The block count is the confirmed height
+from the final readiness sample plus one for genesis, using the committed-block
+height gauge. Average BPS divides that count by the full, unrounded duration in
+seconds. This is overall sync throughput, not instantaneous verifier speed;
+blocks differ in cost and the node may process more blocks during shutdown.
+An estimated tip or an earlier progress sample cannot supply the count. Missing
+heights and zero or missing durations produce an unavailable rate.
+
+For example, a digest can show these illustrative per-run results:
+
+```text
+Dual networking · 1 completed
+• 6h 40m · 3.47M blocks · 145 blocks/sec
+
+Zakura networking only · 3 completed
+• 7h 10m · 3.47M blocks · 134 blocks/sec
+• 7h 00m · 3.47M blocks · 138 blocks/sec
+• 7h 20m · 3.47M blocks · 131 blocks/sec
+
+Legacy networking only · 1 completed
+• 8h 00m · 3.47M blocks · 120 blocks/sec
+```
+
+The Slack summary also retains host IDs and current status for troubleshooting.
+
+Controllers retain the latest 256 completion durations and ending heights in their
+state, independently of run-log cleanup. Audits accumulate up to 256 per-run
+records per host until delivery.
 Older controllers and existing audit caches still contribute their completion
-counts and latest timing. Any missing timings, including those beyond retention,
-are explicitly marked unavailable. Per-run logs and artifacts remain available
+counts and latest timing, with block counts and BPS unavailable for old records.
+Missing records, including those beyond retention, are explicitly marked unavailable.
+Malformed optional controller history is discarded without failing a successful
+sync; completion counters remain authoritative. Retired hosts leave the summary
+after any pending completions have been delivered. Per-run logs and artifacts remain available
 on each host.
 A lost audit cache may repeat already summarized completions or alerts.
 

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -157,7 +157,18 @@ cadence. New failures and recoveries do not wait for the digest. Completion coun
 include runs since the controller enabled digest reporting, then since the last
 successful digest. An unchanged failure appears only in a digest at least 24 hours
 after its last alert or reminder; a recent alert waits for a later digest.
-Per-run logs and artifacts remain available on each host.
+The summary names each networking mode (dual, Zakura only, or legacy only),
+keeps the host ID for troubleshooting, and includes hosts with zero completions.
+It shows each completed run's sync duration in hours and minutes, oldest first,
+and the currently observed controller phase. Sync duration excludes the build
+and includes the readiness confirmation period. Failures still alert immediately.
+
+Controllers retain the latest 256 completion timings in their state, independently
+of run-log cleanup. Audits accumulate up to 256 timings per host until delivery.
+Older controllers and existing audit caches still contribute their completion
+counts and latest timing. Any missing timings, including those beyond retention,
+are explicitly marked unavailable. Per-run logs and artifacts remain available
+on each host.
 A lost audit cache may repeat already summarized completions or alerts.
 
 Alert state is carried between workflow runs in the Actions cache. A failed Slack

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -702,6 +702,11 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
         }
     )
     write_run_json(run_dir, run_state)
+    completion_history = state.get("completion_history", [])
+    if not isinstance(completion_history, list):
+        # Optional reporting history must not turn a successful sync into a halt.
+        print("invalid completion history; preserving counts and starting new history", file=sys.stderr)
+        completion_history = []
     state.update(
         {
             "failed": False,
@@ -710,7 +715,7 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
             "last_success_run": run_id,
             "last_success_duration_seconds": run_state["sync_duration_seconds"],
             # Keep timings independently of run-log retention and audit cadence.
-            "completion_history": (state.get("completion_history", []) + [{
+            "completion_history": (completion_history + [{
                 "number": int(state.get("runs", 0)) + 1,
                 "run_id": run_id,
                 "duration": run_state["sync_duration_seconds"],

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -555,6 +555,12 @@ def wait_for_completion(config: Config, run_dir: Path, run_state: dict[str, Any]
         if sample.get("ready") is True:
             ready_samples += 1
             if ready_samples >= config.policy.ready_samples:
+                # Use the final readiness sample, not a stale progress height or
+                # an estimated network tip. This gauge follows committed blocks.
+                height = sample.get("zcash_chain_verified_block_height")
+                run_state["end_height"] = (
+                    height if type(height) is int and 0 <= height <= 0xFFFFFFFF else None
+                )
                 return
             time.sleep(config.policy.ready_sample_interval_seconds)
         else:
@@ -714,11 +720,13 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
             "last_success_at": completed_at,
             "last_success_run": run_id,
             "last_success_duration_seconds": run_state["sync_duration_seconds"],
+            "last_success_end_height": run_state.get("end_height"),
             # Keep timings independently of run-log retention and audit cadence.
             "completion_history": (completion_history + [{
                 "number": int(state.get("runs", 0)) + 1,
                 "run_id": run_id,
                 "duration": run_state["sync_duration_seconds"],
+                "end_height": run_state.get("end_height"),
             }])[-COMPLETION_HISTORY_LIMIT:],
             "completion_digest": True,
             "completion_digest_start_runs": state.get(

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 STATE_VERSION = 1
+COMPLETION_HISTORY_LIMIT = 256
 
 
 class ControllerError(Exception):
@@ -708,6 +709,12 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
             "last_success_at": completed_at,
             "last_success_run": run_id,
             "last_success_duration_seconds": run_state["sync_duration_seconds"],
+            # Keep timings independently of run-log retention and audit cadence.
+            "completion_history": (state.get("completion_history", []) + [{
+                "number": int(state.get("runs", 0)) + 1,
+                "run_id": run_id,
+                "duration": run_state["sync_duration_seconds"],
+            }])[-COMPLETION_HISTORY_LIMIT:],
             "completion_digest": True,
             "completion_digest_start_runs": state.get(
                 "completion_digest_start_runs", int(state.get("runs", 0))

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -564,6 +564,11 @@ def load_audit_state(path: Path | None) -> dict[str, Any]:
         not isinstance(record, dict)
         or any(type(record.get(key)) is not int or record[key] < 0 for key in ("total", "pending"))
         or any(key not in record for key in ("run_id", "sha", "duration"))
+        or ("details" in record and (
+            not isinstance(record["details"], list)
+            or len(record["details"]) > COMPLETION_DETAIL_LIMIT
+            or any(not isinstance(item, dict) for item in record["details"])
+        ))
         for record in completions.values()
     ):
         data.pop("completions", None)
@@ -690,6 +695,10 @@ def completion_status(data: dict[str, Any] | None) -> str:
         return "halted after failure"
     phase = controller.get("phase")
     if phase == "syncing":
+        if data.get("service_active") is False:
+            return "node service inactive"
+        if (data.get("sample") or {}).get("metrics_status", "ok") != "ok":
+            return "sync status unavailable (metrics unavailable)"
         return "currently syncing"
     if phase == "complete":
         return "between runs"
@@ -716,16 +725,13 @@ def completion_updates(
     preserve the old counts; unavailable timings are explicitly reported.
     """
     records = {name: dict(record) for name, record in previous.get("completions", {}).items()}
-    for name in sorted(set(statuses) | set(labels or {})):
-        record = records.setdefault(name, {})
-        record["label"] = (labels or {}).get(name, record.get("label", name))
     for name, data in statuses.items():
         controller = data.get("controller_state") or {}
         run_id = controller.get("last_success_run")
         total = controller.get("runs")
         if not controller.get("completion_digest") or not run_id or type(total) is not int:
             continue
-        old = records[name]
+        old = records.get(name, {})
         if old.get("run_id") == run_id:
             continue
         baseline = old.get("total", controller.get("completion_digest_start_runs", total - 1))
@@ -741,13 +747,17 @@ def completion_updates(
         }
         details = completion_details(old) + [history[number] for number in sorted(history)]
         records[name] = {
-            "label": old["label"], "run_id": run_id, "total": total,
+            "label": (labels or {}).get(name, old.get("label", name)),
+            "run_id": run_id, "total": total,
+            "sha": controller.get("last_success_sha", "unknown"),
+            "duration": controller.get("last_success_duration_seconds"),
             "pending": old.get("pending", 0) + delta,
             "details": details[-COMPLETION_DETAIL_LIMIT:],
         }
     lines = []
     if digest_due:
-        for name, record in sorted(records.items()):
+        for name in sorted(set(records) | set(statuses) | set(labels or {})):
+            record = records.get(name, {})
             pending = record.get("pending", 0)
             durations = [
                 item["duration"] for item in completion_details(record)
@@ -757,12 +767,14 @@ def completion_updates(
             missing = pending - len(durations)
             if missing:
                 timings.append(f"{missing} duration(s) unavailable")
-            line = f"{record.get('label', name)}: {pending} completed"
+            label = (labels or {}).get(name, record.get("label", name))
+            line = f"{label}: {pending} completed"
             if timings:
                 line += " · " + ", ".join(timings)
             line += " · " + completion_status(statuses.get(name))
             lines.append(line)
-            records[name] = {**record, "pending": 0, "details": []}
+            if name in records:
+                records[name] = {**record, "label": label, "pending": 0, "details": []}
     return lines, records
 
 

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -679,12 +679,12 @@ COMPLETION_DETAIL_LIMIT = 256
 
 def sync_label(node: Node) -> str:
     modes = {
-        "dual": "dual networking",
+        "dual": "Dual networking",
         "zakura": "Zakura networking only",
-        "legacy": "legacy networking only",
+        "legacy": "Legacy networking only",
     }
     mode = modes.get(node.raw.get("p2p_stack"))
-    return f"Mainnet sync — {mode} ({node.name})" if mode else node.name
+    return f"{mode} ({node.name})" if mode else node.name
 
 
 def completion_status(data: dict[str, Any] | None) -> str:
@@ -710,8 +710,25 @@ def completion_details(record: dict[str, Any]) -> list[dict[str, Any]]:
     if "details" in record:
         return list(record["details"])
     if record.get("pending") and record.get("run_id"):
-        return [{"run_id": record["run_id"], "duration": record.get("duration")}]
+        return [{"run_id": record["run_id"], "duration": record.get("duration"),
+                 "end_height": record.get("end_height")}]
     return []
+
+
+def completion_run_text(item: dict[str, Any]) -> str:
+    """Report overall genesis sync throughput only for a confirmed ending height."""
+    duration = item.get("duration")
+    valid_duration = type(duration) is int and duration >= 0
+    timing = (f"{duration // 3600}h {duration % 3600 // 60:02d}m"
+              if valid_duration else "duration unavailable")
+    height = item.get("end_height")
+    if type(height) is not int or not 0 <= height <= 0xFFFFFFFF:
+        return f"{timing} · blocks and BPS unavailable"
+    # Every cycle starts from empty chain state; height zero is genesis.
+    blocks = height + 1
+    count = f"{blocks / 1_000_000:.2f}M" if blocks >= 1_000_000 else f"{blocks:,}"
+    rate = f"{blocks / duration:.0f} blocks/sec" if valid_duration and duration > 0 else "BPS unavailable"
+    return f"{timing} · {count} blocks · {rate}"
 
 
 def completion_updates(
@@ -747,6 +764,7 @@ def completion_updates(
         # Old controllers still provide the latest timing during a staged rollout.
         history[total] = {
             "run_id": run_id, "duration": controller.get("last_success_duration_seconds"),
+            "end_height": controller.get("last_success_end_height"),
         }
         details = completion_details(old) + [history[number] for number in sorted(history)]
         records[name] = {
@@ -754,6 +772,7 @@ def completion_updates(
             "run_id": run_id, "total": total,
             "sha": controller.get("last_success_sha", "unknown"),
             "duration": controller.get("last_success_duration_seconds"),
+            "end_height": controller.get("last_success_end_height"),
             "pending": old.get("pending", 0) + delta,
             "details": details[-COMPLETION_DETAIL_LIMIT:],
         }
@@ -765,20 +784,15 @@ def completion_updates(
         for name in sorted(set(records) | configured):
             record = records.get(name, {})
             pending = record.get("pending", 0)
-            durations = [
-                item["duration"] for item in completion_details(record)
-                if type(item.get("duration")) is int and item["duration"] >= 0
-            ]
-            timings = [f"{seconds // 3600}h {seconds % 3600 // 60:02d}m" for seconds in durations]
-            missing = pending - len(durations)
-            if missing:
-                timings.append(f"{missing} duration(s) unavailable")
+            details = completion_details(record)
             label = (labels or {}).get(name, record.get("label", name))
-            line = f"{label}: {pending} completed"
-            if timings:
-                line += " · " + ", ".join(timings)
-            line += " · " + completion_status(statuses.get(name))
-            lines.append(line)
+            section = [f"*{label} · {pending} completed*"]
+            section.extend(f"• {completion_run_text(item)}" for item in details)
+            missing = pending - len(details)
+            if missing:
+                section.append(f"• {missing} earlier run(s): details unavailable")
+            section.append(completion_status(statuses.get(name)))
+            lines.append("\n".join(section))
             if name not in configured:
                 records.pop(name, None)
             elif name in records:
@@ -829,7 +843,9 @@ def cmd_audit(args: argparse.Namespace) -> int:
     text = audit_message(new_lines, reminder_lines, recovered_lines)
     if completion_lines:
         text += ("\n\n" if text else "") + (
-            ":memo: Mainnet sync summary — since previous digest\n" + "\n".join(completion_lines)
+            ":memo: Mainnet sync summary — since previous digest\n\n"
+            + "\n\n".join(completion_lines)
+            + "\n\nRuns listed oldest first. Each run starts from genesis."
         )
 
     posted = True

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -736,8 +736,11 @@ def completion_updates(
             continue
         baseline = old.get("total", controller.get("completion_digest_start_runs", total - 1))
         delta = max(1, total - baseline) if type(baseline) is int else 1
+        raw_history = controller.get("completion_history", [])
+        if not isinstance(raw_history, list):
+            raw_history = []
         history = {
-            item["number"]: item for item in controller.get("completion_history", [])
+            item["number"]: item for item in raw_history
             if isinstance(item, dict) and type(item.get("number")) is int
             and total - delta < item["number"] <= total and item.get("run_id")
         }

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -756,7 +756,10 @@ def completion_updates(
         }
     lines = []
     if digest_due:
-        for name in sorted(set(records) | set(statuses) | set(labels or {})):
+        configured = set(labels) if labels is not None else set(statuses)
+        records = {name: record for name, record in records.items()
+                   if name in configured or record.get("pending", 0)}
+        for name in sorted(set(records) | configured):
             record = records.get(name, {})
             pending = record.get("pending", 0)
             durations = [
@@ -773,7 +776,9 @@ def completion_updates(
                 line += " · " + ", ".join(timings)
             line += " · " + completion_status(statuses.get(name))
             lines.append(line)
-            if name in records:
+            if name not in configured:
+                records.pop(name, None)
+            elif name in records:
                 records[name] = {**record, "label": label, "pending": 0, "details": []}
     return lines, records
 

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -723,12 +723,11 @@ def completion_run_text(item: dict[str, Any]) -> str:
               if valid_duration else "duration unavailable")
     height = item.get("end_height")
     if type(height) is not int or not 0 <= height <= 0xFFFFFFFF:
-        return f"{timing} · blocks and BPS unavailable"
+        return f"{timing} · BPS unavailable"
     # Every cycle starts from empty chain state; height zero is genesis.
     blocks = height + 1
-    count = f"{blocks / 1_000_000:.2f}M" if blocks >= 1_000_000 else f"{blocks:,}"
     rate = f"{blocks / duration:.0f} blocks/sec" if valid_duration and duration > 0 else "BPS unavailable"
-    return f"{timing} · {count} blocks · {rate}"
+    return f"{timing} · {rate}"
 
 
 def completion_updates(

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -669,42 +669,100 @@ def audit_message(
     return "\n\n".join(sections)
 
 
-def completion_updates(
-    statuses: dict[str, dict[str, Any]], previous: dict[str, Any], digest_due: bool
-) -> tuple[list[str], dict[str, Any]]:
-    """Accumulate completed runs until a digest is successfully delivered.
+COMPLETION_DETAIL_LIMIT = 256
 
-    A new cache counts from when the controller enabled digests. Missing hosts
-    retain pending counts; a counter reset counts the new success once.
+
+def sync_label(node: Node) -> str:
+    modes = {
+        "dual": "dual networking",
+        "zakura": "Zakura networking only",
+        "legacy": "legacy networking only",
+    }
+    mode = modes.get(node.raw.get("p2p_stack"))
+    return f"Mainnet sync — {mode} ({node.name})" if mode else node.name
+
+
+def completion_status(data: dict[str, Any] | None) -> str:
+    if data is None:
+        return "status unavailable"
+    controller = data.get("controller_state") or {}
+    if controller.get("failed"):
+        return "halted after failure"
+    phase = controller.get("phase")
+    if phase == "syncing":
+        return "currently syncing"
+    if phase == "complete":
+        return "between runs"
+    return f"current phase: {phase}" if phase else "status unavailable"
+
+
+def completion_details(record: dict[str, Any]) -> list[dict[str, Any]]:
+    """Upgrade old audit caches without inventing timings for earlier runs."""
+    if "details" in record:
+        return list(record["details"])
+    if record.get("pending") and record.get("run_id"):
+        return [{"run_id": record["run_id"], "duration": record.get("duration")}]
+    return []
+
+
+def completion_updates(
+    statuses: dict[str, dict[str, Any]], previous: dict[str, Any], digest_due: bool,
+    labels: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, Any]]:
+    """Accumulate completions until delivery, preserving timings between audits.
+
+    Counters remain authoritative if history is missing or exceeds retention.
+    Missing hosts retain pending completions. Cache migration and counter resets
+    preserve the old counts; unavailable timings are explicitly reported.
     """
-    records = dict(previous.get("completions", {}))
+    records = {name: dict(record) for name, record in previous.get("completions", {}).items()}
+    for name in sorted(set(statuses) | set(labels or {})):
+        record = records.setdefault(name, {})
+        record["label"] = (labels or {}).get(name, record.get("label", name))
     for name, data in statuses.items():
         controller = data.get("controller_state") or {}
         run_id = controller.get("last_success_run")
         total = controller.get("runs")
         if not controller.get("completion_digest") or not run_id or type(total) is not int:
             continue
-        old = records.get(name, {})
+        old = records[name]
         if old.get("run_id") == run_id:
             continue
         baseline = old.get("total", controller.get("completion_digest_start_runs", total - 1))
         delta = max(1, total - baseline) if type(baseline) is int else 1
+        history = {
+            item["number"]: item for item in controller.get("completion_history", [])
+            if isinstance(item, dict) and type(item.get("number")) is int
+            and total - delta < item["number"] <= total and item.get("run_id")
+        }
+        # Old controllers still provide the latest timing during a staged rollout.
+        history[total] = {
+            "run_id": run_id, "duration": controller.get("last_success_duration_seconds"),
+        }
+        details = completion_details(old) + [history[number] for number in sorted(history)]
         records[name] = {
-            "run_id": run_id, "total": total,
+            "label": old["label"], "run_id": run_id, "total": total,
             "pending": old.get("pending", 0) + delta,
-            "sha": controller.get("last_success_sha", "unknown"),
-            "duration": controller.get("last_success_duration_seconds"),
+            "details": details[-COMPLETION_DETAIL_LIMIT:],
         }
     lines = []
     if digest_due:
         for name, record in sorted(records.items()):
-            if record.get("pending", 0):
-                lines.append(
-                    f"{name}: {record['pending']} completed run(s); "
-                    f"latest={record['run_id']} | sha={record['sha']} | "
-                    f"sync time={record['duration']}s"
-                )
-                records[name] = {**record, "pending": 0}
+            pending = record.get("pending", 0)
+            durations = [
+                item["duration"] for item in completion_details(record)
+                if type(item.get("duration")) is int and item["duration"] >= 0
+            ]
+            timings = [f"{seconds // 3600}h {seconds % 3600 // 60:02d}m" for seconds in durations]
+            missing = pending - len(durations)
+            if missing:
+                timings.append(f"{missing} duration(s) unavailable")
+            line = f"{record.get('label', name)}: {pending} completed"
+            if timings:
+                line += " · " + ", ".join(timings)
+            line += " · " + completion_status(statuses.get(name))
+            lines.append(line)
+            records[name] = {**record, "pending": 0, "details": []}
     return lines, records
 
 
@@ -744,12 +802,14 @@ def cmd_audit(args: argparse.Namespace) -> int:
         destination=destination,
     )
     state["problems"].update({k: v for k, v in prior_problems.items() if k not in selected})
-    completion_lines, state["completions"] = completion_updates(statuses, previous, digest_due)
+    completion_lines, state["completions"] = completion_updates(
+        statuses, previous, digest_due, {node.name: sync_label(node) for node in nodes}
+    )
     state["last_digest_at"] = timestamp if digest_due else last_digest
     text = audit_message(new_lines, reminder_lines, recovered_lines)
     if completion_lines:
         text += ("\n\n" if text else "") + (
-            ":memo: Zakura continuous sync digest — completions\n" + "\n".join(completion_lines)
+            ":memo: Mainnet sync summary — since previous digest\n" + "\n".join(completion_lines)
         )
 
     posted = True

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1292,7 +1292,10 @@ class NotificationTests(unittest.TestCase):
                     result, post = self.audit(path, data, boundary)
                     self.assertEqual(result, 1)
                     if age < 86400:
-                        post.assert_not_called()
+                        post.assert_called_once()
+                        self.assertIn("0 completed", post.call_args.args[0])
+                        self.assertNotIn("unresolved", post.call_args.args[0])
+                        self.assertNotIn("controller halted: boom", post.call_args.args[0])
                         self.assertEqual(deploy.load_audit_state(path)["problems"]["node"]["last_sent"], sent_at)
                     else:
                         post.assert_called_once()
@@ -1382,6 +1385,86 @@ class NotificationTests(unittest.TestCase):
         lines, _ = deploy.completion_updates(data, {"completions": delivered}, True)
         self.assertIn("0 completed", lines[0])
         self.assertNotIn("7h", lines[0])
+
+    def test_multiple_audits_and_failed_delivery_preserve_each_duration(self):
+        data = {"controller_state": {
+            "completion_digest": True, "completion_digest_start_runs": 0,
+            "last_success_run": "run-1", "last_success_duration_seconds": 3600,
+            "runs": 1, "phase": "syncing",
+            "completion_history": [{"number": 1, "run_id": "run-1", "duration": 3600}],
+        }, "disk_free_bytes": 20 * 1024**3,
+            "service_active": True, "sample": {"metrics_status": "ok"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            _, post = self.audit(path, data, 1000)
+            post.assert_not_called()
+            data["controller_state"].update({
+                "last_success_run": "run-3", "last_success_duration_seconds": 10800,
+                "runs": 3,
+                "completion_history": [
+                    {"number": n, "run_id": f"run-{n}", "duration": n * 3600}
+                    for n in range(1, 4)
+                ],
+            })
+            _, post = self.audit(path, data, 2000)
+            post.assert_not_called()
+            saved = path.read_text()
+            _, post = self.audit(path, data, 87400, posted=False)
+            expected = "3 completed · 1h 00m, 2h 00m, 3h 00m"
+            self.assertIn(expected, post.call_args.args[0])
+            self.assertEqual(path.read_text(), saved)
+            _, post = self.audit(path, data, 87460)
+            self.assertIn(expected, post.call_args.args[0])
+            _, post = self.audit(path, data, 88000)
+            post.assert_not_called()
+            self.assertEqual(deploy.load_audit_state(path)["completions"]["node"]["pending"], 0)
+
+    def test_invalid_cached_details_cannot_break_failure_notifications(self):
+        for details in (None, "bad", [None], [{}] * 257):
+            with self.subTest(details_type=type(details)), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "state.json"
+                deploy.save_audit_state(path, {
+                    "version": deploy.AUDIT_STATE_VERSION, "problems": {},
+                    "completions": {"node": {
+                        "run_id": "old", "total": 1, "pending": 1,
+                        "sha": "abc", "duration": 60, "details": details,
+                    }},
+                })
+                data = self.halted_status()
+                del data["controller_state"]["failure_notification"]
+                result, post = self.audit(path, data, 1000)
+                self.assertEqual(result, 1)
+                self.assertIn("controller halted", post.call_args.args[0])
+
+    def test_zero_completion_summary_does_not_reset_first_completion_baseline(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            data = {"controller_state": {"runs": 260, "phase": "complete"},
+                    "disk_free_bytes": 20 * 1024**3}
+            self.audit(path, data, 1000)
+            _, post = self.audit(path, data, 87400)
+            self.assertIn("0 completed", post.call_args.args[0])
+            data["controller_state"].update({
+                "runs": 261, "completion_digest": True, "completion_digest_start_runs": 260,
+                "last_success_run": "new", "last_success_duration_seconds": 3600,
+            })
+            self.audit(path, data, 88000)
+            records = deploy.load_audit_state(path)["completions"]
+            self.assertEqual(records["node"]["pending"], 1)
+            _, post = self.audit(path, data, 173800)
+            self.assertIn("1 completed · 1h 00m", post.call_args.args[0])
+
+    def test_sync_status_does_not_hide_inactive_service_or_missing_metrics(self):
+        for extra, expected in (
+            ({"service_active": False}, "node service inactive"),
+            ({"sample": {"metrics_status": "connection refused"}},
+             "sync status unavailable (metrics unavailable)"),
+        ):
+            with self.subTest(expected=expected):
+                data = {"controller_state": {"phase": "syncing"}, **extra}
+                lines, _ = deploy.completion_updates({"node": data}, {}, True)
+                self.assertIn(expected, lines[0])
+                self.assertNotIn("currently syncing", lines[0])
 
     def test_digest_upgrade_and_retention_report_missing_timings(self):
         previous = {"completions": {"node": {

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1409,7 +1409,7 @@ class NotificationTests(unittest.TestCase):
             section = next(line for line in lines if f"({mode})" in line)
             expected = [f"*{label} ({mode}) · {len(durations)} completed*"]
             expected.extend(
-                f"• {duration // 3600}h {duration % 3600 // 60:02d}m · 3.47M blocks · {rate} blocks/sec"
+                f"• {duration // 3600}h {duration % 3600 // 60:02d}m · {rate} blocks/sec"
                 for duration, rate in zip(durations, rates)
             )
             expected.append("currently syncing")
@@ -1417,14 +1417,14 @@ class NotificationTests(unittest.TestCase):
 
     def test_completion_throughput_requires_valid_height_and_nonzero_duration(self):
         self.assertEqual(deploy.completion_run_text({"duration": 24000, "end_height": 3469999}),
-                         "6h 40m · 3.47M blocks · 145 blocks/sec")
+                         "6h 40m · 145 blocks/sec")
         self.assertEqual(deploy.completion_run_text({"duration": 2, "end_height": 3}),
-                         "0h 00m · 4 blocks · 2 blocks/sec")
+                         "0h 00m · 2 blocks/sec")
         self.assertEqual(deploy.completion_run_text({"duration": 1, "end_height": 0}),
-                         "0h 00m · 1 blocks · 1 blocks/sec")
+                         "0h 00m · 1 blocks/sec")
         for height in (None, -1, True, "3469999", 2**32):
             with self.subTest(height=height):
-                self.assertIn("blocks and BPS unavailable",
+                self.assertIn("BPS unavailable",
                               deploy.completion_run_text({"duration": 3600, "end_height": height}))
         for duration in (0, None, -1, True, "3600"):
             with self.subTest(duration=duration):
@@ -1504,9 +1504,9 @@ class NotificationTests(unittest.TestCase):
             post.assert_not_called()
             saved = path.read_text()
             _, post = self.audit(path, data, 87400, posted=False)
-            expected = ("• 1h 00m · 3.60M blocks · 1000 blocks/sec\n"
-                        "• 2h 00m · 3.24M blocks · 450 blocks/sec\n"
-                        "• 3h 00m · 3.78M blocks · 350 blocks/sec")
+            expected = ("• 1h 00m · 1000 blocks/sec\n"
+                        "• 2h 00m · 450 blocks/sec\n"
+                        "• 3h 00m · 350 blocks/sec")
             self.assertIn(expected, post.call_args.args[0])
             self.assertEqual(path.read_text(), saved)
             _, post = self.audit(path, data, 87460)

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1359,8 +1359,30 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(records["node"]["pending"], 3)
         lines, records = deploy.completion_updates({}, {"completions": records}, True)
         self.assertIn("3 completed", lines[0])
-        self.assertEqual(records["node"]["pending"], 0)
+        self.assertNotIn("node", records)
         self.assertEqual(previous["completions"]["node"]["pending"], 2)
+
+    def test_retired_hosts_deliver_pending_once_then_leave_the_summary(self):
+        previous = {"completions": {name: {
+            "run_id": name, "total": 2, "pending": pending,
+            "sha": "abc", "duration": 3600,
+        } for name, pending in (("retired", 2), ("already-delivered", 0), ("active", 0))}}
+        labels = {"active": "Active host"}
+        before = json.dumps(previous, sort_keys=True)
+        _, waiting = deploy.completion_updates({}, previous, False, labels)
+        self.assertEqual(waiting, previous["completions"])
+        lines, records = deploy.completion_updates({}, previous, True, labels)
+        self.assertEqual(len(lines), 2)
+        self.assertIn("retired: 2 completed", lines[1])
+        self.assertIn("Active host: 0 completed", lines[0])
+        self.assertEqual(set(records), {"active"})
+        # Failed delivery leaves the input cache intact, so a retry is identical.
+        self.assertEqual(json.dumps(previous, sort_keys=True), before)
+        retry, _ = deploy.completion_updates({}, previous, True, labels)
+        self.assertEqual(retry, lines)
+        later, _ = deploy.completion_updates({}, {"completions": records}, True, labels)
+        self.assertEqual(len(later), 1)
+        self.assertIn("Active host: 0 completed", later[0])
 
     def test_digest_preserves_all_timings_across_missed_audits(self):
         controller = {

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -75,6 +75,28 @@ class ContinuousSyncTests(unittest.TestCase):
         self.assertEqual(status["sync.downloads.in_flight"], 17)
         self.assertEqual(status["sync.downloads.verifying"], 4)
 
+    def test_final_ready_sample_supplies_confirmed_height_without_stale_fallback(self):
+        for final_height in (101, None, -1, True, 2**32):
+            with self.subTest(final_height=final_height), tempfile.TemporaryDirectory() as tmp:
+                config = make_config(Path(tmp))
+                run_dir = Path(tmp) / "run"
+                run_dir.mkdir()
+                early = {"ready": True, "height": 100, "zcash_chain_verified_block_height": 100}
+                final = {"ready": True, "height": 105, "height_source": "estimated_tip_minus_distance",
+                         "zcash_chain_verified_block_height": final_height}
+                run_state = {}
+                with (
+                    patch.object(sync, "service_active", return_value=True),
+                    patch.object(sync, "check_free_space"),
+                    patch.object(sync, "now", return_value=1000),
+                    patch.object(sync.time, "sleep"),
+                    patch.object(sync, "sample_status", side_effect=[early] * 5 + [final]),
+                ):
+                    sync.wait_for_completion(config, run_dir, run_state)
+                self.assertEqual(run_state["end_height"], 101 if final_height == 101 else None)
+                # Progress tracking can still use estimates; throughput cannot.
+                self.assertEqual(run_state["height"], 105)
+
     def test_alert_status_falls_back_to_estimated_height(self):
         metrics = "\n".join(
             [
@@ -1362,6 +1384,53 @@ class NotificationTests(unittest.TestCase):
         self.assertNotIn("node", records)
         self.assertEqual(previous["completions"]["node"]["pending"], 2)
 
+    def test_three_mode_summary_shows_one_three_and_one_runs(self):
+        statuses, labels = {}, {}
+        cases = (
+            ("dual", [24000], "Dual networking", [145]),
+            ("zakura", [25800, 25200, 26400], "Zakura networking only", [134, 138, 131]),
+            ("legacy", [28800], "Legacy networking only", [120]),
+        )
+        for mode, durations, label, rates in cases:
+            node = deploy.Node({"name": mode, "p2p_stack": mode})
+            labels[mode] = deploy.sync_label(node)
+            statuses[mode] = {"controller_state": {
+                "phase": "syncing", "completion_digest": True, "completion_digest_start_runs": 0,
+                "runs": len(durations), "last_success_run": f"{mode}-{len(durations)}",
+                "last_success_duration_seconds": durations[-1], "last_success_end_height": 3469999,
+                "completion_history": [
+                    {"number": n, "run_id": f"{mode}-{n}", "duration": duration, "end_height": 3469999}
+                    for n, duration in enumerate(durations, 1)
+                ],
+            }}
+        lines, _ = deploy.completion_updates(statuses, {}, True, labels)
+        self.assertEqual(len(lines), 3)
+        for mode, durations, label, rates in cases:
+            section = next(line for line in lines if f"({mode})" in line)
+            expected = [f"*{label} ({mode}) · {len(durations)} completed*"]
+            expected.extend(
+                f"• {duration // 3600}h {duration % 3600 // 60:02d}m · 3.47M blocks · {rate} blocks/sec"
+                for duration, rate in zip(durations, rates)
+            )
+            expected.append("currently syncing")
+            self.assertEqual(section, "\n".join(expected))
+
+    def test_completion_throughput_requires_valid_height_and_nonzero_duration(self):
+        self.assertEqual(deploy.completion_run_text({"duration": 24000, "end_height": 3469999}),
+                         "6h 40m · 3.47M blocks · 145 blocks/sec")
+        self.assertEqual(deploy.completion_run_text({"duration": 2, "end_height": 3}),
+                         "0h 00m · 4 blocks · 2 blocks/sec")
+        self.assertEqual(deploy.completion_run_text({"duration": 1, "end_height": 0}),
+                         "0h 00m · 1 blocks · 1 blocks/sec")
+        for height in (None, -1, True, "3469999", 2**32):
+            with self.subTest(height=height):
+                self.assertIn("blocks and BPS unavailable",
+                              deploy.completion_run_text({"duration": 3600, "end_height": height}))
+        for duration in (0, None, -1, True, "3600"):
+            with self.subTest(duration=duration):
+                self.assertIn("BPS unavailable",
+                              deploy.completion_run_text({"duration": duration, "end_height": 3469999}))
+
     def test_retired_hosts_deliver_pending_once_then_leave_the_summary(self):
         previous = {"completions": {name: {
             "run_id": name, "total": 2, "pending": pending,
@@ -1373,8 +1442,8 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(waiting, previous["completions"])
         lines, records = deploy.completion_updates({}, previous, True, labels)
         self.assertEqual(len(lines), 2)
-        self.assertIn("retired: 2 completed", lines[1])
-        self.assertIn("Active host: 0 completed", lines[0])
+        self.assertIn("retired · 2 completed", lines[1])
+        self.assertIn("Active host · 0 completed", lines[0])
         self.assertEqual(set(records), {"active"})
         # Failed delivery leaves the input cache intact, so a retry is identical.
         self.assertEqual(json.dumps(previous, sort_keys=True), before)
@@ -1382,7 +1451,7 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(retry, lines)
         later, _ = deploy.completion_updates({}, {"completions": records}, True, labels)
         self.assertEqual(len(later), 1)
-        self.assertIn("Active host: 0 completed", later[0])
+        self.assertIn("Active host · 0 completed", later[0])
 
     def test_digest_preserves_all_timings_across_missed_audits(self):
         controller = {
@@ -1400,8 +1469,10 @@ class NotificationTests(unittest.TestCase):
         _, records = deploy.completion_updates(data, {}, False, {"node": label})
         before = json.dumps(records, sort_keys=True)
         lines, delivered = deploy.completion_updates(data, {"completions": records}, True)
-        self.assertIn("Mainnet sync — Zakura networking only (node)", lines[0])
-        self.assertIn("3 completed · 7h 29m, 7h 08m, 7h 13m", lines[0])
+        self.assertIn("Zakura networking only (node)", lines[0])
+        self.assertIn("3 completed", lines[0])
+        self.assertEqual([line.split(" · ")[0] for line in lines[0].splitlines()[1:4]],
+                         ["• 7h 29m", "• 7h 08m", "• 7h 13m"])
         self.assertIn("currently syncing", lines[0])
         self.assertEqual(json.dumps(records, sort_keys=True), before)
         lines, _ = deploy.completion_updates(data, {"completions": delivered}, True)
@@ -1413,7 +1484,8 @@ class NotificationTests(unittest.TestCase):
             "completion_digest": True, "completion_digest_start_runs": 0,
             "last_success_run": "run-1", "last_success_duration_seconds": 3600,
             "runs": 1, "phase": "syncing",
-            "completion_history": [{"number": 1, "run_id": "run-1", "duration": 3600}],
+            "last_success_end_height": 3599999,
+            "completion_history": [{"number": 1, "run_id": "run-1", "duration": 3600, "end_height": 3599999}],
         }, "disk_free_bytes": 20 * 1024**3,
             "service_active": True, "sample": {"metrics_status": "ok"}}
         with tempfile.TemporaryDirectory() as tmp:
@@ -1422,17 +1494,19 @@ class NotificationTests(unittest.TestCase):
             post.assert_not_called()
             data["controller_state"].update({
                 "last_success_run": "run-3", "last_success_duration_seconds": 10800,
-                "runs": 3,
+                "last_success_end_height": 3779999, "runs": 3,
                 "completion_history": [
-                    {"number": n, "run_id": f"run-{n}", "duration": n * 3600}
-                    for n in range(1, 4)
+                    {"number": n, "run_id": f"run-{n}", "duration": n * 3600, "end_height": blocks - 1}
+                    for n, blocks in enumerate((3600000, 3240000, 3780000), 1)
                 ],
             })
             _, post = self.audit(path, data, 2000)
             post.assert_not_called()
             saved = path.read_text()
             _, post = self.audit(path, data, 87400, posted=False)
-            expected = "3 completed · 1h 00m, 2h 00m, 3h 00m"
+            expected = ("• 1h 00m · 3.60M blocks · 1000 blocks/sec\n"
+                        "• 2h 00m · 3.24M blocks · 450 blocks/sec\n"
+                        "• 3h 00m · 3.78M blocks · 350 blocks/sec")
             self.assertIn(expected, post.call_args.args[0])
             self.assertEqual(path.read_text(), saved)
             _, post = self.audit(path, data, 87460)
@@ -1474,7 +1548,7 @@ class NotificationTests(unittest.TestCase):
             records = deploy.load_audit_state(path)["completions"]
             self.assertEqual(records["node"]["pending"], 1)
             _, post = self.audit(path, data, 173800)
-            self.assertIn("1 completed · 1h 00m", post.call_args.args[0])
+            self.assertIn("1 completed*\n• 1h 00m", post.call_args.args[0])
 
     def test_sync_status_does_not_hide_inactive_service_or_missing_metrics(self):
         for extra, expected in (
@@ -1505,7 +1579,8 @@ class NotificationTests(unittest.TestCase):
                 records = deploy.load_audit_state(path)["completions"]
                 self.assertEqual(records["node"]["pending"], 3)
                 _, post = self.audit(path, data, 87400)
-                self.assertIn("3 completed · 1h 00m, 2 duration(s) unavailable", post.call_args.args[0])
+                self.assertIn("3 completed*\n• 1h 00m", post.call_args.args[0])
+                self.assertIn("2 earlier run(s): details unavailable", post.call_args.args[0])
 
     def test_digest_upgrade_and_retention_report_missing_timings(self):
         previous = {"completions": {"node": {
@@ -1516,7 +1591,9 @@ class NotificationTests(unittest.TestCase):
             "last_success_duration_seconds": 7200,
         }}}
         lines, _ = deploy.completion_updates(data, previous, True)
-        self.assertIn("5 completed · 1h 00m, 2h 00m, 3 duration(s) unavailable", lines[0])
+        self.assertIn("5 completed*\n• 1h 00m", lines[0])
+        self.assertIn("• 2h 00m", lines[0])
+        self.assertIn("3 earlier run(s): details unavailable", lines[0])
         controller = data["node"]["controller_state"]
         controller.update({
             "completion_digest_start_runs": 0, "runs": 300,
@@ -1529,7 +1606,7 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(len(records["node"]["details"]), 256)
         lines, _ = deploy.completion_updates({}, {"completions": records}, True)
         self.assertIn("300 completed", lines[0])
-        self.assertIn("44 duration(s) unavailable", lines[0])
+        self.assertIn("44 earlier run(s): details unavailable", lines[0])
         self.assertIn("status unavailable", lines[0])
 
     def test_digest_lists_zero_completions_with_observed_status(self):
@@ -1541,9 +1618,9 @@ class NotificationTests(unittest.TestCase):
                   for name, mode in (("dual", "dual"), ("legacy", "legacy"), ("new", "zakura"))}
         lines, _ = deploy.completion_updates(data, {}, True, labels)
         self.assertEqual(len(lines), 3)
-        self.assertIn("dual networking (dual): 0 completed · currently syncing", lines[0])
-        self.assertIn("legacy networking only (legacy): 0 completed · halted after failure", lines[1])
-        self.assertIn("Zakura networking only (new): 0 completed · status unavailable", lines[2])
+        self.assertIn("Dual networking (dual) · 0 completed*\ncurrently syncing", lines[0])
+        self.assertIn("Legacy networking only (legacy) · 0 completed*\nhalted after failure", lines[1])
+        self.assertIn("Zakura networking only (new) · 0 completed*\nstatus unavailable", lines[2])
 
     def test_targeted_audit_cannot_recover_unobserved_nodes_or_consume_digest(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1570,10 +1647,12 @@ class NotificationTests(unittest.TestCase):
                     config = make_config(Path(tmp))
                     for name in (
                         "preflight", "build_binary", "sha256_file", "install_binary", "stop_service",
-                        "safe_wipe_state", "render_config", "start_service", "wait_for_completion",
+                        "safe_wipe_state", "render_config", "start_service",
                         "archive_run_log", "cleanup_retention",
                     ):
                         stack.enter_context(patch.object(sync, name, return_value="test"))
+                    stack.enter_context(patch.object(sync, "wait_for_completion",
+                        side_effect=lambda _config, _run_dir, run_state: run_state.update(end_height=3469999)))
                     stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))
                     stack.enter_context(patch.object(sync, "now", return_value=1000))
                     post = stack.enter_context(patch.object(sync, "post_slack"))
@@ -1592,7 +1671,9 @@ class NotificationTests(unittest.TestCase):
                     ))
                     self.assertEqual(history[-1], {
                         "number": 261, "run_id": state["current_run"], "duration": 0,
+                        "end_height": 3469999,
                     })
+                    self.assertEqual(state["last_success_end_height"], 3469999)
                     self.assertEqual(state["completion_digest_start_runs"], 260)
                     self.assertEqual(sync.load_state(path)["last_success_run"], state["current_run"])
 

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1265,10 +1265,10 @@ class NotificationTests(unittest.TestCase):
             _, post = self.audit(path, data, 87400, posted=False)
             text = post.call_args.args[0]
             self.assertIn("unresolved", text)
-            self.assertIn("3 completed run(s)", text)
+            self.assertIn("3 completed", text)
             self.assertEqual(path.read_text(), old)
             _, post = self.audit(path, data, 87460)
-            self.assertIn("3 completed run(s)", post.call_args.args[0])
+            self.assertIn("3 completed", post.call_args.args[0])
             _, post = self.audit(path, data, 88000)
             post.assert_not_called()
 
@@ -1320,7 +1320,7 @@ class NotificationTests(unittest.TestCase):
             result, post = self.audit(path, data, 87400)
             self.assertEqual(result, 1)
             post.assert_called_once()
-            self.assertIn("3 completed run(s)", post.call_args.args[0])
+            self.assertIn("3 completed", post.call_args.args[0])
             self.assertNotIn("unresolved", post.call_args.args[0])
             self.assertEqual(deploy.load_audit_state(path)["problems"]["node"]["last_sent"], 87395)
 
@@ -1355,9 +1355,71 @@ class NotificationTests(unittest.TestCase):
         self.assertEqual(lines, [])
         self.assertEqual(records["node"]["pending"], 3)
         lines, records = deploy.completion_updates({}, {"completions": records}, True)
-        self.assertIn("3 completed run(s)", lines[0])
+        self.assertIn("3 completed", lines[0])
         self.assertEqual(records["node"]["pending"], 0)
         self.assertEqual(previous["completions"]["node"]["pending"], 2)
+
+    def test_digest_preserves_all_timings_across_missed_audits(self):
+        controller = {
+            "completion_digest": True, "completion_digest_start_runs": 0,
+            "last_success_run": "run-3", "runs": 3,
+            "last_success_duration_seconds": 25989, "phase": "syncing",
+            "completion_history": [
+                {"number": 1, "run_id": "run-1", "duration": 26979},
+                {"number": 2, "run_id": "run-2", "duration": 25696},
+                {"number": 3, "run_id": "run-3", "duration": 25989},
+            ],
+        }
+        data = {"node": {"controller_state": controller}}
+        label = deploy.sync_label(deploy.Node({"name": "node", "p2p_stack": "zakura"}))
+        _, records = deploy.completion_updates(data, {}, False, {"node": label})
+        before = json.dumps(records, sort_keys=True)
+        lines, delivered = deploy.completion_updates(data, {"completions": records}, True)
+        self.assertIn("Mainnet sync — Zakura networking only (node)", lines[0])
+        self.assertIn("3 completed · 7h 29m, 7h 08m, 7h 13m", lines[0])
+        self.assertIn("currently syncing", lines[0])
+        self.assertEqual(json.dumps(records, sort_keys=True), before)
+        lines, _ = deploy.completion_updates(data, {"completions": delivered}, True)
+        self.assertIn("0 completed", lines[0])
+        self.assertNotIn("7h", lines[0])
+
+    def test_digest_upgrade_and_retention_report_missing_timings(self):
+        previous = {"completions": {"node": {
+            "run_id": "old", "total": 4, "pending": 3, "duration": 3600,
+        }}}
+        data = {"node": {"controller_state": {
+            "completion_digest": True, "last_success_run": "new", "runs": 6,
+            "last_success_duration_seconds": 7200,
+        }}}
+        lines, _ = deploy.completion_updates(data, previous, True)
+        self.assertIn("5 completed · 1h 00m, 2h 00m, 3 duration(s) unavailable", lines[0])
+        controller = data["node"]["controller_state"]
+        controller.update({
+            "completion_digest_start_runs": 0, "runs": 300,
+            "completion_history": [
+                {"number": n, "run_id": f"run-{n}", "duration": 3600}
+                for n in range(1, 300)
+            ],
+        })
+        _, records = deploy.completion_updates(data, {}, False)
+        self.assertEqual(len(records["node"]["details"]), 256)
+        lines, _ = deploy.completion_updates({}, {"completions": records}, True)
+        self.assertIn("300 completed", lines[0])
+        self.assertIn("44 duration(s) unavailable", lines[0])
+        self.assertIn("status unavailable", lines[0])
+
+    def test_digest_lists_zero_completions_with_observed_status(self):
+        data = {
+            "dual": {"controller_state": {"phase": "syncing"}},
+            "legacy": {"controller_state": {"phase": "syncing", "failed": True}},
+        }
+        labels = {name: deploy.sync_label(deploy.Node({"name": name, "p2p_stack": mode}))
+                  for name, mode in (("dual", "dual"), ("legacy", "legacy"), ("new", "zakura"))}
+        lines, _ = deploy.completion_updates(data, {}, True, labels)
+        self.assertEqual(len(lines), 3)
+        self.assertIn("dual networking (dual): 0 completed · currently syncing", lines[0])
+        self.assertIn("legacy networking only (legacy): 0 completed · halted after failure", lines[1])
+        self.assertIn("Zakura networking only (new): 0 completed · status unavailable", lines[2])
 
     def test_targeted_audit_cannot_recover_unobserved_nodes_or_consume_digest(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1387,10 +1449,20 @@ class NotificationTests(unittest.TestCase):
             stack.enter_context(patch.object(sync, "now", return_value=1000))
             post = stack.enter_context(patch.object(sync, "post_slack"))
             path = config.paths.state_dir / "state.json"
-            state = sync.one_cycle(config, path, {"runs": 4})
+            state = sync.one_cycle(config, path, {
+                "runs": 260, "completion_history": [
+                    {"number": n, "run_id": f"old-{n}", "duration": 100}
+                    for n in range(5, 261)
+                ],
+            })
             post.assert_not_called()
-            self.assertEqual(state["runs"], 5)
-            self.assertEqual(state["completion_digest_start_runs"], 4)
+            self.assertEqual(state["runs"], 261)
+            history = sync.load_state(path)["completion_history"]
+            self.assertEqual(len(history), sync.COMPLETION_HISTORY_LIMIT)
+            self.assertEqual(history[-1], {
+                "number": 261, "run_id": state["current_run"], "duration": 0,
+            })
+            self.assertEqual(state["completion_digest_start_runs"], 260)
             self.assertEqual(sync.load_state(path)["last_success_run"], state["current_run"])
 
 

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1488,6 +1488,25 @@ class NotificationTests(unittest.TestCase):
                 self.assertIn(expected, lines[0])
                 self.assertNotIn("currently syncing", lines[0])
 
+    def test_malformed_controller_history_preserves_counts_and_failure_alerts(self):
+        for history in (None, {}, "bad", 7, [None, {"number": "bad"}]):
+            with self.subTest(history_type=type(history)), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "state.json"
+                data = self.halted_status()
+                del data["controller_state"]["failure_notification"]
+                data["controller_state"].update({
+                    "completion_digest": True, "completion_digest_start_runs": 0,
+                    "runs": 3, "last_success_run": "run-3",
+                    "last_success_duration_seconds": 3600, "completion_history": history,
+                })
+                result, post = self.audit(path, data, 1000)
+                self.assertEqual(result, 1)
+                self.assertIn("controller halted", post.call_args.args[0])
+                records = deploy.load_audit_state(path)["completions"]
+                self.assertEqual(records["node"]["pending"], 3)
+                _, post = self.audit(path, data, 87400)
+                self.assertIn("3 completed · 1h 00m, 2 duration(s) unavailable", post.call_args.args[0])
+
     def test_digest_upgrade_and_retention_report_missing_timings(self):
         previous = {"completions": {"node": {
             "run_id": "old", "total": 4, "pending": 3, "duration": 3600,
@@ -1542,33 +1561,40 @@ class NotificationTests(unittest.TestCase):
             self.assertEqual(loaded["last_digest_at"], 1)
 
     def test_successful_cycle_records_digest_without_sending_routine_message(self):
-        with tempfile.TemporaryDirectory() as tmp, contextlib.ExitStack() as stack:
-            config = make_config(Path(tmp))
-            for name in (
-                "preflight", "build_binary", "sha256_file", "install_binary", "stop_service",
-                "safe_wipe_state", "render_config", "start_service", "wait_for_completion",
-                "archive_run_log", "cleanup_retention",
-            ):
-                stack.enter_context(patch.object(sync, name, return_value="test"))
-            stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))
-            stack.enter_context(patch.object(sync, "now", return_value=1000))
-            post = stack.enter_context(patch.object(sync, "post_slack"))
-            path = config.paths.state_dir / "state.json"
-            state = sync.one_cycle(config, path, {
-                "runs": 260, "completion_history": [
-                    {"number": n, "run_id": f"old-{n}", "duration": 100}
-                    for n in range(5, 261)
-                ],
-            })
-            post.assert_not_called()
-            self.assertEqual(state["runs"], 261)
-            history = sync.load_state(path)["completion_history"]
-            self.assertEqual(len(history), sync.COMPLETION_HISTORY_LIMIT)
-            self.assertEqual(history[-1], {
-                "number": 261, "run_id": state["current_run"], "duration": 0,
-            })
-            self.assertEqual(state["completion_digest_start_runs"], 260)
-            self.assertEqual(sync.load_state(path)["last_success_run"], state["current_run"])
+        valid_history = [
+            {"number": n, "run_id": f"old-{n}", "duration": 100} for n in range(5, 261)
+        ]
+        for persisted_history in (valid_history, None, {}, "bad", 7, [None]):
+            with self.subTest(history_type=type(persisted_history)):
+                with tempfile.TemporaryDirectory() as tmp, contextlib.ExitStack() as stack:
+                    config = make_config(Path(tmp))
+                    for name in (
+                        "preflight", "build_binary", "sha256_file", "install_binary", "stop_service",
+                        "safe_wipe_state", "render_config", "start_service", "wait_for_completion",
+                        "archive_run_log", "cleanup_retention",
+                    ):
+                        stack.enter_context(patch.object(sync, name, return_value="test"))
+                    stack.enter_context(patch.object(sync, "resolve_sha", return_value="a" * 40))
+                    stack.enter_context(patch.object(sync, "now", return_value=1000))
+                    post = stack.enter_context(patch.object(sync, "post_slack"))
+                    path = config.paths.state_dir / "state.json"
+                    state = sync.one_cycle(config, path, {
+                        "runs": 260, "completion_history": persisted_history,
+                    })
+                    post.assert_not_called()
+                    self.assertFalse(state["failed"])
+                    self.assertEqual(state["phase"], "complete")
+                    self.assertEqual(state["runs"], 261)
+                    history = sync.load_state(path)["completion_history"]
+                    self.assertEqual(len(history), min(
+                        len(persisted_history) + 1 if isinstance(persisted_history, list) else 1,
+                        sync.COMPLETION_HISTORY_LIMIT,
+                    ))
+                    self.assertEqual(history[-1], {
+                        "number": 261, "run_id": state["current_run"], "duration": 0,
+                    })
+                    self.assertEqual(state["completion_digest_start_runs"], 260)
+                    self.assertEqual(sync.load_state(path)["last_success_run"], state["current_run"])
 
 
 class CanaryNotificationTests(unittest.TestCase):


### PR DESCRIPTION
## Motivation

The daily summary uses numbered machine names and shows only the latest duration, even when several syncs completed. It does not show each run’s average speed.

## Solution

Group runs by networking mode and show a separate row for each run: duration and average blocks per second. Hosts with zero completions still show their current status. New failures continue to alert immediately.

BPS uses the confirmed height at the final readiness check, including genesis. Block counts are kept for calculation but omitted from Slack. Average speed uses the full elapsed seconds; startup, readiness confirmation, shutdown, and log archiving are included. Missing historical data is marked unavailable. Retired hosts disappear after their pending results are delivered, and malformed optional history cannot halt a successful sync.

Example with illustrative numbers (Slack also includes host IDs and current status):

```text
Dual networking · 1 completed
• 6h 40m · 145 blocks/sec

Zakura networking only · 3 completed
• 7h 10m · 134 blocks/sec
• 7h 00m · 138 blocks/sec
• 7h 20m · 131 blocks/sec

Legacy networking only · 1 completed
• 8h 00m · 120 blocks/sec
```

Deployment requires updating the host controllers while preserving the newer storage changes already running there. The shared test fixture has been reconciled with the merged storage changes.

## Testing

All 97 combined continuous-sync and canary tests pass, including the three-mode example, per-run height/duration pairing across audits and delivery retries, missing or invalid metrics, zero duration, old caches, malformed history, retired hosts, and immediate failure alerts. Markdown lint passes. No production changes were made.
