### PR TITLE
chore(release): align the v1.4.0-rc0 end-of-support halt with v1.3.2

### DIFF
--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_475_945;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_477_083;
 
 /// The estimated number of blocks per day after Blossom.
 ///
@@ -28,12 +28,12 @@ pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Currently set to 27 days
+/// - Currently set to 24 days
 ///
-/// Note: v1.3.1 is estimated to release at height 3,470,235 (~2026-09-03)
-/// and halts 27 days later at height 3,501,339 (~2026-09-30) — the same
-/// halt block as v1.3.0, the day before October 1st.
-pub const EOS_PANIC_AFTER: u32 = 27;
+/// Note: v1.4.0-rc0 is estimated to release at height 3,477,083 (~2026-09-09)
+/// and halts 24 days later at height 3,504,731 (~2026-10-03) — the same
+/// halt block and date as v1.3.2, the previous release.
+pub const EOS_PANIC_AFTER: u32 = 24;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 3;

--- a/docs/changelog/unreleased/915.md
+++ b/docs/changelog/unreleased/915.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Shortened the end-of-support window to 24 days so v1.4.0-rc0 halts at block
+  3,504,731 — the same halt block and date (~2026-10-03) as v1.3.2
+  ([#915](https://github.com/zakura-core/zakura/pull/915)).


### PR DESCRIPTION
## Motivation

The v1.4.0-rc0 release must halt on roughly the same day as the previous
release. v1.3.2 halts at block 3,504,731 (~2026-10-03), but after the #914
release-state import raised the end-of-support floor to 3,475,945, preparing
v1.4.0-rc0 with the unchanged 27-day panic window would have produced a halt
at block 3,507,049 (~2026-10-05) — two days later than v1.3.2.

## Solution

Apply the same halt-parity recipe as #863 (which aligned v1.3.1 with v1.3.0),
against the new floor F = 3,475,945 and the v1.3.2 halt H = 3,504,731:

- `EOS_PANIC_AFTER = floor((H − F) / 1152) = 24`
- `ESTIMATED_RELEASE_HEIGHT = H − 24 × 1152 = 3,477,083`

The estimated release height lands 1,138 blocks above the floor (within
[F, F+1151]), so it passes release-state validation without a waiver, and it
is above the projected tag-time tip, so `prepare-release.sh` passes it through
untouched. The halt is exactly block 3,504,731 and the warn start
(always halt − 3 days) is 3,501,275 — both identical to v1.3.2.

This lands on main before the v1.4.0-rc0 prep workflow runs, so the release
branch needs no clobberable judgment commit.

## Testing

- `cargo test -p zakura end_of_support` — all 6 tests pass with the new
  constants (the halt/warn heights and dates are recomputed from the
  constants, and the date test tolerates the ~Oct 3 halt).
- `cargo fmt --all -- --check` — clean.
- Halt block verified by hand: 3,477,083 + 24 × 1,152 = 3,504,731 =
  3,473,627 + 27 × 1,152 (the v1.3.2 halt).

## Changelog

Fragment `docs/changelog/unreleased/915.md` added, following the #863
precedent (user-visible Changed entry). `./scripts/changelog.py check` and Markdown lint pass.

### Specifications & References

- #863 (v1.3.1 ↔ v1.3.0 halt alignment precedent)
- #914 (release-state import that raised the floor)

### Follow-up Work

The first release whose support window extends past 2026-10-01 without a
parity constraint should revisit `EOS_PANIC_AFTER` (the pre-1.3 value
was 40 days).
