### PR TITLE
fix(rpc): report block template transaction dependencies

### DIFF
--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -2753,7 +2753,7 @@ where
 
                 precomputed_coinbase = wait_for_new_tip => {
                     let chain_info = fetch_chain_info(read_state.clone()).await?;
-                    let mempool_tx_deps = TransactionDependencies::default();
+                    let mempool_tx_deps = Default::default();
 
                     let server_long_poll_id = LongPollInput::new(
                         chain_info.tip_height,

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -2753,6 +2753,7 @@ where
 
                 precomputed_coinbase = wait_for_new_tip => {
                     let chain_info = fetch_chain_info(read_state.clone()).await?;
+                    let mempool_tx_deps = TransactionDependencies::default();
 
                     let server_long_poll_id = LongPollInput::new(
                         chain_info.tip_height,
@@ -2783,6 +2784,7 @@ where
                         &chain_info,
                         server_long_poll_id,
                         vec![],
+                        &mempool_tx_deps,
                         submit_old,
                     )
                     .into())
@@ -2827,7 +2829,7 @@ where
             height,
             miner_params,
             mempool_txs,
-            mempool_tx_deps,
+            mempool_tx_deps.clone(),
         );
 
         tracing::debug!(
@@ -2847,6 +2849,7 @@ where
             &chain_info,
             server_long_poll_id,
             mempool_txs,
+            &mempool_tx_deps,
             submit_old,
         )
         .into())

--- a/crates/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template.rs
@@ -9,6 +9,7 @@ pub mod zip317;
 mod tests;
 
 use std::{
+    collections::HashMap,
     fmt::{self},
     sync::Arc,
 };
@@ -71,6 +72,56 @@ pub use proposal::{BlockProposalResponse, BlockTemplateTimeSource};
 /// See the `dependencies_depth()` function in [`zip317`] for more details.
 #[cfg(test)]
 type InBlockTxDependenciesDepth = usize;
+
+/// Converts selected mempool transactions into templates with their one-based
+/// direct dependency indexes.
+fn mempool_transaction_templates(
+    mempool_txs: &[VerifiedUnminedTx],
+    mempool_tx_deps: &TransactionDependencies,
+) -> Vec<TransactionTemplate<amount::NonNegative>> {
+    let transaction_indexes: HashMap<_, _> = mempool_txs
+        .iter()
+        .enumerate()
+        .map(|(index, tx)| {
+            let one_based_index = u16::try_from(index + 1)
+                .expect("the block size limit keeps transaction indexes within u16");
+
+            (tx.transaction.id().mined_id(), one_based_index)
+        })
+        .collect();
+
+    mempool_txs
+        .iter()
+        .enumerate()
+        .map(|(index, tx)| {
+            let transaction_id = tx.transaction.id().mined_id();
+            let mut dependency_indexes: Vec<_> = mempool_tx_deps
+                .dependencies()
+                .get(&transaction_id)
+                .into_iter()
+                .flatten()
+                .map(|dependency_id| {
+                    *transaction_indexes.get(dependency_id).expect(
+                        "selected dependent transactions have all dependencies in the template",
+                    )
+                })
+                .collect();
+
+            dependency_indexes.sort_unstable();
+
+            debug_assert!(
+                dependency_indexes
+                    .iter()
+                    .all(|dependency_index| usize::from(*dependency_index) <= index),
+                "transaction dependencies must precede their dependents"
+            );
+
+            let mut template = TransactionTemplate::from(tx);
+            template.depends = dependency_indexes;
+            template
+        })
+        .collect()
+}
 
 /// A serialized `getblocktemplate` RPC response in template mode.
 ///
@@ -277,6 +328,7 @@ impl BlockTemplateResponse {
         long_poll_id: LongPollId,
         #[cfg(not(test))] mempool_txs: Vec<VerifiedUnminedTx>,
         #[cfg(test)] mempool_txs: Vec<(InBlockTxDependenciesDepth, VerifiedUnminedTx)>,
+        mempool_tx_deps: &TransactionDependencies,
         submit_old: Option<bool>,
     ) -> Self {
         // Determine the next block height.
@@ -284,11 +336,6 @@ impl BlockTemplateResponse {
             .tip_height
             .next()
             .expect("chain tip must be below Height::MAX");
-
-        // Convert transactions into TransactionTemplates.
-        #[cfg(not(test))]
-        let (mempool_tx_templates, mempool_txs): (Vec<_>, Vec<_>) =
-            mempool_txs.into_iter().map(|tx| ((&tx).into(), tx)).unzip();
 
         // Transaction selection returns transactions in an arbitrary order,
         // but Zebra's snapshot tests expect the same order every time.
@@ -298,28 +345,23 @@ impl BlockTemplateResponse {
         // Transactions that spend outputs created in the same block must appear
         // after the transactions that create those outputs.
         #[cfg(test)]
-        let (mempool_tx_templates, mempool_txs): (Vec<_>, Vec<_>) = {
-            let mut mempool_txs_with_templates: Vec<(
-                InBlockTxDependenciesDepth,
-                TransactionTemplate<amount::NonNegative>,
-                VerifiedUnminedTx,
-            )> = mempool_txs
-                .into_iter()
-                .map(|(min_tx_index, tx)| (min_tx_index, (&tx).into(), tx))
-                .collect();
+        let mempool_txs: Vec<_> = {
+            let mut mempool_txs = mempool_txs;
 
             // `zcashd` sorts in serialized data order, excluding the length byte.
             // It sometimes seems to do this, but other times the order is arbitrary.
             // Sort by hash, this is faster.
-            mempool_txs_with_templates.sort_by_key(|(min_tx_index, tx_template, _tx)| {
-                (*min_tx_index, tx_template.hash.bytes_in_display_order())
+            mempool_txs.sort_by_key(|(dependency_depth, tx)| {
+                (
+                    *dependency_depth,
+                    tx.transaction.id().mined_id().bytes_in_display_order(),
+                )
             });
 
-            mempool_txs_with_templates
-                .into_iter()
-                .map(|(_, template, tx)| (template, tx))
-                .unzip()
+            mempool_txs.into_iter().map(|(_, tx)| tx).collect()
         };
+
+        let mempool_tx_templates = mempool_transaction_templates(&mempool_txs, mempool_tx_deps);
 
         let txs_fee = mempool_txs
             .iter()

--- a/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -20,11 +20,49 @@ use zakura_chain::{
     transaction::Transaction,
     transparent,
 };
+use zakura_node_services::mempool::TransactionDependencies;
 
 use crate::client::TransactionTemplate;
 use crate::config::mining::{default_miner_address, MinerAddressType};
 
 use super::MinerParams;
+
+#[test]
+fn transaction_templates_report_direct_dependency_indexes() {
+    let mempool_txs: Vec<_> = Network::Mainnet
+        .unmined_transactions_in_blocks(..)
+        .take(4)
+        .collect();
+    assert_eq!(mempool_txs.len(), 4, "test vectors must contain four txs");
+
+    let transaction_ids: Vec<_> = mempool_txs
+        .iter()
+        .map(|tx| tx.transaction.id().mined_id())
+        .collect();
+    let mut mempool_tx_deps = TransactionDependencies::default();
+    mempool_tx_deps.add(
+        transaction_ids[2],
+        vec![
+            transparent::OutPoint::from_usize(transaction_ids[1], 0),
+            transparent::OutPoint::from_usize(transaction_ids[0], 0),
+        ],
+    );
+    mempool_tx_deps.add(
+        transaction_ids[3],
+        vec![transparent::OutPoint::from_usize(transaction_ids[2], 0)],
+    );
+
+    let templates = super::mempool_transaction_templates(&mempool_txs, &mempool_tx_deps);
+    let dependency_indexes: Vec<_> = templates
+        .iter()
+        .map(|template| template.depends.clone())
+        .collect();
+
+    assert_eq!(
+        dependency_indexes,
+        vec![vec![], vec![], vec![1, 2], vec![3]]
+    );
+}
 
 /// Tests transparent coinbase generation at every configured Sapling-and-later
 /// network upgrade activation.

--- a/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -31,6 +31,7 @@ use super::MinerParams;
 fn transaction_templates_report_direct_dependency_indexes() {
     let mempool_txs: Vec<_> = Network::Mainnet
         .unmined_transactions_in_blocks(..)
+        .filter(|tx| !tx.transaction.transaction().is_coinbase())
         .take(4)
         .collect();
     assert_eq!(mempool_txs.len(), 4, "test vectors must contain four txs");

--- a/crates/zakura-rpc/src/methods/types/transaction.rs
+++ b/crates/zakura-rpc/src/methods/types/transaction.rs
@@ -66,8 +66,6 @@ where
     /// The transactions in this block template that this transaction depends upon.
     /// These are 1-based indexes in the `transactions` list.
     ///
-    /// Zebra's mempool does not support transaction dependencies, so this list is always empty.
-    ///
     /// We use `u16` because 2 MB blocks are limited to around 39,000 transactions.
     pub(crate) depends: Vec<u16>,
 
@@ -105,7 +103,7 @@ impl From<&VerifiedUnminedTx> for TransactionTemplate<NonNegative> {
                 .auth_digest()
                 .unwrap_or(AUTH_DIGEST_PLACEHOLDER),
 
-            // Always empty, not supported by Zebra's mempool.
+            // Filled during block template construction after transaction ordering.
             depends: Vec::new(),
 
             fee: tx.miner_fee,

--- a/docs/changelog/unreleased/923.md
+++ b/docs/changelog/unreleased/923.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed `getblocktemplate` transaction dependencies so mining pools can safely
+  remove or reorder transactions
+  ([#923](https://github.com/zakura-core/zakura/pull/923)).


### PR DESCRIPTION
## Motivation

getblocktemplate advertises transactions as mutable, but every transaction currently reports an empty depends list. Pools that remove or reorder transactions therefore cannot preserve parent-before-child ordering and can construct blocks that fail transparent spend validation.

## Solution

Convert selected mempool transactions after their final template order is known, map transaction hashes to one-based indexes, and populate each transaction template with its sorted direct dependency indexes from the mempool dependency graph.

## Testing

- cargo test -p zakura-rpc --lib transaction_templates_report_direct_dependency_indexes
- cargo test -p zakura-rpc --lib get_block_template -- --skip shielded_coinbase_paths
- cargo clippy -p zakura-rpc --lib -- -D warnings
- cargo fmt --all -- --check
- npm exec --yes markdownlint-cli -- docs/changelog/unreleased/923.md --config .github/.markdownlint.yaml
- ./scripts/changelog.py check
- git diff --check

The focused unit test covers independent transactions, multiple direct parents, and a transitive child.

## Changelog

- Added docs/changelog/unreleased/923.md.

### Specifications & References

- BIP 22 getblocktemplate transaction depends field
