### PR TITLE
fix(state): cap block template times to local validation limit

### DIFF
--- a/crates/zakura-state/src/response.rs
+++ b/crates/zakura-state/src/response.rs
@@ -644,7 +644,7 @@ pub struct GetBlockTemplateChainInfo {
     pub min_time: DateTime32,
 
     /// The maximum time the miner can use in this block.
-    /// Depends on the `tip_hash`, and the local clock on testnet.
+    /// Depends on the `tip_hash` and the local clock.
     pub max_time: DateTime32,
 }
 

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -256,8 +256,7 @@ fn difficulty_time_and_history_tree(
         tip_height,
         network,
         relevant_data.iter().cloned(),
-    )
-    .expect("the mining template requires a complete committed difficulty context");
+    )?;
     let expected_difficulty = difficulty_adjustment.expected_difficulty_threshold();
 
     let mut result = GetBlockTemplateChainInfo {
@@ -423,15 +422,18 @@ fn adjust_difficulty_and_time_for_testnet(
 mod tests {
     use super::*;
 
-    const LOCAL_TIME: DateTime32 = DateTime32::from_seconds(1_700_000_000);
+    fn local_time() -> DateTime32 {
+        1_700_000_000.into()
+    }
 
     #[test]
     fn block_template_max_time_respects_local_future_time_limit() {
-        let median_time_past = LOCAL_TIME
+        let local_time = local_time();
+        let median_time_past = local_time
             .checked_add(Duration32::from_minutes(31))
             .expect("test time is in range");
 
-        let time_range = valid_block_template_time_range(median_time_past, LOCAL_TIME)
+        let time_range = valid_block_template_time_range(median_time_past, local_time)
             .expect("the time ranges overlap");
 
         assert_eq!(
@@ -443,22 +445,44 @@ mod tests {
         assert_eq!(time_range.cur_time, time_range.min_time);
         assert_eq!(
             time_range.max_time,
-            LOCAL_TIME
+            local_time
                 .checked_add(MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK)
                 .expect("test time is in range")
         );
+
+        let mut header = Network::Mainnet
+            .block_parsed_iter()
+            .next()
+            .expect("Mainnet test vectors contain a block")
+            .header
+            .as_ref()
+            .clone();
+        header.time = time_range.max_time.into();
+        header
+            .time_is_valid_at(local_time.into(), &Height::MIN, &header.hash())
+            .expect("the advertised maximum time passes local validation");
+
+        header.time = time_range
+            .max_time
+            .checked_add(Duration32::from_seconds(1))
+            .expect("test time is in range")
+            .into();
+        header
+            .time_is_valid_at(local_time.into(), &Height::MIN, &header.hash())
+            .expect_err("a time above the advertised maximum fails local validation");
     }
 
     #[test]
     fn block_template_max_time_uses_tighter_median_time_limit() {
-        let median_time_past = LOCAL_TIME
+        let local_time = local_time();
+        let median_time_past = local_time
             .checked_sub(Duration32::from_hours(1))
             .expect("test time is in range");
 
-        let time_range = valid_block_template_time_range(median_time_past, LOCAL_TIME)
+        let time_range = valid_block_template_time_range(median_time_past, local_time)
             .expect("the time ranges overlap");
 
-        assert_eq!(time_range.cur_time, LOCAL_TIME);
+        assert_eq!(time_range.cur_time, local_time);
         assert_eq!(
             time_range.max_time,
             median_time_past
@@ -469,12 +493,13 @@ mod tests {
 
     #[test]
     fn block_template_time_range_rejects_non_overlapping_limits() {
-        let median_time_past = LOCAL_TIME
+        let local_time = local_time();
+        let median_time_past = local_time
             .checked_add(MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK)
             .expect("test time is in range");
 
         assert_eq!(
-            valid_block_template_time_range(median_time_past, LOCAL_TIME),
+            valid_block_template_time_range(median_time_past, local_time),
             Err("the local clock is too far behind the chain tip to create a valid block template")
         );
     }

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -37,6 +37,16 @@ use crate::{
 /// This is a Zebra-specific standard rule.
 pub const EXTRA_TIME_TO_MINE_A_BLOCK: u32 = POST_BLOSSOM_POW_TARGET_SPACING * 2;
 
+/// The local-clock limit enforced by [`block::Header::time_is_valid_at`].
+const MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK: Duration32 = Duration32::from_hours(2);
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct BlockTemplateTimeRange {
+    min_time: DateTime32,
+    cur_time: DateTime32,
+    max_time: DateTime32,
+}
+
 fn finalized_state_query_interrupted_error() -> BoxError {
     "Zakura is committing too many blocks to the state, \
      wait until it syncs to the chain tip"
@@ -44,6 +54,11 @@ fn finalized_state_query_interrupted_error() -> BoxError {
 }
 
 /// Returns the [`GetBlockTemplateChainInfo`] for the current best chain.
+///
+/// # Errors
+///
+/// Returns an error if the state queries are interrupted or the local clock is
+/// too far behind the chain tip to create a valid template time range.
 ///
 /// # Panics
 ///
@@ -71,13 +86,13 @@ pub fn get_block_template_chain_info(
     let (best_tip_height, best_tip_hash, best_relevant_chain, best_tip_history_tree) =
         best_relevant_chain_and_history_tree_result?;
 
-    Ok(difficulty_time_and_history_tree(
+    difficulty_time_and_history_tree(
         best_relevant_chain,
         best_tip_height,
         best_tip_hash,
         network,
         best_tip_history_tree,
-    ))
+    )
 }
 
 /// Accepts a `non_finalized_state`, [`ZakuraDb`], `num_blocks`, and a block hash to start at.
@@ -212,13 +227,11 @@ fn difficulty_time_and_history_tree(
     tip_hash: block::Hash,
     network: &Network,
     history_tree: Arc<HistoryTree>,
-) -> GetBlockTemplateChainInfo {
+) -> Result<GetBlockTemplateChainInfo, BoxError> {
     let relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)> = relevant_chain
         .iter()
         .map(|block| (block.header.difficulty_threshold, block.header.time))
         .collect();
-
-    let cur_time = DateTime32::now();
 
     // > For each block other than the genesis block , nTime MUST be strictly greater than
     // > the median-time-past of that block.
@@ -231,19 +244,11 @@ fn difficulty_time_and_history_tree(
             .collect(),
     );
 
-    let min_time = median_time_past
-        .checked_add(Duration32::from_seconds(1))
-        .expect("a valid block time plus a small constant is in-range");
-
-    // > For each block at block height 2 or greater on Mainnet, or block height 653606 or greater on Testnet, nTime
-    // > MUST be less than or equal to the median-time-past of that block plus 90 * 60 seconds.
-    //
-    // We ignore the height as we are checkpointing on Canopy or higher in Mainnet and Testnet.
-    let max_time = median_time_past
-        .checked_add(Duration32::from_seconds(BLOCK_MAX_TIME_SINCE_MEDIAN))
-        .expect("a valid block time plus a small constant is in-range");
-
-    let cur_time = cur_time.clamp(min_time, max_time);
+    let BlockTemplateTimeRange {
+        min_time,
+        cur_time,
+        max_time,
+    } = valid_block_template_time_range(median_time_past, DateTime32::now())?;
 
     // Now that we have a valid time, get the difficulty for that time.
     let difficulty_adjustment = AdjustedDifficulty::new_from_header_time(
@@ -267,7 +272,46 @@ fn difficulty_time_and_history_tree(
 
     adjust_difficulty_and_time_for_testnet(&mut result, network, tip_height, relevant_data);
 
-    result
+    Ok(result)
+}
+
+/// Intersects the deterministic median-time range with the local-clock rule.
+///
+/// Returns an error if the local future-time limit is out of range or does not
+/// overlap the median-time range.
+fn valid_block_template_time_range(
+    median_time_past: DateTime32,
+    local_time: DateTime32,
+) -> Result<BlockTemplateTimeRange, &'static str> {
+    let min_time = median_time_past
+        .checked_add(Duration32::from_seconds(1))
+        .expect("a valid block time plus a small constant is in-range");
+
+    // > For each block at block height 2 or greater on Mainnet, or block height
+    // > 653606 or greater on Testnet, nTime MUST be less than or equal to the
+    // > median-time-past of that block plus 90 * 60 seconds.
+    //
+    // We ignore the height as we are checkpointing on Canopy or higher in
+    // Mainnet and Testnet.
+    let median_time_max = median_time_past
+        .checked_add(Duration32::from_seconds(BLOCK_MAX_TIME_SINCE_MEDIAN))
+        .expect("a valid block time plus a small constant is in-range");
+    let local_time_max = local_time
+        .checked_add(MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK)
+        .ok_or("the local future-time limit is outside the timestamp range")?;
+    let max_time = median_time_max.min(local_time_max);
+
+    if min_time > max_time {
+        return Err(
+            "the local clock is too far behind the chain tip to create a valid block template",
+        );
+    }
+
+    Ok(BlockTemplateTimeRange {
+        min_time,
+        cur_time: local_time.clamp(min_time, max_time),
+        max_time,
+    })
 }
 
 /// Adjust the difficulty and time for the testnet minimum difficulty rule.
@@ -372,5 +416,66 @@ fn adjust_difficulty_and_time_for_testnet(
         )
         .expect("the testnet mining template retains the same complete difficulty context")
         .expected_difficulty_threshold();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOCAL_TIME: DateTime32 = DateTime32::from_seconds(1_700_000_000);
+
+    #[test]
+    fn block_template_max_time_respects_local_future_time_limit() {
+        let median_time_past = LOCAL_TIME
+            .checked_add(Duration32::from_minutes(31))
+            .expect("test time is in range");
+
+        let time_range = valid_block_template_time_range(median_time_past, LOCAL_TIME)
+            .expect("the time ranges overlap");
+
+        assert_eq!(
+            time_range.min_time,
+            median_time_past
+                .checked_add(Duration32::from_seconds(1))
+                .expect("test time is in range")
+        );
+        assert_eq!(time_range.cur_time, time_range.min_time);
+        assert_eq!(
+            time_range.max_time,
+            LOCAL_TIME
+                .checked_add(MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK)
+                .expect("test time is in range")
+        );
+    }
+
+    #[test]
+    fn block_template_max_time_uses_tighter_median_time_limit() {
+        let median_time_past = LOCAL_TIME
+            .checked_sub(Duration32::from_hours(1))
+            .expect("test time is in range");
+
+        let time_range = valid_block_template_time_range(median_time_past, LOCAL_TIME)
+            .expect("the time ranges overlap");
+
+        assert_eq!(time_range.cur_time, LOCAL_TIME);
+        assert_eq!(
+            time_range.max_time,
+            median_time_past
+                .checked_add(Duration32::from_seconds(BLOCK_MAX_TIME_SINCE_MEDIAN))
+                .expect("test time is in range")
+        );
+    }
+
+    #[test]
+    fn block_template_time_range_rejects_non_overlapping_limits() {
+        let median_time_past = LOCAL_TIME
+            .checked_add(MAX_BLOCK_TIME_SINCE_LOCAL_CLOCK)
+            .expect("test time is in range");
+
+        assert_eq!(
+            valid_block_template_time_range(median_time_past, LOCAL_TIME),
+            Err("the local clock is too far behind the chain tip to create a valid block template")
+        );
     }
 }

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -450,13 +450,12 @@ mod tests {
                 .expect("test time is in range")
         );
 
-        let mut header = Network::Mainnet
+        let mut header = *Network::Mainnet
             .block_parsed_iter()
             .next()
             .expect("Mainnet test vectors contain a block")
             .header
-            .as_ref()
-            .clone();
+            .as_ref();
         header.time = time_range.max_time.into();
         header
             .time_is_valid_at(local_time.into(), &Height::MIN, &header.hash())

--- a/docs/changelog/unreleased/924.md
+++ b/docs/changelog/unreleased/924.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed `getblocktemplate` time limits so miners are not given timestamps the
+  local node would reject as too far in the future
+  ([#924](https://github.com/zakura-core/zakura/pull/924)).


### PR DESCRIPTION
## Motivation

Block template maxtime is currently bounded only by median-time-past plus 90 minutes. If the chain median is more than 30 minutes ahead of the local clock, the advertised maxtime exceeds the validators local two-hour future-time limit. A miner using that advertised value can therefore create a block the same node rejects.

## Solution

Intersect the median-time template window with the local future-time acceptance window. Return an error when the two windows do not overlap, since no immediately valid template can be produced. Keep the testnet difficulty adjustment inside the resulting valid range.

## Testing

- cargo test -p zakura-state --lib block_template_
- cargo test -p zakura-state: 549 unit tests and 2 integration tests passed; 3 ignored
- cargo test -p zakura-rpc --lib get_block_template -- --skip shielded_coinbase_paths
- cargo clippy -p zakura-state --lib -- -D warnings
- cargo fmt --all -- --check
- npm exec --yes markdownlint-cli -- docs/changelog/unreleased/924.md --config .github/.markdownlint.yaml
- ./scripts/changelog.py check
- git diff --check

Focused tests cover the local-clock cap, the unchanged median-time cap, the no-overlap error, and the exact boundary enforced by Header::time_is_valid_at.

## Changelog

- Added docs/changelog/unreleased/924.md.

### Specifications & References

- Zcash Protocol Specification, block-header time rules
