### PR TITLE
build(deps): bump Zakura Common crates to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,9 +7696,9 @@ checksum = "b799969db8487a99e4de20d81ddc52d4b8142f3af62925a1ca5948fa8efbe481"
 
 [[package]]
 name = "zakura-bellman"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6b7239d41621cc0c39349882001442d49bbc8dc46390c4826feb85a55a8d47"
+checksum = "6668703cc9a72754c4081991cc81180fed31e25b8069c1ff5c3c4fdb41e1850f"
 dependencies = [
  "bitvec",
  "blake2s_simd",
@@ -7713,9 +7713,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-bls12-381"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2c114620056f8c97ecc17d7333add6c818ff376434943c7ff4974320426887"
+checksum = "2edea13b7bba94ccb7aa473b30e4c390549ffe7c25d83919d6ba4e9b65626497"
 dependencies = [
  "ff",
  "group",
@@ -7844,9 +7844,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-gadgets"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af79f971003d67f4a198985469834c083f37354d604bf93f892c9c9f5a129ae0"
+checksum = "f5d24d27771c16598da80f900efcf8051282221b035931e0b61dd465e70c7e3f"
 dependencies = [
  "arrayvec",
  "ff",
@@ -7860,15 +7860,15 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-legacy-pdqsort"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c91d2f5fd4fc95a9c42d43744fa9512b2d7d996ea454f3b21faac6fb36a9806"
+checksum = "3ab38fc11181f44ad3158e16e9a247c8a76a1bcf73adfa08b9ea29d3d9f68be6"
 
 [[package]]
 name = "zakura-halo2-poseidon"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdac6fc73528451edc4ee8cff55946ff2c75359c47937eb42e6d31b83b542d39"
+checksum = "7f7ea83759fbaa8a599b7e37b71d1b57e3ac9dcb40e42e572a9fc7a8d927e08b"
 dependencies = [
  "bitvec",
  "ff",
@@ -7878,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-halo2-proofs"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875a590a7d9175fdb47286ca0e5073a1e9ee78775b70ca4309353cf19a6b6ed"
+checksum = "dfa509d1ddcec871a2508ae4d90c89c57a55bd49dc0ddb6456adfaad08069222"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -7922,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-jubjub"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9915c2c7f2c021379453608c91548f2811d1ba59b7e8505bb8ba32f51e494db"
+checksum = "e7cc2178b04ba26be2676cd74018add8768fcda53326aae8255e7b676f877ee6"
 dependencies = [
  "bitvec",
  "ff",
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-keys"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df47ed252741a6fcefc2b92aa773034c602eca361c5f974ffbb4f67a49fe2c78"
+checksum = "5f301a02dd34dbc50d9ceb59b552501b73f74c47a137f58eba59c9415febf2bd"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -8021,9 +8021,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-orchard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7edaa754f9bafb4965559e38af6d337eb001f76de666fe20e510fb8e1cf631"
+checksum = "6ff7912c408024e03ec9c731e62cf848231fcbd0b7385e9032540d53ebc9a665"
 dependencies = [
  "aes",
  "bitvec",
@@ -8058,18 +8058,18 @@ dependencies = [
 
 [[package]]
 name = "zakura-pairing"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59445f1cb78bef29da023f8ecdba607ed00f2df51c245e1d50964af2a3e7b800"
+checksum = "5bb93e2fa3d808aee507f0ce5167b2819f692d9c915b2d543eab820050deef73"
 dependencies = [
  "group",
 ]
 
 [[package]]
 name = "zakura-pasta-curves"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e878bab2110a70ed4496e377b4b3f3039d6a227c5d79e171b316f334857531b9"
+checksum = "33817e907eaf89e5871ab0cdfc1054907ec0b3a86759c7a9d41875690f6fd9f4"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -8084,9 +8084,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-primitives"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799de508ecd41846dd0dfd06490e30ec6ee918008ceba19155e09f2545f3df73"
+checksum = "f6d512f69295e815987e4c2802da5a3f37fa86418acca9e35d75f3ba8dc34a5d"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8115,9 +8115,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-proofs"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506fc870df35b86053fa50a24f3f02c50189a3a609c62478bbd1b7c94943d188"
+checksum = "dddd09d8b3deb3be91a83ca16325778595a345460cf2e33ec9b05d7c9114f9da"
 dependencies = [
  "blake2b_simd",
  "document-features",
@@ -8135,9 +8135,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-reddsa"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3391ff6c3e6222f5176c046e1d3645748be5b211880747e279d0f17860d51526"
+checksum = "23f5849526a1f308f3c522ebdcccd49e4add198d7b31297dedcfce9ff392c9e4"
 dependencies = [
  "blake2b_simd",
  "frost-rerandomized",
@@ -8153,9 +8153,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-redjubjub"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174ffd325c22f5dbb4c4dfe6f825bd82c3ca88a91bbe603b5cdf0dd7590d0a9c"
+checksum = "0ff05cf4b8580b495f180942e702c0f9ecf92346e1204b3b2f8ceb71f98b55b5"
 dependencies = [
  "rand_core 0.10.1",
  "serde",
@@ -8235,9 +8235,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sapling-crypto"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadf81594078e0e18f6c1744d978a9ee418fce988c293567131bc4870247ee85"
+checksum = "cdfa36cec0a3b20da86caee7931f636a80071e27077fff2da7ca03536848d05c"
 dependencies = [
  "aes",
  "bitvec",
@@ -8287,9 +8287,9 @@ dependencies = [
 
 [[package]]
 name = "zakura-sinsemilla"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "582ec66fe58b717034b8f5c8b54834d93abd515fc20a0ce2ab769d522432b8ca"
+checksum = "ad8f2ee21b5341be7586c4b5ed7d4e114cf85a576837ed68a2da72f4434d26b7"
 dependencies = [
  "group",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,26 +49,26 @@ edition = "2021"
 # gate refers to `zakura-assets` and nothing else.
 zakura-assets = { version = "=0.3472489.0" }
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = { version = "1.1.0", package = "zakura-orchard" }
-sapling-crypto = { version = "1.1.0", package = "zakura-sapling-crypto" }
+orchard = { version = "1.2.0", package = "zakura-orchard" }
+sapling-crypto = { version = "1.2.0", package = "zakura-sapling-crypto" }
 zcash_address = "0.13.0"
 zcash_history = "0.5.0"
-zcash_keys = { version = "1.1.0", package = "zakura-keys" }
-zcash_primitives = { version = "1.1.0", package = "zakura-primitives" }
-zcash_proofs = { version = "1.1.0", package = "zakura-proofs" }
+zcash_keys = { version = "1.2.0", package = "zakura-keys" }
+zcash_primitives = { version = "1.2.0", package = "zakura-primitives" }
+zcash_proofs = { version = "1.2.0", package = "zakura-proofs" }
 zcash_transparent = "0.10.0"
 zcash_protocol = "0.10.1"
 abscissa_core = { version = "0.7", default-features = false }
 base64 = "0.22.1"
 bech32 = "0.11.0"
-bellman = { version = "1.1.0", package = "zakura-bellman" }
+bellman = { version = "1.2.0", package = "zakura-bellman" }
 bincode = "1.3"
 bitflags = "2.9"
 bitflags-serde-legacy = "0.1.1"
 bitvec = "1.0"
 blake2b_simd = "1.0"
 blake2s_simd = "1.0"
-bls12_381 = { version = "1.1.0", package = "zakura-bls12-381" }
+bls12_381 = { version = "1.2.0", package = "zakura-bls12-381" }
 bs58 = "0.5"
 byteorder = "1.5"
 bytes = "1.10"
@@ -87,7 +87,7 @@ futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 group = "0.14"
-halo2 = { version = "1.1.0", package = "zakura-halo2-proofs" }
+halo2 = { version = "1.2.0", package = "zakura-halo2-proofs" }
 hex = "0.4.3"
 hex-literal = "0.4"
 howudoin = "0.1"
@@ -106,7 +106,7 @@ itertools = "0.14"
 jsonrpsee = "0.24.8"
 jsonrpsee-proc-macros = "0.24.9"
 jsonrpsee-types = "0.24.9"
-jubjub = { version = "1.1.0", package = "zakura-jubjub" }
+jubjub = { version = "1.2.0", package = "zakura-jubjub" }
 lazy_static = "1.4"
 libzcash_script = "0.1"
 log = "0.4.27"
@@ -129,8 +129,8 @@ rand_10 = { package = "rand", version = "0.10" }
 rand_chacha_10 = { package = "rand_chacha", version = "0.10" }
 rand_core_10 = { package = "rand_core", version = "0.10" }
 rayon = "1.10"
-reddsa = { version = "1.1.0", package = "zakura-reddsa" }
-redjubjub = { version = "1.1.0", package = "zakura-redjubjub" }
+reddsa = { version = "1.2.0", package = "zakura-reddsa" }
+redjubjub = { version = "1.2.0", package = "zakura-redjubjub" }
 regex = "1.11"
 reqwest = { version = "0.12", default-features = false }
 ripemd = "0.1"
@@ -151,7 +151,7 @@ serde_json = "1.0.140"
 serde_with = "3.12"
 sha2 = "0.10"
 schemars = "1"
-sinsemilla = { version = "1.1.0", package = "zakura-sinsemilla" }
+sinsemilla = { version = "1.2.0", package = "zakura-sinsemilla" }
 spandoc = "0.2"
 anyhow = "1.0"
 strum = "0.27"

--- a/docs/changelog/unreleased/925.md
+++ b/docs/changelog/unreleased/925.md
@@ -1,0 +1,5 @@
+## Changed
+
+- Updated the Zakura Common (`zakura-core/common`) crates from `1.1.0` to
+  `1.2.0`
+  ([#925](https://github.com/zakura-core/zakura/pull/925)).

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -392,87 +392,87 @@ version = "0.52.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zakura-bellman]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-bls12-381]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-gadgets]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-legacy-pdqsort]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-poseidon]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-halo2-proofs]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-jubjub]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-keys]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-orchard]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pairing]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-pasta-curves]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-primitives]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-proofs]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-reddsa]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-redjubjub]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sapling-crypto]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 
 [[exemptions.zakura-sinsemilla]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 notes = "Coordinated Zakura fork release; retain this exact-version exemption pending direct package audit."
 


### PR DESCRIPTION
## Motivation

The Zakura Common libraries (`zakura-core/common`) published their 1.2.0
release. The workspace should track it ahead of the v1.4.0-rc1 release so the
release candidate ships against the current fork suite.

## Solution

- Bump the 12 direct `zakura-*` fork dependencies in the root `Cargo.toml`
  from `1.1.0` to `1.2.0`.
- Refresh `Cargo.lock`: exactly the 17 `zakura-*` fork entries (12 direct + 5
  transitive) move to `1.2.0`; no other lockfile entries change.
- Move the 17 matching exact-version `[[exemptions.zakura-*]]` pins in
  `qa/supply-chain/config.toml` to `1.2.0` in lockstep.

`1.2.0` is semver-compatible with the existing caret requirements, so no
cascade republish of workspace crates is required (unlike the
`zakura-header-chain 2.0.0` cascade in #885); the `crates.io publish graph`
CI job verifies this against the live index.

## Testing

- `cargo check --workspace --all-targets` passes against the bumped suite.
- `cargo vet check --store-path ./qa/supply-chain/` passes (CI-equivalent).
- Verified all 17 crates have `1.2.0` published on the crates.io index.
- Full test suite, publish-graph, and packaging checks run in PR CI.

## Changelog

`docs/changelog/unreleased/925.md` (Changed entry), validated with
`./scripts/changelog.py check` and `markdownlint`.

### Specifications & References

- Previous suite bump: #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

