### PR TITLE
chore(release): align the v1.4.0-rc1 end-of-support halt with v1.4.0-rc0

### DIFF
--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_478_266;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_479_387;
 
 /// The estimated number of blocks per day after Blossom.
 ///
@@ -28,12 +28,12 @@ pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Currently set to 24 days
+/// - Currently set to 22 days
 ///
-/// Note: v1.4.0-rc0 is estimated to release at height 3,477,083 (~2026-09-09)
-/// and halts 24 days later at height 3,504,731 (~2026-10-03) — the same
-/// halt block and date as v1.3.2, the previous release.
-pub const EOS_PANIC_AFTER: u32 = 24;
+/// Note: v1.4.0-rc1 is estimated to release at height 3,479,387 (~2026-09-11)
+/// and halts 22 days later at height 3,504,731 (~2026-10-03) — the same
+/// halt block and date as v1.4.0-rc0 and v1.3.2.
+pub const EOS_PANIC_AFTER: u32 = 22;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 3;

--- a/docs/changelog/unreleased/927.md
+++ b/docs/changelog/unreleased/927.md
@@ -1,0 +1,6 @@
+## Changed
+
+- Shortened the end-of-support window to 22 days so v1.4.0-rc1 halts at block
+  3,504,731 — the same halt block and date (~2026-10-03) as v1.4.0-rc0 and
+  v1.3.2
+  ([#927](https://github.com/zakura-core/zakura/pull/927)).


### PR DESCRIPTION
## Motivation

The #926 release-state import raised the end-of-support floor to 3,478,266.
With the unchanged 24-day panic window, the v1.4.0-rc1 halt would drift to
block 3,505,914 (~2026-10-04), a day past the v1.4.0-rc0 halt. The standing
policy is that each release halts on roughly the same day as the previous
release.

## Solution

Apply the halt-parity recipe against the v1.4.0-rc0 halt block H = 3,504,731
and the new floor F = 3,478,266 (checkpoint 3,474,810 + 3,456):

- `EOS_PANIC_AFTER`: 24 → 22 (N = floor((H − F) / 1,152))
- `ESTIMATED_RELEASE_HEIGHT`: 3,478,266 → 3,479,387 (E = H − N·1,152;
  1,121 above the floor, so no floor violation)

The halt lands at exactly block 3,504,731 (~2026-10-03 06:46 UTC, anchored on
the live Mainnet tip), the same halt block and date as v1.4.0-rc0 and v1.3.2.
The warn window (halt − 3 days) is unchanged. Same approach as #915 and #863.

## Testing

- `cargo test -p zakura --test end_of_support`: all 6 tests pass.
- Halt-date estimate cross-checked against the live chain tip
  (3,476,334 at 2026-09-08 15:10 UTC) at 1,152 blocks/day.

## Changelog

`docs/changelog/unreleased/927.md` (Changed entry), validated with
`./scripts/changelog.py check` and `markdownlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

