### PR TITLE
docs(p2p): preserve responses during GetBlocks admission

### DIFF
--- a/docs/specs/peer-message-regulation.md
+++ b/docs/specs/peer-message-regulation.md
@@ -251,8 +251,8 @@ refund = upper_bound_response_bytes - actual_response_bytes
   admission boundary. It MUST stop reading that peer's ordered stream until Work becomes available.
   The existing bounded application and QUIC queues MUST provide backpressure. The implementation
   MUST NOT add a delayed-request queue or scheduler.
-  The GetBlocks rule below is an exception to these read-pause and queue requirements, because
-  requests and responses share the same ordered stream.
+  Pausing reads MUST NOT prevent either peer from completing an active response. The bounded
+  GetBlocks queue defined below is an exception to the read-pause and no-queue requirements.
 - Pausing reads MUST propagate to the QUIC receive buffer. The transport MUST stop granting further
   stream credit as that buffer fills, so the peer cannot send more stream data after it exhausts
   existing credit. The resource bound MUST include already authorized data. The implementation MUST
@@ -679,8 +679,10 @@ Block sync already regulates its rate on the requesting side. Each sender sizes 
 limit the receiver advertises and operating at the measured bandwidth-delay product, which is
 normally far below that clamp. That window is the outbound obligation matching this inbound rule.
 
-The two sides meet through `Delay`. A receiver whose Work is unavailable delays starting the
-request, but MUST continue reading so responses to its own downloads can progress. It MUST retain
+The two sides meet through `Delay`. GetBlocks requests can arrive ahead of responses on the same
+ordered stream. If both peers pause reading while their response writers are blocked, neither side
+can finish. A receiver whose Work is unavailable therefore delays starting the request, but MUST
+continue reading. It MUST retain
 waiting GetBlocks requests in arrival order, storing only their request fields. The waiting queue
 and its single admission waiter together MUST NOT exceed the receiver's advertised inflight limit.
 Only the oldest waiting request competes for Work; the active response retains its Work ownership.

--- a/docs/specs/peer-message-regulation.md
+++ b/docs/specs/peer-message-regulation.md
@@ -251,6 +251,8 @@ refund = upper_bound_response_bytes - actual_response_bytes
   admission boundary. It MUST stop reading that peer's ordered stream until Work becomes available.
   The existing bounded application and QUIC queues MUST provide backpressure. The implementation
   MUST NOT add a delayed-request queue or scheduler.
+  The GetBlocks rule below is an exception to these read-pause and queue requirements, because
+  requests and responses share the same ordered stream.
 - Pausing reads MUST propagate to the QUIC receive buffer. The transport MUST stop granting further
   stream credit as that buffer fills, so the peer cannot send more stream data after it exhausts
   existing credit. The resource bound MUST include already authorized data. The implementation MUST
@@ -677,9 +679,13 @@ Block sync already regulates its rate on the requesting side. Each sender sizes 
 limit the receiver advertises and operating at the measured bandwidth-delay product, which is
 normally far below that clamp. That window is the outbound obligation matching this inbound rule.
 
-The two sides meet through `Delay`. A receiver whose Work bucket is empty stops reading further
-frames from that peer's ordered stream until Work becomes available. Its bounded queues apply QUIC
-flow control instead of adding another request scheduler. The delay lengthens the sender's
+The two sides meet through `Delay`. A receiver whose Work is unavailable delays starting the
+request, but MUST continue reading so responses to its own downloads can progress. It MUST retain
+waiting GetBlocks requests in arrival order, storing only their request fields. The waiting queue
+and its single admission waiter together MUST NOT exceed the receiver's advertised inflight limit.
+Only the oldest waiting request competes for Work; the active response retains its Work ownership.
+If the waiting queue is full, the receiver MUST close that block-sync stream without scoring the
+peer: an older requester may have retried before earlier responses finished. The delay lengthens the sender's
 round-trip samples, the sender's delay gradient shrinks its window, and the sender settles below the
 rate the receiver serves.
 


### PR DESCRIPTION
## Motivation

Two peers can stop reading their shared block-sync stream while each waits for its outgoing response to finish. Neither writer can finish until the other peer resumes reading.

## Solution

Amend the Work rule and GetBlocks paragraph to permit bounded waiting request fields while responses continue to be read. Preserve request order, active Work ownership, and an explicit queue-overflow outcome. This changes only those two paragraphs in the draft from #747.

## Testing

Markdown and spelling checks pass. Used Codex to prepare the focused amendment.
