### PR TITLE
fix(rpc): avoid fabricated difficulty values

### DIFF
--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -5457,7 +5457,8 @@ where
     // # TODO
     // - add a separate request like BestChainNextMedianTimePast, but skipping the
     //   consistency check, because any block's difficulty is ok for display
-    // - return 1.0 for a "not enough blocks in the state" error, like `zcashd`:
+    //
+    // Return the minimum difficulty when the state is unavailable, like `zcashd`:
     // <https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L40-L41>
     let response = state
         .ready()
@@ -5466,9 +5467,7 @@ where
 
     let response = match (should_use_default, response) {
         (_, Ok(res)) => res,
-        (true, Err(_)) => {
-            return Ok((U256::from(network.target_difficulty_limit()) >> 128).as_u128() as f64);
-        }
+        (true, Err(_)) => return Ok(1.0),
         (false, Err(error)) => return Err(error).map_error(0),
     };
 

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -77,7 +77,7 @@ use zakura_chain::{
     transparent::{self, Address, OutputIndex},
     value_balance::ValueBalance,
     work::{
-        difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty, U256},
+        difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
         equihash::Solution,
     },
 };
@@ -1441,9 +1441,8 @@ where
 
         let relay_fee = zakura_chain::transaction::zip317::MIN_MEMPOOL_TX_FEE_RATE as f64
             / (zakura_chain::amount::COIN as f64);
-        let difficulty = chain_tip_difficulty(self.network.clone(), self.read_state.clone(), true)
-            .await
-            .expect("should always be Ok when `should_use_default` is true");
+        let difficulty =
+            chain_tip_difficulty(self.network.clone(), self.read_state.clone(), true).await?;
 
         let response = GetInfoResponse {
             version,
@@ -1550,8 +1549,7 @@ where
                 Err(_) => ((Height::MIN, network.genesis_hash()), Default::default()),
             };
 
-            let difficulty = chain_tip_difficulty
-                .expect("should always be Ok when `should_use_default` is true");
+            let difficulty = chain_tip_difficulty?;
 
             (
                 size_on_disk,
@@ -5454,11 +5452,7 @@ where
 {
     let request = ReadRequest::ChainInfo;
 
-    // # TODO
-    // - add a separate request like BestChainNextMedianTimePast, but skipping the
-    //   consistency check, because any block's difficulty is ok for display
-    //
-    // Return the minimum difficulty when the state is unavailable, like `zcashd`:
+    // Return the minimum difficulty for an empty state, like `zcashd`:
     // <https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L40-L41>
     let response = state
         .ready()
@@ -5467,7 +5461,18 @@ where
 
     let response = match (should_use_default, response) {
         (_, Ok(res)) => res,
-        (true, Err(_)) => return Ok(1.0),
+        (true, Err(error)) => {
+            let tip_response = state
+                .ready()
+                .and_then(|service| service.call(ReadRequest::Tip))
+                .await;
+
+            match tip_response {
+                Ok(ReadResponse::Tip(None)) => return Ok(1.0),
+                Ok(ReadResponse::Tip(Some(_))) | Err(_) => return Err(error).map_error(0),
+                Ok(_) => unreachable!("unmatched response to a tip request"),
+            }
+        }
         (false, Err(error)) => return Err(error).map_error(0),
     };
 
@@ -5476,44 +5481,11 @@ where
         _ => unreachable!("unmatched response to a chain info request"),
     };
 
-    // This RPC is typically used for display purposes, so it is not consensus-critical.
-    // But it uses the difficulty consensus rules for its calculations.
-    //
-    // Consensus:
-    // https://zips.z.cash/protocol/protocol.pdf#nbits
-    //
-    // The zcashd implementation performs to_expanded() on f64,
-    // and then does an inverse division:
-    // https://github.com/zcash/zcash/blob/d6e2fada844373a8554ee085418e68de4b593a6c/src/rpc/blockchain.cpp#L46-L73
-    //
-    // But in Zebra we divide the high 128 bits of each expanded difficulty. This gives
-    // a similar result, because the lower 128 bits are insignificant after conversion
-    // to `f64` with a 53-bit mantissa.
-    //
-    // `pow_limit >> 128 / difficulty >> 128` is the same as the work calculation
-    // `(2^256 / pow_limit) / (2^256 / difficulty)`, but it's a bit more accurate.
-    //
-    // To simplify the calculation, we don't scale for leading zeroes. (Bitcoin's
-    // difficulty currently uses 68 bits, so even it would still have full precision
-    // using this calculation.)
-
-    // Get expanded difficulties (256 bits), these are the inverse of the work
-    let pow_limit: U256 = network.target_difficulty_limit().into();
-    let Some(difficulty) = chain_info.expected_difficulty.to_expanded() else {
+    if chain_info.expected_difficulty.to_expanded().is_none() {
         return Ok(0.0);
-    };
+    }
 
-    // Shift out the lower 128 bits (256 bits, but the top 128 are all zeroes)
-    let pow_limit = pow_limit >> 128;
-    let difficulty = U256::from(difficulty) >> 128;
-
-    // Convert to u128 then f64.
-    // We could also convert U256 to String, then parse as f64, but that's slower.
-    let pow_limit = pow_limit.as_u128() as f64;
-    let difficulty = difficulty.as_u128() as f64;
-
-    // Invert the division to give approximately: `work(difficulty) / work(pow_limit)`
-    Ok(pow_limit / difficulty)
+    Ok(chain_info.expected_difficulty.relative_to_network(&network))
 }
 
 /// Commands for the `addnode` RPC method.

--- a/crates/zakura-rpc/src/methods/tests/prop.rs
+++ b/crates/zakura-rpc/src/methods/tests/prop.rs
@@ -667,6 +667,12 @@ proptest! {
                     .expect("getblockchaininfo should call mock state service with correct request")
                     .respond(Err(BoxError::from("chain info not available")));
 
+                state
+                    .expect_request(zakura_state::ReadRequest::Tip)
+                    .await
+                    .expect("getblockchaininfo should confirm the state is empty")
+                    .respond(zakura_state::ReadResponse::Tip(None));
+
                 }
             };
 
@@ -677,6 +683,7 @@ proptest! {
             prop_assert_eq!(response.best_block_hash, genesis_block.header.hash());
             prop_assert_eq!(response.chain, network.bip70_network_name());
             prop_assert_eq!(response.blocks, Height::MIN);
+            prop_assert_eq!(response.difficulty, 1.0);
             prop_assert_eq!(response.value_pools, GetBlockchainInfoBalance::value_pools(ValueBalance::zero(), None));
 
             let genesis_branch_id = NetworkUpgrade::current(&network, Height::MIN).branch_id().unwrap_or(ConsensusBranchId::RPC_MISSING_ID);

--- a/crates/zakura-rpc/src/methods/tests/snapshot.rs
+++ b/crates/zakura-rpc/src/methods/tests/snapshot.rs
@@ -31,7 +31,7 @@ use zakura_chain::{
     serialization::{DateTime32, ZcashDeserializeInto},
     subtree::NoteCommitmentSubtreeData,
     transaction::Transaction,
-    work::difficulty::CompactDifficulty,
+    work::difficulty::{CompactDifficulty, ParameterDifficulty},
 };
 use zakura_consensus::Request;
 use zakura_network::{

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -4021,6 +4021,27 @@ async fn rpc_z_validateaddress_regtest() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn chain_tip_difficulty_uses_minimum_on_state_error() {
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state_handler = read_state.clone();
+
+    let difficulty_fut = chain_tip_difficulty(Mainnet, read_state, true);
+    let state_error_fut = async move {
+        read_state_handler
+            .expect_request_that(|request| matches!(request, ReadRequest::ChainInfo))
+            .await
+            .respond(Err(BoxError::from("chain info is unavailable")));
+    };
+
+    let (difficulty, ()) = tokio::join!(difficulty_fut, state_error_fut);
+
+    assert_eq!(
+        difficulty.expect("the fallback difficulty is available"),
+        1.0
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn rpc_getdifficulty() {
     let _init_guard = zakura_test::init();
 

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -4021,7 +4021,7 @@ async fn rpc_z_validateaddress_regtest() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn chain_tip_difficulty_uses_minimum_on_state_error() {
+async fn chain_tip_difficulty_uses_minimum_for_empty_state() {
     let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let mut read_state_handler = read_state.clone();
 
@@ -4031,6 +4031,10 @@ async fn chain_tip_difficulty_uses_minimum_on_state_error() {
             .expect_request_that(|request| matches!(request, ReadRequest::ChainInfo))
             .await
             .respond(Err(BoxError::from("chain info is unavailable")));
+        read_state_handler
+            .expect_request_that(|request| matches!(request, ReadRequest::Tip))
+            .await
+            .respond(ReadResponse::Tip(None));
     };
 
     let (difficulty, ()) = tokio::join!(difficulty_fut, state_error_fut);
@@ -4039,6 +4043,88 @@ async fn chain_tip_difficulty_uses_minimum_on_state_error() {
         difficulty.expect("the fallback difficulty is available"),
         1.0
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chain_tip_difficulty_propagates_state_error_when_tip_exists() {
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state_handler = read_state.clone();
+
+    let difficulty_fut = chain_tip_difficulty(Mainnet, read_state, true);
+    let state_error_fut = async move {
+        read_state_handler
+            .expect_request_that(|request| matches!(request, ReadRequest::ChainInfo))
+            .await
+            .respond(Err(BoxError::from("chain info is unavailable")));
+        read_state_handler
+            .expect_request_that(|request| matches!(request, ReadRequest::Tip))
+            .await
+            .respond(ReadResponse::Tip(Some((
+                Height::MIN,
+                Mainnet.genesis_hash(),
+            ))));
+    };
+
+    let (difficulty, ()) = tokio::join!(difficulty_fut, state_error_fut);
+    let error = difficulty.expect_err("a non-empty state must not use a fallback difficulty");
+
+    assert!(error.message().contains("chain info is unavailable"));
+}
+
+async fn mock_chain_tip_difficulty(
+    network: zakura_chain::parameters::Network,
+    expected_difficulty: CompactDifficulty,
+) -> f64 {
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state_handler = read_state.clone();
+    let response_network = network.clone();
+
+    let difficulty_fut = chain_tip_difficulty(network, read_state, false);
+    let state_response_fut = async move {
+        read_state_handler
+            .expect_request_that(|request| matches!(request, ReadRequest::ChainInfo))
+            .await
+            .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                expected_difficulty,
+                tip_height: Height::MIN,
+                tip_hash: response_network.genesis_hash(),
+                cur_time: DateTime32::from(1),
+                min_time: DateTime32::from(1),
+                max_time: DateTime32::from(1),
+                chain_history_root: fake_history_tree(&response_network).hash(),
+            }));
+    };
+
+    let (difficulty, ()) = tokio::join!(difficulty_fut, state_response_fut);
+    difficulty.expect("valid chain information has a display difficulty")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chain_tip_difficulty_supports_small_network_limit() {
+    let network = Parameters::build()
+        .with_network_name("small_difficulty_limit")
+        .expect("the custom network name is valid")
+        .with_target_difficulty_limit(U256::from(0x1234_u32))
+        .expect("the target difficulty limit is valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("the custom network parameters are valid");
+    let expected_difficulty = network.target_difficulty_limit().to_compact();
+
+    let difficulty = mock_chain_tip_difficulty(network, expected_difficulty).await;
+
+    assert_eq!(difficulty, 1.0);
+    assert!(difficulty.is_finite());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn chain_tip_difficulty_supports_small_expected_target() {
+    let expected_difficulty = ExpandedDifficulty::from(U256::from(0x1234_u32)).to_compact();
+
+    let difficulty = mock_chain_tip_difficulty(Mainnet, expected_difficulty).await;
+
+    assert!(difficulty > 1.0);
+    assert!(difficulty.is_finite());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/docs/changelog/unreleased/934.md
+++ b/docs/changelog/unreleased/934.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Fixed `getinfo` and `getblockchaininfo` reporting an invalid difficulty when
-  chain information is temporarily unavailable
+- Fixed difficulty RPCs reporting fabricated or non-finite values when chain
+  information is unavailable or a configured network uses a small target
   ([#934](https://github.com/zakura-core/zakura/pull/934)).

--- a/docs/changelog/unreleased/934.md
+++ b/docs/changelog/unreleased/934.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed `getinfo` and `getblockchaininfo` reporting an invalid difficulty when
+  chain information is temporarily unavailable
+  ([#934](https://github.com/zakura-core/zakura/pull/934)).


### PR DESCRIPTION
## Motivation

When the state `ChainInfo` query fails, default-enabled difficulty callers
return the high 128 bits of the proof-of-work target as a floating-point
value. That raw target fragment is not normalized difficulty, so `getinfo` and
`getblockchaininfo` can report an enormous plausible-looking value.

Returning `1.0` for every state error would still fabricate minimum difficulty
when a chain tip exists. The successful calculation also discards the low 128
bits of both targets, which can produce `NaN` or infinity for valid configured
networks with small targets.

## Solution

- Confirm the state has no chain tip before using the zcashd-compatible `1.0`
  default. If a tip exists, preserve the original `ChainInfo` error.
- Let `getinfo` and `getblockchaininfo` propagate non-empty-state difficulty
  errors instead of assuming the fallback always succeeds.
- Use [`CompactDifficulty::relative_to_network`] for the normalized display
  calculation. It handles the full compact exponent range and is already used
  by the block RPCs.

This helper is not on the `getblocktemplate` call path. Template timestamp
admission remains a separate GBT-boundary concern.

## Testing

- `cargo test -p zakura-rpc --lib chain_tip_difficulty_`
- `cargo test -p zakura-rpc --lib rpc_getdifficulty`
- `cargo test -p zakura-rpc --lib`
- `cargo clippy -p zakura-rpc --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm exec --yes markdownlint-cli -- docs/changelog/unreleased/934.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `git diff --check`

The regression tests cover the empty-state default, error propagation when a
tip exists, and finite normalized values for both a sub-`2^128` network limit
and a sub-`2^128` expected target.

## Changelog

- Added `docs/changelog/unreleased/934.md`.

### Specifications & References

- V12 finding F-270317: https://v12.sh/runs/7546/270317
- Follow-up V12 finding F-270551: https://v12.sh/runs/7560/270551
- zcashd difficulty calculation: https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L35-L73
