### PR TITLE
fix(ops): send daily sync summaries at 5 p.m. Denver

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -222,6 +222,9 @@ jobs:
       - name: Continuous-sync tests
         if: ${{ !cancelled() }}
         run: python3 deploy/continuous-sync/tests/test_continuous_sync.py
+      - name: Daily sync summary tests
+        if: ${{ !cancelled() }}
+        run: python3 deploy/continuous-sync/tests/test_daily_summary.py
 
       - name: Cluster dashboard and watchdog tests
         if: ${{ !cancelled() }}

--- a/.github/workflows/zakura-continuous-sync.yml
+++ b/.github/workflows/zakura-continuous-sync.yml
@@ -191,7 +191,7 @@ jobs:
           fi
         env:
           SLACK_WEB_HOOK: ${{ secrets.SLACK_WEB_HOOK }}
-          # Remind about an unresolved failure every 6 hours.
+          # Remind about an unresolved failure daily; routine summaries have a host timer.
           REMINDER_INTERVAL: "86400"
           # A run is capped at 48h, so only flag a node that has not completed one
           # in four days -- long enough that a legitimately long run cannot trip it.
@@ -201,9 +201,13 @@ jobs:
       # never record its `last_sent` and would re-page on every cycle.
       - name: Save audit alert state
         if: always() && env.ACTION == 'audit'
-        # A lost state save only costs one duplicate reminder; never fail the job for it.
+        # Routine summary cursors live on the sender; this cache only tracks audit alerts.
         continue-on-error: true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: .audit-alert-state
           key: continuous-sync-audit-state-${{ github.run_id }}
+
+      - name: Check daily summary delivery
+        if: always() && env.ACTION == 'audit'
+        run: python3 deploy/continuous-sync/deploy.py summary-status

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -128,7 +128,8 @@ python3 deploy/continuous-sync/deploy.py status
 python3 deploy/continuous-sync/deploy.py --node temp-zakura-sync-test-5 status
 ```
 
-The scheduled workflow runs `audit` twice per hour. It alerts when a host is
+The workflow requests `audit` twice per hour, but GitHub scheduling can delay or
+skip runs for hours. It alerts when a host is
 unreachable, the controller is halted, the node service is inactive while a run
 claims to be syncing, metrics are unavailable during sync, disk free space is
 below the configured 10 GiB floor, or the node has not completed a run in four
@@ -149,13 +150,36 @@ receipt confirms delivery there. It does not send recoveries for incidents known
 only to the old destination. Cache records without a destination cannot suppress
 an alert without a matching receipt.
 
-Unchanged failures and routine completions share a daily digest, replacing the
-six-hour reminders and individual completion messages. The first digest is due
-24 hours after the audit begins tracking it; subsequent digests follow that
-cadence. New failures and recoveries do not wait for the digest. Completion counts
-include runs since the controller enabled digest reporting, then since the last
-successful digest. An unchanged failure appears only in a digest at least 24 hours
-after its last alert or reminder; a recent alert waits for a later digest.
+Unchanged failures remain in the audit's daily reminder. New failures and
+recoveries do not wait for that reminder. Routine completions are delivered by
+the separate daily sender described below; normal audits never emit them.
+
+### Daily summary
+
+`daily_summary.py` runs on the single sender named in `[summary]` in `nodes.toml`.
+`zakura-sync-summary.timer` checks once per minute, with a deadline of **5:00 p.m.
+America/Denver**, following daylight saving changes. The first check at or after
+the deadline sends the summary. A failed delivery retries on the next check.
+For example, a post delayed until 5:10 p.m. does not move tomorrow's 5:00 p.m.
+deadline. After downtime, one catch-up post includes all still-unreported runs.
+
+The sender uses the existing monitor's read-only peer SSH access and stores the
+last delivered run number and ID for each node in
+`/var/lib/zakura-sync-summary/state.json`, independently of the Actions cache and
+disposable chain state. Only a confirmed Slack response advances these cursors.
+The state file is atomically replaced and flushed to disk, and a file lock prevents
+concurrent senders on that host. Missing or corrupt state fails visibly instead
+of restarting a 24-hour wait or replaying old completions. The configured Slack
+destination must match the saved delivery history.
+
+Each post includes runs completed since that node was last successfully reported.
+Runs still in progress wait for the next day. An unavailable node is identified in
+the message and retains its cursor, so its unreported runs are included when it
+becomes reachable. A reset or inconsistent completion counter is treated as
+unavailable until the operator restores the correct history. New nodes require an
+explicit cursor; use number zero and an empty run ID only if none of their runs
+have ever been reported. Before retiring a node, deliver its pending results.
+
 The summary names each networking mode (dual, Zakura only, or legacy only),
 keeps the host ID for troubleshooting, and includes hosts with zero completions.
 It shows one row per completed run, with duration and average blocks
@@ -190,22 +214,75 @@ Legacy networking only · 1 completed
 The Slack summary also retains host IDs and current status for troubleshooting.
 
 Controllers retain the latest 256 completion durations and ending heights in their
-state, independently of run-log cleanup. Audits accumulate up to 256 per-run
-records per host until delivery.
-Older controllers and existing audit caches still contribute their completion
-counts and latest timing, with BPS unavailable for old records.
+state, independently of run-log cleanup. The sender reads these on each delivery
+attempt. Counts remain available when older timings are no longer retained.
 Missing records, including those beyond retention, are explicitly marked unavailable.
 Malformed optional controller history is discarded without failing a successful
-sync; completion counters remain authoritative. Retired hosts leave the summary
-after any pending completions have been delivered. Per-run logs and artifacts remain available
-on each host.
-A lost audit cache may repeat already summarized completions or alerts.
+sync; completion counters remain authoritative. Per-run logs and artifacts remain
+available on each host.
 
-Alert state is carried between workflow runs in the Actions cache. A failed Slack
+Failure-alert state is still carried between workflow runs in the Actions cache;
+cache loss can repeat audit alerts but cannot reset the daily summary. A failed Slack
 post does not advance notification state; the next audit retries it. Targeted
 audits preserve other nodes' incidents and do not send the fleet digest. The audit
-job still exits non-zero whenever an inspected node has a problem, including when
-its notification has already been delivered.
+job exits non-zero when an inspected node has a problem or Slack delivery fails.
+The workflow also checks that the daily sender's timer is active and its latest
+deadline is no more than 15 minutes overdue. Host-local failures appear in
+`systemctl status zakura-sync-summary.service` and its journal immediately; the
+external check remains subject to GitHub scheduling delays.
+
+### Sender rollout and recovery
+
+Install from the reviewed revision, without starting the sender or restarting any
+sync controller:
+
+```bash
+python3 deploy/continuous-sync/deploy.py deploy-summary --no-start
+```
+
+On the sender, prepare a root-only seed JSON file with `last_posted_at` (UTC Unix
+seconds of the last confirmed summary) and `cursors`. Each cursor is keyed by the
+configured node name and contains `number` and `run_id` from that node's last
+reported completion. Verify them against the Slack post and controller history;
+do not use the current counters, which would silently skip pending runs, or a
+reset Actions cache, which may include previously reported runs. Initialization
+requires every configured node and refuses to overwrite existing state.
+
+After the GitHub audit revision that disables routine summaries is active, and
+any older audit has finished, initialize and preview on the sender:
+
+```bash
+systemd-run --wait --collect -p EnvironmentFile=/etc/zakura-alerts.env \
+  /usr/bin/python3 /opt/zakura-sync-summary/daily_summary.py \
+  initialize --from-file /root/sync-summary-seed.json
+systemd-run --wait --collect -p EnvironmentFile=/etc/zakura-alerts.env \
+  /usr/bin/python3 /opt/zakura-sync-summary/daily_summary.py run --dry-run
+```
+
+The preview respects the deadline and never advances state. Enable the timer only
+after reviewing the migration and pending message:
+
+```bash
+systemctl enable --now zakura-sync-summary.timer
+python3 /opt/zakura-sync-summary/daily_summary.py status
+journalctl -u zakura-sync-summary.service --since today
+```
+
+If today's deadline has passed, enabling sends one catch-up summary on the next
+minute. Check delivery and the saved cursors before declaring rollout complete.
+Keep a backup of the delivery state. For a host replacement, stop the old sender
+first and restore that state on the newly configured owner. Missing state must be
+reconstructed from confirmed posts; never silently initialize from the present.
+Changing the destination or schedule also requires reviewing the saved history.
+
+Slack incoming webhooks do not make delivery and the local state update one atomic
+operation. If Slack accepts a post but its response is lost, or the host crashes
+before saving confirmation, a retry can duplicate that post. Known failed
+deliveries retain all runs; the sender never claims exactly-once delivery.
+
+For rollback, stop the timer first. `audit --legacy-digest` retains the old reporting
+path, but its cache is not updated by the new sender; reconstruct its completion
+baseline from the last confirmed post before using it. Never enable both senders.
 
 ### VCT canary notifications
 
@@ -219,8 +296,8 @@ cancelled and skipped results do not clear it. Delivery failure retains the prio
 state, and missing cache state causes another alert rather than suppressing one.
 
 A completely unreachable host cannot run its local minute monitor. Its fallback
-alert therefore comes from the audit, with an expected maximum detection delay
-of about 30 minutes, plus GitHub Actions scheduling and job startup time.
+alert comes from the audit. The requested cadence is 30 minutes, but observed
+GitHub scheduling gaps mean this is not a maximum detection delay.
 
 On a host:
 

--- a/deploy/continuous-sync/daily_summary.py
+++ b/deploy/continuous-sync/daily_summary.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Deliver the fleet summary at a fixed local time with durable completion cursors."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+from datetime import datetime, time as wall_time, timedelta
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import time
+import tomllib
+from zoneinfo import ZoneInfo
+
+from deploy import DeployError, Node, completion_updates, post_slack, slack_webhook_url, sync_label
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+STATE_VERSION = 1
+spec = importlib.util.spec_from_file_location("summary_monitor", SCRIPT_DIR / "alert-monitor.py")
+monitor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(monitor)
+
+
+def latest_slot(timestamp: int, settings: dict) -> tuple[str, int]:
+    """Return the latest daily deadline, including yesterday before today's cutoff."""
+    zone = ZoneInfo(settings["timezone"])
+    hour, minute = map(int, settings["time"].split(":"))
+    local = datetime.fromtimestamp(timestamp, zone)
+    deadline = datetime.combine(local.date(), wall_time(hour, minute), zone)
+    if local < deadline:
+        deadline -= timedelta(days=1)
+    return deadline.date().isoformat(), int(deadline.timestamp())
+
+
+def load_state(path: Path, timestamp: int, settings: dict, names: set[str]) -> dict:
+    """Missing or invalid delivery history requires recovery, never a fresh timer."""
+    try:
+        state = json.loads(path.read_text())
+        if (state["version"] != STATE_VERSION
+                or type(state["last_posted_at"]) is not int
+                or not 0 < state["last_posted_at"] <= timestamp
+                or state["last_slot"] != latest_slot(state["last_posted_at"], settings)[0]
+                or not isinstance(state["destination"], str)
+                or len(state["destination"]) != 64):
+            raise ValueError("invalid delivery metadata")
+        cursors = state["cursors"]
+        if not isinstance(cursors, dict) or not names <= cursors.keys():
+            raise ValueError("missing completion cursors")
+        unavailable = state.get("unavailable", [])
+        if not isinstance(unavailable, list) or any(not isinstance(name, str) for name in unavailable):
+            raise ValueError("invalid unavailable node list")
+        for cursor in cursors.values():
+            if (type(cursor["number"]) is not int or cursor["number"] < 0
+                    or not isinstance(cursor["run_id"], str)
+                    or bool(cursor["run_id"]) != (cursor["number"] > 0)):
+                raise ValueError("invalid completion cursor")
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        raise DeployError("summary delivery state missing or invalid; restore it or initialize from the last confirmed post") from error
+    return state
+
+
+def save_state(path: Path, state: dict) -> None:
+    """Atomically replace and fsync delivery state on the persistent host filesystem."""
+    temporary = path.with_suffix(".tmp")
+    with temporary.open("w") as file:
+        json.dump(state, file, indent=2, sort_keys=True)
+        file.write("\n")
+        file.flush()
+        os.fsync(file.fileno())
+    temporary.replace(path)
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def collect_statuses(config: dict, cursors: dict) -> tuple[dict, dict]:
+    """Use the existing read-only monitor access; retain cursors for unavailable nodes."""
+    statuses = {}
+    next_cursors = dict(cursors)
+    nodes = config["nodes"]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as pool:
+        results = pool.map(lambda node: monitor.query_node(config, node), nodes)
+        for node, data in zip(nodes, results):
+            name = node["name"]
+            data = data if isinstance(data, dict) else {}
+            controller = data.get("controller_state")
+            controller = controller if isinstance(controller, dict) else {}
+            total, run_id = controller.get("runs"), controller.get("last_success_run")
+            cursor = cursors[name]
+            if type(total) is int and total == 0 and cursor["number"] == 0 and not data.get("query_error"):
+                statuses[name] = data
+                continue
+            valid = (
+                not data.get("query_error")
+                and controller.get("completion_digest") is True
+                and type(total) is int and total >= cursor["number"]
+                and isinstance(run_id, str) and bool(run_id)
+                and ((total == cursor["number"]) == (run_id == cursor["run_id"]))
+            )
+            if not valid:
+                print(f"{name}: completion status unavailable or counter reset; retaining delivered cursor", file=sys.stderr)
+                continue
+            statuses[name] = {**data, "sample": {"metrics_status": data.get("metrics_status", "unknown")}}
+            next_cursors[name] = {"number": total, "run_id": run_id}
+    return statuses, next_cursors
+
+
+def deliver(config: dict, path: Path, timestamp: int, *, dry_run: bool = False) -> int:
+    settings = config["summary"]
+    names = {node["name"] for node in config["nodes"]}
+    state = load_state(path, timestamp, settings, names)
+    slot, _ = latest_slot(timestamp, settings)
+    destination = slack_webhook_url()
+    if not destination or hashlib.sha256(destination.encode()).hexdigest() != state["destination"]:
+        raise DeployError("summary Slack destination missing or changed; explicitly restore delivery history for this destination")
+    if state["last_slot"] >= slot:
+        print(f"summary already delivered for {slot}")
+        return 0
+    statuses, cursors = collect_statuses(config, state["cursors"])
+    previous = {"completions": {
+        name: {"total": cursor["number"], "run_id": cursor["run_id"], "pending": 0,
+               "details": [], "sha": "unknown", "duration": None}
+        for name, cursor in state["cursors"].items()
+    }}
+    labels = {node["name"]: sync_label(Node(node)) for node in config["nodes"]}
+    lines, _ = completion_updates(statuses, previous, True, labels)
+    unavailable = names - statuses.keys()
+    # The shared formatter returns one section per configured name, sorted by name.
+    lines = [f"*{labels[name]}*\nstatus unavailable; unreported runs retained" if name in unavailable else line
+             for name, line in zip(sorted(labels), lines)]
+    text = ":memo: Mainnet sync summary — since previous digest\n\n" + "\n\n".join(lines)
+    if unavailable:
+        text += "\n\nUnavailable nodes retain their unreported runs for the next summary."
+    caught_up = [name for name in state.get("unavailable", []) if name in statuses
+                 and cursors[name]["number"] > state["cursors"][name]["number"]]
+    if caught_up:
+        text += "\n\nIncludes earlier unreported runs from previously unavailable nodes: " + ", ".join(sorted(caught_up)) + "."
+    text += "\n\nRuns listed oldest first. Each run starts from genesis."
+    if dry_run:
+        print(text)
+        return 0
+    if not post_slack(text):
+        raise DeployError("summary Slack delivery failed; completion cursors retained for retry")
+    # The slot belongs to this attempt's snapshot. A later retry never shifts the next deadline.
+    save_state(path, {**state, "last_slot": slot, "last_posted_at": timestamp,
+                      "cursors": cursors, "unavailable": sorted(unavailable)})
+    print(f"summary delivered for {slot}; {len(unavailable)} node(s) unavailable")
+    return 0
+
+
+def initialize(config: dict, path: Path, seed_path: Path, timestamp: int) -> int:
+    """Seed only explicitly supplied, already-reported cursors; never overwrite state."""
+    if path.exists():
+        raise DeployError("summary state already exists; initialization cannot overwrite delivery history")
+    state = json.loads(seed_path.read_text())
+    destination = slack_webhook_url()
+    if not destination:
+        raise DeployError("summary Slack destination is not configured")
+    state = {**state, "version": STATE_VERSION,
+             "destination": hashlib.sha256(destination.encode()).hexdigest(),
+             "last_slot": latest_slot(state["last_posted_at"], config["summary"])[0]}
+    candidate = path.with_suffix(".seed")
+    try:
+        save_state(candidate, state)
+        load_state(candidate, timestamp, config["summary"], {node["name"] for node in config["nodes"]})
+        save_state(path, state)
+    finally:
+        candidate.unlink(missing_ok=True)
+    print("initialized from confirmed delivery history; no Slack post sent")
+    return 0
+
+
+def check_status(config: dict, path: Path, timestamp: int) -> int:
+    settings = config["summary"]
+    state = load_state(path, timestamp, settings, {node["name"] for node in config["nodes"]})
+    slot, deadline = latest_slot(timestamp, settings)
+    overdue = state["last_slot"] < slot and timestamp - deadline > 900
+    print(json.dumps({"last_posted_at": state["last_posted_at"], "last_slot": state["last_slot"],
+                      "due_slot": slot, "overdue": overdue}))
+    return int(overdue)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=SCRIPT_DIR / "nodes.toml")
+    sub = parser.add_subparsers(dest="command", required=True)
+    run = sub.add_parser("run")
+    run.add_argument("--dry-run", action="store_true")
+    seed = sub.add_parser("initialize")
+    seed.add_argument("--from-file", type=Path, required=True)
+    sub.add_parser("status")
+    args = parser.parse_args()
+    try:
+        with args.config.open("rb") as file:
+            config = tomllib.load(file)
+        settings = config["summary"]
+        if socket.gethostname().split(".", 1)[0] != settings["hostname"]:
+            raise DeployError("this host is not the configured summary sender")
+        path = Path(settings["state_file"])
+        timestamp = int(time.time())
+        if args.command == "status":
+            return check_status(config, path, timestamp)
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with path.with_suffix(".lock").open("w") as lock:
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as error:
+                raise DeployError("another summary invocation holds the delivery lock") from error
+            if args.command == "initialize":
+                return initialize(config, path, args.from_file, timestamp)
+            return deliver(config, path, timestamp, dry_run=args.dry_run)
+    except (DeployError, OSError, ValueError, KeyError, TypeError) as error:
+        print(f"summary failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -64,6 +64,7 @@ def run(
     capture: bool = False,
     check: bool = True,
     input_text: str | None = None,
+    timeout: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
@@ -72,6 +73,7 @@ def run(
             capture_output=capture,
             text=True,
             input=input_text,
+            timeout=timeout,
         )
     except subprocess.CalledProcessError as error:
         detail = ""
@@ -389,6 +391,50 @@ def remote_json(node: Node, command: str) -> tuple[bool, dict[str, Any] | str]:
 def cmd_deploy(args: argparse.Namespace) -> int:
     nodes = load_nodes(args.config, args.node)
     return summarize_parallel(nodes, lambda node: deploy_node(node, args))
+
+
+def summary_node(args: argparse.Namespace) -> Node:
+    """Resolve the single inventory-owned sender without granting peer write access."""
+    with args.config.open("rb") as file:
+        hostname = tomllib.load(file)["summary"]["hostname"]
+    nodes = [node for node in load_nodes(args.config, None) if node.raw["hostname"] == hostname]
+    if len(nodes) != 1 or args.node:
+        raise DeployError("summary operations require one configured sender and no --node override")
+    return nodes[0]
+
+
+def cmd_deploy_summary(args: argparse.Namespace) -> int:
+    """Install reporting separately from controllers; never initialize delivery history."""
+    node = summary_node(args)
+    # Disable new invocations without interrupting a post between delivery and state save.
+    run(node.ssh_cmd(
+        "if systemctl cat zakura-sync-summary.timer >/dev/null 2>&1; then "
+        "systemctl disable --now zakura-sync-summary.timer; fi; "
+        "if systemctl cat zakura-sync-summary.service >/dev/null 2>&1; then "
+        'case "$(systemctl show --value --property=ActiveState zakura-sync-summary.service)" in '
+        "inactive|failed) ;; *) echo 'sender still running; wait for completion and retry installation' >&2; exit 1;; esac; fi"
+    ), timeout=30)
+    run(node.ssh_cmd("install -d -m 755 /opt/zakura-sync-summary"), timeout=30)
+    for name in ("daily_summary.py", "deploy.py", "alert-monitor.py"):
+        run(node.scp_to(SCRIPT_DIR / name, f"/opt/zakura-sync-summary/{name}"), timeout=30)
+    run(node.scp_to(args.config, "/opt/zakura-sync-summary/nodes.toml"), timeout=30)
+    for name in ("zakura-sync-summary.service", "zakura-sync-summary.timer"):
+        run(node.scp_to(TEMPLATES_DIR / name, f"/etc/systemd/system/{name}"), timeout=30)
+    run(node.ssh_cmd("systemctl daemon-reload"), timeout=30)
+    if not args.no_start:
+        with args.config.open("rb") as file:
+            state_path = tomllib.load(file)["summary"]["state_file"]
+        run(node.ssh_cmd(f"test -s {shlex.quote(state_path)} && systemctl enable --now zakura-sync-summary.timer"), timeout=30)
+    return 0
+
+
+def cmd_summary_status(args: argparse.Namespace) -> int:
+    node = summary_node(args)
+    proc = subprocess.run(node.ssh_cmd(
+        "systemctl is-active --quiet zakura-sync-summary.timer && "
+        "python3 /opt/zakura-sync-summary/daily_summary.py status"
+    ), timeout=30)
+    return proc.returncode
 
 
 def cmd_status(args: argparse.Namespace) -> int:
@@ -843,9 +889,13 @@ def cmd_audit(args: argparse.Namespace) -> int:
         destination=destination,
     )
     state["problems"].update({k: v for k, v in prior_problems.items() if k not in selected})
-    completion_lines, state["completions"] = completion_updates(
-        statuses, previous, digest_due, {node.name: sync_label(node) for node in nodes}
-    )
+    completion_lines = []
+    # Normal audits no longer own routine summaries. Keep explicit legacy mode for rollback.
+    state["completions"] = previous.get("completions", {})
+    if getattr(args, "legacy_digest", False):
+        completion_lines, state["completions"] = completion_updates(
+            statuses, previous, digest_due, {node.name: sync_label(node) for node in nodes}
+        )
     state["last_digest_at"] = timestamp if digest_due else last_digest
     text = audit_message(new_lines, reminder_lines, recovered_lines)
     if completion_lines:
@@ -881,7 +931,7 @@ def cmd_audit(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
 
-    return 1 if problems else 0
+    return 1 if problems or not posted else 0
 
 
 def summarize_parallel(nodes: list[Node], fn) -> int:
@@ -911,10 +961,14 @@ def parse_args() -> argparse.Namespace:
     deploy = sub.add_parser("deploy", help="install controller/config/systemd files")
     deploy.add_argument("--no-start", action="store_true", help="install but do not start controller")
     deploy.add_argument("--dry-run", action="store_true", help="render local files only")
+    summary = sub.add_parser("deploy-summary", help="install the daily sender without restarting nodes")
+    summary.add_argument("--no-start", action="store_true", help="install only; initialize delivery state before enabling")
+    sub.add_parser("summary-status", help="check the sender timer and overdue delivery")
     sub.add_parser("status", help="fetch controller status JSON")
     sub.add_parser("resume", help="clear durable failure marker and restart controller")
     audit = sub.add_parser("audit", help="scheduled external audit for CI")
     audit.add_argument("--dry-run", action="store_true")
+    audit.add_argument("--legacy-digest", action="store_true", help="rollback only: emit summaries from the old audit cache")
     audit.add_argument(
         "--max-completion-age",
         type=int,
@@ -941,6 +995,10 @@ def main() -> int:
     try:
         if args.command == "deploy":
             return cmd_deploy(args)
+        if args.command == "deploy-summary":
+            return cmd_deploy_summary(args)
+        if args.command == "summary-status":
+            return cmd_summary_status(args)
         if args.command == "status":
             return cmd_status(args)
         if args.command == "resume":

--- a/deploy/continuous-sync/nodes.toml
+++ b/deploy/continuous-sync/nodes.toml
@@ -52,6 +52,12 @@ bootstrap_peers = [
     "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
 ]
 
+[summary]
+hostname = "temp-zakura-sync-test-1"
+timezone = "America/Denver"
+time = "17:00"
+state_file = "/var/lib/zakura-sync-summary/state.json"
+
 [[nodes]]
 name = "temp-zakura-sync-test-1"
 hostname = "temp-zakura-sync-test-1"

--- a/deploy/continuous-sync/templates/zakura-sync-summary.service
+++ b/deploy/continuous-sync/templates/zakura-sync-summary.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Deliver the Zakura daily mainnet sync summary
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=/etc/zakura-alerts.env
+ExecStart=/usr/bin/python3 /opt/zakura-sync-summary/daily_summary.py run
+StateDirectory=zakura-sync-summary
+StateDirectoryMode=0700
+UMask=0077
+TimeoutStartSec=90

--- a/deploy/continuous-sync/templates/zakura-sync-summary.timer
+++ b/deploy/continuous-sync/templates/zakura-sync-summary.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Check the fixed daily summary deadline and retry failed delivery
+
+[Timer]
+# The sender checks 17:00 America/Denver, including daylight saving changes.
+OnCalendar=*-*-* *:*:00
+AccuracySec=1s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -1319,6 +1319,7 @@ class NotificationTests(unittest.TestCase):
         args = argparse.Namespace(
             config=Path("unused"), node=selected, dry_run=False,
             max_completion_age=0, reminder_interval=86400, state_file=path,
+            legacy_digest=True,
         )
         node = deploy.Node({"name": "node", "ssh_string": "root@host"})
         with (

--- a/deploy/continuous-sync/tests/test_daily_summary.py
+++ b/deploy/continuous-sync/tests/test_daily_summary.py
@@ -1,0 +1,217 @@
+"""Exercise calendar delivery and durable cursors without contacting hosts or Slack."""
+
+import argparse
+import contextlib
+from datetime import datetime
+import fcntl
+import hashlib
+import io
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+import daily_summary as summary
+import deploy
+
+
+def stamp(value):
+    return int(datetime.fromisoformat(value).timestamp())
+
+
+class DailySummaryTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / "state.json"
+        self.config = {
+            "summary": {"hostname": "node", "time": "17:00", "timezone": "America/Denver",
+                        "state_file": str(self.path)},
+            "nodes": [{"name": "node", "hostname": "node", "ssh_string": "root@node", "p2p_stack": "dual"}],
+        }
+        self.webhook = "https://slack.invalid/summary-test"
+        self.last = stamp("2026-09-07T23:46:00+00:00")
+        self.due = stamp("2026-09-08T23:00:00+00:00")
+        self.state = {
+            "version": 1, "last_posted_at": self.last, "last_slot": "2026-09-07",
+            "destination": hashlib.sha256(self.webhook.encode()).hexdigest(),
+            "cursors": {"node": {"number": 2, "run_id": "run2"}},
+        }
+        summary.save_state(self.path, self.state)
+
+    def data(self, total=3):
+        return {"service_active": True, "metrics_status": "ok", "controller_state": {
+            "phase": "syncing", "completion_digest": True, "runs": total,
+            "last_success_run": f"run{total}", "completion_digest_start_runs": 0,
+            "last_success_duration_seconds": 3600, "last_success_end_height": 999,
+            "completion_history": [{"number": n, "run_id": f"run{n}", "duration": 3600,
+                                    "end_height": 999} for n in range(1, total + 1)],
+        }}
+
+    def deliver(self, timestamp, *, posted=True, statuses=None, dry_run=False):
+        with patch.object(summary, "slack_webhook_url", return_value=self.webhook), \
+             patch.object(summary, "post_slack", return_value=posted) as post, \
+             patch.object(summary.monitor, "query_node", side_effect=lambda _, node: (statuses or {"node": self.data()})[node["name"]]), \
+             contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            result = summary.deliver(self.config, self.path, timestamp, dry_run=dry_run)
+        return result, post
+
+    def test_fixed_deadline_does_not_wait_24_hours_after_late_post(self):
+        _, post = self.deliver(self.due - 1)
+        post.assert_not_called()
+        _, post = self.deliver(self.due)
+        self.assertIn("1 completed", post.call_args.args[0])
+        self.assertNotIn("3 completed", post.call_args.args[0])
+        _, post = self.deliver(self.due + 60)
+        post.assert_not_called()
+
+    def test_spring_and_fall_dst_keep_five_pm_local(self):
+        for deadline in ["2026-03-08T00:00:00+00:00", "2026-03-08T23:00:00+00:00",
+                         "2026-10-31T23:00:00+00:00", "2026-11-02T00:00:00+00:00"]:
+            timestamp = stamp(deadline)
+            self.assertEqual(summary.latest_slot(timestamp, self.config["summary"])[1], timestamp)
+            self.assertLess(summary.latest_slot(timestamp - 1, self.config["summary"])[1], timestamp)
+
+    def test_failed_delivery_retries_all_new_completions_without_moving_deadline(self):
+        before = self.path.read_text()
+        with self.assertRaisesRegex(deploy.DeployError, "delivery failed"):
+            self.deliver(self.due, posted=False)
+        self.assertEqual(self.path.read_text(), before)
+        _, post = self.deliver(self.due + 600, statuses={"node": self.data(4)})
+        self.assertIn("2 completed", post.call_args.args[0])
+        _, post = self.deliver(self.due + 86400, statuses={"node": self.data(5)})
+        self.assertIn("1 completed", post.call_args.args[0])
+
+    def test_missing_corrupt_and_incomplete_state_do_not_reset_timer(self):
+        for contents in [None, "{}", "invalid", json.dumps({**self.state, "cursors": {}})]:
+            if contents is None:
+                self.path.unlink(missing_ok=True)
+            else:
+                self.path.write_text(contents)
+            with self.assertRaisesRegex(deploy.DeployError, "state missing or invalid"):
+                self.deliver(self.due)
+            self.assertEqual(self.path.read_text() if self.path.exists() else None, contents)
+
+    def test_unreachable_node_is_reported_and_caught_up_next_day(self):
+        self.config["nodes"].append({"name": "peer", "hostname": "peer", "p2p_stack": "legacy"})
+        self.state["cursors"]["peer"] = {"number": 2, "run_id": "run2"}
+        summary.save_state(self.path, self.state)
+        _, post = self.deliver(self.due, statuses={"node": self.data(3), "peer": {"query_error": "unreachable"}})
+        self.assertIn("status unavailable", post.call_args.args[0])
+        self.assertNotIn("peer) · 0 completed", post.call_args.args[0])
+        self.assertEqual(json.loads(self.path.read_text())["cursors"]["peer"]["number"], 2)
+        _, post = self.deliver(self.due + 86400, statuses={"node": self.data(4), "peer": self.data(5)})
+        self.assertIn("peer) · 3 completed", post.call_args.args[0])
+        self.assertIn("earlier unreported runs", post.call_args.args[0])
+
+    def test_zero_completions_and_counter_reset_do_not_replay_history(self):
+        _, post = self.deliver(self.due, statuses={"node": self.data(2)})
+        self.assertIn("0 completed", post.call_args.args[0])
+        _, post = self.deliver(self.due + 86400, statuses={"node": self.data(1)})
+        self.assertIn("status unavailable", post.call_args.args[0])
+        self.assertEqual(json.loads(self.path.read_text())["cursors"]["node"]["number"], 2)
+
+    def test_new_node_with_no_finished_runs_shows_its_phase(self):
+        self.state["cursors"]["node"] = {"number": 0, "run_id": ""}
+        summary.save_state(self.path, self.state)
+        _, post = self.deliver(self.due, statuses={"node": {"controller_state": {"runs": 0, "phase": "building"}}})
+        self.assertIn("0 completed", post.call_args.args[0])
+        self.assertIn("building", post.call_args.args[0])
+
+    def test_malformed_status_cannot_consume_a_cursor(self):
+        for data in [[], {"controller_state": []}, self.data(True)]:
+            summary.save_state(self.path, self.state)
+            _, post = self.deliver(self.due, statuses={"node": data})
+            self.assertIn("status unavailable", post.call_args.args[0])
+            self.assertEqual(json.loads(self.path.read_text())["cursors"], self.state["cursors"])
+
+    def test_restart_after_multiple_missed_days_posts_one_catchup(self):
+        _, post = self.deliver(self.due + 3 * 86400, statuses={"node": self.data(10)})
+        self.assertIn("8 completed", post.call_args.args[0])
+        _, post = self.deliver(self.due + 3 * 86400 + 60)
+        post.assert_not_called()
+
+    def test_destination_change_fails_without_consuming_cursors(self):
+        self.webhook += "-changed"
+        before = self.path.read_text()
+        with self.assertRaisesRegex(deploy.DeployError, "destination missing or changed"):
+            self.deliver(self.due)
+        self.assertEqual(self.path.read_text(), before)
+
+    def test_dry_run_does_not_post_or_advance(self):
+        before = self.path.read_text()
+        _, post = self.deliver(self.due, dry_run=True)
+        post.assert_not_called()
+        self.assertEqual(self.path.read_text(), before)
+
+    def test_initialize_requires_confirmed_cursors_and_cannot_overwrite(self):
+        seed = self.path.with_name("seed.json")
+        seed.write_text(json.dumps({"last_posted_at": self.last, "cursors": self.state["cursors"]}))
+        self.path.unlink()
+        with patch.object(summary, "slack_webhook_url", return_value=self.webhook):
+            summary.initialize(self.config, self.path, seed, self.due)
+            with self.assertRaisesRegex(deploy.DeployError, "already exists"):
+                summary.initialize(self.config, self.path, seed, self.due)
+        self.assertEqual(json.loads(self.path.read_text()), self.state)
+        _, post = self.deliver(self.due)
+        self.assertIn("1 completed", post.call_args.args[0])
+
+    def test_status_reports_overdue_after_grace_without_contacting_slack(self):
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(summary.check_status(self.config, self.path, self.due + 900), 0)
+            self.assertEqual(summary.check_status(self.config, self.path, self.due + 901), 1)
+        self.deliver(self.due + 902)
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(summary.check_status(self.config, self.path, self.due + 903), 0)
+
+    def invoke_main(self):
+        args = argparse.Namespace(config=self.path, command="run", dry_run=False)
+        with patch.object(summary.argparse.ArgumentParser, "parse_args", return_value=args), \
+             patch.object(summary.tomllib, "load", return_value=self.config), \
+             patch.object(summary.socket, "gethostname", return_value="node"), \
+             patch.object(summary.time, "time", return_value=self.due), \
+             contextlib.redirect_stderr(io.StringIO()):
+            return summary.main()
+
+    def test_delivery_lock_blocks_a_second_invocation(self):
+        with self.path.with_suffix(".lock").open("w") as lock, patch.object(summary, "deliver") as deliver:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self.assertEqual(self.invoke_main(), 1)
+            deliver.assert_not_called()
+
+    def test_failed_slack_post_fails_the_service(self):
+        with patch.object(summary, "slack_webhook_url", return_value=self.webhook), \
+             patch.object(summary, "post_slack", return_value=False), \
+             patch.object(summary.monitor, "query_node", return_value=self.data()):
+            self.assertEqual(self.invoke_main(), 1)
+        self.assertEqual(json.loads(self.path.read_text()), self.state)
+
+    def test_regular_audit_cannot_emit_a_second_summary(self):
+        args = argparse.Namespace(config=Path("unused"), node=None, dry_run=False, max_completion_age=0,
+                                  reminder_interval=86400, state_file=self.path, legacy_digest=False)
+        data = {**self.data(), "sample": {"metrics_status": "ok"}, "disk_free_bytes": 20 * 1024**3}
+        self.path.write_text(json.dumps({"version": 2, "problems": {}, "last_digest_at": 1}))
+        with patch.object(deploy, "load_nodes", return_value=[deploy.Node(self.config["nodes"][0])]), \
+             patch.object(deploy, "remote_json", return_value=(True, data)), \
+             patch.object(deploy, "post_slack") as post, contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(deploy.cmd_audit(args), 0)
+            post.assert_not_called()
+
+    def test_installer_does_not_restart_sync_controllers_or_start_when_staging(self):
+        args = argparse.Namespace(config=ROOT / "nodes.toml", node=None, no_start=True)
+        with patch.object(deploy, "run") as run:
+            deploy.cmd_deploy_summary(args)
+        commands = "\n".join(" ".join(call.args[0]) for call in run.call_args_list)
+        self.assertNotIn("zakura-continuous-sync.service", commands)
+        self.assertNotIn("systemctl stop zakura-sync-summary.service", commands)
+        self.assertNotIn("enable --now", commands)
+        self.assertIn("zakura-sync-summary.timer", commands)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The daily mainnet sync summary depended on an evictable Actions cache and waited 24 hours after the previous delivery. Cache loss restarted that wait and replayed older completions; delayed audits also moved the posting time later each day.

## Solution

Send at 5 p.m. America/Denver from one configured fleet host, using durable per-node delivery cursors and minute retries. Only confirmed delivery advances the cursors, unavailable nodes retain their pending runs, and missing history fails visibly. GitHub audits retain failure alerts and check that the sender is active and not overdue. Initial rollout requires seeding from the last confirmed post and enabling only one sender; an ambiguous webhook response can still cause a duplicate.

## Testing

All 114 focused Python tests passed, including DST, late delivery, retries, missing state, migration, unavailable-node recovery, locking, and installation isolation. YAML and changelog checks passed. Read-only checks verified the sender's existing peer access and timezone support; an offline preview matched 11 unreported live runs. Production rollout is pending. Used Codex for implementation, tests, and this description.

## Changelog

<!-- changelog: none -->
Notification infrastructure only; the operator README documents the new behavior and migration.
