### PR TITLE
fix(ci): pin compatible PRECIS profiles in semver builds

### DIFF
--- a/.github/workflows/scripts/affected_semver_packages.py
+++ b/.github/workflows/scripts/affected_semver_packages.py
@@ -54,7 +54,14 @@ def directly_changed_packages(metadata, changed_files):
     workspace_root = Path(metadata["workspace_root"]).resolve()
     changed_paths = [Path(path) for path in changed_files]
 
-    if Path("Cargo.toml") in changed_paths:
+    # Registry patches affect fresh resolution for every semver build.
+    if any(
+        path in changed_paths
+        for path in (
+            Path("Cargo.toml"),
+            Path(".github/workflows/scripts/patch_registry_for_semver.sh"),
+        )
+    ):
         return set(packages)
 
     roots_by_depth = sorted(

--- a/.github/workflows/scripts/patch_registry_for_semver.sh
+++ b/.github/workflows/scripts/patch_registry_for_semver.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 #   build script panics with "a `libclang` shared library is not loaded on this
 #   thread". The workspace enables `bindgen-runtime`, but published baselines
 #   cannot change, so give the crate's bindgen build-dependency the feature.
+# - stun-rs 0.1.11 uses precis-core 0.1 traits, but precis-profiles 0.1.14
+#   switched to precis-core 0.2. Pin its profiles dependency to the compatible
+#   version in our workspace lock file.
 readonly original_cargo_home="${CARGO_HOME:-$HOME/.cargo}"
 patch_root=$(mktemp -d "$RUNNER_TEMP/semver-registry.XXXXXX")
 readonly patch_root
@@ -65,6 +68,18 @@ fi
 sed -i '/^\[build-dependencies\.bindgen\]$/,/^default-features = false$/ s/^default-features = false$/default-features = false\nfeatures = ["runtime"]/' \
   "$librocksdb_sys_manifest"
 
+readonly stun_rs_version=0.1.11
+stun_rs_source=$(copy_registry_source stun-rs "$stun_rs_version")
+readonly stun_rs_source
+readonly stun_rs_manifest="$stun_rs_source/Cargo.toml"
+expected_profiles_block=$'[dependencies.precis-profiles]\nversion = "0.1.12"'
+if [[ "$(grep -Fx -A1 '[dependencies.precis-profiles]' "$stun_rs_manifest")" != "$expected_profiles_block" ]]; then
+  echo "stun-rs $stun_rs_version no longer matches the expected precis-profiles dependency" >&2
+  exit 1
+fi
+sed -i '/^\[dependencies\.precis-profiles\]$/,/^version = / s/^version = "0.1.12"$/version = "=0.1.13"/' \
+  "$stun_rs_manifest"
+
 mkdir -p "$patched_cargo_home"
 ln -s "$original_cargo_home/registry" "$patched_cargo_home/registry"
 if [[ -d "$original_cargo_home/git" ]]; then
@@ -74,6 +89,7 @@ cat > "$patched_cargo_home/config.toml" <<EOF
 [patch.crates-io]
 tinyvec = { path = "$tinyvec_source" }
 librocksdb-sys = { path = "$librocksdb_sys_source" }
+stun-rs = { path = "$stun_rs_source" }
 EOF
 
 echo "CARGO_HOME=$patched_cargo_home" >> "$GITHUB_ENV"

--- a/.github/workflows/scripts/test_affected_semver_packages.py
+++ b/.github/workflows/scripts/test_affected_semver_packages.py
@@ -102,6 +102,22 @@ class AffectedSemverPackagesTest(unittest.TestCase):
 
         self.assertEqual(affected, [])
 
+    def test_registry_patch_selects_every_publishable_library(self):
+        packages = [
+            self.package("zakura-rpc"),
+            self.package("zakura-network"),
+            self.package("private", publish=[]),
+            self.package("zakura"),
+            self.package("zakura-header-chain"),
+        ]
+
+        affected = affected_semver_packages.affected_publishable_packages(
+            self.metadata(packages),
+            changed_files=[".github/workflows/scripts/patch_registry_for_semver.sh"],
+        )
+
+        self.assertEqual(affected, ["zakura-network", "zakura-rpc"])
+
     def test_package_manifest_selects_that_package(self):
         registry_dependency = {
             "name": "registry-package",


### PR DESCRIPTION
## Motivation

Semver CI fails before API comparison because `stun-rs 0.1.11` imports `precis-core 0.1` traits while freshly resolved `precis-profiles 0.1.14` implements `precis-core 0.2` traits. Current `main` has the same failure as #930 and #931. The workspace lockfile retains compatible `precis-profiles 0.1.13`, but semver builds resolve dependencies independently.

## Solution

Extend the existing isolated registry patch to pin the copied `stun-rs` manifest to `precis-profiles =0.1.13`. Current and published-baseline builds receive the patch. The script verifies the expected dependency declaration before editing it.

Select all published libraries when the registry patch changes so this PR exercises the semver matrix.

## Testing

- An isolated crate depending only on `stun-rs =0.1.11` reproduced all 12 E0599 compiler errors without the patch.
- The same crate passed `cargo check` and `cargo doc --no-deps` with the patched Cargo home.
- `cargo semver-checks --baseline-root . --default-features` built both sides of the isolated reproduction with CI's `RUSTFLAGS='-D warnings'`.
- All seven package-selection tests passed, including the regression for registry-patch changes.
- Shell syntax and `git diff --check` passed.

### Specifications & References

- [Failure on main](https://github.com/zakura-core/zakura/actions/runs/34290566544)
- [Failure on #930](https://github.com/zakura-core/zakura/actions/runs/34291384128/job/102278517644)
