### PR TITLE
perf(network): prepare checkpoint prefixes before body starvation

### DIFF
--- a/crates/zakura-network/src/zakura/header_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor.rs
@@ -1495,6 +1495,10 @@ impl HeaderSyncReactor {
             self.report_misbehavior(peer, HeaderSyncMisbehavior::MalformedMessage);
             return;
         };
+        let checkpoint_prefix_ready = self
+            .committed_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| Self::should_prepare_checkpoint_prefix(snapshot, active));
         let _ = active;
         debug_assert_eq!(
             self.peer_work_queue.owned_header_count(&peer),
@@ -1504,7 +1508,8 @@ impl HeaderSyncReactor {
         // A peer can advertise an arbitrarily distant target.
         // The reactor bounds response staging by admitting a validated prefix at capacity.
         // The reactor limits continuations to remaining capacity.
-        // This limit prevents a peer from forcing small prefix commits with short pages.
+        // A local checkpoint-sized minimum also allows a selected extension to unblock
+        // body validation without letting short peer pages force tiny prefix commits.
         let durable_prefix_full = self.committed_snapshot.as_ref().is_some_and(|snapshot| {
             Self::request_header_prefix_remaining(
                 snapshot,
@@ -1512,8 +1517,13 @@ impl HeaderSyncReactor {
                 target_tip_height,
             ) == 0
         });
-        let bounded_prefix =
-            !complete && (self.peer_work_queue.budget_is_full() || durable_prefix_full);
+        let bounded_prefix = !complete
+            && (self.peer_work_queue.budget_is_full()
+                || durable_prefix_full
+                || checkpoint_prefix_ready);
+        if !complete && checkpoint_prefix_ready {
+            metrics::counter!("sync.header.checkpoint_prefix.prepared.total").increment(1);
+        }
         let active = self
             .peer_work_queue
             .active_mut(&peer)
@@ -2900,6 +2910,28 @@ impl HeaderSyncReactor {
             .saturating_sub(selected_non_finalized)
             .saturating_sub(claimed);
         u32::try_from(remaining).unwrap_or(u32::MAX)
+    }
+
+    /// Prepare enough selected-chain headers for a checkpoint and its VCT successor
+    /// when the admitted body pipeline has less than that much work remaining.
+    fn should_prepare_checkpoint_prefix(
+        snapshot: &zakura_header_chain::EngineSnapshot,
+        active: &ActiveHeaderRequest,
+    ) -> bool {
+        let checkpoint_gap =
+            zakura_chain::parameters::checkpoint::constants::MAX_CHECKPOINT_HEIGHT_GAP;
+        let body_lag = snapshot
+            .frontiers
+            .header_best
+            .height
+            .0
+            .saturating_sub(snapshot.frontiers.verified_best.height.0);
+        snapshot.mode == zakura_header_chain::EngineMode::Integrated
+            && matches!(active.purpose, HeaderTargetPurpose::Normal)
+            && active.common_ancestor == Some(snapshot.frontiers.header_best)
+            && active.entries.len() > checkpoint_gap
+            && usize::try_from(body_lag).expect("u32 body lag fits usize on supported targets")
+                <= checkpoint_gap
     }
 
     /// Return requester headroom after both the durable DAG limit and the integrated body window.

--- a/crates/zakura-network/src/zakura/header_sync/reactor/tests/completion.rs
+++ b/crates/zakura-network/src/zakura/header_sync/reactor/tests/completion.rs
@@ -83,6 +83,122 @@ fn empty_complete_response_requires_the_exact_height_qualified_ancestor() {
 }
 
 #[test]
+fn early_checkpoint_prefix_preserves_minimum_work_and_exact_branch_scope() {
+    let (reactor, _actions, mut snapshot, peer, _source, _owner) = peer_violation_fixture();
+    let mut active = reactor.peer_work_queue.active(&peer).unwrap().clone();
+    let entry = active.entries[0].clone();
+    for (count, expected) in [(1, false), (250, false), (400, false), (401, true)] {
+        active.entries = vec![entry.clone(); count];
+        assert_eq!(
+            HeaderSyncReactor::should_prepare_checkpoint_prefix(&snapshot, &active),
+            expected
+        );
+    }
+    snapshot.frontiers.header_best.height = block::Height(401);
+    active.common_ancestor = Some(snapshot.frontiers.header_best);
+    assert!(
+        !HeaderSyncReactor::should_prepare_checkpoint_prefix(&snapshot, &active),
+        "a checkpoint-sized body backlog already has enough work"
+    );
+    snapshot.frontiers.verified_best.height = block::Height(1);
+    assert!(HeaderSyncReactor::should_prepare_checkpoint_prefix(
+        &snapshot, &active
+    ));
+    active.common_ancestor = Some(snapshot.frontiers.finalized);
+    assert!(
+        !HeaderSyncReactor::should_prepare_checkpoint_prefix(&snapshot, &active),
+        "a competing branch cannot use the selected-extension shortcut"
+    );
+    active.common_ancestor = Some(snapshot.frontiers.header_best);
+    snapshot.mode = zakura_header_chain::EngineMode::HeadersOnly;
+    assert!(!HeaderSyncReactor::should_prepare_checkpoint_prefix(
+        &snapshot, &active
+    ));
+    snapshot.mode = zakura_header_chain::EngineMode::Integrated;
+    active.purpose = HeaderTargetPurpose::SelectedAuxiliaryRepair {
+        selected_target: snapshot.frontiers.header_best,
+        repair_generation: 0,
+    };
+    assert!(
+        !HeaderSyncReactor::should_prepare_checkpoint_prefix(&snapshot, &active),
+        "auxiliary repair must complete its exact owned range"
+    );
+}
+
+#[test]
+fn requester_prepares_checkpoint_sized_extension_before_the_chunk_budget_fills() {
+    let (mut reactor, mut actions, snapshot, peer, _source, owner) = peer_violation_fixture();
+    let active = reactor.peer_work_queue.active_mut(&peer).unwrap();
+    active.phase = HeaderTargetPhase::Receiving;
+    active.entries.clear();
+    active.target.status.selected_tip_height = block::Height(10_000);
+    active.max_header_count = 250;
+    let mut parent = snapshot.frontiers.header_best.hash;
+    let mut entries = Vec::new();
+    for index in 0..500 {
+        let mut header = *regtest_genesis_block().header;
+        header.previous_block_hash = parent;
+        header.time += chrono::Duration::seconds(index + 1);
+        parent = header.hash();
+        entries.push(HeaderEntry {
+            header: Arc::new(header),
+            body_size: 0,
+            tree_aux: None,
+        });
+    }
+    let response_entries = entries.split_off(250);
+    active.entries = entries;
+    let staged_tip = active.staged_tip().unwrap();
+    reactor
+        .peer_work_queue
+        .set_capacity_for_test(&peer, 250, 250);
+    reactor.handle_headers(
+        peer.clone(),
+        owner.session_id(),
+        owner.header_authority(),
+        Headers {
+            request_id: owner.request_id().get(),
+            target_tip_hash: owner.header_authority().branch.target_tip_hash,
+            common_ancestor_height: staged_tip.height,
+            common_ancestor_hash: staged_tip.hash,
+            complete: false,
+            tree_aux_schema: AuxSchema::None,
+            entries: response_entries,
+        },
+    );
+    let HeaderPortOperation::PrepareHeaderTarget {
+        entries,
+        owner: prefix_owner,
+        target,
+        completion,
+        ..
+    } = actions
+        .try_recv()
+        .expect("two full response pages unblock checkpoint validation")
+    else {
+        panic!("the prefix must still pass normal header preparation");
+    };
+    assert_eq!(entries.len(), 500);
+    assert_eq!(target.height, block::Height(500));
+    assert_eq!(
+        prefix_owner.header_authority().branch.target_tip_hash,
+        target.hash
+    );
+    assert_eq!(
+        completion,
+        zakura_header_chain::TargetCompletion::TargetPrefix {
+            common_ancestor: snapshot.frontiers.header_best,
+        }
+    );
+    assert_eq!(reactor.peer_work_queue.chunk_budget_usage(), (0, 500));
+    assert!(matches!(
+        reactor.peer_work_queue.active(&peer).unwrap().phase,
+        HeaderTargetPhase::Preparing
+    ));
+    assert!(actions.try_recv().is_err());
+}
+
+#[test]
 fn requester_admits_its_owned_prefix_when_the_chunk_budget_is_exhausted() {
     let (mut reactor, mut actions, snapshot, peer, _source, owner) = peer_violation_fixture();
     let active = reactor

--- a/docs/changelog/unreleased/938.md
+++ b/docs/changelog/unreleased/938.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Reduced header-fetch waits during integrated chain sync by preparing a
+  checkpoint-sized prefix when admitted block work is running low
+  ([#938](https://github.com/zakura-core/zakura/pull/938)).


### PR DESCRIPTION
## Motivation

A selected-chain header request can keep accumulating pages while block validation runs out of admitted work. For example, with at most 400 admitted blocks remaining, two 250-header pages already provide enough headers for a checkpoint and its VCT successor, but the reactor previously waited for the target or a capacity boundary.

## Solution

Prepare that prefix through the existing validation and ownership path once more than 400 headers are staged. Apply this only to normal requests extending the exact selected tip in integrated mode; retain the existing behavior for competing branches, headers-only operation and auxiliary repair. Request and memory budgets are unchanged.

## Testing

Formatting, Markdown lint, changelog validation and release Clippy pass. The release network suite ran 1,119 tests: 1,116 passed (one reported a leaked handle), three existing listener tests failed binding `127.0.0.2`, and 45 were skipped. A standalone socket probe reproduces that macOS address error. Both added tests pass and cover the minimum-work boundary, backlog threshold, exact branch scope, excluded modes/purposes and preservation of owned capacity through normal preparation. Earlier isolated VCT-enabled genesis pairs for this optimization measured 144.0→161.0 BPS in dual mode and 144.2→167.9 BPS in Zakura-only mode; these single-pair observations do not establish repeatability. [Dual evidence](https://github.com/zakura-core/zakura/actions/runs/34355015102) · [Zakura-only evidence](https://github.com/zakura-core/zakura/actions/runs/34355150283).

## Changelog

Added `docs/changelog/unreleased/938.md` for the sync improvement.
