### PR TITLE
fix(consensus): preserve checkpoint progress on block rejection

### DIFF
--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -1261,6 +1261,8 @@ where
         // we don't reject the entire checkpoint.
         // Instead, we reset the verifier to the successfully committed state tip.
         let state_service = self.state_service.clone();
+        let recovery_state = self.state_service.clone();
+        let reset_sender = self.reset_sender.clone();
         let network = self.network.clone();
         let commit_checkpoint_verified = tokio::spawn(async move {
             let queued_result = req_block
@@ -1303,32 +1305,17 @@ where
             }
             .await;
 
-            (result, reset_generation)
-        });
-
-        let state_service = self.state_service.clone();
-        let reset_sender = self.reset_sender.clone();
-        async move {
-            let commit_result = commit_checkpoint_verified.await;
-            // Avoid a panic on shutdown
-            //
-            // When `zakurad` is terminated using Ctrl-C, the `commit_checkpoint_verified` task
-            // can return a `JoinError::Cancelled`. We expect task cancellation on shutdown,
-            // so we don't need to panic here. The persistent state is correct even when the
-            // task is cancelled, because block data is committed inside transactions, in
-            // height order.
+            // The commit task owns recovery so a canceled caller cannot discard the reset.
             if zakura_chain::shutdown::is_shutting_down() {
                 return Err(VerifyCheckpointError::ShuttingDown);
             }
-            let (result, reset_generation) =
-                commit_result.expect("commit_checkpoint_verified should not panic");
             // Only a failed state commit can leave verified progress ahead of the state.
             // Block rejections must preserve progress while a verified range commits:
             // resetting to the lagging state tip would reopen an already-consumed range.
             // Duplicate commits also leave progress intact.
             if let Err(error @ VerifyCheckpointError::CommitCheckpointVerified(_)) = &result {
                 if !error.is_duplicate_request() {
-                    let tip = match state_service
+                    let tip = match recovery_state
                         .oneshot(zs::Request::Tip)
                         .await
                         .map_err(VerifyCheckpointError::Tip)?
@@ -1345,6 +1332,15 @@ where
                 }
             }
             result
+        });
+
+        async move {
+            let commit_result = commit_checkpoint_verified.await;
+            // Shutdown can cancel the commit task. State commits remain transactional.
+            if zakura_chain::shutdown::is_shutting_down() {
+                return Err(VerifyCheckpointError::ShuttingDown);
+            }
+            commit_result.expect("commit_checkpoint_verified should not panic")
         }
         .boxed()
     }

--- a/crates/zakura-consensus/src/checkpoint.rs
+++ b/crates/zakura-consensus/src/checkpoint.rs
@@ -1322,17 +1322,12 @@ where
             }
             let (result, reset_generation) =
                 commit_result.expect("commit_checkpoint_verified should not panic");
-            // Only reset on real commit/state desyncs. Duplicate / NewerRequest
-            // failures are expected when sync resubmits in-queue bodies; resetting
-            // for them rewinds progress behind the already-verified checkpoint and
-            // leaves a permanent queue gap for the next range.
-            if let Err(error) = &result {
-                if !error.is_duplicate_request()
-                    && !matches!(
-                        error,
-                        VerifyCheckpointError::ShuttingDown | VerifyCheckpointError::Dropped
-                    )
-                {
+            // Only a failed state commit can leave verified progress ahead of the state.
+            // Block rejections must preserve progress while a verified range commits:
+            // resetting to the lagging state tip would reopen an already-consumed range.
+            // Duplicate commits also leave progress intact.
+            if let Err(error @ VerifyCheckpointError::CommitCheckpointVerified(_)) = &result {
+                if !error.is_duplicate_request() {
                     let tip = match state_service
                         .oneshot(zs::Request::Tip)
                         .await

--- a/crates/zakura-consensus/src/checkpoint/tests.rs
+++ b/crates/zakura-consensus/src/checkpoint/tests.rs
@@ -1300,6 +1300,56 @@ async fn queued_commit_failure_after_reset_must_reset_recovered_progress() -> Re
     Ok(())
 }
 
+/// A canceled caller must not discard recovery after a failed state commit.
+#[tokio::test]
+async fn dropped_response_must_preserve_failed_commit_reset() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+    let genesis =
+        Arc::<Block>::zcash_deserialize(&zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])?;
+    let block = Arc::<Block>::zcash_deserialize(&zakura_test::vectors::BLOCK_MAINNET_1_BYTES[..])?;
+    let initial_tip = (block::Height(0), genesis.hash());
+    let checkpoints = BTreeMap::from([initial_tip, (block::Height(1), block.hash())]);
+    let (release, gate) = tokio::sync::watch::channel(false);
+    let state = tower::service_fn(move |request: zs::Request| {
+        let mut gate = gate.clone();
+        async move {
+            match request {
+                zs::Request::CommitCheckpointVerifiedBlock(_) => {
+                    gate.wait_for(|released| *released)
+                        .await
+                        .expect("the test retains the sender");
+                    Err::<zs::Response, BoxError>(
+                        std::io::Error::other("injected commit failure").into(),
+                    )
+                }
+                zs::Request::Tip => Ok(zs::Response::Tip(Some(initial_tip))),
+                _ => unreachable!("the verifier only commits blocks and reads the tip"),
+            }
+        }
+    });
+    let mut verifier =
+        CheckpointVerifier::from_list(checkpoints, &Mainnet, Some(initial_tip), state)
+            .map_err(|error| eyre!(error))?;
+    let response = verifier.call(block);
+    assert_eq!(verifier.previous_checkpoint_height(), FinalCheckpoint);
+    drop(response);
+    release.send_replace(true);
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while verifier.reset_generation == 0 {
+            verifier.apply_pending_reset();
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a failed commit must request recovery even after its caller drops the response");
+    assert_eq!(
+        verifier.previous_checkpoint_height(),
+        InitialTip(block::Height(0))
+    );
+    Ok(())
+}
+
 /// Duplicate block errors must stay classified as duplicate requests after the
 /// state wraps them, so they don't restart the syncer during checkpoint sync.
 #[test]

--- a/crates/zakura-consensus/src/checkpoint/tests.rs
+++ b/crates/zakura-consensus/src/checkpoint/tests.rs
@@ -1025,6 +1025,85 @@ async fn newer_request_must_not_rewind_verified_checkpoint_progress() -> Result<
     Ok(())
 }
 
+/// A side-chain rejection must preserve verified progress while state commits lag behind.
+#[tokio::test]
+async fn side_chain_must_not_rewind_committing_checkpoint_range() -> Result<(), Report> {
+    let _init_guard = zakura_test::init();
+    let blocks: Vec<_> = zakura_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .values()
+        .map(|bytes| Arc::<Block>::zcash_deserialize(*bytes).expect("block deserializes"))
+        .collect();
+    let checkpoints: BTreeMap<_, _> = [0usize, 3, 6, 10]
+        .into_iter()
+        .map(|index| {
+            (
+                blocks[index].coinbase_height().unwrap(),
+                blocks[index].hash(),
+            )
+        })
+        .collect();
+    let initial_tip = (block::Height(3), blocks[3].hash());
+    let (release_commits, gate) = tokio::sync::watch::channel(false);
+    let state = tower::service_fn(move |request: zs::Request| {
+        let mut gate = gate.clone();
+        async move {
+            match request {
+                zs::Request::Tip => Ok(zs::Response::Tip(Some(initial_tip))),
+                zs::Request::CommitCheckpointVerifiedBlock(block) => {
+                    gate.wait_for(|released| *released)
+                        .await
+                        .expect("the test retains the commit gate");
+                    Ok::<_, BoxError>(zs::Response::Committed(block.hash))
+                }
+                _ => unreachable!("the verifier only requests commits and the tip"),
+            }
+        }
+    });
+    let mut verifier =
+        CheckpointVerifier::from_list(checkpoints, &Mainnet, Some(initial_tip), state)
+            .map_err(|error| eyre!(error))?;
+
+    let side_chain = verifier.call(blocks[4].clone());
+    // Model a competing block after basic validation without mining another valid PoW.
+    let side_hash = block::Hash([0xAA; 32]);
+    verifier.queued.get_mut(&block::Height(4)).unwrap()[0].block =
+        CheckpointVerifiedBlock::new(blocks[4].clone(), Some(side_hash), None);
+    let mut commits = FuturesUnordered::new();
+    for block in &blocks[4..=6] {
+        commits.push(verifier.call(block.clone()));
+    }
+    assert_eq!(
+        verifier.previous_checkpoint_height(),
+        PreviousCheckpoint(block::Height(6))
+    );
+    assert!(matches!(
+        timeout(Duration::from_secs(VERIFY_TIMEOUT_SECONDS), side_chain).await.unwrap(),
+        Err(VerifyCheckpointError::UnexpectedSideChain { found, .. }) if found == side_hash
+    ));
+
+    // This call applies any reset while the state tip remains at height 3.
+    commits.push(verifier.call(blocks[7].clone()));
+    assert_eq!(
+        verifier.previous_checkpoint_height(),
+        PreviousCheckpoint(block::Height(6)),
+        "a side-chain rejection must not reopen the consumed checkpoint range"
+    );
+    assert_eq!(verifier.reset_generation, 0);
+    for block in &blocks[8..=10] {
+        commits.push(verifier.call(block.clone()));
+    }
+    release_commits.send_replace(true);
+    timeout(Duration::from_secs(VERIFY_TIMEOUT_SECONDS), async {
+        while let Some(result) = commits.next().await {
+            result.expect("both checkpoint ranges must commit");
+        }
+    })
+    .await
+    .expect("checkpoint commits must finish");
+    assert_eq!(verifier.previous_checkpoint_height(), FinalCheckpoint);
+    Ok(())
+}
+
 /// A late reset from an earlier commit generation must not rewind recovered progress.
 #[tokio::test(flavor = "multi_thread")]
 async fn stale_commit_reset_must_not_rewind_recovered_checkpoint_progress() -> Result<(), Report> {

--- a/docs/changelog/unreleased/939.md
+++ b/docs/changelog/unreleased/939.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Prevent checkpoint verification stalls when a side-chain block is rejected while
+  a verified checkpoint range is still committing
+  ([#939](https://github.com/zakura-core/zakura/pull/939)).

--- a/docs/changelog/unreleased/939.md
+++ b/docs/changelog/unreleased/939.md
@@ -1,5 +1,6 @@
 ## Fixed
 
 - Prevent checkpoint verification stalls when the verifier rejects a side-chain
-  block while the state commits a verified checkpoint range
+  block while the state commits a verified checkpoint range, or when a canceled
+  caller drops recovery from a failed state commit
   ([#939](https://github.com/zakura-core/zakura/pull/939)).

--- a/docs/changelog/unreleased/939.md
+++ b/docs/changelog/unreleased/939.md
@@ -1,5 +1,5 @@
 ## Fixed
 
-- Prevent checkpoint verification stalls when a side-chain block is rejected while
-  a verified checkpoint range is still committing
+- Prevent checkpoint verification stalls when the verifier rejects a side-chain
+  block while the state commits a verified checkpoint range
   ([#939](https://github.com/zakura-core/zakura/pull/939)).


### PR DESCRIPTION
## Motivation

A side-chain rejection can reset checkpoint progress to the state tip while a verified range is still committing. That reset reopens a range whose blocks the verifier already consumed, which can stall checkpoint verification.

A canceled caller can also discard recovery after a failed commit. The commit task survives cancellation, but the response future previously owned the reset request.

## Solution

Adapt Zebra #11385 to reset progress only after a non-duplicate `CommitCheckpointVerified` error. Preserve Zakura's duplicate-commit exclusion and reset-generation handling.

Keep reset handling inside the commit task so recovery survives caller cancellation.

## Testing

- `cargo +1.97.0 test -p zakura-consensus --lib checkpoint::tests --locked`: 16 passed.
- `cargo +1.97.0 clippy -p zakura-consensus --lib --tests --locked -- -D warnings`: passed.
- `cargo +1.97.0 fmt --all -- --check` and `git diff --check`: passed.
- The new regression injects a competing hash into the validated queue and holds state commits open. It checks that the rejection preserves checkpoint progress and that both ranges finish. With the original reset filter, it fails because progress rewinds from height 6 to height 3.
- Existing duplicate-request and reset-generation regressions pass.
- A new regression drops the response before a state commit fails. It confirms that the verifier resets from the final checkpoint to the durable state tip. The test fails without the cancellation fix because no reset arrives.
- Combined with #940: 89 sync tests, 5 block-sync driver tests, 5 UTXO lookup tests, 16 checkpoint tests, and 7 router tests passed. One UTXO timing benchmark remained ignored.

## Changelog

`docs/changelog/unreleased/939.md` records the checkpoint verification fix. `./scripts/changelog.py check` passes.

### Specifications & References

Backports https://github.com/ZcashFoundation/zebra/pull/11385.

Related sync timeout backport: https://github.com/zakura-core/zakura/pull/940. Both PRs target `main` independently.
