### PR TITLE
fix(mining): keep rejected work withdrawn across tip changes and eviction

### DIFF
--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -1180,7 +1180,7 @@ async fn prepare_one_server_template<BlockVerifierRouter, Tip, SyncStatus>(
 
     // Once a parent needs recovery, only foreground-validated fallback work may be published.
     // Discard its queued speculative preparations.
-    if gbt.template_rejections.borrow().needs_fallback() {
+    if gbt.template_rejections.borrow().needs_fallback_on(parent) {
         return;
     }
     if !gbt.speculation_breaker.allows(parent) {
@@ -1223,16 +1223,8 @@ async fn prepare_one_server_template<BlockVerifierRouter, Tip, SyncStatus>(
                 .send_if_modified(|state| state.mark_prepared(parent, &work_id));
         }
         Ok(Preparation::Rejected) => {
-            gbt.template_rejections.send_if_modified(|state| {
-                // A reorg away from this parent and back leaves the rejection state naming
-                // another parent while this validation finishes. Re-point it when the chain is
-                // back here, so the rejection is recorded rather than silently dropped.
-                if state.parent != Some(parent) && latest_chain_tip.best_tip_hash() == Some(parent)
-                {
-                    state.set_parent(parent);
-                }
-                state.reject(parent, &work_id)
-            });
+            gbt.template_rejections
+                .send_if_modified(|state| state.reject(parent, &work_id));
             metrics::counter!("mining.template_preparation.rejected").increment(1);
         }
         // The background path has no inner deadline, so `TimedOut` cannot reach here: both
@@ -1426,12 +1418,11 @@ where
     /// Returns `None` when `latest_chain_tip` no longer agrees with the tip a template is being
     /// built on, so the caller must fetch the chain state again.
     ///
-    /// The tip is checked while the rejection state is locked, because `set_parent` clears every
-    /// rejection recorded for the parent it replaces. Holding the lock across the check stops two
-    /// concurrent requests interleaving their checks and writes, so a request that already lost
-    /// the tip cannot erase the withdrawals of the parent that replaced it. `rejections` is both
-    /// the snapshot the caller works from and the marker of what it has seen, taken together so a
-    /// rejection published in between cannot be acknowledged unread.
+    /// The tip is checked while the rejection state is locked, so two concurrent requests cannot
+    /// interleave their checks and writes and leave `parent` naming a parent the chain has
+    /// already left. `rejections` is both the snapshot the caller works from and the marker of
+    /// what it has seen, taken together so a rejection published in between cannot be
+    /// acknowledged unread.
     fn track_template_parent(
         &self,
         tip_hash: block::Hash,
@@ -1448,9 +1439,7 @@ where
                 return false;
             }
 
-            let changed = state.parent != Some(tip_hash);
-            state.set_parent(tip_hash);
-            changed
+            state.track_parent(tip_hash)
         });
 
         tip_is_current.then(|| rejections.borrow_and_update().clone())
@@ -1490,7 +1479,7 @@ where
             }
         }
 
-        if state.saturated {
+        if state.saturated() {
             return Err(ErrorObject::owned(
                 0,
                 "template rejection limit reached; wait for a new tip",

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -1395,15 +1395,8 @@ where
             return std::future::pending().await;
         };
         let mut rejections = self.gbt.template_rejections.subscribe();
-        let revision = rejections.borrow().revision;
         loop {
-            let withdrawn = {
-                let state = rejections.borrow_and_update();
-                // Eviction can erase a rejection before this waiter observes it.
-                // Retained rejections use the predicate so other parents cannot cancel this work.
-                state.withdrawn(work_id)
-                    || (state.evicted_revision > revision && !state.is_prepared(work_id))
-            };
+            let withdrawn = rejections.borrow_and_update().withdrawn(work_id);
             if withdrawn {
                 return;
             }
@@ -1426,6 +1419,7 @@ where
     fn track_template_parent(
         &self,
         tip_hash: block::Hash,
+        tip_height: block::Height,
         rejections: &mut watch::Receiver<types::get_block_template::TemplateRejections>,
     ) -> Option<types::get_block_template::TemplateRejections> {
         let mut tip_is_current = true;
@@ -1439,7 +1433,7 @@ where
                 return false;
             }
 
-            state.track_parent(tip_hash)
+            state.track_parent(tip_hash, tip_height)
         });
 
         tip_is_current.then(|| rejections.borrow_and_update().clone())
@@ -1448,45 +1442,39 @@ where
     /// Returns the template to publish, recovering an empty one when this parent needs a fallback.
     async fn finish_mining_template(
         &self,
-        template: BlockTemplateResponse,
+        mut template: BlockTemplateResponse,
         chain_info: &zakura_state::GetBlockTemplateChainInfo,
         miner_params: &types::get_block_template::MinerParams,
     ) -> Result<GetBlockTemplateResponse> {
-        let mut state = self.gbt.template_rejections.borrow().clone();
-
-        // Transaction selection ran after the chain state was fetched, so re-check both the
-        // rejection state's parent and the chain tip itself: neither request retargets the other.
-        if state.parent != Some(chain_info.tip_hash)
-            || self
-                .latest_chain_tip
-                .best_tip_hash()
-                .is_some_and(|tip| tip != chain_info.tip_hash)
-        {
-            return Err(ErrorObject::owned(
-                0,
-                "template parent changed; retry",
-                None::<()>,
-            ));
-        }
-
-        if !state.needs_fallback() {
-            self.prepare_template_in_background(&template);
-            // A rejection can land between the snapshot above and this point, which would leave
-            // this brand-new work withdrawn the moment it reaches the miner. Recover instead.
-            state = self.gbt.template_rejections.borrow().clone();
+        let state = {
+            let state = self.gbt.template_rejections.borrow();
+            if state.parent != Some(chain_info.tip_hash)
+                || self
+                    .latest_chain_tip
+                    .best_tip_hash()
+                    .is_some_and(|tip| tip != chain_info.tip_hash)
+            {
+                return Err(ErrorObject::owned(
+                    0,
+                    "template parent changed; retry",
+                    None::<()>,
+                ));
+            }
+            template.work_id = state.scope_work_id(template.work_id());
             if !state.needs_fallback() {
+                // Keep the guard through publication so rejection cannot precede this decision.
+                self.prepare_template_in_background(&template);
                 return Ok(template.into());
             }
-        }
-
-        if state.saturated() {
-            return Err(ErrorObject::owned(
-                0,
-                "template rejection limit reached; wait for a new tip",
-                None::<()>,
-            ));
-        }
-
+            if state.saturated() {
+                return Err(ErrorObject::owned(
+                    0,
+                    "template rejection limit reached; wait for a new tip",
+                    None::<()>,
+                ));
+            }
+            state.clone()
+        };
         self.recover_template(template, chain_info, miner_params, &state)
             .await
     }
@@ -1511,7 +1499,7 @@ where
             template.submit_old
         };
         long_poll_id.revision = state.current_revision();
-        let template = BlockTemplateResponse::new_internal(
+        let mut template = BlockTemplateResponse::new_internal(
             &self.network,
             None,
             miner_params,
@@ -1520,6 +1508,8 @@ where
             vec![],
             submit_old,
         );
+
+        template.work_id = state.scope_work_id(template.work_id());
 
         match prepare_server_template(
             self.gbt.block_verifier_router(),
@@ -1556,32 +1546,39 @@ where
             }
         }
 
-        if self.recovery_context_changed(state, &template, chain_info.tip_hash) {
+        let mut context_changed = false;
+        self.gbt.template_rejections.send_if_modified(|current| {
+            if self.recovery_context_changed(current, state, &template, chain_info.tip_hash) {
+                context_changed = true;
+                return false;
+            }
+            let changed = current.mark_prepared(chain_info.tip_hash, template.work_id());
+            if template.long_poll_id.revision != current.current_revision() {
+                template.submit_old = Some(false);
+            }
+            template.long_poll_id.revision = current.current_revision();
+            changed
+        });
+        if context_changed {
             return Err(ErrorObject::owned(
                 0,
                 "template changed during recovery; retry",
                 None::<()>,
             ));
         }
-
-        self.gbt
-            .template_rejections
-            .send_if_modified(|state| state.mark_prepared(chain_info.tip_hash, template.work_id()));
-
         Ok(template.into())
     }
 
     /// Whether anything a recovered template was validated against has moved on since.
     fn recovery_context_changed(
         &self,
+        current: &types::get_block_template::TemplateRejections,
         state: &types::get_block_template::TemplateRejections,
         template: &BlockTemplateResponse,
         tip_hash: block::Hash,
     ) -> bool {
-        let current = self.gbt.template_rejections.borrow();
-
         // Another rejection landed on this parent, or withdrew this very work.
-        current.parent != state.parent
+        current.parent != Some(tip_hash)
             || current.current_revision() != state.current_revision()
             || current.contains(template.work_id())
             // The chain moved off the parent this template was built on.
@@ -3135,7 +3132,7 @@ where
             // Tracking this iteration's parent marks the rejection state it snapshots as seen:
             // this iteration's own parent update is not a reason to wake long polling again.
             let Some(rejection_state) =
-                self.track_template_parent(tip_hash, &mut template_rejections)
+                self.track_template_parent(tip_hash, tip_height, &mut template_rejections)
             else {
                 continue;
             };
@@ -3289,7 +3286,7 @@ where
                 precomputed_coinbase = wait_for_new_tip => {
                     let chain_info = fetch_chain_info(read_state.clone()).await?;
                     let Some(rejection_state) =
-                        self.track_template_parent(chain_info.tip_hash, &mut template_rejections)
+                        self.track_template_parent(chain_info.tip_hash, chain_info.tip_height, &mut template_rejections)
                     else {
                         continue;
                     };

--- a/crates/zakura-rpc/src/methods.rs
+++ b/crates/zakura-rpc/src/methods.rs
@@ -1399,10 +1399,10 @@ where
         loop {
             let withdrawn = {
                 let state = rejections.borrow_and_update();
-                // A parent change can clear a rejection before this waiter observes it.
-                // Keep the revision so clearing the work sets cannot erase that notification.
+                // Eviction can erase a rejection before this waiter observes it.
+                // Retained rejections use the predicate so other parents cannot cancel this work.
                 state.withdrawn(work_id)
-                    || (state.revision != revision && !state.is_prepared(work_id))
+                    || (state.evicted_revision > revision && !state.is_prepared(work_id))
             };
             if withdrawn {
                 return;
@@ -1505,12 +1505,12 @@ where
     ) -> Result<GetBlockTemplateResponse> {
         let mut long_poll_id = template.long_poll_id;
         // A miner holding work from an earlier revision must not resubmit it.
-        let submit_old = if long_poll_id.revision != state.revision {
+        let submit_old = if long_poll_id.revision != state.current_revision() {
             Some(false)
         } else {
             template.submit_old
         };
-        long_poll_id.revision = state.revision;
+        long_poll_id.revision = state.current_revision();
         let template = BlockTemplateResponse::new_internal(
             &self.network,
             None,
@@ -1582,7 +1582,7 @@ where
 
         // Another rejection landed on this parent, or withdrew this very work.
         current.parent != state.parent
-            || current.revision != state.revision
+            || current.current_revision() != state.current_revision()
             || current.contains(template.work_id())
             // The chain moved off the parent this template was built on.
             || self
@@ -3169,7 +3169,7 @@ where
                 mempool_txs.iter().map(|tx| tx.transaction.id()),
             )
             .generate_id();
-            server_long_poll_id.revision = rejection_state.revision;
+            server_long_poll_id.revision = rejection_state.current_revision();
 
             // The loop finishes if:
             // - the client didn't pass a long poll ID,
@@ -3301,7 +3301,7 @@ where
                         vec![]
                     )
                     .generate_id();
-                    server_long_poll_id.revision = rejection_state.revision;
+                    server_long_poll_id.revision = rejection_state.current_revision();
 
                     let submit_old = client_long_poll_id
                         .as_ref()

--- a/crates/zakura-rpc/src/methods/tests/snapshot.rs
+++ b/crates/zakura-rpc/src/methods/tests/snapshot.rs
@@ -870,8 +870,11 @@ fn snapshot_rpc_getblocktemplate(
         insta::assert_json_snapshot!(format!("get_block_template_{variant}"), block_template, {
             ".workid" => dynamic_redaction(|value, _path| {
                 let work_id = value.as_str().expect("workid must be a string");
-                assert_eq!(work_id.len(), 32, "workid must encode 16 bytes");
-                assert!(work_id.bytes().all(|byte| byte.is_ascii_hexdigit()));
+                let (namespace, template) = work_id.split_once(':').expect("workid includes its parent namespace");
+                for component in [namespace, template] {
+                    assert_eq!(component.len(), 32, "each workid component encodes 16 bytes");
+                    assert!(component.bytes().all(|byte| byte.is_ascii_hexdigit()));
+                }
                 "[WorkId]"
             }),
         })
@@ -1348,6 +1351,12 @@ pub async fn test_mining_rpcs<State, ReadState>(
     );
 
     let mut server_preparation_verifier = mock_block_verifier_router.clone();
+    let mut server_template = server_template;
+    let mut rejections = rpc_mock_state_verifier.gbt.template_rejections.subscribe();
+    let tracked = rpc_mock_state_verifier
+        .track_template_parent(fake_tip_hash, fake_tip_height, &mut rejections)
+        .expect("the snapshot fixture tracks its template parent");
+    server_template.work_id = tracked.scope_work_id(&hex::encode([0; 16]));
     rpc_mock_state_verifier.prepare_template_in_background(&server_template);
     server_preparation_verifier
         .expect_request_that(|request| {

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_basic@mainnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_basic@mainnet_10.snap
@@ -1,5 +1,5 @@
 ---
-source: zebra-rpc/src/methods/tests/snapshot.rs
+source: crates/zakura-rpc/src/methods/tests/snapshot.rs
 expression: block_template
 ---
 {
@@ -27,7 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
-  "longpollid": "00016871043eab7f731654008728000000000000000000",
+  "longpollid": "00016871043eab7f7316540087280000000000000000000000000000000001",
   "target": "0005555400000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_basic@testnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_basic@testnet_10.snap
@@ -1,5 +1,5 @@
 ---
-source: zebra-rpc/src/methods/tests/snapshot.rs
+source: crates/zakura-rpc/src/methods/tests/snapshot.rs
 expression: block_template
 ---
 {
@@ -27,7 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
-  "longpollid": "00018424203eab7f731654008728000000000000000000",
+  "longpollid": "00018424203eab7f7316540087280000000000000000000000000000000001",
   "target": "0555540000000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_long_poll@mainnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_long_poll@mainnet_10.snap
@@ -1,5 +1,5 @@
 ---
-source: zebra-rpc/src/methods/tests/snapshot.rs
+source: crates/zakura-rpc/src/methods/tests/snapshot.rs
 expression: block_template
 ---
 {
@@ -27,7 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
-  "longpollid": "00016871043eab7f731654008728000000000000000000",
+  "longpollid": "00016871043eab7f7316540087280000000000000000000000000000000001",
   "target": "0005555400000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [

--- a/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_long_poll@testnet_10.snap
+++ b/crates/zakura-rpc/src/methods/tests/snapshots/get_block_template_long_poll@testnet_10.snap
@@ -1,5 +1,5 @@
 ---
-source: zebra-rpc/src/methods/tests/snapshot.rs
+source: crates/zakura-rpc/src/methods/tests/snapshot.rs
 expression: block_template
 ---
 {
@@ -27,7 +27,7 @@ expression: block_template
     "sigops": 0,
     "required": true
   },
-  "longpollid": "00018424203eab7f731654008728000000000000000000",
+  "longpollid": "00018424203eab7f7316540087280000000000000000000000000000000001",
   "target": "0555540000000000000000000000000000000000000000000000000000000000",
   "mintime": 1654008606,
   "mutable": [

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -4646,12 +4646,12 @@ fn speculative_test_template(parent: Hash) -> BlockTemplateResponse {
     )
 }
 
-/// A request whose tip went stale must not erase the current parent's withdrawals.
+/// A request whose tip went stale must not retarget the parent templates are built on.
 ///
-/// `set_parent` clears every rejection recorded for the parent it replaces, so a request that no
-/// longer agrees with the chain tip must return without writing anything.
+/// The request would otherwise publish a template on a parent the chain has already left, and
+/// hand the miner a long poll ID built from that parent's state.
 #[tokio::test]
-async fn a_stale_request_does_not_erase_the_current_parent_withdrawals() {
+async fn a_stale_request_does_not_retarget_the_template_parent() {
     let _init_guard = zakura_test::init();
     let current = Hash([1; 32]);
     let stale = Hash([2; 32]);
@@ -4715,7 +4715,10 @@ async fn a_stale_request_does_not_erase_the_current_parent_withdrawals() {
     tip_sender.send_best_tip_hash(stale);
     rpc.track_template_parent(stale, &mut rejections)
         .expect("the new tip is tracked");
-    assert!(!rpc.mining_template_withdrawn("work"));
+    assert!(
+        rpc.mining_template_withdrawn("work"),
+        "a rejection names one template, so a parent change does not revive it",
+    );
     assert!(
         futures::poll!(&mut withdrawal).is_ready(),
         "a parent change must not erase a rejection the waiter has not read",
@@ -4869,6 +4872,119 @@ async fn a_rejection_that_arrives_after_the_deadline_still_withdraws_the_templat
     assert!(
         rpc.mining_template_withdrawn(&work_id),
         "a rejection the node waited past its deadline for is still recorded",
+    );
+}
+
+/// A rejection is recorded on the parent it was validating, not on the current one.
+///
+/// A reorg away from a parent and back, or `invalidateblock` followed by `reconsiderblock`, can
+/// leave a validation legitimately finishing while templates are built on another parent. The
+/// answer still condemns the template it ran on, and the parent it was recorded under still has
+/// it when the chain returns.
+#[tokio::test]
+async fn a_rejection_is_recorded_on_the_parent_it_validated() {
+    let _init_guard = zakura_test::init();
+    let parent = Hash([1; 32]);
+    let sibling = Hash([2; 32]);
+    let (tip, tip_sender) = MockChainTip::new();
+    let height = NetworkUpgrade::Nu5.activation_height(&Mainnet).unwrap();
+    tip_sender.send_best_tip_height(height);
+    tip_sender.send_best_tip_hash(parent);
+    tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+    let mut sync = MockSyncStatus::default();
+    sync.set_is_close_to_tip(true);
+    let mempool = tower::service_fn(move |_| async move {
+        Ok::<_, BoxError>(mempool::Response::FullTransactions {
+            transactions: vec![],
+            transaction_dependencies: Default::default(),
+            last_seen_tip_hash: parent,
+        })
+    });
+    let chain_info = GetBlockTemplateChainInfo {
+        expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+        tip_height: height,
+        tip_hash: parent,
+        cur_time: 1654008617.into(),
+        min_time: 1654008606.into(),
+        max_time: 1654008728.into(),
+        chain_history_root: fake_history_tree(&Mainnet).hash(),
+    };
+    let read_state = tower::service_fn(move |request| {
+        let chain_info = chain_info.clone();
+        async move {
+            assert!(matches!(request, ReadRequest::ChainInfo));
+            Ok::<_, BoxError>(ReadResponse::ChainInfo(chain_info))
+        }
+    });
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut verifier: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _queue) = RpcImpl::new(
+        Mainnet,
+        mining::Config {
+            miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+                NetworkType::Main,
+                [0x7e; 20],
+            )),
+            ..Default::default()
+        },
+        false,
+        "0.0.1",
+        "parent ABA test",
+        Buffer::new(mempool, 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state, 1),
+        Buffer::new(verifier.clone(), 1),
+        sync,
+        tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let template = rpc
+        .get_block_template(None)
+        .await
+        .expect("the first template is returned");
+    let work_id = match &template {
+        GetBlockTemplateResponse::TemplateMode(template) => template.work_id().clone(),
+        GetBlockTemplateResponse::ProposalMode(_) => unreachable!("template mode was requested"),
+    };
+    let preparation = verifier
+        .expect_request_that(|request| matches!(request, zakura_consensus::Request::Prepare { .. }))
+        .await;
+
+    // The chain leaves the parent while its template is still being validated.
+    let mut rejections = rpc.gbt.template_rejections.subscribe();
+    tip_sender.send_best_tip_hash(sibling);
+    rpc.track_template_parent(sibling, &mut rejections)
+        .expect("the sibling is tracked");
+
+    preparation.respond(Err::<Hash, _>(zakura_consensus::BoxError::from(
+        zakura_consensus::VerifyBlockError::Block {
+            source: zakura_consensus::error::BlockError::MissingHeight(Hash([3; 32])),
+        },
+    )));
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        rpc.mining_template_withdrawn(&work_id),
+        "a rejection recorded while the chain was elsewhere still withdraws its own work",
+    );
+    assert!(
+        !rpc.mining_template_withdrawn("sibling-work"),
+        "the parent the chain moved to is not put into fallback by another parent's rejection",
+    );
+
+    // The chain comes back to the parent, which still knows what it rejected there.
+    tip_sender.send_best_tip_hash(parent);
+    rpc.track_template_parent(parent, &mut rejections)
+        .expect("the original parent is tracked again");
+    assert!(rpc.mining_template_rejected(&work_id));
+    assert!(
+        rpc.mining_template_withdrawn("older-work"),
+        "the parent returns to fallback, so it hands out only work it has validated",
     );
 }
 

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -4719,9 +4719,17 @@ async fn a_stale_request_does_not_retarget_the_template_parent() {
         rpc.mining_template_withdrawn("work"),
         "a rejection names one template, so a parent change does not revive it",
     );
+    // Eight more parents evict the rejection before the waiter reads its notification.
+    for byte in 3..=10 {
+        let parent = Hash([byte; 32]);
+        tip_sender.send_best_tip_hash(parent);
+        rpc.track_template_parent(parent, &mut rejections)
+            .expect("the new tip is tracked");
+    }
+    assert!(!rpc.mining_template_withdrawn("work"));
     assert!(
         futures::poll!(&mut withdrawal).is_ready(),
-        "a parent change must not erase a rejection the waiter has not read",
+        "eviction must not erase a rejection the waiter has not read",
     );
 }
 
@@ -4909,8 +4917,10 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
         max_time: 1654008728.into(),
         chain_history_root: fake_history_tree(&Mainnet).hash(),
     };
+    let read_tip = tip.clone();
     let read_state = tower::service_fn(move |request| {
-        let chain_info = chain_info.clone();
+        let mut chain_info = chain_info.clone();
+        chain_info.tip_hash = read_tip.best_tip_hash().expect("the test sets a tip");
         async move {
             assert!(matches!(request, ReadRequest::ChainInfo));
             Ok::<_, BoxError>(ReadResponse::ChainInfo(chain_info))
@@ -4957,8 +4967,13 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
     // The chain leaves the parent while its template is still being validated.
     let mut rejections = rpc.gbt.template_rejections.subscribe();
     tip_sender.send_best_tip_hash(sibling);
-    rpc.track_template_parent(sibling, &mut rejections)
+    let sibling_state = rpc
+        .track_template_parent(sibling, &mut rejections)
         .expect("the sibling is tracked");
+
+    let sibling_withdrawal = rpc.wait_for_mining_template_withdrawal(Some("sibling-work"));
+    tokio::pin!(sibling_withdrawal);
+    assert!(futures::poll!(&mut sibling_withdrawal).is_pending());
 
     preparation.respond(Err::<Hash, _>(zakura_consensus::BoxError::from(
         zakura_consensus::VerifyBlockError::Block {
@@ -4975,6 +4990,31 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
     assert!(
         !rpc.mining_template_withdrawn("sibling-work"),
         "the parent the chain moved to is not put into fallback by another parent's rejection",
+    );
+    assert!(
+        futures::poll!(&mut sibling_withdrawal).is_pending(),
+        "another parent's rejection must not interrupt the sibling's solver",
+    );
+
+    assert!(
+        !rpc.recovery_context_changed(
+            &sibling_state,
+            &speculative_test_template(sibling),
+            sibling,
+        ),
+        "another parent's rejection must not abort the sibling's recovery",
+    );
+    let sibling_template = rpc
+        .get_block_template(None)
+        .await
+        .expect("the sibling can still publish work")
+        .try_into_template()
+        .expect("template mode was requested");
+    assert_eq!(sibling_template.previous_block_hash, sibling);
+    assert_eq!(
+        sibling_template.long_poll_id.revision,
+        sibling_state.current_revision(),
+        "another parent's rejection must not change the sibling's long-poll ID",
     );
 
     // The chain comes back to the parent, which still knows what it rejected there.

--- a/crates/zakura-rpc/src/methods/tests/vectors.rs
+++ b/crates/zakura-rpc/src/methods/tests/vectors.rs
@@ -3242,6 +3242,90 @@ async fn check_template_rejection_recovery(reject_before_poll: bool) {
     assert_ne!(replacement.long_poll_id, old_id);
     assert!(replacement.transactions.is_empty());
 
+    if !reject_before_poll {
+        // Fill the prepared-work bound with real recovery responses.
+        for _ in 1..64 {
+            let recovery = tokio::spawn({
+                let rpc = rpc.clone();
+                async move { rpc.get_block_template(None).await }
+            });
+            verifier
+                .expect_request_that(|request| {
+                    matches!(request, zakura_consensus::Request::Prepare { .. })
+                })
+                .await
+                .respond(Hash([2; 32]));
+            let recovered = recovery
+                .await
+                .unwrap()
+                .unwrap()
+                .try_into_template()
+                .unwrap();
+            assert_eq!(recovered.long_poll_id, replacement.long_poll_id);
+        }
+        assert!(!rpc.mining_template_withdrawn(&replacement.work_id));
+        let old_id = replacement.long_poll_id;
+        let long_poll = tokio::spawn({
+            let rpc = rpc.clone();
+            async move {
+                rpc.get_block_template(Some(GetBlockTemplateParameters::new(
+                    GetBlockTemplateRequestMode::Template,
+                    None,
+                    vec![],
+                    Some(old_id),
+                    None,
+                )))
+                .await
+            }
+        });
+        let previous_calls = *calls.borrow_and_update();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while *calls.borrow_and_update() <= previous_calls {
+                calls.changed().await.unwrap();
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!long_poll.is_finished());
+        let eviction = tokio::spawn({
+            let rpc = rpc.clone();
+            async move { rpc.get_block_template(None).await }
+        });
+        verifier
+            .expect_request_that(|request| {
+                matches!(request, zakura_consensus::Request::Prepare { .. })
+            })
+            .await
+            .respond(Hash([2; 32]));
+        let eviction = eviction
+            .await
+            .unwrap()
+            .unwrap()
+            .try_into_template()
+            .unwrap();
+        assert!(rpc.mining_template_withdrawn(&replacement.work_id));
+        assert!(eviction.long_poll_id.revision > old_id.revision);
+        assert_eq!(eviction.submit_old, Some(false));
+        verifier
+            .expect_request_that(|request| {
+                matches!(request, zakura_consensus::Request::Prepare { .. })
+            })
+            .await
+            .respond(Hash([2; 32]));
+        let awakened = tokio::time::timeout(Duration::from_secs(1), long_poll)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .try_into_template()
+            .unwrap();
+        assert_eq!(awakened.submit_old, Some(false));
+        assert_eq!(
+            awakened.long_poll_id.revision,
+            rpc.gbt.template_rejections.borrow().current_revision()
+        );
+    }
+
     // A failed fallback must never reach a miner.
     let recovery = tokio::spawn({
         let rpc = rpc.clone();
@@ -3256,6 +3340,21 @@ async fn check_template_rejection_recovery(reject_before_poll: bool) {
         .unwrap()
         .unwrap()
         .is_err());
+    let recovery = tokio::spawn({
+        let rpc = rpc.clone();
+        async move { rpc.get_block_template(None).await }
+    });
+    let pending = verifier
+        .expect_request_that(|request| matches!(request, zakura_consensus::Request::Prepare { .. }))
+        .await;
+    rpc.gbt.template_rejections.send_if_modified(|state| {
+        state.reject(parent, &state.scope_work_id("concurrent-rejection"))
+    });
+    pending.respond(Hash([2; 32]));
+    assert!(
+        recovery.await.unwrap().is_err(),
+        "recovery cannot publish across a changed rejection revision"
+    );
     queue.abort();
 }
 
@@ -4688,49 +4787,59 @@ async fn a_stale_request_does_not_retarget_the_template_parent() {
     );
 
     let mut rejections = rpc.gbt.template_rejections.subscribe();
-    rpc.track_template_parent(current, &mut rejections)
+    rpc.track_template_parent(current, Height(1), &mut rejections)
         .expect("the current tip is tracked");
-    let withdrawal = rpc.wait_for_mining_template_withdrawal(Some("work"));
+    let work = rpc.gbt.template_rejections.borrow().scope_work_id("work");
+    let withdrawal = rpc.wait_for_mining_template_withdrawal(Some(&work));
     tokio::pin!(withdrawal);
     assert!(futures::poll!(&mut withdrawal).is_pending());
     rpc.gbt
         .template_rejections
-        .send_if_modified(|state| state.reject(current, "work"));
+        .send_if_modified(|state| state.reject(current, &work));
 
     assert!(
-        rpc.track_template_parent(stale, &mut rejections).is_none(),
+        rpc.track_template_parent(stale, Height(2), &mut rejections)
+            .is_none(),
         "a request built on a parent the chain has left is told to fetch the tip again",
     );
     assert!(
-        rpc.mining_template_withdrawn("work"),
+        rpc.mining_template_withdrawn(&work),
         "the stale request must not clear the current parent's rejections",
     );
 
     let tracked = rpc
-        .track_template_parent(current, &mut rejections)
+        .track_template_parent(current, Height(1), &mut rejections)
         .expect("the current tip is still tracked");
     assert_eq!(tracked.parent, Some(current));
-    assert!(tracked.contains("work"));
+    assert!(tracked.contains(&work));
 
+    tip_sender.send_best_tip_height(Height(2));
     tip_sender.send_best_tip_hash(stale);
-    rpc.track_template_parent(stale, &mut rejections)
+    rpc.track_template_parent(stale, Height(2), &mut rejections)
         .expect("the new tip is tracked");
     assert!(
-        rpc.mining_template_withdrawn("work"),
+        rpc.mining_template_withdrawn(&work),
         "a rejection names one template, so a parent change does not revive it",
     );
     // Eight more parents evict the rejection before the waiter reads its notification.
     for byte in 3..=10 {
         let parent = Hash([byte; 32]);
+        tip_sender.send_best_tip_height(Height(u32::from(byte)));
         tip_sender.send_best_tip_hash(parent);
-        rpc.track_template_parent(parent, &mut rejections)
+        rpc.track_template_parent(parent, Height(u32::from(byte)), &mut rejections)
             .expect("the new tip is tracked");
     }
-    assert!(!rpc.mining_template_withdrawn("work"));
+    assert!(rpc.mining_template_withdrawn(&work));
     assert!(
         futures::poll!(&mut withdrawal).is_ready(),
         "eviction must not erase a rejection the waiter has not read",
     );
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        rpc.wait_for_mining_template_withdrawal(Some(&work)),
+    )
+    .await
+    .expect("a re-armed waiter must observe retired work immediately");
 }
 
 /// A preparation deadline classifies the cost; it does not stop the computation.
@@ -4921,6 +5030,7 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
     let read_state = tower::service_fn(move |request| {
         let mut chain_info = chain_info.clone();
         chain_info.tip_hash = read_tip.best_tip_hash().expect("the test sets a tip");
+        chain_info.tip_height = read_tip.best_tip_height().expect("the test sets a height");
         async move {
             assert!(matches!(request, ReadRequest::ChainInfo));
             Ok::<_, BoxError>(ReadResponse::ChainInfo(chain_info))
@@ -4966,12 +5076,14 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
 
     // The chain leaves the parent while its template is still being validated.
     let mut rejections = rpc.gbt.template_rejections.subscribe();
+    tip_sender.send_best_tip_height((height + 1).unwrap());
     tip_sender.send_best_tip_hash(sibling);
     let sibling_state = rpc
-        .track_template_parent(sibling, &mut rejections)
+        .track_template_parent(sibling, (height + 1).unwrap(), &mut rejections)
         .expect("the sibling is tracked");
 
-    let sibling_withdrawal = rpc.wait_for_mining_template_withdrawal(Some("sibling-work"));
+    let sibling_work = sibling_state.scope_work_id("sibling-work");
+    let sibling_withdrawal = rpc.wait_for_mining_template_withdrawal(Some(&sibling_work));
     tokio::pin!(sibling_withdrawal);
     assert!(futures::poll!(&mut sibling_withdrawal).is_pending());
 
@@ -4988,7 +5100,7 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
         "a rejection recorded while the chain was elsewhere still withdraws its own work",
     );
     assert!(
-        !rpc.mining_template_withdrawn("sibling-work"),
+        !rpc.mining_template_withdrawn(&sibling_work),
         "the parent the chain moved to is not put into fallback by another parent's rejection",
     );
     assert!(
@@ -4998,6 +5110,7 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
 
     assert!(
         !rpc.recovery_context_changed(
+            &rpc.gbt.template_rejections.borrow(),
             &sibling_state,
             &speculative_test_template(sibling),
             sibling,
@@ -5018,8 +5131,9 @@ async fn a_rejection_is_recorded_on_the_parent_it_validated() {
     );
 
     // The chain comes back to the parent, which still knows what it rejected there.
+    tip_sender.send_best_tip_height(height);
     tip_sender.send_best_tip_hash(parent);
-    rpc.track_template_parent(parent, &mut rejections)
+    rpc.track_template_parent(parent, height, &mut rejections)
         .expect("the original parent is tracked again");
     assert!(rpc.mining_template_rejected(&work_id));
     assert!(
@@ -5094,7 +5208,11 @@ async fn a_stale_preparation_holds_the_worker_until_it_finishes() {
             assert!(matches!(request, ReadRequest::ChainInfo));
             Ok::<_, BoxError>(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
                 expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
-                tip_height: height,
+                tip_height: if tip_hash == first_parent {
+                    height
+                } else {
+                    (height + 1).unwrap()
+                },
                 tip_hash,
                 cur_time: 1654008617.into(),
                 min_time: 1654008606.into(),
@@ -5140,6 +5258,7 @@ async fn a_stale_preparation_holds_the_worker_until_it_finishes() {
     // The chain moves on. The node stops waiting for a preparation built on the old parent, but
     // that verification is still computing.
     state_tip.send_replace(second_parent);
+    tip_sender.send_best_tip_height((height + 1).unwrap());
     tip_sender.send_best_tip_hash(second_parent);
     tokio::task::yield_now().await;
 

--- a/crates/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template.rs
@@ -74,35 +74,101 @@ const MAX_REJECTED_WORK_IDS: usize = 64;
 /// holding very old work loses its withdrawal exemption rather than growing this queue.
 const MAX_PREPARED_WORK_IDS: usize = 64;
 
-/// Rejections for the current template parent. Overflow fails closed until the tip changes.
+/// How many parents retain what they recorded. The least recently tracked parent is forgotten
+/// first.
+const MAX_TRACKED_PARENTS: usize = 8;
+
+/// What one parent's templates are known to be worth. Overflow fails closed for that parent.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct TemplateRejections {
-    pub(crate) parent: Option<block::Hash>,
-    pub(crate) revision: u64,
+struct ParentRejections {
     rejected: HashSet<String>,
     prepared: VecDeque<String>,
-    pub(crate) saturated: bool,
+    saturated: bool,
+}
+
+impl ParentRejections {
+    /// Whether this parent condemned `work_id`, or condemned so much that it trusts none of its
+    /// own templates.
+    fn contains(&self, work_id: &str) -> bool {
+        self.saturated || self.rejected.contains(work_id)
+    }
+
+    /// Whether this parent may only hand out templates it validated in the foreground.
+    fn needs_fallback(&self) -> bool {
+        self.saturated || !self.rejected.is_empty()
+    }
+
+    /// Whether this parent validated `work_id` and has not condemned it since.
+    fn is_prepared(&self, work_id: &str) -> bool {
+        self.prepared.iter().any(|id| id == work_id) && !self.contains(work_id)
+    }
+}
+
+/// What every tracked parent recorded about its templates, and which parent they are built on now.
+///
+/// A work ID names one template, and that template extends one parent, so a rejection recorded
+/// under that parent stays true for as long as the work does. Retaining one entry per parent is
+/// what lets the chain leave a parent and come back to it — a reorg, or `invalidateblock`
+/// followed by `reconsiderblock` — without losing what was learned there.
+///
+/// Only the explicit rejection follows the work across parents. Fallback and saturation are
+/// policies about which templates a parent may hand out, so they stay scoped to the parent
+/// templates are built on now: one saturated parent must not withdraw every other parent's work.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TemplateRejections {
+    /// The parent templates are built on now.
+    pub(crate) parent: Option<block::Hash>,
+    /// Counts rejections, and never restarts: a waiter can tell it missed one it never read,
+    /// whatever the parent has done since.
+    pub(crate) revision: u64,
+    /// Least recently tracked first. The entries are shared, so cloning this state for one
+    /// request does not copy every tracked parent's work IDs.
+    parents: VecDeque<(block::Hash, Arc<ParentRejections>)>,
 }
 
 impl TemplateRejections {
-    pub(crate) fn set_parent(&mut self, parent: block::Hash) {
-        if self.parent != Some(parent) {
-            self.parent = Some(parent);
-            self.rejected.clear();
-            self.prepared.clear();
-            self.saturated = false;
+    /// Points `parent` at the parent templates are built on now, and returns whether that moved.
+    ///
+    /// Nothing is forgotten here. A parent that is tracked again keeps everything it recorded
+    /// before and returns to the back of the eviction order.
+    pub(crate) fn track_parent(&mut self, parent: block::Hash) -> bool {
+        let moved = self.parent != Some(parent);
+        self.parent = Some(parent);
+
+        let entry = match self.position(parent) {
+            Some(position) => self
+                .parents
+                .remove(position)
+                .expect("position is in bounds"),
+            None => (parent, Arc::default()),
+        };
+        self.parents.push_back(entry);
+        while self.parents.len() > MAX_TRACKED_PARENTS {
+            self.parents.pop_front();
         }
+
+        moved
     }
 
+    /// Records that `work_id` failed validation on `parent`, and returns whether that is news.
+    ///
+    /// `parent` need not be the parent templates are built on now. A validation that finishes
+    /// while the chain is elsewhere still condemns the work it was validating, and that answer is
+    /// the only one the node will get.
     pub(crate) fn reject(&mut self, parent: block::Hash, work_id: &str) -> bool {
-        if self.parent != Some(parent) || self.contains(work_id) {
+        let Some(entry) = self.entry_mut(parent) else {
+            return false;
+        };
+        if entry.contains(work_id) {
             return false;
         }
-        if self.rejected.len() == MAX_REJECTED_WORK_IDS {
-            self.saturated = true;
+
+        if entry.rejected.len() == MAX_REJECTED_WORK_IDS {
+            entry.saturated = true;
         } else {
-            self.rejected.insert(work_id.to_owned());
+            entry.rejected.insert(work_id.to_owned());
         }
+
         self.revision = self
             .revision
             .checked_add(1)
@@ -110,38 +176,95 @@ impl TemplateRejections {
         true
     }
 
-    pub(crate) fn contains(&self, work_id: &str) -> bool {
-        self.saturated || self.rejected.contains(work_id)
-    }
-
-    pub(crate) fn needs_fallback(&self) -> bool {
-        self.saturated || !self.rejected.is_empty()
-    }
-
     /// Records that `work_id` passed validation on `parent`.
     ///
     /// Returns whether this withdrew any other work: the oldest prepared ID is forgotten when the
-    /// queue is full, and during fallback losing that exemption withdraws it. Waiters observe
-    /// withdrawal through the watch channel, so the caller must publish that change.
+    /// queue is full, and during that parent's fallback losing that exemption withdraws it.
+    /// Waiters observe withdrawal through the watch channel, so the caller must publish that
+    /// change.
     pub(crate) fn mark_prepared(&mut self, parent: block::Hash, work_id: &str) -> bool {
-        if self.parent != Some(parent) || self.prepared.iter().any(|id| id == work_id) {
+        let Some(entry) = self.entry_mut(parent) else {
+            return false;
+        };
+        if entry.prepared.iter().any(|id| id == work_id) {
             return false;
         }
-        let evicted = if self.prepared.len() == MAX_PREPARED_WORK_IDS {
-            self.prepared.pop_front().is_some()
+
+        let evicted = if entry.prepared.len() == MAX_PREPARED_WORK_IDS {
+            entry.prepared.pop_front().is_some()
         } else {
             false
         };
-        self.prepared.push_back(work_id.to_owned());
-        evicted && self.needs_fallback()
+        entry.prepared.push_back(work_id.to_owned());
+        evicted && entry.needs_fallback()
     }
 
+    /// Whether the parent templates are built on now condemned `work_id`.
+    pub(crate) fn contains(&self, work_id: &str) -> bool {
+        self.current().is_some_and(|entry| entry.contains(work_id))
+    }
+
+    /// Whether any tracked parent condemned `work_id` by name.
+    ///
+    /// Saturation is deliberately not consulted here: it says a parent stopped trusting its own
+    /// templates, not that this work was validated and found invalid.
+    fn rejected_anywhere(&self, work_id: &str) -> bool {
+        self.parents
+            .iter()
+            .any(|(_, entry)| entry.rejected.contains(work_id))
+    }
+
+    /// Whether the parent templates are built on now may only hand out validated templates.
+    pub(crate) fn needs_fallback(&self) -> bool {
+        self.current().is_some_and(ParentRejections::needs_fallback)
+    }
+
+    /// Whether `parent` may only hand out templates validated in the foreground.
+    pub(crate) fn needs_fallback_on(&self, parent: block::Hash) -> bool {
+        self.entry(parent)
+            .is_some_and(ParentRejections::needs_fallback)
+    }
+
+    /// Whether the parent templates are built on now has stopped trusting its own templates.
+    pub(crate) fn saturated(&self) -> bool {
+        self.current().is_some_and(|entry| entry.saturated)
+    }
+
+    /// Whether the parent templates are built on now validated `work_id`.
     pub(crate) fn is_prepared(&self, work_id: &str) -> bool {
-        self.prepared.iter().any(|id| id == work_id) && !self.contains(work_id)
+        self.current()
+            .is_some_and(|entry| entry.is_prepared(work_id))
     }
 
+    /// Whether a miner holding `work_id` must stop working on it.
     pub(crate) fn withdrawn(&self, work_id: &str) -> bool {
+        // A rejection follows the work: the parent it was recorded under condemned this exact
+        // template, and returning to that parent does not make the template valid again.
+        if self.rejected_anywhere(work_id) {
+            return true;
+        }
+
+        // Fallback is what the parent templates are built on now will still hand out, so it is
+        // asked of that parent alone.
         self.contains(work_id) || (self.needs_fallback() && !self.is_prepared(work_id))
+    }
+
+    fn current(&self) -> Option<&ParentRejections> {
+        self.entry(self.parent?)
+    }
+
+    fn entry(&self, parent: block::Hash) -> Option<&ParentRejections> {
+        self.position(parent)
+            .map(|position| &*self.parents[position].1)
+    }
+
+    fn entry_mut(&mut self, parent: block::Hash) -> Option<&mut ParentRejections> {
+        let position = self.position(parent)?;
+        Some(Arc::make_mut(&mut self.parents[position].1))
+    }
+
+    fn position(&self, parent: block::Hash) -> Option<usize> {
+        self.parents.iter().position(|(hash, _)| *hash == parent)
     }
 }
 

--- a/crates/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template.rs
@@ -81,6 +81,8 @@ const MAX_TRACKED_PARENTS: usize = 8;
 /// What one parent's templates are known to be worth. Overflow fails closed for that parent.
 #[derive(Clone, Debug, Default)]
 struct ParentRejections {
+    /// The global revision assigned to this parent's last rejection.
+    revision: u64,
     rejected: HashSet<String>,
     prepared: VecDeque<String>,
     saturated: bool,
@@ -121,6 +123,8 @@ pub(crate) struct TemplateRejections {
     /// Counts rejections, and never restarts: a waiter can tell it missed one it never read,
     /// whatever the parent has done since.
     pub(crate) revision: u64,
+    /// The newest rejection revision lost through parent eviction.
+    pub(crate) evicted_revision: u64,
     /// Least recently tracked first. The entries are shared, so cloning this state for one
     /// request does not copy every tracked parent's work IDs.
     parents: VecDeque<(block::Hash, Arc<ParentRejections>)>,
@@ -129,8 +133,7 @@ pub(crate) struct TemplateRejections {
 impl TemplateRejections {
     /// Points `parent` at the parent templates are built on now, and returns whether that moved.
     ///
-    /// Nothing is forgotten here. A parent that is tracked again keeps everything it recorded
-    /// before and returns to the back of the eviction order.
+    /// A retained parent keeps its state and returns to the back of the eviction order.
     pub(crate) fn track_parent(&mut self, parent: block::Hash) -> bool {
         let moved = self.parent != Some(parent);
         self.parent = Some(parent);
@@ -144,7 +147,11 @@ impl TemplateRejections {
         };
         self.parents.push_back(entry);
         while self.parents.len() > MAX_TRACKED_PARENTS {
-            self.parents.pop_front();
+            let (_, evicted) = self
+                .parents
+                .pop_front()
+                .expect("the queue exceeds capacity");
+            self.evicted_revision = self.evicted_revision.max(evicted.revision);
         }
 
         moved
@@ -156,6 +163,7 @@ impl TemplateRejections {
     /// while the chain is elsewhere still condemns the work it was validating, and that answer is
     /// the only one the node will get.
     pub(crate) fn reject(&mut self, parent: block::Hash, work_id: &str) -> bool {
+        let revision = self.revision;
         let Some(entry) = self.entry_mut(parent) else {
             return false;
         };
@@ -169,10 +177,10 @@ impl TemplateRejections {
             entry.rejected.insert(work_id.to_owned());
         }
 
-        self.revision = self
-            .revision
+        entry.revision = revision
             .checked_add(1)
             .expect("template revision cannot exhaust u64");
+        self.revision = entry.revision;
         true
     }
 
@@ -217,6 +225,11 @@ impl TemplateRejections {
     /// Whether the parent templates are built on now may only hand out validated templates.
     pub(crate) fn needs_fallback(&self) -> bool {
         self.current().is_some_and(ParentRejections::needs_fallback)
+    }
+
+    /// The current parent's last rejection revision, or zero before its first rejection.
+    pub(crate) fn current_revision(&self) -> u64 {
+        self.current().map_or(0, |entry| entry.revision)
     }
 
     /// Whether `parent` may only hand out templates validated in the foreground.

--- a/crates/zakura-rpc/src/methods/types/get_block_template.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template.rs
@@ -78,105 +78,116 @@ const MAX_PREPARED_WORK_IDS: usize = 64;
 /// first.
 const MAX_TRACKED_PARENTS: usize = 8;
 
-/// What one parent's templates are known to be worth. Overflow fails closed for that parent.
-#[derive(Clone, Debug, Default)]
+/// Retains one parent's validation results and work-ID namespace.
+#[derive(Clone, Debug)]
 struct ParentRejections {
-    /// The global revision assigned to this parent's last rejection.
     revision: u64,
+    namespace: String,
     rejected: HashSet<String>,
     prepared: VecDeque<String>,
+    requires_recovery: bool,
     saturated: bool,
 }
 
 impl ParentRejections {
-    /// Whether this parent condemned `work_id`, or condemned so much that it trusts none of its
-    /// own templates.
+    fn owns(&self, work_id: &str) -> bool {
+        work_id
+            .split_once(':')
+            .is_some_and(|(namespace, _)| namespace == self.namespace)
+    }
+
     fn contains(&self, work_id: &str) -> bool {
-        self.saturated || self.rejected.contains(work_id)
+        self.owns(work_id) && (self.saturated || self.rejected.contains(work_id))
     }
 
-    /// Whether this parent may only hand out templates it validated in the foreground.
     fn needs_fallback(&self) -> bool {
-        self.saturated || !self.rejected.is_empty()
+        self.requires_recovery || self.saturated || !self.rejected.is_empty()
     }
 
-    /// Whether this parent validated `work_id` and has not condemned it since.
     fn is_prepared(&self, work_id: &str) -> bool {
         self.prepared.iter().any(|id| id == work_id) && !self.contains(work_id)
     }
 }
 
-/// What every tracked parent recorded about its templates, and which parent they are built on now.
-///
-/// A work ID names one template, and that template extends one parent, so a rejection recorded
-/// under that parent stays true for as long as the work does. Retaining one entry per parent is
-/// what lets the chain leave a parent and come back to it — a reorg, or `invalidateblock`
-/// followed by `reconsiderblock` — without losing what was learned there.
-///
-/// Only the explicit rejection follows the work across parents. Fallback and saturation are
-/// policies about which templates a parent may hand out, so they stay scoped to the parent
-/// templates are built on now: one saturated parent must not withdraw every other parent's work.
+/// Retains bounded parent state. Eviction retires that entry's work-ID namespace.
+/// A recreated parent gets a fresh revision and requires recovery at an observed height.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TemplateRejections {
-    /// The parent templates are built on now.
+    /// The parent used for new templates.
     pub(crate) parent: Option<block::Hash>,
-    /// Counts rejections, and never restarts: a waiter can tell it missed one it never read,
-    /// whatever the parent has done since.
+    /// Assigns revisions to new parent entries and withdrawal events.
     pub(crate) revision: u64,
-    /// The newest rejection revision lost through parent eviction.
-    pub(crate) evicted_revision: u64,
-    /// Least recently tracked first. The entries are shared, so cloning this state for one
-    /// request does not copy every tracked parent's work IDs.
+    /// Allows new forward heights to speculate without forgetting trust loss on older parents.
+    max_parent_height: Option<block::Height>,
+    /// Least recently tracked first. Snapshots share each parent's work sets.
     parents: VecDeque<(block::Hash, Arc<ParentRejections>)>,
 }
 
 impl TemplateRejections {
-    /// Points `parent` at the parent templates are built on now, and returns whether that moved.
-    ///
-    /// A retained parent keeps its state and returns to the back of the eviction order.
-    pub(crate) fn track_parent(&mut self, parent: block::Hash) -> bool {
+    /// Tracks the current parent. A retained entry keeps its validation results.
+    pub(crate) fn track_parent(&mut self, parent: block::Hash, height: block::Height) -> bool {
         let moved = self.parent != Some(parent);
         self.parent = Some(parent);
-
         let entry = match self.position(parent) {
             Some(position) => self
                 .parents
                 .remove(position)
                 .expect("position is in bounds"),
-            None => (parent, Arc::default()),
+            None => {
+                self.revision = self
+                    .revision
+                    .checked_add(1)
+                    .expect("template revision cannot exhaust u64");
+                let requires_recovery = self
+                    .max_parent_height
+                    .is_some_and(|maximum| height <= maximum);
+                self.max_parent_height = Some(
+                    self.max_parent_height
+                        .map_or(height, |maximum| maximum.max(height)),
+                );
+                (
+                    parent,
+                    Arc::new(ParentRejections {
+                        revision: self.revision,
+                        namespace: new_work_id(),
+                        rejected: HashSet::new(),
+                        prepared: VecDeque::new(),
+                        requires_recovery,
+                        saturated: false,
+                    }),
+                )
+            }
         };
         self.parents.push_back(entry);
-        while self.parents.len() > MAX_TRACKED_PARENTS {
-            let (_, evicted) = self
-                .parents
-                .pop_front()
-                .expect("the queue exceeds capacity");
-            self.evicted_revision = self.evicted_revision.max(evicted.revision);
+        if self.parents.len() > MAX_TRACKED_PARENTS {
+            self.parents.pop_front();
         }
-
         moved
     }
 
-    /// Records that `work_id` failed validation on `parent`, and returns whether that is news.
-    ///
-    /// `parent` need not be the parent templates are built on now. A validation that finishes
-    /// while the chain is elsewhere still condemns the work it was validating, and that answer is
-    /// the only one the node will get.
+    /// Binds a fresh template ID to the retained parent entry that owns it.
+    pub(crate) fn scope_work_id(&self, work_id: &str) -> String {
+        let entry = self
+            .current()
+            .expect("template publication tracks its parent first");
+        format!("{}:{work_id}", entry.namespace)
+    }
+
+    /// Records a rejection only while the work's parent namespace remains retained.
+    /// A retired namespace already withdraws all its work, including late results.
     pub(crate) fn reject(&mut self, parent: block::Hash, work_id: &str) -> bool {
         let revision = self.revision;
         let Some(entry) = self.entry_mut(parent) else {
             return false;
         };
-        if entry.contains(work_id) {
+        if !entry.owns(work_id) || entry.contains(work_id) {
             return false;
         }
-
         if entry.rejected.len() == MAX_REJECTED_WORK_IDS {
             entry.saturated = true;
         } else {
             entry.rejected.insert(work_id.to_owned());
         }
-
         entry.revision = revision
             .checked_add(1)
             .expect("template revision cannot exhaust u64");
@@ -184,82 +195,72 @@ impl TemplateRejections {
         true
     }
 
-    /// Records that `work_id` passed validation on `parent`.
-    ///
-    /// Returns whether this withdrew any other work: the oldest prepared ID is forgotten when the
-    /// queue is full, and during that parent's fallback losing that exemption withdraws it.
-    /// Waiters observe withdrawal through the watch channel, so the caller must publish that
-    /// change.
+    /// Records prepared work and advances the revision if eviction withdraws another ID.
     pub(crate) fn mark_prepared(&mut self, parent: block::Hash, work_id: &str) -> bool {
+        let revision = self.revision;
         let Some(entry) = self.entry_mut(parent) else {
             return false;
         };
-        if entry.prepared.iter().any(|id| id == work_id) {
+        if !entry.owns(work_id)
+            || entry.contains(work_id)
+            || entry.prepared.iter().any(|id| id == work_id)
+        {
             return false;
         }
-
-        let evicted = if entry.prepared.len() == MAX_PREPARED_WORK_IDS {
-            entry.prepared.pop_front().is_some()
+        let evicted = entry.prepared.len() == MAX_PREPARED_WORK_IDS;
+        if evicted {
+            entry.prepared.pop_front();
+        }
+        entry.prepared.push_back(work_id.to_owned());
+        if evicted && entry.needs_fallback() {
+            entry.revision = revision
+                .checked_add(1)
+                .expect("template revision cannot exhaust u64");
+            self.revision = entry.revision;
+            true
         } else {
             false
-        };
-        entry.prepared.push_back(work_id.to_owned());
-        evicted && entry.needs_fallback()
+        }
     }
 
-    /// Whether the parent templates are built on now condemned `work_id`.
+    /// Whether the current parent condemned this work.
     pub(crate) fn contains(&self, work_id: &str) -> bool {
         self.current().is_some_and(|entry| entry.contains(work_id))
     }
 
-    /// Whether any tracked parent condemned `work_id` by name.
-    ///
-    /// Saturation is deliberately not consulted here: it says a parent stopped trusting its own
-    /// templates, not that this work was validated and found invalid.
-    fn rejected_anywhere(&self, work_id: &str) -> bool {
-        self.parents
-            .iter()
-            .any(|(_, entry)| entry.rejected.contains(work_id))
-    }
-
-    /// Whether the parent templates are built on now may only hand out validated templates.
+    /// Whether the current parent requires foreground recovery.
     pub(crate) fn needs_fallback(&self) -> bool {
         self.current().is_some_and(ParentRejections::needs_fallback)
     }
 
-    /// The current parent's last rejection revision, or zero before its first rejection.
+    /// The current parent's publication/withdrawal revision.
     pub(crate) fn current_revision(&self) -> u64 {
         self.current().map_or(0, |entry| entry.revision)
     }
 
-    /// Whether `parent` may only hand out templates validated in the foreground.
+    /// Whether speculative work on this parent must stop.
     pub(crate) fn needs_fallback_on(&self, parent: block::Hash) -> bool {
         self.entry(parent)
-            .is_some_and(ParentRejections::needs_fallback)
+            .is_none_or(ParentRejections::needs_fallback)
     }
 
-    /// Whether the parent templates are built on now has stopped trusting its own templates.
+    /// Whether the current parent has exhausted its rejection budget.
     pub(crate) fn saturated(&self) -> bool {
         self.current().is_some_and(|entry| entry.saturated)
     }
 
-    /// Whether the parent templates are built on now validated `work_id`.
+    /// Whether the current parent validated this work.
     pub(crate) fn is_prepared(&self, work_id: &str) -> bool {
         self.current()
             .is_some_and(|entry| entry.is_prepared(work_id))
     }
 
-    /// Whether a miner holding `work_id` must stop working on it.
+    /// Whether this work was rejected, lost its exemption, or belongs to a retired namespace.
     pub(crate) fn withdrawn(&self, work_id: &str) -> bool {
-        // A rejection follows the work: the parent it was recorded under condemned this exact
-        // template, and returning to that parent does not make the template valid again.
-        if self.rejected_anywhere(work_id) {
+        let Some((_, entry)) = self.parents.iter().find(|(_, entry)| entry.owns(work_id)) else {
             return true;
-        }
-
-        // Fallback is what the parent templates are built on now will still hand out, so it is
-        // asked of that parent alone.
-        self.contains(work_id) || (self.needs_fallback() && !self.is_prepared(work_id))
+        };
+        entry.contains(work_id) || (entry.needs_fallback() && !entry.is_prepared(work_id))
     }
 
     fn current(&self) -> Option<&ParentRejections> {

--- a/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -26,156 +26,154 @@ use crate::config::mining::{default_miner_address, MinerAddressType};
 
 use super::{MinerParams, TemplatePreparationQueue};
 
-/// A rejection names one template, so it survives the chain leaving that template's parent.
-///
-/// Work IDs are drawn at random per response, so one names exactly one template on exactly one
-/// parent. Fallback and prepared work are policies about a single parent, so they follow the
-/// parent templates are built on now rather than the work.
 #[test]
 fn template_rejection_follows_the_work_across_parents() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let next_parent = zakura_chain::block::Hash([2; 32]);
     let mut state = super::TemplateRejections::default();
-    assert!(state.track_parent(parent));
-    state.mark_prepared(parent, "new");
-    assert!(state.reject(parent, "old"));
-    assert!(state.contains("old"));
-    assert!(!state.contains("new"));
-    assert!(state.is_prepared("new"));
-    assert!(!state.is_prepared("unknown"));
-    assert!(!state.withdrawn("new"));
-    assert!(state.withdrawn("unknown"));
-    assert!(!state.reject(parent, "old"));
-    assert_eq!(state.revision, 1);
-    assert_eq!(state.current_revision(), 1);
-
-    // The chain leaves the parent. Its fallback and its prepared work go with it, but the work it
-    // condemned stays condemned, and a validation that only now finishes is still recorded.
-    assert!(state.track_parent(next_parent));
-    assert!(!state.needs_fallback());
-    assert_eq!(state.current_revision(), 0);
-    assert!(!state.is_prepared("new"));
-    assert!(state.withdrawn("old"));
-    assert!(!state.withdrawn("new"));
-    assert!(state.reject(parent, "late"));
-    assert_eq!(state.revision, 2);
-    assert_eq!(state.current_revision(), 0);
-    assert!(state.withdrawn("late"));
-
-    // The chain comes back. The parent knows everything it knew before.
-    assert!(state.track_parent(parent));
+    assert!(state.track_parent(parent, Height(1)));
+    let prepared = state.scope_work_id("prepared");
+    let rejected = state.scope_work_id("rejected");
+    let late = state.scope_work_id("late");
+    state.mark_prepared(parent, &prepared);
+    assert!(state.reject(parent, &rejected));
+    assert!(!state.reject(parent, &rejected));
+    assert!(state.withdrawn(&rejected));
+    assert!(!state.withdrawn(&prepared));
+    assert!(state.track_parent(next_parent, Height(2)));
+    let next_revision = state.current_revision();
+    let next_work = state.scope_work_id("next");
+    assert!(state.reject(parent, &late));
+    assert_eq!(state.current_revision(), next_revision);
+    assert!(state.withdrawn(&late));
+    assert!(!state.withdrawn(&next_work));
+    assert!(!state.withdrawn(&prepared));
+    assert!(state.track_parent(parent, Height(1)));
     assert!(state.needs_fallback());
-    assert_eq!(state.current_revision(), 2);
-    assert!(state.is_prepared("new"));
-    assert!(!state.withdrawn("new"));
-    assert!(state.withdrawn("old"));
-    assert!(!state.track_parent(parent));
+    assert!(state.is_prepared(&prepared));
+    assert!(state.withdrawn(&rejected));
+    assert!(!state.track_parent(parent, Height(1)));
 }
 
 #[test]
 fn template_rejection_storage_fails_closed_at_capacity() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(parent);
+    state.track_parent(parent, Height(1));
     for id in 0..100 {
-        state.reject(parent, &id.to_string());
+        state.reject(parent, &state.scope_work_id(&id.to_string()));
     }
     assert_eq!(state.entry(parent).unwrap().rejected.len(), 64);
-    assert!(state.contains("unknown"));
+    assert!(state.contains(&state.scope_work_id("unknown")));
     assert!(state.needs_fallback());
 }
 
-/// One parent's saturation must not withdraw another parent's work.
-///
-/// Saturation says a parent stopped trusting its own templates. Reading it across parents would
-/// let a single unlucky parent withdraw every miner's work for as long as it is tracked.
 #[test]
 fn a_saturated_parent_does_not_withdraw_another_parents_work() {
     let saturated = zakura_chain::block::Hash([1; 32]);
     let current = zakura_chain::block::Hash([2; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(saturated);
+    state.track_parent(saturated, Height(1));
+    let old_work = state.scope_work_id("old");
     for id in 0..=super::MAX_REJECTED_WORK_IDS {
-        state.reject(saturated, &id.to_string());
+        state.reject(saturated, &state.scope_work_id(&id.to_string()));
     }
     assert!(state.entry(saturated).unwrap().saturated);
-
-    state.track_parent(current);
-    state.mark_prepared(current, "work");
-    assert!(!state.withdrawn("work"));
-    assert!(!state.withdrawn("unrelated"));
-
-    // The parent that saturated still fails closed when the chain returns to it.
-    state.track_parent(saturated);
-    assert!(state.withdrawn("unrelated"));
+    state.track_parent(current, Height(2));
+    let work = state.scope_work_id("work");
+    assert!(!state.withdrawn(&work));
+    state.track_parent(saturated, Height(1));
+    assert!(state.withdrawn(&old_work));
+    assert!(!state.withdrawn(&work));
 }
 
 #[test]
-fn template_rejections_forget_the_least_recently_tracked_parent() {
+fn parent_eviction_retires_work_and_requires_recovery_on_return() {
     let first = zakura_chain::block::Hash([0; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(first);
-    assert!(state.reject(first, "condemned"));
-
+    state.track_parent(first, Height(0));
+    let rejected = state.scope_work_id("condemned");
+    let late = state.scope_work_id("late");
+    assert!(state.reject(first, &rejected));
+    let old_revision = state.current_revision();
     for id in 1..=super::MAX_TRACKED_PARENTS {
-        state.track_parent(zakura_chain::block::Hash([id as u8; 32]));
+        state.track_parent(
+            zakura_chain::block::Hash([u8::try_from(id).unwrap(); 32]),
+            Height(u32::try_from(id).unwrap()),
+        );
     }
-
-    assert!(!state.withdrawn("condemned"));
-    assert_eq!(state.evicted_revision, 1);
-    assert!(
-        !state.reject(first, "late"),
-        "a forgotten parent records nothing",
-    );
+    assert!(state.withdrawn(&rejected));
+    assert!(state.withdrawn(&late));
+    assert!(!state.reject(first, &late));
+    state.track_parent(first, Height(0));
+    assert!(state.needs_fallback());
+    assert!(state.current_revision() > old_revision);
+    let revision = state.current_revision();
+    assert!(!state.reject(first, &late));
+    assert_eq!(state.current_revision(), revision);
+    let recovery = state.scope_work_id("recovery");
+    assert!(state.withdrawn(&recovery));
+    state.mark_prepared(first, &recovery);
+    assert!(!state.withdrawn(&recovery));
+    assert!(state.withdrawn(&rejected));
+    assert!(state.withdrawn(&late));
+    assert_eq!(state.parents.len(), super::MAX_TRACKED_PARENTS);
 }
 
 #[test]
-fn tracking_a_parent_again_keeps_it_from_being_forgotten() {
-    let first = zakura_chain::block::Hash([0; 32]);
+fn unrelated_eviction_preserves_retained_work() {
+    let retained = zakura_chain::block::Hash([0; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(first);
-    assert!(state.reject(first, "condemned"));
-
-    for id in 1..super::MAX_TRACKED_PARENTS {
-        state.track_parent(zakura_chain::block::Hash([id as u8; 32]));
+    state.track_parent(retained, Height(0));
+    let work = state.scope_work_id("valid");
+    for id in 1..=super::MAX_TRACKED_PARENTS * 2 {
+        let parent = zakura_chain::block::Hash([u8::try_from(id).unwrap(); 32]);
+        state.track_parent(parent, Height(u32::try_from(id).unwrap()));
+        state.reject(parent, &state.scope_work_id("rejected"));
+        state.track_parent(retained, Height(0));
+        assert!(!state.withdrawn(&work));
     }
-    // Returning to the parent moves it back to the newest end of the eviction order, so the next
-    // parent forgets one of the others instead.
-    state.track_parent(first);
-    state.track_parent(zakura_chain::block::Hash([200; 32]));
-
-    assert!(state.withdrawn("condemned"));
-    assert_eq!(state.evicted_revision, 0);
+    assert_eq!(state.parents.len(), super::MAX_TRACKED_PARENTS);
 }
 
 #[test]
-fn prepared_template_tracking_keeps_new_recovery_work_at_capacity() {
+fn prepared_eviction_advances_the_withdrawal_revision() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(parent);
-    state.reject(parent, "invalid");
-    for id in 0..100 {
-        state.mark_prepared(parent, &id.to_string());
+    state.track_parent(parent, Height(1));
+    state.reject(parent, &state.scope_work_id("invalid"));
+    let oldest = state.scope_work_id("0");
+    for id in 0..super::MAX_PREPARED_WORK_IDS {
+        assert!(!state.mark_prepared(parent, &state.scope_work_id(&id.to_string())));
     }
-    assert_eq!(state.entry(parent).unwrap().prepared.len(), 64);
-    assert!(!state.withdrawn("99"));
-    assert!(state.withdrawn("0"));
+    assert!(!state.withdrawn(&oldest));
+    let previous_revision = state.current_revision();
+    let newest = state.scope_work_id("newest");
+    assert!(state.mark_prepared(parent, &newest));
+    assert!(state.current_revision() > previous_revision);
+    assert_eq!(
+        state.entry(parent).unwrap().prepared.len(),
+        super::MAX_PREPARED_WORK_IDS
+    );
+    assert!(state.withdrawn(&oldest));
+    assert!(!state.withdrawn(&newest));
 }
 
 #[tokio::test]
 async fn template_rejection_retains_notifications_for_late_subscribers() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.track_parent(parent);
+    state.track_parent(parent, Height(1));
+    let work = state.scope_work_id("work");
     let sender = tokio::sync::watch::channel(state).0;
     let mut early = sender.subscribe();
-    sender.send_if_modified(|state| state.reject(parent, "work"));
+    sender.send_if_modified(|state| state.reject(parent, &work));
     tokio::time::timeout(std::time::Duration::from_secs(1), early.changed())
         .await
         .unwrap()
         .unwrap();
-    assert!(early.borrow_and_update().contains("work"));
-    assert!(sender.subscribe().borrow().contains("work"));
+    assert!(early.borrow_and_update().withdrawn(&work));
+    assert!(sender.subscribe().borrow().withdrawn(&work));
 }
 
 #[test]

--- a/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -26,12 +26,17 @@ use crate::config::mining::{default_miner_address, MinerAddressType};
 
 use super::{MinerParams, TemplatePreparationQueue};
 
+/// A rejection names one template, so it survives the chain leaving that template's parent.
+///
+/// Work IDs are drawn at random per response, so one names exactly one template on exactly one
+/// parent. Fallback and prepared work are policies about a single parent, so they follow the
+/// parent templates are built on now rather than the work.
 #[test]
-fn template_rejection_targets_work_and_ignores_old_parents() {
+fn template_rejection_follows_the_work_across_parents() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let next_parent = zakura_chain::block::Hash([2; 32]);
     let mut state = super::TemplateRejections::default();
-    state.set_parent(parent);
+    assert!(state.track_parent(parent));
     state.mark_prepared(parent, "new");
     assert!(state.reject(parent, "old"));
     assert!(state.contains("old"));
@@ -42,38 +47,111 @@ fn template_rejection_targets_work_and_ignores_old_parents() {
     assert!(state.withdrawn("unknown"));
     assert!(!state.reject(parent, "old"));
     assert_eq!(state.revision, 1);
-    state.set_parent(next_parent);
+
+    // The chain leaves the parent. Its fallback and its prepared work go with it, but the work it
+    // condemned stays condemned, and a validation that only now finishes is still recorded.
+    assert!(state.track_parent(next_parent));
     assert!(!state.needs_fallback());
     assert!(!state.is_prepared("new"));
-    assert!(!state.reject(parent, "late"));
-    assert_eq!(state.revision, 1);
-    assert!(state.reject(next_parent, "new"));
+    assert!(state.withdrawn("old"));
+    assert!(!state.withdrawn("new"));
+    assert!(state.reject(parent, "late"));
     assert_eq!(state.revision, 2);
+    assert!(state.withdrawn("late"));
+
+    // The chain comes back. The parent knows everything it knew before.
+    assert!(state.track_parent(parent));
+    assert!(state.needs_fallback());
+    assert!(state.is_prepared("new"));
+    assert!(!state.withdrawn("new"));
+    assert!(state.withdrawn("old"));
+    assert!(!state.track_parent(parent));
 }
 
 #[test]
 fn template_rejection_storage_fails_closed_at_capacity() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.set_parent(parent);
+    state.track_parent(parent);
     for id in 0..100 {
         state.reject(parent, &id.to_string());
     }
-    assert_eq!(state.rejected.len(), 64);
+    assert_eq!(state.entry(parent).unwrap().rejected.len(), 64);
     assert!(state.contains("unknown"));
     assert!(state.needs_fallback());
+}
+
+/// One parent's saturation must not withdraw another parent's work.
+///
+/// Saturation says a parent stopped trusting its own templates. Reading it across parents would
+/// let a single unlucky parent withdraw every miner's work for as long as it is tracked.
+#[test]
+fn a_saturated_parent_does_not_withdraw_another_parents_work() {
+    let saturated = zakura_chain::block::Hash([1; 32]);
+    let current = zakura_chain::block::Hash([2; 32]);
+    let mut state = super::TemplateRejections::default();
+    state.track_parent(saturated);
+    for id in 0..=super::MAX_REJECTED_WORK_IDS {
+        state.reject(saturated, &id.to_string());
+    }
+    assert!(state.entry(saturated).unwrap().saturated);
+
+    state.track_parent(current);
+    state.mark_prepared(current, "work");
+    assert!(!state.withdrawn("work"));
+    assert!(!state.withdrawn("unrelated"));
+
+    // The parent that saturated still fails closed when the chain returns to it.
+    state.track_parent(saturated);
+    assert!(state.withdrawn("unrelated"));
+}
+
+#[test]
+fn template_rejections_forget_the_least_recently_tracked_parent() {
+    let first = zakura_chain::block::Hash([0; 32]);
+    let mut state = super::TemplateRejections::default();
+    state.track_parent(first);
+    assert!(state.reject(first, "condemned"));
+
+    for id in 1..=super::MAX_TRACKED_PARENTS {
+        state.track_parent(zakura_chain::block::Hash([id as u8; 32]));
+    }
+
+    assert!(!state.withdrawn("condemned"));
+    assert!(
+        !state.reject(first, "late"),
+        "a forgotten parent records nothing",
+    );
+}
+
+#[test]
+fn tracking_a_parent_again_keeps_it_from_being_forgotten() {
+    let first = zakura_chain::block::Hash([0; 32]);
+    let mut state = super::TemplateRejections::default();
+    state.track_parent(first);
+    assert!(state.reject(first, "condemned"));
+
+    for id in 1..super::MAX_TRACKED_PARENTS {
+        state.track_parent(zakura_chain::block::Hash([id as u8; 32]));
+    }
+    // Returning to the parent moves it back to the newest end of the eviction order, so the next
+    // parent forgets one of the others instead.
+    state.track_parent(first);
+    state.track_parent(zakura_chain::block::Hash([200; 32]));
+
+    assert!(state.withdrawn("condemned"));
 }
 
 #[test]
 fn prepared_template_tracking_keeps_new_recovery_work_at_capacity() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.set_parent(parent);
+    state.track_parent(parent);
     state.reject(parent, "invalid");
     for id in 0..100 {
         state.mark_prepared(parent, &id.to_string());
     }
-    assert_eq!(state.prepared.len(), 64);
+    assert_eq!(state.entry(parent).unwrap().prepared.len(), 64);
     assert!(!state.withdrawn("99"));
     assert!(state.withdrawn("0"));
 }
@@ -82,7 +160,7 @@ fn prepared_template_tracking_keeps_new_recovery_work_at_capacity() {
 async fn template_rejection_retains_notifications_for_late_subscribers() {
     let parent = zakura_chain::block::Hash([1; 32]);
     let mut state = super::TemplateRejections::default();
-    state.set_parent(parent);
+    state.track_parent(parent);
     let sender = tokio::sync::watch::channel(state).0;
     let mut early = sender.subscribe();
     sender.send_if_modified(|state| state.reject(parent, "work"));

--- a/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
+++ b/crates/zakura-rpc/src/methods/types/get_block_template/tests.rs
@@ -47,21 +47,25 @@ fn template_rejection_follows_the_work_across_parents() {
     assert!(state.withdrawn("unknown"));
     assert!(!state.reject(parent, "old"));
     assert_eq!(state.revision, 1);
+    assert_eq!(state.current_revision(), 1);
 
     // The chain leaves the parent. Its fallback and its prepared work go with it, but the work it
     // condemned stays condemned, and a validation that only now finishes is still recorded.
     assert!(state.track_parent(next_parent));
     assert!(!state.needs_fallback());
+    assert_eq!(state.current_revision(), 0);
     assert!(!state.is_prepared("new"));
     assert!(state.withdrawn("old"));
     assert!(!state.withdrawn("new"));
     assert!(state.reject(parent, "late"));
     assert_eq!(state.revision, 2);
+    assert_eq!(state.current_revision(), 0);
     assert!(state.withdrawn("late"));
 
     // The chain comes back. The parent knows everything it knew before.
     assert!(state.track_parent(parent));
     assert!(state.needs_fallback());
+    assert_eq!(state.current_revision(), 2);
     assert!(state.is_prepared("new"));
     assert!(!state.withdrawn("new"));
     assert!(state.withdrawn("old"));
@@ -118,6 +122,7 @@ fn template_rejections_forget_the_least_recently_tracked_parent() {
     }
 
     assert!(!state.withdrawn("condemned"));
+    assert_eq!(state.evicted_revision, 1);
     assert!(
         !state.reject(first, "late"),
         "a forgotten parent records nothing",
@@ -140,6 +145,7 @@ fn tracking_a_parent_again_keeps_it_from_being_forgotten() {
     state.track_parent(zakura_chain::block::Hash([200; 32]));
 
     assert!(state.withdrawn("condemned"));
+    assert_eq!(state.evicted_revision, 0);
 }
 
 #[test]

--- a/docs/changelog/params.md
+++ b/docs/changelog/params.md
@@ -32,6 +32,7 @@ Keep entries **newest-first**. Each row records:
 
 | Parameter | Location | Old → New | PR | Why |
 | --- | --- | --- | --- | --- |
+| `MAX_TRACKED_PARENTS` | `crates/zakura-rpc/src/methods/types/get_block_template.rs` | one parent (cleared on every parent change) → `8` parents retained | [#947](https://github.com/zakura-core/zakura/pull/947) | Keep what each parent rejected across a reorg away from it and back, forgetting the least recently tracked parent first. Bounds the retained work IDs at eight parents by the existing per-parent limits. |
 | `MAX_CONCURRENT_UTXO_LOOKUPS` | `crates/zakura-consensus/src/transaction.rs` | serial (`1`) → `64` per block transaction | [#918](https://github.com/zakura-core/zakura/pull/918) | Overlap external UTXO waits while bounding pending lookups per transaction. Concurrent lookups start their six-minute timeout clocks together. |
 | `MAX_MINED_SUBMISSIONS` | `crates/zakura-rpc/src/methods/types/submit_block.rs` | unbounded → `16` submissions | [#748](https://github.com/zakura-core/zakura/pull/748) | Bound detached verification work across RPC cancellation. |
 | `non_finalized_write_slots` | `crates/zakura-state/src/service.rs` | unbounded → `1,000` contextual writes | [#748](https://github.com/zakura-core/zakura/pull/748) | Bound writer block bodies using the existing orphan queue capacity. |

--- a/docs/changelog/params.md
+++ b/docs/changelog/params.md
@@ -32,7 +32,7 @@ Keep entries **newest-first**. Each row records:
 
 | Parameter | Location | Old → New | PR | Why |
 | --- | --- | --- | --- | --- |
-| `MAX_TRACKED_PARENTS` | `crates/zakura-rpc/src/methods/types/get_block_template.rs` | one parent (cleared on every parent change) → `8` parents retained | [#947](https://github.com/zakura-core/zakura/pull/947) | Keep what each parent rejected across a reorg away from it and back, forgetting the least recently tracked parent first. Bounds the retained work IDs at eight parents by the existing per-parent limits. |
+| `MAX_TRACKED_PARENTS` | `crates/zakura-rpc/src/methods/types/get_block_template.rs` | one parent (cleared on every parent change) → `8` parents retained | [#947](https://github.com/zakura-core/zakura/pull/947) | Retain each parent's results across reorgs. Eviction retires its work-ID namespace. Returning to a forgotten height requires foreground recovery and a fresh revision. |
 | `MAX_CONCURRENT_UTXO_LOOKUPS` | `crates/zakura-consensus/src/transaction.rs` | serial (`1`) → `64` per block transaction | [#918](https://github.com/zakura-core/zakura/pull/918) | Overlap external UTXO waits while bounding pending lookups per transaction. Concurrent lookups start their six-minute timeout clocks together. |
 | `MAX_MINED_SUBMISSIONS` | `crates/zakura-rpc/src/methods/types/submit_block.rs` | unbounded → `16` submissions | [#748](https://github.com/zakura-core/zakura/pull/748) | Bound detached verification work across RPC cancellation. |
 | `non_finalized_write_slots` | `crates/zakura-state/src/service.rs` | unbounded → `1,000` contextual writes | [#748](https://github.com/zakura-core/zakura/pull/748) | Bound writer block bodies using the existing orphan queue capacity. |

--- a/docs/changelog/unreleased/947.md
+++ b/docs/changelog/unreleased/947.md
@@ -1,0 +1,14 @@
+## Fixed
+
+- A mining template rejection is now recorded against the parent whose template was validated,
+  and every tracked parent keeps what it recorded. A chain that leaves a parent and returns to it
+  — a reorg, or `invalidateblock` followed by `reconsiderblock` — no longer hands miners work it
+  had already condemned there, and no longer loses the fallback that parent needed. Previously the
+  server tracked one parent and cleared its rejected and validated work IDs whenever that parent
+  moved, so a miner holding pre-reorg work was never told to stop and mined a template the node
+  already knew would fail contextual validation
+  ([#947](https://github.com/zakura-core/zakura/pull/947)).
+
+- A rejection that finishes validating while the chain is on another parent is recorded there
+  directly, instead of depending on the chain having returned to that parent at that moment
+  ([#947](https://github.com/zakura-core/zakura/pull/947)).

--- a/docs/changelog/unreleased/947.md
+++ b/docs/changelog/unreleased/947.md
@@ -12,3 +12,8 @@
 - A rejection that finishes validating while the chain is on another parent is recorded there
   directly, instead of depending on the chain having returned to that parent at that moment
   ([#947](https://github.com/zakura-core/zakura/pull/947)).
+
+- A late rejection on another parent no longer cancels the current parent's mining work,
+  changes its long-poll revision, or aborts its template recovery. Withdrawal waiters still
+  detect rejections that parent eviction removes before they read the notification
+  ([#947](https://github.com/zakura-core/zakura/pull/947)).

--- a/docs/changelog/unreleased/947.md
+++ b/docs/changelog/unreleased/947.md
@@ -1,19 +1,12 @@
 ## Fixed
 
-- A mining template rejection is now recorded against the parent whose template was validated,
-  and every tracked parent keeps what it recorded. A chain that leaves a parent and returns to it
-  — a reorg, or `invalidateblock` followed by `reconsiderblock` — no longer hands miners work it
-  had already condemned there, and no longer loses the fallback that parent needed. Previously the
-  server tracked one parent and cleared its rejected and validated work IDs whenever that parent
-  moved, so a miner holding pre-reorg work was never told to stop and mined a template the node
-  already knew would fail contextual validation
+- Mining template rejections remain bound to their parent across tip changes.
+  Each retained parent owns a work-ID namespace. Evicting that parent retires its
+  work, including for withdrawal waiters that subscribe later. Other parents keep
+  their work and revisions. Returning to a forgotten parent requires validated
+  recovery and assigns a fresh long-poll revision
   ([#947](https://github.com/zakura-core/zakura/pull/947)).
-
-- A rejection that finishes validating while the chain is on another parent is recorded there
-  directly, instead of depending on the chain having returned to that parent at that moment
-  ([#947](https://github.com/zakura-core/zakura/pull/947)).
-
-- A late rejection on another parent no longer cancels the current parent's mining work,
-  changes its long-poll revision, or aborts its template recovery. Withdrawal waiters still
-  detect rejections that parent eviction removes before they read the notification
+- Evicting prepared recovery work advances the withdrawal revision and wakes
+  external long polls with `submitold: false`. Template publication checks the
+  parent, rejection revision, and prepared-work registration together
   ([#947](https://github.com/zakura-core/zakura/pull/947)).

--- a/docs/specs/mining-template-withdrawal.md
+++ b/docs/specs/mining-template-withdrawal.md
@@ -34,66 +34,55 @@ The cases above describe possible triggers, not observed production incidents.
 
 ## Implementation
 
-1. Retain rejected server work IDs in a watch channel scoped to the current parent.
-   Retained state covers failures before subscription and between checking and waiting.
-   Ignore late results for another parent.
-   Bound rejection storage at 64 IDs; stop issuing templates on overflow until the
-   parent changes.
-2. Classify concrete consensus and contextual errors.
-   Unwrap the consensus router error before classification.
-   Keep missing-context, stale-parent, timeout, and service failures retryable.
-   Withdraw a server template that cannot form a proposal.
-3. Let internal template generation watch the active work ID during RPC requests and
-   refresh delays.
-   Clear the active template on rejection.
-   The existing solver callback observes the cleared template and stops at its next
-   cancellation check.
-   Preserve internal work that already passed validation when another candidate fails
-   on the same parent. Cancel unvalidated work conservatively.
-4. Increment the long-poll withdrawal revision on rejection.
-   Wake long polls even when the parent and mempool stay unchanged.
-   Accept legacy 46-character IDs; append 16 hex digits after a withdrawal.
-   External miners receive a replacement with `submitold: false`.
-   External miners must cooperate; RPC cannot force them to stop.
-5. Enter empty-template recovery for the affected parent.
-   Validate the empty template before returning it.
-   Return an error if validation fails or exceeds 30 seconds.
-   Recheck the recovery context before publication.
-   Do not issue further speculative transaction sets until the parent changes.
-   This conservative recovery avoids an unbounded candidate fingerprint blacklist.
-6. Discard queued speculative preparation during recovery.
-   Drop the preparation future when its parent becomes stale or after 30 seconds.
-   Keep solved-block verification and commit outside this cancellation path.
+The server retains eight parent entries in least-recently-used order.
+Each entry owns a random work-ID namespace, up to 64 rejected IDs, and up to 64
+prepared IDs. A work ID identifies one template within that namespace.
+A rejection applies to its own parent even when validation finishes after a tip change.
+Saturation withdraws that parent's work and stops publication on that parent.
+
+Evicting an entry retires its namespace. A withdrawal waiter checks the namespace
+and current result together, so it detects retirement even when it subscribes after
+the rejection and eviction. Another parent's retirement cannot withdraw retained work.
+A late validation result cannot mutate a replacement entry for the same parent hash.
+
+Each new parent entry receives a fresh long-poll revision. The tracker retains the
+greatest parent height it has observed. A new entry at that height or below requires
+foreground empty-template recovery. This rule covers forgotten-parent returns with
+bounded memory. A new forward height can still use speculative preparation.
+Returning to a retained parent preserves its existing policy and results.
+
+A concrete rejection or prepared-ID eviction advances the affected parent's revision.
+Long polls wake even when the parent and mempool stay unchanged. The server accepts
+legacy long-poll IDs. New parent entries and withdrawal events use the revision suffix.
+A response that replaces an older revision sets `submitold: false`.
+External miners must cooperate with withdrawal.
+
+The server holds the rejection-state guard through the fast publication decision.
+Recovery validates an empty template, then checks the live parent and revision,
+registers the prepared ID, and sets the response revision in one write closure.
+Recovery returns an error if validation fails, times out, or loses its context.
+A later rejection can still withdraw work that was valid at publication.
+
+The background queue retains one running computation and one newest pending template.
+A deadline classifies its cost; it does not release ownership of work still computing.
+A late rejection still counts. Queued speculative work on a recovery parent is discarded.
+Solved-block verification and commit use separate ownership.
 
 ## Tests
 
-- `zakura-consensus`: `template_rejection_distinguishes_expiry_from_service_failure`
-  separates a real transaction-expiry rejection from a service failure.
-- `zakura-rpc`: `template_rejection_wakes_long_poll_and_validates_recovery` and
-  `template_rejection_before_long_poll_is_not_lost` cover withdrawal, validated
-  recovery, and a rejection that precedes the long poll it must wake.
-- `zakura-rpc`: `template_rejection_targets_work_and_ignores_old_parents`,
-  `template_rejection_storage_fails_closed_at_capacity`,
-  `prepared_template_tracking_keeps_new_recovery_work_at_capacity`, and
-  `template_rejection_retains_notifications_for_late_subscribers` cover the
-  rejection state itself.
-- `zakura-rpc`: `long_poll_withdrawal_changes_id_and_disallows_old_work` checks that a
-  withdrawal disallows old shares and that the revised ID round-trips.
-- `zakurad`: `template_rejection_cancels_during_rpc_wait` and
-  `template_rejection_cancels_during_refresh_delay` cover the internal miner's two
-  cancellation points.
+The RPC suite covers parent ABA, late rejection, parent retirement before waiter
+subscription, unrelated parent eviction, and prepared-ID eviction. The long-poll
+regression fills the prepared bound with real recovery responses and confirms that
+eviction wakes a waiting client with `submitold: false` and the current revision.
+A concurrent rejection prevents recovery publication.
+The internal miner tests cover cancellation during RPC waits and refresh delays.
 
-## Limits and follow-up measurements
+## Limits
 
-Dropping an async preparation future does not preempt cryptographic work that a
-buffered service, batch verifier, or blocking thread already owns.
-The block verifier already returns on the first transaction error it observes.
-This change does not claim that every submitted proof check stops at that instant.
-Fine-grained proof-task cancellation requires a separate ownership audit.
+Revisiting a forgotten height requires foreground empty-template recovery even when
+that particular parent has never failed validation. This conservative policy avoids
+an unbounded parent blacklist. Normal forward heights retain speculative preparation.
 
-Recovery may repeat empty-template validation for concurrent requests.
-Candidate deduplication and preparation scheduling remain performance follow-ups;
-they do not gate withdrawal correctness.
-Measure preparation CPU, cache-hit rate, solved-block latency, and rejection-to-solver
-stop latency before selecting a preparation rate limit.
-The implementation counts rejected, cancelled, and timed-out preparations.
+Recovery can repeat validation for concurrent requests. Candidate deduplication and
+recovery admission remain performance follow-ups. Background preparation remains
+bounded independently of RPC cancellation and validation latency.


### PR DESCRIPTION
#748 lets miners start work before background proposal validation finishes. If validation later rejects a template, the node must withdraw that work and tell miners to stop using it. This PR keeps that withdrawal effective across tip changes, delayed validation results, and eviction from bounded tracking state.

This follows #748 and is stacked on #930.

For example, the node can publish work on parent A, switch to parent B, and then receive a rejection for the work on A. If the node forgets that rejection when the tip changes or an entry is evicted, returning to A can restore speculative mining on a parent that requires recovery. A miner that resumes waiting after eviction can also miss the withdrawal. External miners can keep waiting if a withdrawal changes internal state without changing the long-poll ID.

The node needs enough retained state to connect an asynchronous validation result to the work miners received. Each work ID belongs to one retained parent entry. Eviction permanently retires that entry's work IDs. A late result cannot modify a replacement entry, and eviction of an unrelated parent cannot withdraw retained work.

The tracker remains bounded to eight parents, with at most 64 rejected IDs and 64 prepared IDs per parent. When the node revisits a forgotten height, it validates an empty recovery template before publishing work. This conservative recovery rule lets the node forget old entries without treating forgotten rejection history as permission to resume speculative mining. Normal progress to a new height retains speculative preparation.

Withdrawal also advances the affected parent's long-poll revision. External miners receive `submitold: false`, and the internal miner cancels withdrawn work. Template publication checks the live parent and withdrawal state together so a concurrent rejection cannot slip through the final publication decision. External miners must honor the withdrawal response.

This preserves the early-publication behavior introduced by #748. Miners can still start on a candidate before validation rejects it; requiring every template to pass validation before publication would change that behavior.

Validation on top of #930 with Rust 1.97.0:

- RPC unit tests: 150 passed, 1 ignored.
- Internal-miner cancellation tests with `--features internal-miner`: 2 passed.
- Regressions cover returning to an earlier parent, parent eviction, late results, resumed waiters, unrelated-parent eviction, concurrent rejection during recovery, and external long polling after prepared-work eviction.
- RPC Clippy with warnings denied, formatting, diff, and changelog checks passed.

Manual regtest reorg checks have not been run. The changelog, parameter ledger, and mining-template withdrawal specification document the behavior and bounds.
