### PR TITLE
fix(state): handle repeated invalid verdicts and missing context

### DIFF
--- a/crates/zakura-header-chain/src/graph/mod.rs
+++ b/crates/zakura-header-chain/src/graph/mod.rs
@@ -639,10 +639,9 @@ impl MemHeaderStore {
     ///
     /// Returns `true` when the state changes and `false` when it is unchanged.
     /// A consensus-invalid body-validation state makes the node and its
-    /// descendants ineligible. Replaying the same consensus-invalid
-    /// body-validation state leaves the node unchanged. This method rejects a
-    /// different consensus-invalid body-validation state. It also rejects any
-    /// later non-invalid body-validation state.
+    /// descendants ineligible. Further consensus-invalid verdicts leave the
+    /// first verdict unchanged, even if their evidence or rule differs.
+    /// This method rejects any later non-invalid body-validation state.
     /// Consensus invalidity is permanent.
     ///
     /// This method does not enforce transitions between non-invalid
@@ -669,10 +668,12 @@ impl MemHeaderStore {
             }
             _ => None,
         };
-        if let Some(existing) = self.consensus_invalid_body_tombstones.get(&hash) {
-            if tombstone.as_ref() != Some(existing) {
-                return Err(GraphError::PermanentBodyInvalidity(hash));
-            }
+        if self.consensus_invalid_body_tombstones.contains_key(&hash) {
+            return if tombstone.is_some() {
+                Ok(false)
+            } else {
+                Err(GraphError::PermanentBodyInvalidity(hash))
+            };
         }
         let (changed, eligibility_changed) = {
             let node = self
@@ -683,7 +684,7 @@ impl MemHeaderStore {
                 node.body_validation_state,
                 BodyValidationState::ConsensusInvalid { .. }
             ) {
-                return if node.body_validation_state == body_validation_state {
+                return if tombstone.is_some() {
                     Ok(false)
                 } else {
                     Err(GraphError::PermanentBodyInvalidity(hash))
@@ -2047,7 +2048,7 @@ mod tests {
                     rule: BodyRuleId::new("test.conflicting-invalid"),
                 },
             ),
-            Err(GraphError::PermanentBodyInvalidity(target.hash))
+            Ok(false)
         );
         assert_eq!(
             store.set_body_validation_state(target.hash, BodyValidationState::Unknown),

--- a/crates/zakura-header-chain/src/graph/overlay.rs
+++ b/crates/zakura-header-chain/src/graph/overlay.rs
@@ -955,14 +955,17 @@ impl<'a> GraphOverlay<'a> {
             }
             _ => None,
         };
-        if let Some(existing) = self
+        if self
             .new_consensus_invalid_body_tombstones_by_hash
             .get(&hash)
             .or_else(|| self.base_graph.consensus_invalid_body_tombstones.get(&hash))
+            .is_some()
         {
-            if tombstone.as_ref() != Some(existing) {
-                return Err(GraphError::PermanentBodyInvalidity(hash));
-            }
+            return if tombstone.is_some() {
+                Ok(false)
+            } else {
+                Err(GraphError::PermanentBodyInvalidity(hash))
+            };
         }
         let (changed, eligibility_changed) = {
             let node = self.stage_header_node(hash)?;
@@ -970,7 +973,7 @@ impl<'a> GraphOverlay<'a> {
                 node.body_validation_state,
                 BodyValidationState::ConsensusInvalid { .. }
             ) {
-                return if node.body_validation_state == body_validation_state {
+                return if tombstone.is_some() {
                     Ok(false)
                 } else {
                     Err(GraphError::PermanentBodyInvalidity(hash))
@@ -1591,6 +1594,52 @@ mod tests {
             .expect("the fixture child inserts")
         {
             InsertResult::Inserted(frontier) | InsertResult::AlreadyPresent(frontier) => frontier,
+        }
+    }
+
+    #[test]
+    fn repeated_invalid_verdict_preserves_first_tombstone_in_staged_and_base_graphs() {
+        let mut base = store();
+        let anchor = base.finalized_frontier();
+        let child = insert_child(&mut base, anchor.hash, 1);
+        let first = BodyValidationState::ConsensusInvalid {
+            evidence: EvidenceId::from_digest([2; 32]),
+            rule: crate::BodyRuleId::new("test.first"),
+        };
+        let second = BodyValidationState::ConsensusInvalid {
+            evidence: EvidenceId::from_digest([3; 32]),
+            rule: crate::BodyRuleId::new("test.second"),
+        };
+
+        for persisted in [false, true] {
+            if persisted {
+                base.set_body_validation_state(child.hash, first.clone())
+                    .expect("the first verdict installs a tombstone");
+            }
+            let mut overlay = GraphOverlay::new(&base);
+            overlay
+                .set_body_validation_state(child.hash, first.clone())
+                .expect("the first verdict is accepted");
+            assert_eq!(
+                overlay.set_body_validation_state(child.hash, second.clone()),
+                Ok(false)
+            );
+            assert_eq!(
+                overlay
+                    .header_node(child.hash)
+                    .unwrap()
+                    .body_validation_state,
+                first
+            );
+            assert_eq!(
+                overlay.set_body_validation_state(
+                    child.hash,
+                    BodyValidationState::Verified {
+                        evidence: EvidenceId::from_digest([4; 32]),
+                    },
+                ),
+                Err(GraphError::PermanentBodyInvalidity(child.hash))
+            );
         }
     }
 

--- a/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
+++ b/crates/zakura-header-chain/src/transition/planner/tests/body_evidence.rs
@@ -124,8 +124,8 @@ fn invalidating_a_losing_body_advances_header_generation_without_a_reason_delta(
             .checked_next()
             .expect("the fixture generation has capacity")
     );
-    let projected_graph = projected_graph(&store.graph, &plan);
-    let changed = projected_graph
+    let invalid_graph = projected_graph(&store.graph, &plan);
+    let changed = invalid_graph
         .header_node(losing.hash)
         .expect("the invalid losing node remains retained");
     assert_eq!(
@@ -136,6 +136,32 @@ fn invalidating_a_losing_body_advances_header_generation_without_a_reason_delta(
         }
     );
     assert!(changed.eligibility.direct_reasons.is_empty());
+
+    store.commit(&plan);
+    let repeated = apply_transition(
+        &store,
+        TransitionRequest {
+            expected_version: store.metadata.state_version,
+            event: TransitionEvent::BodyEvidence(BodyEvidence::ConsensusInvalid(
+                crate::ConsensusBodyInvalid {
+                    hash: losing.hash,
+                    evidence: EvidenceId::from_digest([0x35; 32]),
+                    rule: BodyRuleId::new("test.another-invalid-rule"),
+                    source: SourceId::from_digest([0x36; 32]),
+                },
+            )),
+        },
+        &context(&config, &clock, Some(&authority)),
+    )
+    .expect("a different invalid verdict must not fail the transition");
+    let replayed_graph = projected_graph(&store.graph, &repeated);
+    assert_eq!(
+        replayed_graph
+            .header_node(losing.hash)
+            .unwrap()
+            .body_validation_state,
+        changed.body_validation_state
+    );
 }
 
 #[test]

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -448,7 +448,7 @@ impl FinalizedState {
         if enforce_resume_guard
             && new_state.vct.is_below_last_checkpoint()
             && (new_state.vct.source().is_none()
-                || !config.enable_zakura_header_seed_from_committed_blocks)
+                || (!read_only && !config.enable_zakura_header_seed_from_committed_blocks))
         {
             panic!(
                 "this database was previously synced in verified commitment tree mode that was \

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -446,16 +446,17 @@ impl FinalizedState {
         // source to resume. Without it, the legacy committer would refuse every
         // remaining checkpoint block.
         if enforce_resume_guard
+            && !read_only
             && new_state.vct.is_below_last_checkpoint()
             && (new_state.vct.source().is_none()
-                || (!read_only && !config.enable_zakura_header_seed_from_committed_blocks))
+                || !config.enable_zakura_header_seed_from_committed_blocks)
         {
             panic!(
                 "this database was previously synced in verified commitment tree mode that was \
                  interrupted below the last checkpoint height. the fast path that supplies \
                  the verified roots needed to resume the VCT sync is disabled. Set \
                  `consensus.checkpoint_sync = true`, `consensus.vct_fast_sync = true`, and \
-                 `network.p2p_stack = \"v2\"` or `\"dual\"` to \
+                 `network.p2p_stack = \"zakura\"` or `\"dual\"` to \
                  finish the VCT sync, or delete the cache directory and re-sync from genesis"
             );
         }

--- a/crates/zakura-state/src/service/finalized_state.rs
+++ b/crates/zakura-state/src/service/finalized_state.rs
@@ -447,13 +447,15 @@ impl FinalizedState {
         // remaining checkpoint block.
         if enforce_resume_guard
             && new_state.vct.is_below_last_checkpoint()
-            && new_state.vct.source().is_none()
+            && (new_state.vct.source().is_none()
+                || !config.enable_zakura_header_seed_from_committed_blocks)
         {
             panic!(
                 "this database was previously synced in verified commitment tree mode that was \
                  interrupted below the last checkpoint height. the fast path that supplies \
                  the verified roots needed to resume the VCT sync is disabled. Set \
-                 `consensus.checkpoint_sync = true` and `consensus.vct_fast_sync = true` to \
+                 `consensus.checkpoint_sync = true`, `consensus.vct_fast_sync = true`, and \
+                 `network.p2p_stack = \"v2\"` or `\"dual\"` to \
                  finish the VCT sync, or delete the cache directory and re-sync from genesis"
             );
         }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1440,6 +1440,41 @@ fn reopening_interrupted_fast_sync_on_legacy_stack_refuses_to_park() {
 }
 
 #[test]
+fn read_only_interrupted_fast_sync_accepts_disabled_sync_settings() {
+    let _init_guard = zakura_test::init();
+    let dir = tempfile::tempdir().expect("temp dir is created");
+    let config = Config {
+        cache_dir: dir.path().to_path_buf(),
+        ephemeral: false,
+        checkpoint_sync: true,
+        vct_fast_sync: true,
+        enable_zakura_header_seed_from_committed_blocks: true,
+        ..Config::default()
+    };
+    {
+        let state = new_state_with_blocks(&config, &Mainnet);
+        let mut batch = DiskWriteBatch::new();
+        batch.update_vct_sync_marker(&state.db, Height(100));
+        state.db.write_batch(batch).expect("marker batch writes");
+    }
+    for checkpoint_sync in [false, true] {
+        for vct_fast_sync in [false, true] {
+            for enable_zakura_header_seed_from_committed_blocks in [false, true] {
+                let reader_config = Config {
+                    checkpoint_sync,
+                    vct_fast_sync,
+                    enable_zakura_header_seed_from_committed_blocks,
+                    ..config.clone()
+                };
+                let reader = FinalizedState::new_with_debug(&reader_config, &Mainnet, true, true)
+                    .expect("readers do not need a VCT repair source");
+                assert_eq!(reader.db.vct_synced_below(), Some(Height(100)));
+            }
+        }
+    }
+}
+
+#[test]
 fn validate_storage_mode_enforces_retention_floor() {
     let pruned = |tx_retention| Config {
         storage_mode: StorageMode::Pruned(PruningConfig { tx_retention }),

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1432,6 +1432,9 @@ fn reopening_interrupted_fast_sync_on_legacy_stack_refuses_to_park() {
         let state = FinalizedState::new(&v2_config, &Mainnet)
             .expect("the v2 stack can resume the interrupted VCT sync");
         assert_eq!(state.db.vct_synced_below(), Some(Height(100)));
+        let reader = FinalizedState::new_with_debug(&config, &Mainnet, true, true)
+            .expect("a read-only state does not resume VCT writes");
+        assert_eq!(reader.db.vct_synced_below(), Some(Height(100)));
     }
     let _state = FinalizedState::new(&config, &Mainnet);
 }

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1406,6 +1406,37 @@ fn reopening_interrupted_fast_sync_with_vct_disabled_panics() {
 }
 
 #[test]
+#[should_panic(expected = "network.p2p_stack")]
+fn reopening_interrupted_fast_sync_on_legacy_stack_refuses_to_park() {
+    let _init_guard = zakura_test::init();
+    let dir = tempfile::tempdir().expect("temp dir is created");
+    let config = Config {
+        cache_dir: dir.path().to_path_buf(),
+        ephemeral: false,
+        checkpoint_sync: true,
+        vct_fast_sync: true,
+        enable_zakura_header_seed_from_committed_blocks: false,
+        ..Config::default()
+    };
+    {
+        let state = new_state_with_blocks(&config, &Mainnet);
+        let mut batch = DiskWriteBatch::new();
+        batch.update_vct_sync_marker(&state.db, Height(100));
+        state.db.write_batch(batch).expect("marker batch writes");
+    }
+    {
+        let v2_config = Config {
+            enable_zakura_header_seed_from_committed_blocks: true,
+            ..config.clone()
+        };
+        let state = FinalizedState::new(&v2_config, &Mainnet)
+            .expect("the v2 stack can resume the interrupted VCT sync");
+        assert_eq!(state.db.vct_synced_below(), Some(Height(100)));
+    }
+    let _state = FinalizedState::new(&config, &Mainnet);
+}
+
+#[test]
 fn validate_storage_mode_enforces_retention_floor() {
     let pruned = |tx_retention| Config {
         storage_mode: StorageMode::Pruned(PruningConfig { tx_retention }),

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -306,9 +306,7 @@ fn adjust_difficulty_and_time_for_testnet(
 
     // The tip is the first relevant data block, because they are in reverse order.
     let previous_block_time = relevant_data.first().expect("has at least one block").1;
-    let previous_block_time: DateTime32 = previous_block_time
-        .try_into()
-        .expect("valid blocks have in-range times");
+    let previous_block_time: DateTime32 = previous_block_time.try_into()?;
 
     let Some(minimum_difficulty_spacing) =
         NetworkUpgrade::minimum_difficulty_spacing_for_height(network, previous_block_height)
@@ -317,9 +315,7 @@ fn adjust_difficulty_and_time_for_testnet(
         return Ok(());
     };
 
-    let minimum_difficulty_spacing: Duration32 = minimum_difficulty_spacing
-        .try_into()
-        .expect("small positive values are in-range");
+    let minimum_difficulty_spacing: Duration32 = minimum_difficulty_spacing.try_into()?;
 
     // The first minimum difficulty time is strictly greater than the spacing.
     let std_difficulty_max_time = previous_block_time

--- a/crates/zakura-state/src/service/read/difficulty.rs
+++ b/crates/zakura-state/src/service/read/difficulty.rs
@@ -45,9 +45,7 @@ fn finalized_state_query_interrupted_error() -> BoxError {
 
 /// Returns the [`GetBlockTemplateChainInfo`] for the current best chain.
 ///
-/// # Panics
-///
-/// - If we don't have enough blocks in the state.
+/// Returns an error if the state cannot supply the complete difficulty context.
 pub fn get_block_template_chain_info(
     non_finalized_state: &NonFinalizedState,
     db: &ZakuraDb,
@@ -71,13 +69,13 @@ pub fn get_block_template_chain_info(
     let (best_tip_height, best_tip_hash, best_relevant_chain, best_tip_history_tree) =
         best_relevant_chain_and_history_tree_result?;
 
-    Ok(difficulty_time_and_history_tree(
+    difficulty_time_and_history_tree(
         best_relevant_chain,
         best_tip_height,
         best_tip_hash,
         network,
         best_tip_history_tree,
-    ))
+    )
 }
 
 /// Accepts a `non_finalized_state`, [`ZakuraDb`], `num_blocks`, and a block hash to start at.
@@ -212,7 +210,10 @@ fn difficulty_time_and_history_tree(
     tip_hash: block::Hash,
     network: &Network,
     history_tree: Arc<HistoryTree>,
-) -> GetBlockTemplateChainInfo {
+) -> Result<GetBlockTemplateChainInfo, BoxError> {
+    if relevant_chain.is_empty() {
+        return Err("mining template difficulty context is empty".into());
+    }
     let relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)> = relevant_chain
         .iter()
         .map(|block| (block.header.difficulty_threshold, block.header.time))
@@ -251,8 +252,7 @@ fn difficulty_time_and_history_tree(
         tip_height,
         network,
         relevant_data.iter().cloned(),
-    )
-    .expect("the mining template requires a complete committed difficulty context");
+    )?;
     let expected_difficulty = difficulty_adjustment.expected_difficulty_threshold();
 
     let mut result = GetBlockTemplateChainInfo {
@@ -265,9 +265,9 @@ fn difficulty_time_and_history_tree(
         max_time,
     };
 
-    adjust_difficulty_and_time_for_testnet(&mut result, network, tip_height, relevant_data);
+    adjust_difficulty_and_time_for_testnet(&mut result, network, tip_height, relevant_data)?;
 
-    result
+    Ok(result)
 }
 
 /// Adjust the difficulty and time for the testnet minimum difficulty rule.
@@ -278,9 +278,9 @@ fn adjust_difficulty_and_time_for_testnet(
     network: &Network,
     previous_block_height: Height,
     relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)>,
-) {
+) -> Result<(), BoxError> {
     if network == &Network::Mainnet {
-        return;
+        return Ok(());
     }
 
     // On testnet, changing the block time can also change the difficulty,
@@ -314,7 +314,7 @@ fn adjust_difficulty_and_time_for_testnet(
         NetworkUpgrade::minimum_difficulty_spacing_for_height(network, previous_block_height)
     else {
         // Returns early if the testnet minimum difficulty consensus rule is not active
-        return;
+        return Ok(());
     };
 
     let minimum_difficulty_spacing: Duration32 = minimum_difficulty_spacing
@@ -369,8 +369,41 @@ fn adjust_difficulty_and_time_for_testnet(
             previous_block_height,
             network,
             relevant_data.iter().cloned(),
-        )
-        .expect("the testnet mining template retains the same complete difficulty context")
+        )?
         .expected_difficulty_threshold();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zakura_chain::serialization::ZcashDeserializeInto;
+
+    #[test]
+    fn mining_template_rejects_incomplete_difficulty_context() {
+        let block: Arc<Block> = zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+            .zcash_deserialize_into()
+            .expect("the genesis vector is valid");
+
+        for network in [Network::Mainnet, Network::new_default_testnet()] {
+            for tip in [0, 1, 26, 27, 28, 3_474_810] {
+                let required = usize::try_from((tip + 1).min(28)).unwrap();
+                for count in 0..=required {
+                    let result = difficulty_time_and_history_tree(
+                        vec![block.clone(); count],
+                        Height(tip),
+                        block.hash(),
+                        &network,
+                        Arc::new(HistoryTree::default()),
+                    );
+                    assert_eq!(
+                        result.is_ok(),
+                        count == required,
+                        "network={network:?}, tip={tip}, count={count}: {result:?}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/docs/changelog/unreleased/948.md
+++ b/docs/changelog/unreleased/948.md
@@ -6,6 +6,9 @@
 - Refuse to resume an interrupted VCT sync on the legacy P2P stack, with a
   diagnostic identifying the required configuration
   ([#948](https://github.com/zakura-core/zakura/pull/948)).
+- Allow read-only access to an interrupted VCT database when checkpoint sync,
+  VCT fast sync, or native P2P is disabled
+  ([#948](https://github.com/zakura-core/zakura/pull/948)).
 - Return an error from `getblocktemplate` when the state cannot supply a complete
   difficulty window
   ([#948](https://github.com/zakura-core/zakura/pull/948)).

--- a/docs/changelog/unreleased/948.md
+++ b/docs/changelog/unreleased/948.md
@@ -1,0 +1,11 @@
+## Fixed
+
+- Preserve the first invalid-block verdict when another invalid verdict arrives
+  with different evidence or a different rule
+  ([#948](https://github.com/zakura-core/zakura/pull/948)).
+- Refuse to resume an interrupted VCT sync on the legacy P2P stack, with a
+  diagnostic identifying the required configuration
+  ([#948](https://github.com/zakura-core/zakura/pull/948)).
+- Return an error from `getblocktemplate` when the state cannot supply a complete
+  difficulty window
+  ([#948](https://github.com/zakura-core/zakura/pull/948)).


### PR DESCRIPTION
## Motivation

Three confirmed failure paths remain in the consensus audit:

- CA-004: a second invalid verdict for one block hash fails the header transition when its rule or evidence differs.
- CA-029: an interrupted VCT database can reopen on the legacy P2P stack with VCT enabled, then wait for roots that the stack cannot deliver.
- CA-021: mining-template construction panics when readable bodies do not provide the complete difficulty window.

## Solution

Preserve the first invalid-body tombstone when later invalid verdicts arrive. Keep rejecting attempts to replace invalidity with a valid or unknown state. Check header-root delivery configuration when reopening an interrupted VCT database for writes. Preserve read-only access when checkpoint sync, VCT fast sync, or native P2P is disabled. The startup diagnostic names the supported `zakura` and `dual` settings. Propagate incomplete difficulty context through the existing state/RPC error channel.

## Testing

Rust 1.97:

- 43 selected header-chain tests passed, including staged and persisted tombstone replay, eligibility invariants, and a repeated body-evidence transition with different evidence, rule, and supplier.
- 26 selected state tests passed, including interrupted VCT reopen on legacy versus v2, completed VCT reopen, difficulty windows from genesis through the full 28-header span on both networks, and existing anchor/UTXO checks.
- `cargo fmt --all -- --check` and `git diff --check` passed.
- `cargo clippy -p zakura-header-chain -p zakura-state --lib --tests --locked -- -D warnings` passed.
- `scripts/check-release-state.sh` passed without an override.
- `scripts/changelog.py check` passed.

V12 follow-up validation at `e5313ba20`: all 27 state pruning/startup tests passed, including the new eight-combination read-only interrupted-VCT regression and existing writable/completed reopen cases. State Clippy, formatting, diff, and fragment validation passed.

## Changelog

Added `docs/changelog/unreleased/948.md`.

### Follow-up Work

CA-001 remains a release-rollout deadline; this PR preserves the support policy deliberately set in #927. CA-002's shared writer-failure reporting already exists on main. Its coherence failures and CA-003's capacity recovery need a reproducer before replacing failure handling with retries. The exact-parent contextual checks do not establish CA-005's proposed transient path, so their classification stays unchanged.

CA-011 remains conditional on NU7. Section F's comparison harnesses remain separate work and were not run here. An oracle mismatch needs reachability triage before receiving FORK-HIGH severity.

This PR overlaps #924 in the mining-template helper. The two PRs address different failures and may need reconciliation before merge.

