### PR TITLE
chore(release): align the v1.4.0 end-of-support halt with the release candidates

### DIFF
--- a/crates/zakurad/src/components/sync/end_of_support.rs
+++ b/crates/zakurad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zakura_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_479_466;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_480_539;
 
 /// The estimated number of blocks per day after Blossom.
 ///
@@ -28,12 +28,12 @@ pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Currently set to 22 days
+/// - Currently set to 21 days
 ///
-/// Note: v1.4.0-rc1 is estimated to release at height 3,479,387 (~2026-09-11)
-/// and halts 22 days later at height 3,504,731 (~2026-10-03) — the same
-/// halt block and date as v1.4.0-rc0 and v1.3.2.
-pub const EOS_PANIC_AFTER: u32 = 22;
+/// Note: v1.4.0 is estimated to release at height 3,480,539 (~2026-09-12)
+/// and halts 21 days later at height 3,504,731 (~2026-10-03) — the same
+/// halt block and date as the v1.4.0 release candidates and v1.3.2.
+pub const EOS_PANIC_AFTER: u32 = 21;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 3;

--- a/docs/changelog/unreleased/952.md
+++ b/docs/changelog/unreleased/952.md
@@ -1,0 +1,6 @@
+## Changed
+
+- Shortened the end-of-support window to 21 days so v1.4.0 halts at block
+  3,504,731 — the same halt block and date (~2026-10-03) as the v1.4.0
+  release candidates and v1.3.2
+  ([#952](https://github.com/zakura-core/zakura/pull/952)).


### PR DESCRIPTION
## Motivation

Every release keeps end-of-support halt parity with the previous release. The #951 release-state import raised the end-of-support floor to 3,479,466 and left `EOS_PANIC_AFTER` at 22 days, which would have moved the v1.4.0 halt to block 3,504,810 — about 1.7 hours past the halt block shared by v1.4.0-rc0, v1.4.0-rc1, and v1.3.2.

## Solution

Set `EOS_PANIC_AFTER` to 21 and `ESTIMATED_RELEASE_HEIGHT` to 3,480,539 (1,073 blocks above the floor, so no waiver is needed and `prepare-release.sh` passes both values through untouched). The halt lands at exactly block 3,504,731 (~2026-10-03 06:30 UTC), the same halt block and date as both v1.4.0 release candidates and v1.3.2. `EOS_WARN_AFTER` stays derived at `EOS_PANIC_AFTER - 3`, so warning behavior keeps the same 3-day lead.

Verified against the live chain tip (3,477,965 at 2026-09-10 00:48 UTC via Blockchair): 26,766 blocks to the halt ≈ 23.2 days ≈ 2026-10-03.

## Testing

- `cargo test -p zakura --test end_of_support` (all end-of-support tests, run locally on this branch)
- CI unit tests cover the constants through the same suite

## Changelog

`docs/changelog/unreleased/952.md` — Changed entry.

### Specifications & References

- #951 (release-state import that raised the floor)
- #927, #915 (the same alignment for v1.4.0-rc1 and v1.4.0-rc0)

### Follow-up Work

The first release after 2026-10-01 should revisit `EOS_PANIC_AFTER`; the shortened window exists only to force pre-October halts on the current line.

## AI Disclosure

Prepared by Claude (Fable 5) operated by @sbowe as part of the v1.4.0 release preparation; human-reviewed before merge.
