### PR TITLE
fix(ci): pin the public API diff jobs to a working nightly

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -237,6 +237,15 @@ jobs:
     needs: select-packages
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # rustdoc on nightly 2026-09-07 and later hits a next-trait-solver ICE
+      # ("did not expect successful goal when collecting ambiguity errors",
+      # rust-lang/rust#124834) on the tower-batch-control `Service` impls in
+      # zakura-consensus, zakura-network, and zakura-state. Pin the last good
+      # nightly, and drop the pin once a current nightly documents these
+      # crates again. cargo-public-api has no toolchain option, so the rustup
+      # `+` shim selects the toolchain for its rustdoc builds.
+      PUBLIC_API_NIGHTLY: nightly-2026-09-06
     strategy:
       fail-fast: false
       matrix:
@@ -260,16 +269,17 @@ jobs:
       - name: Patch registry crates for semver rustdoc builds
         run: .github/workflows/scripts/patch_registry_for_semver.sh
 
-      - name: Install nightly rustdoc toolchain
-        run: rustup toolchain install nightly --profile minimal
+      - name: Install pinned nightly rustdoc toolchain
+        run: rustup toolchain install "$PUBLIC_API_NIGHTLY" --profile minimal
 
       - name: Diff against the latest published API
         env:
           PACKAGE: ${{ matrix.package }}
         run: |
           # cargo-public-api builds both the current and published crate with
-          # nightly. Nightly-only warnings are evidence, not the lint gate.
-          RUSTFLAGS='' cargo public-api diff latest -p "$PACKAGE" -sss
+          # the pinned nightly. Nightly-only warnings are evidence, not the
+          # lint gate.
+          RUSTFLAGS='' cargo "+$PUBLIC_API_NIGHTLY" public-api diff latest -p "$PACKAGE" -sss
 
   warm-baselines:
     name: Warm semver baselines


### PR DESCRIPTION
## Motivation

The three advisory `public API (…)` shards failed on both recent release PRs (#928 for v1.4.0-rc1, #953 for v1.4.0). The job installs the **unpinned** `nightly` channel, and rustdoc on nightly 2026-09-07 and later hits a next-trait-solver ICE — `did not expect successful goal when collecting ambiguity errors` ([rust-lang/rust#124834](https://github.com/rust-lang/rust/issues/124834)) — while documenting the `tower-batch-control` `Service` impls in `zakura-consensus`, `zakura-network`, and `zakura-state`. Every run inherits whatever regression the current nightly carries.

This is independent of #937, which fixed the cargo-semver-checks family (registry PRECIS pin); all per-crate `semver (…)` shards were already green on #953.

## Solution

Pin the `public-api-diff` job to `nightly-2026-09-06`, the last nightly that documents these crates, with a comment stating exactly when to drop the pin. `cargo-public-api` (v0.52) has no toolchain option, so the pinned toolchain is selected through the rustup `+` shim, which its internal rustdoc builds inherit.

## Testing

The `public-api-diff` job only runs on `release/v*` pull requests, so this PR's CI cannot exercise it. Verified locally on the v1.4.0 workspace instead, same crate and machine:

- `cargo public-api diff latest -p zakura-consensus -sss` on `nightly (a36d05efa 2026-09-09)` — the exact nightly the failing CI run installed: **fails, 6 ICE occurrences**.
- `RUSTFLAGS='' cargo +nightly-2026-09-06 public-api diff latest -p zakura-consensus -sss`: **exit 0, clean report** (no removed/changed/added items), confirming both the pin date and the rustup-shim selection mechanism.

YAML lint passes. First real exercise will be the next `release/v*` PR.

## Changelog

Workflow-only change; no changelog fragment required (matches #937).

### Specifications & References

- [rust-lang/rust#124834](https://github.com/rust-lang/rust/issues/124834)
- Failing shards on #953: [run 34427313712](https://github.com/zakura-core/zakura/actions/runs/34427313712)
- #937 (the companion fix for the cargo-semver-checks family)

### Follow-up Work

Drop the pin once a current nightly documents these crates again.

## AI Disclosure

Prepared by Claude (Fable 5) operated by @ebfull; human-reviewed before merge.
