### PR TITLE
fix: stop banning peers for non-final mempool transactions and harden misbehavior scoring

### DIFF
--- a/crates/zakura-consensus/src/error.rs
+++ b/crates/zakura-consensus/src/error.rs
@@ -546,9 +546,15 @@ impl TransactionError {
             | OrchardProofSize
             | IronwoodProofSize
             | WrongConsensusBranchId
-            | MissingConsensusBranchId
-            | LockedUntilAfterBlockHeight(_)
-            | LockedUntilAfterBlockTime(_) => 100,
+            | MissingConsensusBranchId => 100,
+
+            // Lock-time finality is checked against the local next-block height
+            // and median-time-past, so a transaction that is final for the
+            // sender can be non-final on a node whose tip or chain time lags
+            // slightly behind. Like zcashd, treat non-final transactions as
+            // premature rather than malicious: reject them without a peer
+            // penalty.
+            LockedUntilAfterBlockHeight(_) | LockedUntilAfterBlockTime(_) => 0,
 
             // NU6.2 mempool transactions are invalid under NU6.3 rules, but
             // honest peers can relay them briefly while their chain tips converge.
@@ -618,6 +624,20 @@ mod tests {
             TransactionError::RedPallas(zakura_chain::primitives::reddsa::Error::InvalidSignature),
         ] {
             assert_eq!(error.mempool_misbehavior_score(), 100);
+        }
+    }
+
+    /// Non-final lock times depend on the local tip height and chain time, so
+    /// they are not evidence of peer misconduct.
+    #[test]
+    fn lock_time_errors_have_no_misbehavior_score() {
+        for error in [
+            TransactionError::LockedUntilAfterBlockHeight(block::Height(1_000_000)),
+            TransactionError::LockedUntilAfterBlockTime(
+                DateTime::from_timestamp(1_000_000_000, 0).expect("timestamp is valid"),
+            ),
+        ] {
+            assert_eq!(error.mempool_misbehavior_score(), 0);
         }
     }
 

--- a/crates/zakura-network/src/address_book.rs
+++ b/crates/zakura-network/src/address_book.rs
@@ -261,7 +261,10 @@ pub struct AddressBook {
     // TODO: Replace with `by_ip: HashMap<IpAddr, BTreeMap<DateTime32, MetaAddr>>` to support configured `max_connections_per_ip` greater than 1
     most_recent_by_ip: Option<HashMap<IpAddr, MetaAddr>>,
 
-    /// A list of banned addresses, with the time they were banned.
+    /// A bounded FIFO list of banned peer IP addresses.
+    ///
+    /// Bans do not store timestamps and have no expiry: they last until the
+    /// process exits or the entry is evicted at [`constants::MAX_BANNED_IPS`].
     bans_by_ip: BannedIps,
 
     /// The local listener address.

--- a/crates/zakura-network/src/meta_addr.rs
+++ b/crates/zakura-network/src/meta_addr.rs
@@ -1175,7 +1175,9 @@ impl MetaAddrChange {
                 last_attempt: None,
                 last_failure: None,
                 last_connection_state: self.peer_addr_state(),
-                misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
+                misbehavior_score: previous
+                    .misbehavior_score
+                    .saturating_add(self.misbehavior_score()),
                 is_inbound: previous.is_inbound || self.is_inbound(),
             })
         } else {
@@ -1201,7 +1203,9 @@ impl MetaAddrChange {
                 last_failure: self.last_failure(instant_now).or(previous.last_failure),
                 // Replace the state with the updated state.
                 last_connection_state: self.peer_addr_state(),
-                misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
+                misbehavior_score: previous
+                    .misbehavior_score
+                    .saturating_add(self.misbehavior_score()),
                 is_inbound: previous.is_inbound || self.is_inbound(),
             })
         }

--- a/crates/zakura-network/src/meta_addr/tests/vectors.rs
+++ b/crates/zakura-network/src/meta_addr/tests/vectors.rs
@@ -569,3 +569,48 @@ fn new_misbehavior_canonicalizes_ipv4_mapped_addr() {
     assert_eq!(updated.addr(), canonical_addr);
     assert_eq!(updated.misbehavior(), 100);
 }
+
+/// Misbehavior updates must saturate at `u32::MAX` instead of overflowing and
+/// wrapping the accumulated score back below the ban threshold.
+#[test]
+fn misbehavior_score_accumulation_saturates() {
+    let _init_guard = zakura_test::init();
+
+    let instant_now = Instant::now();
+    let chrono_now = Utc::now();
+
+    let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+
+    // A never-attempted entry that is already near the maximum score.
+    let never_attempted = MetaAddr {
+        addr,
+        services: Default::default(),
+        untrusted_last_seen: None,
+        last_response: None,
+        rtt: None,
+        ping_sent_at: None,
+        last_attempt: None,
+        last_failure: None,
+        last_connection_state: Default::default(),
+        misbehavior_score: u32::MAX - 1,
+        is_inbound: false,
+    };
+
+    let updated = MetaAddr::new_misbehavior(addr, u32::MAX)
+        .apply_to_meta_addr(never_attempted, instant_now, chrono_now)
+        .expect("misbehavior updates apply to never-attempted entries");
+    assert_eq!(updated.misbehavior(), u32::MAX);
+
+    // An attempted (connected) entry near the maximum score.
+    let mut connected = MetaAddr::new_connected(addr, &PeerServices::NODE_NETWORK, false)
+        .into_new_meta_addr(
+            instant_now,
+            chrono_now.try_into().expect("will succeed until 2038"),
+        );
+    connected.misbehavior_score = u32::MAX - 1;
+
+    let updated = MetaAddr::new_misbehavior(addr, u32::MAX)
+        .apply_to_meta_addr(connected, instant_now, chrono_now)
+        .expect("misbehavior updates apply to attempted entries");
+    assert_eq!(updated.misbehavior(), u32::MAX);
+}

--- a/crates/zakura-network/src/peer_set/initialize.rs
+++ b/crates/zakura-network/src/peer_set/initialize.rs
@@ -95,10 +95,12 @@ async fn batch_misbehavior_reports(
     loop {
         tokio::select! {
             msg = misbehavior_rx.recv() => match msg {
-                Some((peer_addr, score_increment)) => *misbehaviors
-                    .entry(peer_addr)
-                    .or_default()
-                    += score_increment,
+                Some((peer_addr, score_increment)) => {
+                    let score = misbehaviors.entry(peer_addr).or_default();
+                    // Saturate so accumulated reports can't wrap a peer's score
+                    // back below the ban threshold.
+                    *score = score.saturating_add(score_increment);
+                }
                 None => break,
             },
 

--- a/crates/zakurad/src/components/mempool.rs
+++ b/crates/zakurad/src/components/mempool.rs
@@ -427,9 +427,12 @@ impl Mempool {
     fn enable_at_tip(&mut self, tip_action: &TipAction) {
         let (last_seen_tip_hash, tip_height) = tip_action.best_tip_hash_and_height();
 
+        // Attribute the readiness claim to the heuristic: the sync status is
+        // estimated from recent sync history, it is not proof that the local
+        // chain has reached the current network frontier.
         info!(
             ?tip_height,
-            "activating mempool: Zakura is close to the tip"
+            "activating mempool: sync status heuristic reports Zakura is close to the tip"
         );
 
         let tx_downloads = Box::pin(TxDownloads::new(
@@ -751,7 +754,16 @@ impl Service<Request> for Mempool {
                     Ok(Err(boxed_err)) => {
                         let (tx_id, error) = *boxed_err;
                         if let Some((advertiser_addr, score)) = transaction_misbehavior(&error) {
-                            let _ = self.misbehavior_sender.try_send((advertiser_addr, score));
+                            // The channel is bounded, so a full channel silently
+                            // drops the report and the peer keeps its old score.
+                            if self
+                                .misbehavior_sender
+                                .try_send((advertiser_addr, score))
+                                .is_err()
+                            {
+                                metrics::counter!("mempool.misbehavior.reports.dropped.total")
+                                    .increment(1);
+                            }
                         }
 
                         let peer_label =

--- a/crates/zakurad/src/components/mempool/tests/vector.rs
+++ b/crates/zakurad/src/components/mempool/tests/vector.rs
@@ -61,6 +61,27 @@ fn policy_rejection_has_no_misbehavior_score() {
     );
 }
 
+/// Non-final lock-time rejections depend on the local tip height and chain
+/// time, so they must not add a misbehavior score to the sending peer.
+#[test]
+fn nonfinal_lock_time_rejections_have_no_misbehavior_score() {
+    let advertiser_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));
+
+    for consensus_error in [
+        TransactionError::LockedUntilAfterBlockHeight(zakura_chain::block::Height(1_000_000)),
+        TransactionError::LockedUntilAfterBlockTime(
+            chrono::DateTime::from_timestamp(1_000_000_000, 0).expect("timestamp is valid"),
+        ),
+    ] {
+        let invalid_error = TransactionDownloadVerifyError::Invalid {
+            error: consensus_error,
+            advertiser_addr: Some(advertiser_addr),
+        };
+
+        assert_eq!(transaction_misbehavior(&invalid_error), None);
+    }
+}
+
 #[test]
 fn invalid_shielded_proof_sizes_ban_mempool_peers() {
     let advertiser_addr = PeerSocketAddr::from(([203, 0, 113, 7], 8233));

--- a/docs/changelog/unreleased/957.md
+++ b/docs/changelog/unreleased/957.md
@@ -1,0 +1,10 @@
+## Fixed
+
+- Peers are no longer penalized or banned for relaying transactions whose lock
+  time makes them non-final under the node's current chain view; these
+  transactions are still rejected until they become final
+  ([#957](https://github.com/zakura-core/zakura/pull/957)).
+- Peer misbehavior scores now accumulate with saturating arithmetic, and
+  misbehavior reports dropped by a full internal channel are counted in the new
+  `mempool.misbehavior.reports.dropped.total` metric
+  ([#957](https://github.com/zakura-core/zakura/pull/957)).


### PR DESCRIPTION
## Motivation

The peer misbehavior scoring around mempool transaction verification punishes some failures that are relative to the local chain view rather than evidence of peer misconduct, and the surrounding penalty plumbing has a few rough edges:

- `LockedUntilAfterBlockHeight` and `LockedUntilAfterBlockTime` were scored at 100, which is exactly the ban threshold (`MAX_PEER_MISBEHAVIOR_SCORE`). Lock-time finality is checked against the local next-block height and median-time-past, so an honest peer relaying a just-final transaction can be banned by a node whose tip or chain time lags slightly behind. The ban is IP-wide and has no expiry, so catching up does not undo it.
- Misbehavior scores were accumulated with ordinary unsigned addition in the report batcher and in the address book metadata merge, so peer-driven report streams could in principle wrap an accumulated score (or panic in debug builds), violating the monotonic-penalty invariant.
- Misbehavior reports are sent over a bounded channel with `try_send`, and drops were silent, so operators could not observe missed score updates.
- The `bans_by_ip` field comment claimed ban times are stored; the `BanList` type stores only an IP set and FIFO insertion order.
- The mempool activation log asserted "Zakura is close to the tip" as fact, although the sync status is a heuristic over recent sync lengths.

## Solution

- Classify both lock-time errors as non-punitive (score 0) in `mempool_misbehavior_score`. The transaction is still rejected and still enters the exact-tip rejection cache (cleared when the tip grows), so nothing becomes acceptable that wasn't before. This matches zcashd, which rejects non-final transactions as premature without a DoS penalty. The classifier is shared with block verification via `VerifyBlockError::misbehavior_score`, where the same tip-relative reasoning applies.
- Use `saturating_add` in both score-accumulation sites, matching the existing saturating sum in the sync-status length average.
- Count dropped misbehavior reports in a new `mempool.misbehavior.reports.dropped.total` metric.
- Correct the `bans_by_ip` comment to document the actual ban lifetime (process-local, no expiry, FIFO-evicted at capacity) and attribute the activation log's readiness claim to the heuristic.

## Testing

- `lock_time_errors_have_no_misbehavior_score` asserts the classifier scores both lock-time variants at 0, alongside the existing tests that keep policy rejections at 0 and context-independent verification failures at 100.
- `nonfinal_lock_time_rejections_have_no_misbehavior_score` asserts the mempool's misbehavior-report path returns no `(address, score)` pair for attributed lock-time failures, exercising the same helper that feeds the ban channel.
- `misbehavior_score_accumulation_saturates` applies misbehavior changes to never-attempted and attempted address book entries already near `u32::MAX` and asserts the score saturates instead of wrapping (the pre-fix code overflows in debug builds).
- Ran `cargo fmt --all -- --check` and `cargo clippy --locked -p zakura-network -p zakura-consensus -p zakura --all-targets -- -D warnings` (clean), the mempool test suite (96 passed), the consensus error/block score tests (15 passed), and the `zakura-network` lib suite (1156 passed). Three `zcashd_compat` listener tests failed locally on macOS because binding `127.0.0.2` needs an `lo0` alias; they fail identically on `main` in the same environment and are unrelated to this change (Linux CI can bind any `127.0.0.0/8` address).
- Acceptance tests match on the `"activating mempool"` log prefix, which is preserved.
- `./scripts/changelog.py check` validates the fragment.

## Changelog

`docs/changelog/unreleased/957.md` adds two `Fixed` entries.

### Follow-up Work

- Non-final lock times are one class of tip-relative rejection; upgrade-context-dependent failures (branch IDs outside the existing NU6.3 grace window, v4 signature-context mismatches) still score 100 and need a separate, more careful treatment.
- Ban lifetime remains unbounded; expiry/reconsideration is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)