### PR TITLE
build: add an experimental NU7 feature

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -336,6 +336,32 @@ jobs:
       - name: Check generated zakurad config compatibility
         run: cargo nextest run --profile zakura-config --archive-file "${RUNNER_TEMP}/nextest-archive.tar.zst" --no-fail-fast
 
+  nu7-experimental:
+    name: Experimental NU7 feature tests
+    needs: changes
+    # Compiles its own binaries, because the shared nextest archive is built
+    # without this feature.
+    if: needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
+        with:
+          toolchain: stable
+      - uses: ./.github/actions/setup-zakura-build
+      - name: Test experimental NU7 builds
+        run: |
+          cargo test --locked --features nu7-experimental \
+            -p zakura-consensus --lib
+          cargo check --locked -p zakura --features nu7-experimental
+
   network-dependent:
     name: network-dependent acceptance tests
     needs: changes
@@ -464,6 +490,7 @@ jobs:
       - build-tests
       - unit-tests
       - zakura-config
+      - nu7-experimental
       - network-dependent
       - pruned-storage
       - check-no-git-dependencies
@@ -481,7 +508,7 @@ jobs:
           # check-no-git-dependencies is A-release-label only, publish-graph
           # skips on PRs that do not touch Cargo manifests or this check.
           # Failed, non-skipped jobs still fail this aggregate status.
-          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, publish-graph
+          allowed-skips: check-no-git-dependencies, pruned-storage, zakura-config, build-tests, unit-tests, network-dependent, nu7-experimental, publish-graph
 
   report-nightly-result:
     name: report nightly release test result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,7 +7607,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.5.0"
+version = "1.4.1"
 dependencies = [
  "abscissa_core",
  "bytes",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "8.1.0"
+version = "8.0.1"
 dependencies = [
  "blake2b_simd",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,7 +7607,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zakura"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "abscissa_core",
  "bytes",
@@ -7795,7 +7795,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "blake2b_simd",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.5.0 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.4.1 zakura
 ```
 
 You can start Zakura by running

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cargo install --locked zakura
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/zakura-core/zakura --tag v1.4.0 zakura
+cargo install --git https://github.com/zakura-core/zakura --tag v1.5.0 zakura
 ```
 
 You can start Zakura by running

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "8.0.0"
+version = "8.1.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true
@@ -21,6 +21,9 @@ categories = ["asynchronous", "cryptography::cryptocurrencies"]
 
 [features]
 default = []
+
+# Experimental candidate NU7 consensus rules, dormant until NU7 activates.
+nu7-experimental = []
 
 # Production features that activate extra dependencies, or extra features in dependencies
 

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-consensus"
-version = "8.1.0"
+version = "8.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.5.0"
+version = "1.4.1"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -7,7 +7,7 @@ name = "zakura"
 # [package.metadata.release] below does it automatically, but only under the
 # full `cargo release` flow (`cargo release version` skips the replace step) -
 # keep the two in sync when bumping by hand.
-version = "1.4.0"
+version = "1.5.0"
 authors.workspace = true
 description = "Zakura, an independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -82,6 +82,11 @@ default-release-binaries = ["release_max_level_info", "progress-bar", "prometheu
 default = ["default-release-binaries"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
+
+# Experimental candidate NU7 consensus rules, dormant until NU7 activates.
+nu7-experimental = [
+    "zakura-consensus/nu7-experimental",
+]
 
 # Indexer support
 indexer = ["zakura-state/indexer", "zakura-rpc/indexer"]

--- a/crates/zakurad/tests/common/configs/v1.4.1.toml
+++ b/crates/zakurad/tests/common/configs/v1.4.1.toml
@@ -1,0 +1,151 @@
+# Default configuration for zakurad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zakurad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zakura/latest/zakurad/config/struct.ZakuradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZAKURA_ prefix (highest precedence)
+#    - Format: ZAKURA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZAKURA_NETWORK__NETWORK=Testnet
+#      - ZAKURA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZAKURA_STATE__CACHE_DIR=/path/to/cache
+#      - ZAKURA_TRACING__FILTER=debug
+#      - ZAKURA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Environment variables with deprecated ZEBRA_ prefix
+#
+# 3. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zakurad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 4. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zakurad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zakura.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zakura.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zakura.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+max_transaction_bytes = 250000
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+optimistic_block_inventory = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+expose_peer_addresses = false
+identity_dir = "identity_dir"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+# The peer-to-peer stack to run:
+# - "legacy": the legacy TCP Zcash P2P stack only.
+# - "zakura": the experimental native Zakura P2P v2 stack only.
+# - "dual": both stacks, enabling experimental v2 with legacy fallback.
+# - "default": Zakura's default for this network, which can change between
+#   releases. Currently "legacy" on Mainnet, and "dual" everywhere else.
+p2p_stack = "default"
+peerset_initial_target_size = 100
+
+[network.zakura]
+bootstrap_peers = [
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca@165.22.54.66:8234",
+    "fd1724385aa0c75b64fb78cd602fa1d991fdebf76b13c58ed702eac835e9f618@104.131.184.123:8234",
+    "9ec67ad6834bc2ca0d659c240e042d3446c37cabcc092b527d459c87d938b4a4@159.65.183.89:8234",
+    "bd3dc5d2a3d44c6bf90e364bf446231dbf9737e38a562ccf9e91ea631ea59b22@143.244.184.176:8234",
+    "14ab98fa0c4b07d40119e1dbc9f3c36d20c8f226ae5ba4216218a2034f148e57@159.203.38.10:8234",
+    "681d21b18644cd82ec13256a97f92bec1fff815683ef6f65dc7c993f098a4fe5@64.227.44.93:8234",
+    "058b3f20dc9bef7bb447f94d7663d793cfbc036720f97e52d7f13661b21818e1@161.35.156.226:8234",
+    "291323d78eb7186c3fa225ef5e305e95363e0ef06d42dca91bd4ef0254aed1ae@139.59.64.115:8234",
+    "85e425233a68697d4be91dd5d542305a8a327cd06d992d53c0913cef2fa75084@168.144.173.250:8234",
+]
+listen_addr = "0.0.0.0:8234"
+max_connections = 256
+max_connections_per_ip = 16
+max_pending_handshakes = 32
+message_rate_per_second = 2048
+stream_open_rate_per_second = 32
+
+[rpc]
+cookie_dir = "cache_dir"
+cookie_file_name = ".cookie"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+should_backup_non_finalized_state = true
+storage_mode = "archive"
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 100
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+zakura_block_apply_concurrency_limit = 32
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+
+[zcashd_compat]
+block_gossip_peer_ips = []
+enabled = false
+manage_zcashd = false
+restart_backoff = "2s"
+restart_backoff_max = "5m"
+restart_reset_after = "1h"
+shutdown_grace_period = "5m"
+startup_delay = "1s"
+zcashd_extra_args = []
+zcashd_source = "path"

--- a/docs/changelog/unreleased/958.md
+++ b/docs/changelog/unreleased/958.md
@@ -1,0 +1,5 @@
+## Added
+
+- Added an off-by-default `nu7-experimental` build feature for staging
+  candidate NU7 consensus rules without changing default-build behavior
+  ([#958](https://github.com/zakura-core/zakura/pull/958)).


### PR DESCRIPTION
## Motivation

Candidate NU7 consensus rules need one off-by-default build switch so they can be reviewed and tested without changing default-build behavior. The earlier ZIP 2003 PR inherited this machinery from its ZIP 218 parent branch.

## Solution

Add `nu7-experimental` to `zakura-consensus` and forward it from the `zakura` package. Add a dedicated CI job that tests the feature-enabled consensus build and checks the feature-enabled node build.

The feature is intentionally dormant in this PR. Individual rules must additionally require an exact NU7 activation height on the configured network.

Patch-bump `zakura-consensus` to 8.0.1 and `zakura` to 1.4.1 for the new published feature surface. Store the unchanged v1.4.1 generated config fixture for compatibility testing.

## Testing

- `cargo test --locked --features nu7-experimental -p zakura-consensus --lib`: 232 passed, 1 ignored
- `cargo check --locked -p zakura --features nu7-experimental`
- `cargo test -p zakura --test acceptance config_tests -- --exact`: passed
- `./scripts/check-crate-publish-graph.sh`: resolves at `zakura@1.4.1` and `zakura-consensus@8.0.1`
- `cargo metadata --locked --no-deps --format-version 1`
- `markdownlint README.md docs/changelog/unreleased/958.md --config .github/.markdownlint.yaml`
- `./scripts/changelog.py check`
- `git diff --check`

## Changelog

Added `docs/changelog/unreleased/958.md`.

### Specifications & References

- Follow-up: remake of #856, ZIP 2003

### Follow-up Work

A stacked PR will implement ZIP 2003 version 4 transaction deprecation behind this feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to optional Cargo features, CI, versioning, and docs; default builds and consensus behavior are unchanged.
> 
> **Overview**
> Introduces an **off-by-default** `nu7-experimental` Cargo feature on `zakura-consensus`, forwarded from the `zakura` package, so upcoming NU7 consensus work can be built and tested without affecting default binaries. The feature is **dormant here** (no rule logic yet).
> 
> CI adds a dedicated **Experimental NU7 feature tests** job that compiles separately from the shared nextest archive and runs `cargo test` on `zakura-consensus --lib` plus `cargo check` on `zakura` with the feature enabled; the aggregate **test success** check treats that job like other path-gated Rust jobs.
> 
> Release housekeeping: patch **zakura** to **1.4.1** and **zakura-consensus** to **8.0.1**, refresh the README git install tag, add a **v1.4.1** generated `zakurad` config fixture for compatibility tests, and document the feature in the unreleased changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6acfd29c4c41638b5a03ddff5601db344fc665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->