### PR TITLE
feat(ops): archive sync traces in Spaces before restarting

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -480,9 +480,25 @@ aws --endpoint-url https://YOUR_REGION.digitaloceanspaces.com s3api put-bucket-l
 The controller verifies seven-day expiration before uploading. It streams gzip
 compressed tar archives into `sync-traces/<hostname>/<run-id>.tar.gz` after the
 node stops. Upload failures halt the next run and preserve local traces.
-Completion digests and failure alerts include private download links valid for
-seven days. Existing stopped runs are archived before retention can remove them.
+Daily reports and failure alerts include private download links valid for
+seven days from upload. A delayed report does not renew the links. Existing stopped runs are archived before retention can remove them.
 The lifecycle rule also removes abandoned multipart uploads after one day.
 
 See [Spaces lifecycle rules](https://docs.digitalocean.com/products/spaces/how-to/configure-lifecycle-rules/)
 and [private download links](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/).
+
+Controller deployment does not update the daily report sender. After deploying
+controllers, update the sender's formatter from the same checkout:
+
+```sh
+python3 deploy/continuous-sync/deploy.py deploy-summary
+python3 deploy/continuous-sync/deploy.py summary-status
+```
+
+This update preserves existing delivery cursors. For a new sender, follow the
+[initialization procedure](#daily-summary) before enabling its timer.
+Configure the AWS CLI, credentials, and lifecycle rule on every sync host before
+controller deployment. Preflight checks archive access and expiration before
+starting a sync. The next daily report includes a download link for each
+unreported completion that has an archive URL. Runs completed before archival
+was enabled have no download link.

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -455,3 +455,34 @@ For a fresh Ubuntu x86_64 host:
   restarts.
 - Secrets are read from host env files or GitHub secrets and are never written to
   repository-managed templates.
+
+## Trace archives
+
+New controller deployments enable `policy.archive_traces`. Install the AWS CLI
+on each sync host. Set these values in `/etc/zakura-traces.env` (mode 0600):
+
+```sh
+ZAKURA_TRACE_SPACE=YOUR_SPACE
+ZAKURA_TRACE_ENDPOINT=https://YOUR_REGION.digitaloceanspaces.com
+AWS_DEFAULT_REGION=YOUR_REGION
+AWS_ACCESS_KEY_ID=YOUR_SPACES_KEY
+AWS_SECRET_ACCESS_KEY=YOUR_SPACES_SECRET
+```
+
+Apply `spaces-lifecycle.json` to a dedicated trace Space before enabling the
+controller. The following command replaces the Space's lifecycle configuration.
+For a shared Space, merge the supplied rule with its existing rules first.
+
+```sh
+aws --endpoint-url https://YOUR_REGION.digitaloceanspaces.com s3api put-bucket-lifecycle-configuration --bucket YOUR_SPACE --lifecycle-configuration file://deploy/continuous-sync/spaces-lifecycle.json
+```
+
+The controller verifies seven-day expiration before uploading. It streams gzip
+compressed tar archives into `sync-traces/<hostname>/<run-id>.tar.gz` after the
+node stops. Upload failures halt the next run and preserve local traces.
+Completion digests and failure alerts include private download links valid for
+seven days. Existing stopped runs are archived before retention can remove them.
+The lifecycle rule also removes abandoned multipart uploads after one day.
+
+See [Spaces lifecycle rules](https://docs.digitalocean.com/products/spaces/how-to/configure-lifecycle-rules/)
+and [private download links](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/).

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -487,6 +487,13 @@ The lifecycle rule also removes abandoned multipart uploads after one day.
 See [Spaces lifecycle rules](https://docs.digitalocean.com/products/spaces/how-to/configure-lifecycle-rules/)
 and [private download links](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/).
 
+The controller deletes each local `traces` directory after persisting the archive
+URL in `run.json`. It syncs the metadata file and directory before deletion.
+It keeps run metadata and logs under the existing retention
+policy. Cleanup also removes trace payloads from previously archived runs,
+including the protected latest failed run. A failed upload preserves the traces.
+Cleanup retries after a controller restart if deletion did not finish.
+
 Controller deployment does not update the daily report sender. After deploying
 controllers, update the sender's formatter from the same checkout:
 

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -634,7 +634,10 @@ def trace_archive_destination() -> tuple[list[str], str]:
 
 def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
     """Upload stopped-node traces before the controller can start another run."""
-    if not config.policy.archive_traces or run_state.get("trace_archive_url"):
+    if not config.policy.archive_traces:
+        return
+    if run_state.get("trace_archive_url"):
+        clear_archived_traces(run_dir)
         return
     traces = run_dir / "traces"
     if traces.is_symlink():
@@ -671,6 +674,24 @@ def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> 
     archived_state = dict(run_state, trace_archive_url=url, trace_archive_key=key)
     write_run_json(run_dir, archived_state)
     run_state.update(archived_state)
+    clear_archived_traces(run_dir)
+
+
+def clear_archived_traces(run_dir: Path) -> None:
+    """Remove trace payloads after their archive metadata reaches disk."""
+    traces = run_dir / "traces"
+    if traces.is_symlink():
+        raise ControllerError(f"refusing to remove symlinked traces: {traces}")
+    if traces.exists():
+        # Make the archive record durable before deleting its local payload.
+        with (run_dir / "run.json").open("rb") as metadata:
+            os.fsync(metadata.fileno())
+        directory_fd = os.open(run_dir, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        shutil.rmtree(traces)
 
 
 def trace_download_text(run_state: dict[str, Any]) -> str:

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -902,6 +902,7 @@ def halt(config: Config, state_path: Path, state: dict[str, Any], run_state: dic
             "failed_at": failed_at,
             "phase": "failed",
             "last_failed_sha": run_state.get("sha"),
+            "last_failed_trace_archive_url": run_state.get("trace_archive_url"),
             "last_failed_run": run_state.get("run_id") or f"preflight-{time.time_ns()}",
         }
     )

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -75,6 +75,7 @@ class Policy:
     ready_samples: int = 6
     ready_sample_interval_seconds: int = 30
     min_free_bytes: int = 10 * 1024 * 1024 * 1024
+    archive_traces: bool = False
     retention_runs: int = 10
     retention_bytes: int = 20 * 1024**3
     trace_file_bytes: int = 128 * 1024**2
@@ -607,6 +608,62 @@ def wait_for_completion(
             time.sleep(config.policy.poll_interval_seconds)
 
 
+def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
+    """Upload stopped-node traces before the controller can start another run."""
+    if not config.policy.archive_traces or run_state.get("trace_archive_url"):
+        return
+    traces = run_dir / "traces"
+    if not traces.exists():
+        return
+    bucket = os.environ.get("ZAKURA_TRACE_SPACE", "")
+    endpoint = os.environ.get("ZAKURA_TRACE_ENDPOINT", "")
+    if not bucket or not re.fullmatch(r"https://[a-z0-9-]+\.digitaloceanspaces\.com", endpoint):
+        raise ControllerError("set ZAKURA_TRACE_SPACE and ZAKURA_TRACE_ENDPOINT")
+    aws = ["aws", "--endpoint-url", endpoint, "--cli-connect-timeout", "30",
+           "--cli-read-timeout", "120"]
+    lifecycle = json.loads(run(aws + ["s3api", "get-bucket-lifecycle-configuration",
+                                    "--bucket", bucket], capture=True, timeout=180).stdout)
+    if not any(rule.get("Status") == "Enabled"
+               and rule.get("Expiration", {}).get("Days") == 7
+               and (rule.get("Prefix") == "sync-traces/"
+                    or rule.get("Filter") == {"Prefix": "sync-traces/"})
+               for rule in lifecycle.get("Rules", [])):
+        raise ControllerError("Space requires a seven-day sync-traces/ expiration rule")
+    host = re.sub(r"[^A-Za-z0-9_.-]", "_", config.policy.hostname)
+    key = f"sync-traces/{host}/{run_dir.name}.tar.gz"
+    uri = f"s3://{bucket}/{key}"
+    size = sum(path.stat().st_size for path in traces.rglob("*")
+               if path.is_file() and not path.is_symlink())
+    # Streaming avoids a second trace-sized allocation on the sync disk.
+    with subprocess.Popen(["tar", "-czf", "-", "-C", str(run_dir), "traces"],
+                          stdout=subprocess.PIPE) as compressor:
+        try:
+            result = subprocess.run(
+                aws + ["s3", "cp", "-", uri, "--only-show-errors", "--expected-size",
+                       str(size + size // 100 + 1024 * 1024)],
+                stdin=compressor.stdout, capture_output=True, timeout=21600,
+            )
+            compressor.stdout.close()
+            code = compressor.wait(timeout=120)
+            if result.returncode or code:
+                raise ControllerError("trace compression or upload failed; local traces retained")
+        finally:
+            if compressor.poll() is None:
+                compressor.kill()
+                compressor.wait()
+    url = run(aws + ["s3", "presign", uri, "--expires-in", "604800"],
+              capture=True, timeout=180).stdout.strip()
+    if not url.startswith("https://"):
+        raise ControllerError("Space returned an invalid download URL")
+    run_state.update(trace_archive_url=url, trace_archive_key=key)
+    write_run_json(run_dir, run_state)
+
+
+def trace_download_text(run_state: dict[str, Any]) -> str:
+    url = run_state.get("trace_archive_url")
+    return f" | <{url}|Download traces (7 days)>" if url else ""
+
+
 def cleanup_retention(
     config: Config, active_run: Path | None = None, *, recovery: bool = False
 ) -> None:
@@ -640,6 +697,8 @@ def cleanup_retention(
             continue
         if not isinstance(data, dict):
             continue
+        if child != active_run:
+            archive_traces(config, child, data)
         size = sum(path.stat().st_size for path in child.rglob("*")
                    if not path.is_symlink() and path.is_file())
         runs.append((data.get("phase"), str(data.get("started_at", "")), child, size))
@@ -674,7 +733,7 @@ def failure_text(config: Config, run_state: dict[str, Any], reason: str) -> str:
     return (
         f":rotating_light: Zakura failed: {p.hostname} | {policy_mode(p)} | "
         f"{ssh_target(p)} | time to failure: {duration} | height: {height_text} | "
-        f"reason: {short_reason(reason)}{run_text}"
+        f"reason: {short_reason(reason)}{run_text}{trace_download_text(run_state)}"
     )
 
 
@@ -777,6 +836,7 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
         }
     )
     write_run_json(run_dir, run_state)
+    archive_traces(config, run_dir, run_state)
     completion_history = state.get("completion_history", [])
     if not isinstance(completion_history, list):
         # Optional reporting history must not turn a successful sync into a halt.
@@ -790,12 +850,14 @@ def one_cycle(config: Config, state_path: Path, state: dict[str, Any]) -> dict[s
             "last_success_run": run_id,
             "last_success_duration_seconds": run_state["sync_duration_seconds"],
             "last_success_end_height": run_state.get("end_height"),
+            "last_success_trace_archive_url": run_state.get("trace_archive_url"),
             # Keep timings independently of run-log retention and audit cadence.
             "completion_history": (completion_history + [{
                 "number": int(state.get("runs", 0)) + 1,
                 "run_id": run_id,
                 "duration": run_state["sync_duration_seconds"],
                 "end_height": run_state.get("end_height"),
+                "trace_archive_url": run_state.get("trace_archive_url"),
             }])[-COMPLETION_HISTORY_LIMIT:],
             "completion_digest": True,
             "completion_digest_start_runs": state.get(
@@ -827,6 +889,11 @@ def halt(config: Config, state_path: Path, state: dict[str, Any], run_state: dic
     )
     run_dir = Path(str(run_state.get("run_dir") or config.paths.runs_dir / "unknown"))
     if run_dir.exists():
+        try:
+            archive_traces(config, run_dir, run_state)
+        except Exception as error:
+            run_state["trace_archive_error"] = str(error)
+            reason += f"; trace archive failed: {error}"
         write_run_json(run_dir, run_state)
     state.update(
         {

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -357,6 +357,8 @@ def preflight(config: Config) -> None:
         if not path.exists():
             raise ControllerError(f"{description} is missing: {path}")
     check_free_space(config)
+    if config.policy.archive_traces:
+        trace_archive_destination()
 
 
 def safe_wipe_state(config: Config) -> None:
@@ -611,15 +613,8 @@ def wait_for_completion(
             time.sleep(config.policy.poll_interval_seconds)
 
 
-def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
-    """Upload stopped-node traces before the controller can start another run."""
-    if not config.policy.archive_traces or run_state.get("trace_archive_url"):
-        return
-    traces = run_dir / "traces"
-    if traces.is_symlink():
-        raise ControllerError(f"refusing to archive symlinked traces: {traces}")
-    if not traces.exists():
-        return
+def trace_archive_destination() -> tuple[list[str], str]:
+    """Validate archive access and expiration before starting a sync or upload."""
     bucket = os.environ.get("ZAKURA_TRACE_SPACE", "")
     endpoint = os.environ.get("ZAKURA_TRACE_ENDPOINT", "")
     if not bucket or not re.fullmatch(r"https://[a-z0-9-]+\.digitaloceanspaces\.com", endpoint):
@@ -634,6 +629,19 @@ def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> 
                     or rule.get("Filter") == {"Prefix": "sync-traces/"})
                for rule in lifecycle.get("Rules", [])):
         raise ControllerError("Space requires a seven-day sync-traces/ expiration rule")
+    return aws, bucket
+
+
+def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
+    """Upload stopped-node traces before the controller can start another run."""
+    if not config.policy.archive_traces or run_state.get("trace_archive_url"):
+        return
+    traces = run_dir / "traces"
+    if traces.is_symlink():
+        raise ControllerError(f"refusing to archive symlinked traces: {traces}")
+    if not traces.exists():
+        return
+    aws, bucket = trace_archive_destination()
     host = re.sub(r"[^A-Za-z0-9_.-]", "_", config.policy.hostname)
     key = f"sync-traces/{host}/{run_dir.name}.tar.gz"
     uri = f"s3://{bucket}/{key}"

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -343,7 +343,10 @@ def check_free_space(config: Config, *, recovery: bool = False) -> None:
 
 
 def preflight(config: Config) -> None:
-    for command in ("cargo", "git", "systemctl", "logrotate"):
+    commands = ("cargo", "git", "systemctl", "logrotate")
+    if config.policy.archive_traces:
+        commands += ("aws", "tar", "gzip")
+    for command in commands:
         if shutil.which(command) is None:
             raise ControllerError(f"required command is unavailable: {command}")
     for path, description in (
@@ -613,6 +616,8 @@ def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> 
     if not config.policy.archive_traces or run_state.get("trace_archive_url"):
         return
     traces = run_dir / "traces"
+    if traces.is_symlink():
+        raise ControllerError(f"refusing to archive symlinked traces: {traces}")
     if not traces.exists():
         return
     bucket = os.environ.get("ZAKURA_TRACE_SPACE", "")
@@ -655,8 +660,9 @@ def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> 
               capture=True, timeout=180).stdout.strip()
     if not url.startswith("https://"):
         raise ControllerError("Space returned an invalid download URL")
-    run_state.update(trace_archive_url=url, trace_archive_key=key)
-    write_run_json(run_dir, run_state)
+    archived_state = dict(run_state, trace_archive_url=url, trace_archive_key=key)
+    write_run_json(run_dir, archived_state)
+    run_state.update(archived_state)
 
 
 def trace_download_text(run_state: dict[str, Any]) -> str:
@@ -936,7 +942,11 @@ def run_loop(config: Config, config_path: Path) -> int:
                 return 2
             stop_service(config)
             safe_wipe_state(config)
-            cleanup_retention(config, recovery=True)
+            try:
+                cleanup_retention(config, recovery=True)
+            except Exception as error:
+                halt(config, state_path, state, {}, f"retention recovery failed: {error}")
+                return 1
             try:
                 check_free_space(config, recovery=True)
             except DiskPressure:
@@ -965,7 +975,11 @@ def run_loop(config: Config, config_path: Path) -> int:
             stop_service(config)
             run_dir = config.paths.runs_dir / str(current_run) if current_run else None
             if isinstance(error, DiskPressure):
-                cleanup_retention(config, active_run=run_dir, recovery=True)
+                try:
+                    cleanup_retention(config, active_run=run_dir, recovery=True)
+                except Exception as recovery_error:
+                    reason += f"; retention recovery failed: {recovery_error}"
+                    error = recovery_error
             halt(config, state_path, state, run_state or state, reason)
             if not isinstance(error, DiskPressure):
                 return 1

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -512,6 +512,8 @@ def audit_problem(
         detail = f"controller halted: {failure}"
         if run_id:
             detail += f" (run {run_id})"
+        if url := state.get("last_failed_trace_archive_url"):
+            detail += f" | <{url}|Download traces (7 days)>"
         return Problem(
             f"controller-halted:{failure}", detail,
             incident_id, delivered_at,

--- a/deploy/continuous-sync/deploy.py
+++ b/deploy/continuous-sync/deploy.py
@@ -775,13 +775,15 @@ def completion_run_text(item: dict[str, Any]) -> str:
     valid_duration = type(duration) is int and duration >= 0
     timing = (f"{duration // 3600}h {duration % 3600 // 60:02d}m"
               if valid_duration else "duration unavailable")
+    url = item.get("trace_archive_url")
+    download = f" · <{url}|Download traces (7 days)>" if url else ""
     height = item.get("end_height")
     if type(height) is not int or not 0 <= height <= 0xFFFFFFFF:
-        return f"{timing} · BPS unavailable"
+        return f"{timing} · BPS unavailable{download}"
     # Every cycle starts from empty chain state; height zero is genesis.
     blocks = height + 1
     rate = f"{blocks / duration:.0f} blocks/sec" if valid_duration and duration > 0 else "BPS unavailable"
-    return f"{timing} · {rate}"
+    return f"{timing} · {rate}{download}"
 
 
 def completion_updates(
@@ -818,6 +820,7 @@ def completion_updates(
         history[total] = {
             "run_id": run_id, "duration": controller.get("last_success_duration_seconds"),
             "end_height": controller.get("last_success_end_height"),
+            "trace_archive_url": controller.get("last_success_trace_archive_url"),
         }
         details = completion_details(old) + [history[number] for number in sorted(history)]
         records[name] = {
@@ -826,6 +829,7 @@ def completion_updates(
             "sha": controller.get("last_success_sha", "unknown"),
             "duration": controller.get("last_success_duration_seconds"),
             "end_height": controller.get("last_success_end_height"),
+            "trace_archive_url": controller.get("last_success_trace_archive_url"),
             "pending": old.get("pending", 0) + delta,
             "details": details[-COMPLETION_DETAIL_LIMIT:],
         }

--- a/deploy/continuous-sync/spaces-lifecycle.json
+++ b/deploy/continuous-sync/spaces-lifecycle.json
@@ -1,0 +1,9 @@
+{
+  "Rules": [{
+    "ID": "sync-traces-seven-days",
+    "Status": "Enabled",
+    "Prefix": "sync-traces/",
+    "Expiration": {"Days": 7},
+    "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 1}
+  }]
+}

--- a/deploy/continuous-sync/templates/controller.toml
+++ b/deploy/continuous-sync/templates/controller.toml
@@ -13,6 +13,7 @@ monitor_log = "{{MONITOR_LOG}}"
 trace_link = "{{TRACE_LINK}}"
 
 [policy]
+archive_traces = true
 branch = "{{BRANCH}}"
 remote = "{{REMOTE}}"
 service_name = "{{SERVICE_NAME}}"

--- a/deploy/continuous-sync/templates/zakura-continuous-sync.service
+++ b/deploy/continuous-sync/templates/zakura-continuous-sync.service
@@ -7,6 +7,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=-/etc/zakura-alerts.env
+EnvironmentFile=-/etc/zakura-traces.env
 Environment=PATH=/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=CARGO_HOME=/root/.cargo
 Environment=RUSTUP_HOME=/root/.rustup

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -39,6 +39,46 @@ alert_status = load_module("continuous_sync_alert_status", ALERT_STATUS_PATH)
 
 
 class ContinuousSyncTests(unittest.TestCase):
+    def test_archive_requires_expiration_and_preserves_traces(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))
+            run_dir = Path(tmp) / "run"
+            traces = run_dir / "traces"
+            traces.mkdir(parents=True)
+            (traces / "events.jsonl").write_text('{"event":"test"}\n')
+            with patch.dict(os.environ, {"ZAKURA_TRACE_SPACE": "test",
+                                        "ZAKURA_TRACE_ENDPOINT": "https://nyc3.digitaloceanspaces.com"}), patch.object(
+                    sync, "run", return_value=subprocess.CompletedProcess([], 0, '{"Rules":[]}')):
+                with self.assertRaisesRegex(sync.ControllerError, "seven-day"):
+                    sync.archive_traces(config, run_dir, {})
+            self.assertTrue((traces / "events.jsonl").exists())
+
+    def test_archive_streams_compressed_traces_and_records_link(self):
+        import gzip
+        import tarfile
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True, hostname="host"))
+            run_dir = Path(tmp) / "run"
+            (run_dir / "traces").mkdir(parents=True)
+            (run_dir / "traces" / "events.csv").write_text("event\ntest\n")
+            uploaded = []
+            def upload(cmd, **kwargs):
+                uploaded.append(kwargs["stdin"].read())
+                return subprocess.CompletedProcess(cmd, 0)
+            state = {}
+            lifecycle = '{"Rules":[{"Status":"Enabled","Prefix":"sync-traces/","Expiration":{"Days":7}}]}'
+            with patch.dict(os.environ, {"ZAKURA_TRACE_SPACE": "test",
+                                        "ZAKURA_TRACE_ENDPOINT": "https://nyc3.digitaloceanspaces.com"}), patch.object(
+                    sync, "run", side_effect=[subprocess.CompletedProcess([], 0, lifecycle),
+                                               subprocess.CompletedProcess([], 0, "https://download")]), patch.object(
+                    sync.subprocess, "run", side_effect=upload):
+                sync.archive_traces(config, run_dir, state)
+            with tarfile.open(fileobj=io.BytesIO(gzip.decompress(uploaded[0]))) as archive:
+                self.assertEqual(archive.extractfile("traces/events.csv").read(), b"event\ntest\n")
+            self.assertEqual(state["trace_archive_url"], "https://download")
+            self.assertIn("https://download", deploy.completion_run_text(state))
+            self.assertTrue((run_dir / "traces" / "events.csv").exists())
+
     def test_metric_value_accepts_dotted_and_prometheus_names(self):
         metrics = "\n".join(
             [
@@ -1944,6 +1984,7 @@ class NotificationTests(unittest.TestCase):
                     self.assertEqual(history[-1], {
                         "number": 261, "run_id": state["current_run"], "duration": 0,
                         "end_height": 3469999,
+                        "trace_archive_url": None,
                     })
                     self.assertEqual(state["last_success_end_height"], 3469999)
                     self.assertEqual(state["completion_digest_start_runs"], 260)

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -121,7 +121,75 @@ class ContinuousSyncTests(unittest.TestCase):
                 self.assertEqual(archive.extractfile("traces/events.csv").read(), b"event\ntest\n")
             self.assertEqual(state["trace_archive_url"], "https://download")
             self.assertIn("https://download", deploy.completion_run_text(state))
-            self.assertTrue((run_dir / "traces" / "events.csv").exists())
+            self.assertFalse((run_dir / "traces").exists())
+
+    def test_archive_failures_preserve_payload_and_allow_retry(self):
+        lifecycle = '{"Rules":[{"Status":"Enabled","Prefix":"sync-traces/","Expiration":{"Days":7}}]}'
+        for failure in ("upload", "metadata", "fsync", "delete"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                config = make_config(root, policy=sync.Policy(archive_traces=True))
+                run_dir = root / "run"
+                traces = run_dir / "traces"
+                traces.mkdir(parents=True)
+                (traces / "events.csv").write_text("event\ntest\n")
+                state = {}
+                def upload(cmd, **kwargs):
+                    kwargs["stdin"].read()
+                    return subprocess.CompletedProcess(cmd, 1 if failure == "upload" else 0)
+                with contextlib.ExitStack() as stack:
+                    stack.enter_context(patch.dict(os.environ, {
+                        "ZAKURA_TRACE_SPACE": "test",
+                        "ZAKURA_TRACE_ENDPOINT": "https://nyc3.digitaloceanspaces.com",
+                    }))
+                    stack.enter_context(patch.object(sync, "run", side_effect=[
+                        subprocess.CompletedProcess([], 0, lifecycle),
+                        subprocess.CompletedProcess([], 0, "https://download"),
+                    ]))
+                    stack.enter_context(patch.object(sync.subprocess, "run", side_effect=upload))
+                    if failure == "metadata":
+                        stack.enter_context(patch.object(sync, "write_run_json", side_effect=OSError("write failed")))
+                    elif failure == "fsync":
+                        stack.enter_context(patch.object(sync.os, "fsync", side_effect=OSError("sync failed")))
+                    elif failure == "delete":
+                        stack.enter_context(patch.object(sync.shutil, "rmtree", side_effect=OSError("delete failed")))
+                    with self.assertRaises((OSError, sync.ControllerError)):
+                        sync.archive_traces(config, run_dir, state)
+                self.assertTrue((traces / "events.csv").exists())
+                if failure in ("upload", "metadata"):
+                    self.assertNotIn("trace_archive_url", state)
+                else:
+                    persisted = json.loads((run_dir / "run.json").read_text())
+                    self.assertEqual(persisted["trace_archive_url"], "https://download")
+                    with patch.object(sync, "run") as command:
+                        sync.archive_traces(config, run_dir, persisted)
+                        command.assert_not_called()
+                    self.assertFalse(traces.exists())
+
+    def test_archived_trace_cleanup_retries_without_uploading(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))
+            run_dir = Path(tmp) / "run"
+            (run_dir / "traces").mkdir(parents=True)
+            (run_dir / "traces" / "old.csv").write_text("old data")
+            (run_dir / "run.json").write_text("{}")
+            with patch.object(sync, "run") as command:
+                sync.archive_traces(config, run_dir, {"trace_archive_url": "https://download"})
+                command.assert_not_called()
+            self.assertFalse((run_dir / "traces").exists())
+            self.assertTrue((run_dir / "run.json").exists())
+
+    def test_trace_cleanup_rejects_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "run"
+            run_dir.mkdir()
+            target = root / "unrelated"
+            target.mkdir()
+            (run_dir / "traces").symlink_to(target)
+            with self.assertRaisesRegex(sync.ControllerError, "symlink"):
+                sync.clear_archived_traces(run_dir)
+            self.assertTrue(target.exists())
 
     def test_failure_audit_preserves_archive_link(self):
         problem = deploy.audit_problem({"controller_state": {

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -79,6 +79,13 @@ class ContinuousSyncTests(unittest.TestCase):
             self.assertIn("https://download", deploy.completion_run_text(state))
             self.assertTrue((run_dir / "traces" / "events.csv").exists())
 
+    def test_failure_audit_preserves_archive_link(self):
+        problem = deploy.audit_problem({"controller_state": {
+            "failed": True, "failure": "stalled", "last_failed_run": "run-1",
+            "last_failed_trace_archive_url": "https://download",
+        }}, 3600)
+        self.assertIn("https://download", problem.detail)
+
     def test_metric_value_accepts_dotted_and_prometheus_names(self):
         metrics = "\n".join(
             [

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -39,6 +39,35 @@ alert_status = load_module("continuous_sync_alert_status", ALERT_STATUS_PATH)
 
 
 class ContinuousSyncTests(unittest.TestCase):
+    def test_retention_archive_failure_reports_halt_during_disk_recovery(self):
+        for restarting in (False, True):
+            with self.subTest(restarting=restarting), tempfile.TemporaryDirectory() as tmp:
+                config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))
+                state_path = config.paths.state_dir / "state.json"
+                if restarting:
+                    sync.save_state(state_path, {"failed": True, "failure": "DiskPressure: low"})
+                with (
+                    patch.object(sync, "one_cycle", side_effect=sync.DiskPressure("low")),
+                    patch.object(sync, "stop_service"),
+                    patch.object(sync, "safe_wipe_state"),
+                    patch.object(sync, "cleanup_retention", side_effect=sync.ControllerError("upload failed")),
+                    patch.object(sync, "post_slack", return_value=False) as post,
+                ):
+                    self.assertEqual(sync.run_loop(config, Path("unused")), 1)
+                self.assertTrue(sync.load_state(state_path)["failed"])
+                self.assertIn("upload failed", sync.load_state(state_path)["failure"])
+                post.assert_called_once()
+
+    def test_archive_rejects_symlink_before_upload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "run"
+            run_dir.mkdir()
+            (run_dir / "traces").symlink_to(root / "missing")
+            config = make_config(root, policy=sync.Policy(archive_traces=True))
+            with self.assertRaisesRegex(sync.ControllerError, "symlink"):
+                sync.archive_traces(config, run_dir, {})
+
     def test_archive_requires_expiration_and_preserves_traces(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -58,6 +58,21 @@ class ContinuousSyncTests(unittest.TestCase):
                 self.assertIn("upload failed", sync.load_state(state_path)["failure"])
                 post.assert_called_once()
 
+    def test_archive_preflight_rejects_missing_configuration_and_expiration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))
+            config.paths.repo_dir.mkdir()
+            config.paths.config_template.write_text("")
+            config.paths.wipe_sentinel.write_text("")
+            with patch.object(sync.shutil, "which", return_value="/usr/bin/tool"), patch.dict(os.environ, {}, clear=True):
+                with self.assertRaisesRegex(sync.ControllerError, "ZAKURA_TRACE_SPACE"):
+                    sync.preflight(config)
+                with patch.dict(os.environ, {"ZAKURA_TRACE_SPACE": "test",
+                                            "ZAKURA_TRACE_ENDPOINT": "https://nyc3.digitaloceanspaces.com"}), patch.object(
+                        sync, "run", return_value=subprocess.CompletedProcess([], 0, '{"Rules":[]}')):
+                    with self.assertRaisesRegex(sync.ControllerError, "seven-day"):
+                        sync.preflight(config)
+
     def test_archive_rejects_symlink_before_upload(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/deploy/continuous-sync/tests/test_daily_summary.py
+++ b/deploy/continuous-sync/tests/test_daily_summary.py
@@ -70,6 +70,26 @@ class DailySummaryTests(unittest.TestCase):
         _, post = self.deliver(self.due + 60)
         post.assert_not_called()
 
+    def test_daily_report_keeps_each_unreported_archive_link_on_retry(self):
+        data = self.data(4)
+        controller = data["controller_state"]
+        for item in controller["completion_history"]:
+            item["trace_archive_url"] = f"https://traces.invalid/run{item['number']}?signature=test&expires=604800"
+        controller["last_success_trace_archive_url"] = controller["completion_history"][-1]["trace_archive_url"]
+        before = self.path.read_text()
+        with self.assertRaisesRegex(deploy.DeployError, "delivery failed"):
+            self.deliver(self.due, posted=False, statuses={"node": data})
+        self.assertEqual(self.path.read_text(), before)
+        _, post = self.deliver(self.due + 60, statuses={"node": data})
+        text = post.call_args.args[0]
+        self.assertIn("2 completed", text)
+        for number in (3, 4):
+            self.assertIn(f"<https://traces.invalid/run{number}?signature=test&expires=604800|Download traces (7 days)>", text)
+        self.assertNotIn("traces.invalid/run2", text)
+        self.assertLess(text.index("traces.invalid/run3"), text.index("traces.invalid/run4"))
+        _, post = self.deliver(self.due + 86400, statuses={"node": data})
+        self.assertNotIn("Download traces", post.call_args.args[0])
+
     def test_spring_and_fall_dst_keep_five_pm_local(self):
         for deadline in ["2026-03-08T00:00:00+00:00", "2026-03-08T23:00:00+00:00",
                          "2026-10-31T23:00:00+00:00", "2026-11-02T00:00:00+00:00"]:


### PR DESCRIPTION
## Motivation
Sync retention can delete diagnostics before operators download them.

## Solution
Stream gzip tar archives to DigitalOcean Spaces after the node stops and before another run starts. Require a seven-day lifecycle rule. Include private download links in completion digests and failure alerts. Preserve local traces and halt on upload failure. Archive older stopped runs before retention removes them.

Report archive failures during disk recovery through the normal halt and alert path. Reject symlinked trace directories before upload. Publish the in-memory archive marker only after writing its metadata. Check archive tools during preflight.

New deployments enable archival. The README documents AWS CLI installation, credentials, Space configuration, and lifecycle setup. No live deployment or Slack message was sent.

## Testing
119 continuous-sync tests completed (2 skipped), including real tar/gzip streaming through a mocked upload and rejection of a missing expiration rule, symlink rejection, and failure reporting during initial and restarted disk recovery. Live Spaces integration remains untested.
