### PR TITLE
fix(ops): clear local traces after each archived sync run

### DIFF
--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -488,7 +488,8 @@ See [Spaces lifecycle rules](https://docs.digitalocean.com/products/spaces/how-t
 and [private download links](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/).
 
 The controller deletes each local `traces` directory after persisting the archive
-URL in `run.json`. It keeps run metadata and logs under the existing retention
+URL in `run.json`. It syncs the metadata file and directory before deletion.
+It keeps run metadata and logs under the existing retention
 policy. Cleanup also removes trace payloads from previously archived runs,
 including the protected latest failed run. A failed upload preserves the traces.
 Cleanup retries after a controller restart if deletion did not finish.

--- a/deploy/continuous-sync/README.md
+++ b/deploy/continuous-sync/README.md
@@ -486,3 +486,9 @@ The lifecycle rule also removes abandoned multipart uploads after one day.
 
 See [Spaces lifecycle rules](https://docs.digitalocean.com/products/spaces/how-to/configure-lifecycle-rules/)
 and [private download links](https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/).
+
+The controller deletes each local `traces` directory after persisting the archive
+URL in `run.json`. It keeps run metadata and logs under the existing retention
+policy. Cleanup also removes trace payloads from previously archived runs,
+including the protected latest failed run. A failed upload preserves the traces.
+Cleanup retries after a controller restart if deletion did not finish.

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -675,6 +675,14 @@ def clear_archived_traces(run_dir: Path) -> None:
     if traces.is_symlink():
         raise ControllerError(f"refusing to remove symlinked traces: {traces}")
     if traces.exists():
+        # Make the archive record durable before deleting its local payload.
+        with (run_dir / "run.json").open("rb") as metadata:
+            os.fsync(metadata.fileno())
+        directory_fd = os.open(run_dir, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
         shutil.rmtree(traces)
 
 

--- a/deploy/continuous-sync/continuous-sync.py
+++ b/deploy/continuous-sync/continuous-sync.py
@@ -613,7 +613,10 @@ def wait_for_completion(
 
 def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> None:
     """Upload stopped-node traces before the controller can start another run."""
-    if not config.policy.archive_traces or run_state.get("trace_archive_url"):
+    if not config.policy.archive_traces:
+        return
+    if run_state.get("trace_archive_url"):
+        clear_archived_traces(run_dir)
         return
     traces = run_dir / "traces"
     if traces.is_symlink():
@@ -663,6 +666,16 @@ def archive_traces(config: Config, run_dir: Path, run_state: dict[str, Any]) -> 
     archived_state = dict(run_state, trace_archive_url=url, trace_archive_key=key)
     write_run_json(run_dir, archived_state)
     run_state.update(archived_state)
+    clear_archived_traces(run_dir)
+
+
+def clear_archived_traces(run_dir: Path) -> None:
+    """Remove trace payloads after their archive metadata reaches disk."""
+    traces = run_dir / "traces"
+    if traces.is_symlink():
+        raise ControllerError(f"refusing to remove symlinked traces: {traces}")
+    if traces.exists():
+        shutil.rmtree(traces)
 
 
 def trace_download_text(run_state: dict[str, Any]) -> str:

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -108,6 +108,49 @@ class ContinuousSyncTests(unittest.TestCase):
             self.assertIn("https://download", deploy.completion_run_text(state))
             self.assertFalse((run_dir / "traces").exists())
 
+    def test_archive_failures_preserve_payload_and_allow_retry(self):
+        lifecycle = '{"Rules":[{"Status":"Enabled","Prefix":"sync-traces/","Expiration":{"Days":7}}]}'
+        for failure in ("upload", "metadata", "fsync", "delete"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                config = make_config(root, policy=sync.Policy(archive_traces=True))
+                run_dir = root / "run"
+                traces = run_dir / "traces"
+                traces.mkdir(parents=True)
+                (traces / "events.csv").write_text("event\ntest\n")
+                state = {}
+                def upload(cmd, **kwargs):
+                    kwargs["stdin"].read()
+                    return subprocess.CompletedProcess(cmd, 1 if failure == "upload" else 0)
+                with contextlib.ExitStack() as stack:
+                    stack.enter_context(patch.dict(os.environ, {
+                        "ZAKURA_TRACE_SPACE": "test",
+                        "ZAKURA_TRACE_ENDPOINT": "https://nyc3.digitaloceanspaces.com",
+                    }))
+                    stack.enter_context(patch.object(sync, "run", side_effect=[
+                        subprocess.CompletedProcess([], 0, lifecycle),
+                        subprocess.CompletedProcess([], 0, "https://download"),
+                    ]))
+                    stack.enter_context(patch.object(sync.subprocess, "run", side_effect=upload))
+                    if failure == "metadata":
+                        stack.enter_context(patch.object(sync, "write_run_json", side_effect=OSError("write failed")))
+                    elif failure == "fsync":
+                        stack.enter_context(patch.object(sync.os, "fsync", side_effect=OSError("sync failed")))
+                    elif failure == "delete":
+                        stack.enter_context(patch.object(sync.shutil, "rmtree", side_effect=OSError("delete failed")))
+                    with self.assertRaises((OSError, sync.ControllerError)):
+                        sync.archive_traces(config, run_dir, state)
+                self.assertTrue((traces / "events.csv").exists())
+                if failure in ("upload", "metadata"):
+                    self.assertNotIn("trace_archive_url", state)
+                else:
+                    persisted = json.loads((run_dir / "run.json").read_text())
+                    self.assertEqual(persisted["trace_archive_url"], "https://download")
+                    with patch.object(sync, "run") as command:
+                        sync.archive_traces(config, run_dir, persisted)
+                        command.assert_not_called()
+                    self.assertFalse(traces.exists())
+
     def test_archived_trace_cleanup_retries_without_uploading(self):
         with tempfile.TemporaryDirectory() as tmp:
             config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))

--- a/deploy/continuous-sync/tests/test_continuous_sync.py
+++ b/deploy/continuous-sync/tests/test_continuous_sync.py
@@ -106,7 +106,32 @@ class ContinuousSyncTests(unittest.TestCase):
                 self.assertEqual(archive.extractfile("traces/events.csv").read(), b"event\ntest\n")
             self.assertEqual(state["trace_archive_url"], "https://download")
             self.assertIn("https://download", deploy.completion_run_text(state))
-            self.assertTrue((run_dir / "traces" / "events.csv").exists())
+            self.assertFalse((run_dir / "traces").exists())
+
+    def test_archived_trace_cleanup_retries_without_uploading(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = make_config(Path(tmp), policy=sync.Policy(archive_traces=True))
+            run_dir = Path(tmp) / "run"
+            (run_dir / "traces").mkdir(parents=True)
+            (run_dir / "traces" / "old.csv").write_text("old data")
+            (run_dir / "run.json").write_text("{}")
+            with patch.object(sync, "run") as command:
+                sync.archive_traces(config, run_dir, {"trace_archive_url": "https://download"})
+                command.assert_not_called()
+            self.assertFalse((run_dir / "traces").exists())
+            self.assertTrue((run_dir / "run.json").exists())
+
+    def test_trace_cleanup_rejects_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_dir = root / "run"
+            run_dir.mkdir()
+            target = root / "unrelated"
+            target.mkdir()
+            (run_dir / "traces").symlink_to(target)
+            with self.assertRaisesRegex(sync.ControllerError, "symlink"):
+                sync.clear_archived_traces(run_dir)
+            self.assertTrue(target.exists())
 
     def test_failure_audit_preserves_archive_link(self):
         problem = deploy.audit_problem({"controller_state": {


### PR DESCRIPTION
## Motivation
Run retention keeps trace payloads alongside metadata, including the protected latest failed run. Those payloads can consume hundreds of gigabytes.

## Solution
Delete local traces as soon as the controller persists a confirmed archive URL and syncs the metadata file and directory to disk. Retry interrupted cleanup without uploading again. Keep run metadata and logs. Reject symlinked trace directories.

Depends on #963; this PR targets its branch.

## Testing
122 continuous-sync tests completed (2 skipped). Tests verify deletion after upload, preservation when archival fails, retry behavior, metadata retention, symlink rejection, and preservation through upload, metadata-write, fsync, and deletion failures.
