### PR TITLE
fix(network): advertise retained block bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8147,7 +8147,7 @@ dependencies = [
 
 [[package]]
 name = "zakura-state"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "bincode",
  "chrono",

--- a/crates/zakura-consensus/Cargo.toml
+++ b/crates/zakura-consensus/Cargo.toml
@@ -71,7 +71,7 @@ tower-fallback = { package = "zakura-tower-fallback", path = "../tower-fallback/
 tower-batch-control = { package = "zakura-tower-batch-control", path = "../tower-batch-control/", version = "1.3.0" }
 
 zakura-script = { path = "../zakura-script", version = "3.2.3" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
+zakura-state = { path = "../zakura-state", version = "8.1.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.4" }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0" }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.1.0" }
@@ -96,7 +96,7 @@ toml = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "8.1.0", features = ["proptest-impl"] }
 zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["proptest-impl"] }
 zakura-test = { path = "../zakura-test/", version = "2.1.0" }
 

--- a/crates/zakura-network/src/zakura/block_sync/README.md
+++ b/crates/zakura-network/src/zakura/block_sync/README.md
@@ -48,9 +48,10 @@ there stops before the pruned gap.
 Incoming status changes allow one extra range update per rate-limit window.
 Further range changes are coalesced and applied when the window expires, even
 if no new message arrives. Status replies remain rate limited.
-Each peer tracks the last status queued on its ordered stream. Ordinary range
-growth uses the configured refresh interval. Contractions have a separate window
-of at most one second, so pruning does not wait behind a tip-growth advertisement.
+Each peer tracks the last status queued on its ordered stream. Changes that raise
+the lower bound or reduce the upper bound use a separate window of at most one
+second, including when pruning and tip growth happen together. All other changes
+use the configured refresh interval, so pruning does not wait behind tip-only growth.
 Further changes coalesce into the latest range. Full queues back off for at most
 100 ms without consuming a range-change allowance. One deadline calculation schedules
 range changes, queue retries, and incomplete status exchanges.

--- a/crates/zakura-network/src/zakura/block_sync/README.md
+++ b/crates/zakura-network/src/zakura/block_sync/README.md
@@ -35,6 +35,39 @@ The distinction matters: anything anchored to the download floor is self-propell
 (downloading moves the floor, which permits more downloading),
 while anything anchored to the verified tip is pinned until real progress commits.
 
+## Retained serving range
+
+Native block-sync status advertises the range of retained, verified block bodies.
+The node initializes its lower bound from the persisted pruning marker. Storage
+publishes each new floor after the durable write and before the corresponding tip,
+so even a tip notification handled first uses the current floor. Archive nodes
+advertise from height zero. Requests for pruned heights return `RangeUnavailable`
+without querying storage. Genesis remains servable separately, and a request starting
+there stops before the pruned gap.
+
+Incoming status changes allow one extra range update per rate-limit window.
+Further range changes are coalesced and applied when the window expires, even
+if no new message arrives. Status replies remain rate limited.
+Each peer tracks the last status queued on its ordered stream. Ordinary range
+growth uses the configured refresh interval. Contractions have a separate window
+of at most one second, so pruning does not wait behind a tip-growth advertisement.
+Further changes coalesce into the latest range. Full queues back off for at most
+100 ms without consuming a range-change allowance. One deadline calculation schedules
+range changes, queue retries, and incomplete status exchanges.
+
+Checkpoint retention can put the lower bound above the verified tip. Until retained
+bodies reach that height, the node advertises only genesis, which is always retained.
+This storage boundary does not advance the node's download floor or discard blocks
+it still needs from other peers. Embedders using pruned state should pass its retained
+height watch in `ZakuraHeaderSyncDriverStartup`, which every production endpoint
+initializer forwards. Direct reactor users attach it with
+`BlockSyncStartup::with_retention`.
+
+Advertisements describe current availability and do not reserve block bodies.
+A request already in flight can overlap pruning before its database read. That
+pre-existing race can still return `RangeUnavailable`; preventing it requires a
+separate serving/read reservation contract.
+
 ## The two lanes: Floor vs AboveFloor
 
 `RequestPriority` classifies a request by its start height

--- a/crates/zakura-network/src/zakura/block_sync/config.rs
+++ b/crates/zakura-network/src/zakura/block_sync/config.rs
@@ -161,7 +161,8 @@ pub enum CwndUnit {
 /// Block-sync peer status advertisement.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct BlockSyncStatus {
-    /// Earliest block body this peer can serve.
+    /// Lower bound of the contiguous advertised body range.
+    /// Separately retained genesis may also be served below this bound.
     pub servable_low: block::Height,
     /// Highest contiguous verified block body this peer can serve.
     pub servable_high: block::Height,

--- a/crates/zakura-network/src/zakura/block_sync/mod.rs
+++ b/crates/zakura-network/src/zakura/block_sync/mod.rs
@@ -47,6 +47,7 @@ mod sequencer;
 mod sequencer_task;
 mod service;
 mod state;
+mod status;
 #[cfg(test)]
 mod tests;
 mod trace;

--- a/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
+++ b/crates/zakura-network/src/zakura/block_sync/peer_routine.rs
@@ -290,10 +290,12 @@ pub(super) struct PeerRoutine {
     /// The reply decision is routine-local; the actual send stays reactor-side via
     /// `RoutineToReactor::StatusReceived`.
     status_reply_meter: super::state::RateMeter,
-    /// Rate meter gating how often this peer's `Status` frames are applied at all,
-    /// so a status flood cannot spin the routine. A status that grows the servable
-    /// range bypasses the meter.
+    /// Rate meter for status application, with one extra range change per window.
     inbound_status_meter: super::state::RateMeter,
+    /// Allows one immediate range change without permitting an unbounded bypass.
+    status_range_bypass_available: bool,
+    /// Latest deferred range change. Applying it on a timer preserves one-shot updates.
+    pending_status: Option<BlockSyncStatus>,
     /// Heights this routine recently returned on a failure, mapped to the instant
     /// after which it may re-take them. While avoided, the routine leaves the
     /// height `pending` (contestable by any other peer) but does not re-grab it
@@ -390,6 +392,8 @@ impl PeerRoutine {
             max_response_bytes,
             status_reply_meter,
             inbound_status_meter,
+            status_range_bypass_available: false,
+            pending_status: None,
             retry_avoid: BTreeMap::new(),
             fill_stop_trace_at: BTreeMap::new(),
             generation,
@@ -462,6 +466,7 @@ impl PeerRoutine {
             Notified::enable(capacity.as_mut());
             Notified::enable(available.as_mut());
 
+            self.flush_pending_status();
             let retry_filter_deadline = if self.session.outbound_capacity() > 0 {
                 self.try_fill().await
             } else {
@@ -655,16 +660,23 @@ impl PeerRoutine {
             return;
         }
         let now = Instant::now();
-        // A status is applied if the rate meter allows it OR it grows our servable
-        // range (so a peer that just extended its range is never throttled out).
-        let grows =
-            status.servable_high > self.servable_high || status.servable_low < self.servable_low;
-        if !self.inbound_status_meter.try_take(now) && !grows {
+        let range_changed =
+            status.servable_high != self.servable_high || status.servable_low != self.servable_low;
+        if self.inbound_status_meter.try_take(now) {
+            self.status_range_bypass_available = true;
+        } else if range_changed && self.status_range_bypass_available {
+            // Allow prompt pruning updates, but only once per window so a peer
+            // cannot flood registry/reactor work by oscillating its range.
+            self.status_range_bypass_available = false;
+        } else {
+            // Keep only the latest changed range. A return to the applied range
+            // cancels an older pending change without causing a status reply loop.
+            self.pending_status = range_changed.then_some(status);
             return;
         }
-        // The reply is best-effort: if both the connect-time Status and this
-        // first reply are dropped by a full outbound queue, recovery depends on
-        // the remote's later Status retry arriving after this meter reopens.
+        self.pending_status = None;
+        // Replies have their own allowance. The reactor also retries any local
+        // status that has not entered this peer's outbound queue.
         let send_reply = self.status_reply_meter.try_take(now);
         self.received_status = true;
         self.servable_low = status.servable_low;
@@ -690,6 +702,15 @@ impl PeerRoutine {
                 peer: self.peer.clone(),
                 send_reply,
             });
+    }
+
+    fn flush_pending_status(&mut self) {
+        if !self.inbound_status_meter.is_ready(Instant::now()) {
+            return;
+        }
+        if let Some(status) = self.pending_status.take() {
+            self.handle_status(status);
+        }
     }
 
     /// React to a committed-view change: refresh the floor/tip the routine reads,
@@ -746,8 +767,8 @@ impl PeerRoutine {
 
     /// Sleep future resolving at the earliest wake the routine schedules for
     /// itself: the soonest outstanding request deadline (own-timeout), block
-    /// liveness deadline, **or** the soonest retry-avoid expiry (local failure bias
-    /// or registry-owned floor-watchdog hard exclude), so a routine that quiet-returned
+    /// liveness deadline, pending status refresh, or the soonest retry-avoid expiry
+    /// (local failure bias or registry-owned floor-watchdog hard exclude), so a routine that quiet-returned
     /// its only work re-runs want-work once the bias lifts even if no external event
     /// arrives. Defaults to a long idle sleep when none exists.
     fn earliest_deadline_sleep(&self, retry_filter_deadline: Option<Instant>) -> time::Sleep {
@@ -769,6 +790,8 @@ impl PeerRoutine {
             floor_watchdog_avoid,
             body_retry_avoid,
             retry_filter_deadline,
+            self.pending_status
+                .map(|_| self.inbound_status_meter.next_allowed),
         ]
         .into_iter()
         .flatten()
@@ -2302,8 +2325,12 @@ mod tests {
     use super::super::sequencer_task::initial_view;
     use super::super::state::{ByteBudget, ThroughputMeter};
     use super::super::work_queue::WorkQueue;
-    use super::super::{BlockSyncFrontiers, BlockSyncPeerSession, ZakuraBlockSyncConfig};
+    use super::super::{
+        BlockSyncFrontiers, BlockSyncMessage, BlockSyncPeerSession, BlockSyncStatus,
+        ZakuraBlockSyncConfig,
+    };
     use super::PeerRoutine;
+    use super::RoutineToReactor;
     use crate::zakura::framed_channel;
     use crate::zakura::trace::ZakuraTrace;
     use crate::zakura::ZakuraPeerId;
@@ -2315,6 +2342,242 @@ mod tests {
             .take_while(|allowed| **allowed)
             .count();
         Some(start..start + len)
+    }
+
+    fn status_test_routine() -> (
+        PeerRoutine,
+        crate::zakura::FramedRecv,
+        mpsc::Receiver<RoutineToReactor>,
+    ) {
+        let config = ZakuraBlockSyncConfig::default();
+        let peer = ZakuraPeerId::new(vec![7u8; 32]).expect("test peer id is within bounds");
+        let cancel = CancellationToken::new();
+        let (out_send, out_recv) = framed_channel(16);
+        let (_in_send, in_recv) = framed_channel(16);
+        let session = BlockSyncPeerSession::for_test(peer.clone(), out_send, cancel.clone());
+        let registry = Arc::new(PeerRegistry::new());
+        let generation = registry
+            .admit_session(&peer, session.direction(), &config, 0, Instant::now())
+            .generation();
+        let work = Arc::new(WorkQueue::new(block::Height(0)));
+        let (sequencer_input_tx, _sequencer_input_rx) = mpsc::channel(16);
+        let (routine_to_reactor_tx, routine_to_reactor_rx) = mpsc::channel(16);
+        let (_view_tx, view_rx) = watch::channel(initial_view(BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        }));
+        let routine = PeerRoutine::new(
+            peer.clone(),
+            0,
+            session,
+            in_recv,
+            config.clone(),
+            true,
+            generation,
+            ByteBudget::new(config.max_inflight_block_bytes),
+            Arc::clone(&work),
+            Arc::clone(&registry),
+            Arc::new(Mutex::new(ThroughputMeter::new(Instant::now()))),
+            sequencer_input_tx,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            routine_to_reactor_tx,
+            view_rx,
+            cancel,
+            ZakuraTrace::noop(),
+        );
+        (routine, out_recv, routine_to_reactor_rx)
+    }
+
+    #[tokio::test]
+    async fn status_flood_cannot_republish_ranges_or_caps_without_a_bound() {
+        let (mut routine, _outbound, mut reactor_events) = status_test_routine();
+        let mut status = BlockSyncStatus {
+            servable_low: block::Height(1),
+            servable_high: block::Height(3),
+            tip_hash: block::Hash([3; 32]),
+            max_blocks_per_response: routine.config.advertised_max_blocks_per_response(),
+            max_inflight_requests: routine.config.advertised_max_inflight_requests(),
+            max_response_bytes: routine.config.advertised_max_response_bytes(),
+        };
+        routine.handle_status(status);
+        let _ = reactor_events
+            .try_recv()
+            .expect("initial status is published");
+        let next_allowed = Instant::now() + Duration::from_secs(60);
+        routine.inbound_status_meter.next_allowed = next_allowed;
+        routine.status_reply_meter.next_allowed = next_allowed;
+
+        status.servable_low = block::Height(2);
+        routine.handle_status(status);
+        assert!(matches!(
+            reactor_events.try_recv(),
+            Ok(RoutineToReactor::StatusReceived {
+                send_reply: false,
+                ..
+            })
+        ));
+        let immediate_range = routine.registry.candidate_snapshot();
+        let immediate_caps = routine.max_response_bytes;
+        status.max_response_bytes /= 2;
+        for (low, high) in [(1, 3), (2, 4), (0, 0), (3, 3)]
+            .into_iter()
+            .cycle()
+            .take(256)
+        {
+            status.servable_low = block::Height(low);
+            status.servable_high = block::Height(high);
+            routine.handle_status(status);
+            assert!(
+                reactor_events.try_recv().is_err(),
+                "range oscillation must not bypass the meter indefinitely"
+            );
+            assert_eq!(routine.registry.candidate_snapshot(), immediate_range);
+            assert_eq!(routine.max_response_bytes, immediate_caps);
+        }
+        routine.flush_pending_status();
+        assert!(reactor_events.try_recv().is_err());
+
+        routine.inbound_status_meter.next_allowed = Instant::now();
+        routine.flush_pending_status();
+        assert_eq!(
+            (routine.servable_low, routine.servable_high),
+            (block::Height(3), block::Height(3)),
+            "the final range must apply after the window opens"
+        );
+        assert_eq!(routine.max_response_bytes, status.max_response_bytes);
+        assert!(matches!(
+            reactor_events.try_recv(),
+            Ok(RoutineToReactor::StatusReceived {
+                send_reply: false,
+                ..
+            })
+        ));
+
+        // A newer return to the applied range must cancel an older deferred change.
+        routine.inbound_status_meter.next_allowed = next_allowed;
+        status.servable_low = block::Height(1);
+        routine.handle_status(status);
+        let _ = reactor_events
+            .try_recv()
+            .expect("one new bypass is available");
+        status.servable_low = block::Height(2);
+        routine.handle_status(status);
+        status.servable_low = block::Height(1);
+        routine.handle_status(status);
+        routine.inbound_status_meter.next_allowed = Instant::now();
+        routine.flush_pending_status();
+        assert!(reactor_events.try_recv().is_err());
+        assert_eq!(routine.servable_low, block::Height(1));
+    }
+
+    #[tokio::test]
+    async fn status_range_changes_bypass_throttle_without_extra_replies() {
+        let (mut routine, mut out_recv, mut routine_to_reactor_rx) = status_test_routine();
+        let config = routine.config.clone();
+        let work = Arc::clone(&routine.work);
+        let registry = Arc::clone(&routine.registry);
+        let peer = routine.peer.clone();
+        let mut status = BlockSyncStatus {
+            servable_low: block::Height(1),
+            servable_high: block::Height(3),
+            tip_hash: block::Hash([3; 32]),
+            max_blocks_per_response: config.advertised_max_blocks_per_response(),
+            max_inflight_requests: config.advertised_max_inflight_requests(),
+            max_response_bytes: config.advertised_max_response_bytes(),
+        };
+        routine.handle_status(status);
+        assert!(matches!(
+            routine_to_reactor_rx.try_recv(),
+            Ok(RoutineToReactor::StatusReceived {
+                send_reply: true,
+                ..
+            })
+        ));
+
+        // Keep both windows closed without depending on the test's runtime speed.
+        let next_allowed = Instant::now() + Duration::from_secs(60);
+        routine.inbound_status_meter.next_allowed = next_allowed;
+        routine.status_reply_meter.next_allowed = next_allowed;
+        for (index, (low, high)) in [(2, 3), (1, 3), (1, 2), (1, 3), (0, 3), (0, 0), (2, 3)]
+            .into_iter()
+            .enumerate()
+        {
+            if index > 0 {
+                routine.inbound_status_meter.next_allowed = Instant::now();
+                routine.handle_status(status);
+                let _ = routine_to_reactor_rx
+                    .try_recv()
+                    .expect("new status window opens");
+                routine.inbound_status_meter.next_allowed = next_allowed;
+            }
+            status.servable_low = block::Height(low);
+            status.servable_high = block::Height(high);
+            routine.handle_status(status);
+            assert_eq!(
+                (routine.servable_low, routine.servable_high),
+                (status.servable_low, status.servable_high),
+                "range changes must apply while the inbound meter is closed"
+            );
+            assert_eq!(
+                registry.candidate_snapshot(),
+                vec![(
+                    peer.clone(),
+                    true,
+                    status.servable_low,
+                    status.servable_high
+                )]
+            );
+            assert!(matches!(
+                routine_to_reactor_rx.try_recv(),
+                Ok(RoutineToReactor::StatusReceived {
+                    send_reply: false,
+                    ..
+                })
+            ));
+        }
+
+        let old_response_bytes = routine.max_response_bytes;
+        status.max_response_bytes /= 2;
+        routine.handle_status(status);
+        assert_eq!(routine.max_response_bytes, old_response_bytes);
+        assert!(
+            routine_to_reactor_rx.try_recv().is_err(),
+            "unchanged ranges must still be rate limited"
+        );
+
+        work.extend(
+            super::super::test_work_scope(),
+            [
+                (
+                    block::Height(1),
+                    block::Hash([1; 32]),
+                    BlockSizeEstimate::Advertised(1_000),
+                ),
+                (
+                    block::Height(2),
+                    block::Hash([2; 32]),
+                    BlockSizeEstimate::Advertised(1_000),
+                ),
+            ],
+        );
+        let _ = routine.try_fill().await;
+        let frame = timeout(Duration::from_secs(5), out_recv.recv())
+            .await
+            .expect("retained block request is sent")
+            .expect("outbound stream remains open");
+        assert!(matches!(
+            BlockSyncMessage::decode_frame(frame).expect("request decodes"),
+            BlockSyncMessage::GetBlocks {
+                start_height: block::Height(2),
+                count: 1,
+            }
+        ));
+        assert!(
+            work.pending_contains(block::Height(1)),
+            "the pruned block must remain available for another peer"
+        );
     }
 
     #[test]

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -1926,19 +1926,17 @@ impl BlockSyncReactor {
         now: Instant,
         reason: &'static str,
     ) -> bool {
-        let Some(peer_state) = self.state.peers.get(peer) else {
+        let Some(peer_state) = self.state.peers.get_mut(peer) else {
             return false;
         };
         let msg = BlockSyncMessage::Status(status);
         let started = Instant::now();
         let session = peer_state.session.clone();
         let result = session.try_send_status(status);
-        if let Some(peer_state) = self.state.peers.get_mut(peer) {
-            match &result {
-                Ok(()) => peer_state.status_delivery.queued(status, now),
-                Err(OrderedSendError::Full) => peer_state.status_delivery.queue_full(now),
-                Err(_) => {}
-            }
+        match &result {
+            Ok(()) => peer_state.status_delivery.queued(status, now),
+            Err(OrderedSendError::Full) => peer_state.status_delivery.queue_full(now),
+            Err(_) => {}
         }
         match result {
             Ok(()) => {

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -494,16 +494,15 @@ impl BlockSyncReactor {
                     }
                 }
                 changed = async {
-                    match retained_height.as_mut() {
-                        Some(retained_height) => retained_height.changed().await,
-                        None => std::future::pending().await,
-                    }
+                    let Some(retained_height) = retained_height.as_mut() else {
+                        return std::future::pending().await;
+                    };
+                    retained_height.changed().await
                 }, if retention_open => {
-                    if changed.is_ok() {
+                    // Preserve the final floor if the state writer shuts down.
+                    retention_open = changed.is_ok();
+                    if retention_open {
                         self.flush_status_refresh();
-                    } else {
-                        // Preserve the final floor if the state writer shuts down.
-                        retention_open = false;
                     }
                 }
                 changed = self.sequencer_view.changed() => {

--- a/crates/zakura-network/src/zakura/block_sync/reactor.rs
+++ b/crates/zakura-network/src/zakura/block_sync/reactor.rs
@@ -119,6 +119,7 @@ pub fn spawn_block_sync_reactor(
     mpsc::Receiver<BlockSyncAction>,
     JoinHandle<()>,
 ) {
+    let body_retention = startup.body_retention.clone();
     debug_assert!(
         !startup.state_queries_enabled
             || startup.committed_views.is_some()
@@ -139,6 +140,10 @@ pub fn spawn_block_sync_reactor(
     }
 
     let state = BlockSyncState::new(&startup);
+    let mut local_status = state.local_status(&startup.config);
+    if let Some(retention) = &body_retention {
+        local_status = retention.apply(local_status);
+    }
     let (events_tx, events_rx) =
         mpsc::channel(startup.config.peer_limits.inbound_queue_depth.max(1));
     let events_keepalive = events_tx.clone();
@@ -157,7 +162,7 @@ pub fn spawn_block_sync_reactor(
         .saturating_add(BS_ACTION_SPARE_POOL);
     let (actions_tx, actions_rx) = mpsc::channel(actions_capacity);
     let (peers_tx, peers_rx) = watch::channel(state.peer_snapshot(startup.config.peer_limits));
-    let (status_tx, status_rx) = watch::channel(state.last_advertised_status);
+    let (status_tx, status_rx) = watch::channel(local_status);
     let (candidates_tx, candidates_rx) = watch::channel(ZakuraBlockSyncCandidateState::default());
 
     // The Sequencer (commit pipeline) and the committed-throughput meter move out
@@ -257,6 +262,8 @@ pub fn spawn_block_sync_reactor(
         routine_wiring: Some(routine_wiring),
     };
     let reactor = BlockSyncReactor {
+        body_retention,
+        status_refresh_at: None,
         verified_block_tip: startup.frontiers.verified_block_tip,
         request_floor: startup.frontiers.verified_block_tip,
         pending_needed_query: None,
@@ -302,6 +309,9 @@ pub fn spawn_block_sync_reactor(
 
 #[derive(Debug)]
 pub(super) struct BlockSyncReactor {
+    body_retention: Option<BodyRetention>,
+    /// Earliest pending status delivery, rebuilt after delivery state changes.
+    status_refresh_at: Option<Instant>,
     startup: BlockSyncStartup,
     state: BlockSyncState,
     /// Latest atomic header-engine view used to stamp body-work ownership.
@@ -399,17 +409,16 @@ impl BlockSyncReactor {
         let mut header_tip = self.startup.header_tip.clone();
         let mut header_tip_open = header_tip.is_some();
         let mut committed_views = self.startup.committed_views.clone();
+        let mut retained_height = self
+            .body_retention
+            .as_ref()
+            .map(|retention| retention.retained_height.clone());
+        let mut retention_open = retained_height.is_some();
         set_block_reactor_active_connection_gauge(self.state.peers.len());
         // Per-peer request timeouts are owned by the routines. This local tick
         // also retries the level-triggered needed-body query, so a lost routine
         // notification or a full action queue cannot consume the refill need.
         let mut metrics_ticks = time::interval(self.startup.config.request_timeout);
-        let mut status_ticks = time::interval(
-            self.startup
-                .config
-                .status_refresh_interval
-                .max(Duration::from_millis(1)),
-        );
 
         self.query_needed_blocks().await;
         self.publish_metrics();
@@ -427,6 +436,14 @@ impl BlockSyncReactor {
             tokio::pin!(empty_state_header_quiet);
             let needed_query_retry = self.needed_query_retry_sleep();
             tokio::pin!(needed_query_retry);
+            let status_refresh_at = self.status_refresh_at;
+            let status_refresh = async move {
+                match status_refresh_at {
+                    Some(deadline) => time::sleep_until(deadline.into()).await,
+                    None => std::future::pending().await,
+                }
+            };
+            tokio::pin!(status_refresh);
             tokio::select! {
                 _ = self.startup.shutdown.cancelled() => break,
                 event = self.lifecycle.recv() => {
@@ -476,6 +493,19 @@ impl BlockSyncReactor {
                         Err(_) => header_tip_open = false,
                     }
                 }
+                changed = async {
+                    match retained_height.as_mut() {
+                        Some(retained_height) => retained_height.changed().await,
+                        None => std::future::pending().await,
+                    }
+                }, if retention_open => {
+                    if changed.is_ok() {
+                        self.flush_status_refresh();
+                    } else {
+                        // Preserve the final floor if the state writer shuts down.
+                        retention_open = false;
+                    }
+                }
                 changed = self.sequencer_view.changed() => {
                     match changed {
                         Ok(()) => {
@@ -511,7 +541,7 @@ impl BlockSyncReactor {
                     self.refresh_throughput();
                     self.trace_sync_state(true);
                 }
-                _ = status_ticks.tick() => self.flush_status_refresh().await,
+                _ = &mut status_refresh => self.flush_status_refresh(),
                 _ = &mut floor_watchdog => {
                     self.run_floor_watchdog(Instant::now());
                     self.publish_metrics();
@@ -791,7 +821,8 @@ impl BlockSyncReactor {
         self.trace_peer_connected(&peer, direction, self.state.peers.len());
         self.publish_peer_snapshot();
         self.publish_candidate_state();
-        self.send_status_and_mark_refresh(&peer, "peer_connected", Instant::now());
+        self.send_status(&peer, self.local_status(), Instant::now(), "peer_connected");
+        self.flush_status_refresh();
         // The routine fills its own slots; it begins want-work as soon as it has
         // a status and work.
     }
@@ -811,6 +842,7 @@ impl BlockSyncReactor {
         }
         self.registry.remove(&peer);
         self.state.parked_peers.remove(&peer);
+        self.flush_status_refresh();
         self.publish_peer_snapshot();
         self.publish_candidate_state();
     }
@@ -1053,7 +1085,6 @@ impl BlockSyncReactor {
         // read-only control inputs; updating them is cheap and idempotent.
         let reset_advanced = view.reset_epoch != self.last_reset_epoch;
         let reaction_advanced = view.reaction_epoch != self.last_reaction_epoch;
-        let old_serving_tip = (self.state.servable_high, self.state.servable_hash);
         let tip_advanced = view.verified_tip > self.verified_block_tip;
 
         if view.verified_tip > block::Height(0) {
@@ -1106,8 +1137,7 @@ impl BlockSyncReactor {
         }
         self.prune_needed_below_floor();
 
-        self.queue_status_refresh_if_changed(old_serving_tip);
-        self.flush_status_refresh().await;
+        self.flush_status_refresh();
         // After a destructive reset the WorkQueue is empty above the new floor, but
         // peer routines clear their registry outstanding asynchronously. A plain query can see the pre-reset outstanding amount, decide the
         // pipeline is "full", and skip the refill, leaving `pending` empty and
@@ -1312,8 +1342,9 @@ impl BlockSyncReactor {
         self.publish_candidate_state();
         self.restart_body_alarm_for_new_supplier();
         if send_reply {
-            self.send_status(&peer, "status_reply");
+            self.send_status(&peer, self.local_status(), Instant::now(), "status_reply");
         }
+        self.flush_status_refresh();
     }
 
     fn restart_body_alarm_for_new_supplier(&mut self) {
@@ -1886,15 +1917,28 @@ impl BlockSyncReactor {
             .max(max_blocks_per_response)
     }
 
-    fn send_status(&self, peer: &ZakuraPeerId, reason: &'static str) -> bool {
+    fn send_status(
+        &mut self,
+        peer: &ZakuraPeerId,
+        status: BlockSyncStatus,
+        now: Instant,
+        reason: &'static str,
+    ) -> bool {
         let Some(peer_state) = self.state.peers.get(peer) else {
             return false;
         };
-        let status = self.local_status();
         let msg = BlockSyncMessage::Status(status);
         let started = Instant::now();
         let session = peer_state.session.clone();
-        match session.try_send_status(status) {
+        let result = session.try_send_status(status);
+        if let Some(peer_state) = self.state.peers.get_mut(peer) {
+            match &result {
+                Ok(()) => peer_state.status_delivery.queued(status, now),
+                Err(OrderedSendError::Full) => peer_state.status_delivery.queue_full(now),
+                Err(_) => {}
+            }
+        }
+        match result {
             Ok(()) => {
                 self.trace_message_sent(peer, &msg, "queued", started.elapsed());
                 self.trace_status_sent(peer, reason, status);
@@ -1929,25 +1973,6 @@ impl BlockSyncReactor {
                 false
             }
         }
-    }
-
-    fn send_status_and_mark_refresh(
-        &mut self,
-        peer: &ZakuraPeerId,
-        reason: &'static str,
-        now: Instant,
-    ) -> bool {
-        if !self.send_status(peer, reason) {
-            return false;
-        }
-
-        // Consume the status-advertisement refresh allowance only after the
-        // Status enters the peer's outbound queue.
-        if let Some(peer_state) = self.state.peers.get_mut(peer) {
-            peer_state.refresh_meter.mark_taken(now);
-        }
-
-        true
     }
 
     fn send_block(&self, peer: &ZakuraPeerId, block: Arc<block::Block>) -> bool {
@@ -2098,78 +2123,49 @@ impl BlockSyncReactor {
         }
     }
 
-    async fn flush_status_refresh(&mut self) {
-        // `received_status` is a registry fact now; snapshot which peers have not
-        // sent us their Status so the retry filter below can read it without
-        // re-locking per peer.
-        let unready: HashSet<ZakuraPeerId> = self
+    fn flush_status_refresh(&mut self) {
+        let status = self.local_status();
+        self.status.send_if_modified(|current| {
+            if *current == status {
+                return false;
+            }
+            *current = status;
+            true
+        });
+        let unready: HashSet<_> = self
             .registry
             .candidate_snapshot()
             .into_iter()
             .filter_map(|(peer, received_status, _, _)| (!received_status).then_some(peer))
             .collect();
-        let has_unready_peers = !unready.is_empty();
-        if !self.state.pending_status_refresh && !has_unready_peers {
-            return;
-        }
         let now = Instant::now();
-
-        // A genuine serving-range change is debounced by the global
-        // `status_refresh` meter so a burst of tip changes advertises once per
-        // window. Only consume that window when there is actually a change to
-        // advertise: a flush that exists only to retry a Status to a peer that
-        // has not acknowledged ours must not poison the change window, or the
-        // first real advertisement after connect is silently dropped (the
-        // connect-time retry would have already taken the window).
-        let status = self.local_status();
-        let status_needs_refresh =
-            self.state.pending_status_refresh && status != self.state.last_advertised_status;
-        let status_changed = status_needs_refresh && self.state.status_refresh.try_take(now);
-
-        // Keep a rate-limited change pending until the periodic tick advertises the
-        // latest status. Clearing the change here can lose a serving-tip advance
-        // when several commits occur during one refresh interval.
-        self.state.pending_status_refresh = status_needs_refresh && !status_changed;
-        if status_changed {
-            self.state.last_advertised_status = status;
-            let _ = self.status.send(status);
-        }
-
-        let peer_ids: Vec<_> = self
+        let due: Vec<_> = self
             .state
             .peers
             .iter()
-            .filter_map(|(peer_id, peer)| {
-                // On a real change, advertise to every peer immediately; the
-                // global meter above already debounced the change, so the
-                // per-peer `unsolicited` meter must not also suppress it. We
-                // still consume the per-peer allowance after the frame queues so
-                // a same-window retry to this peer stays spaced. Otherwise the
-                // only reason to send is a retry to a peer that has not
-                // acknowledged our Status, which stays gated solely by that
-                // peer's `unsolicited` meter.
-                let should_send_status = status_changed
-                    || (unready.contains(peer_id) && peer.refresh_meter.is_ready(now));
-
-                if should_send_status {
-                    Some(peer_id.clone())
-                } else {
-                    None
-                }
+            .filter(|(_, peer)| !peer.session.cancel_token().is_cancelled())
+            .filter_map(|(id, peer)| {
+                peer.status_delivery
+                    .next_deadline(status, !unready.contains(id))
+                    .filter(|deadline| *deadline <= now)
+                    .map(|_| id.clone())
             })
             .collect();
-
-        for peer in peer_ids {
-            self.send_status_and_mark_refresh(&peer, "refresh", now);
+        for peer in due {
+            self.send_status(&peer, status, now, "refresh");
         }
-    }
-
-    fn queue_status_refresh_if_changed(&mut self, old_serving_tip: (block::Height, block::Hash)) {
-        if old_serving_tip != (self.state.servable_high, self.state.servable_hash)
-            && self.local_status() != self.state.last_advertised_status
-        {
-            self.state.pending_status_refresh = true;
-        }
+        // The same delivery rules choose both sends and wakes. A full queue
+        // cannot lose its retry when another peer accepts the new range.
+        self.status_refresh_at = self
+            .state
+            .peers
+            .iter()
+            .filter(|(_, peer)| !peer.session.cancel_token().is_cancelled())
+            .filter_map(|(id, peer)| {
+                peer.status_delivery
+                    .next_deadline(status, !unready.contains(id))
+            })
+            .min();
     }
 
     fn floor_gap_diagnostics(&self, now: Instant) -> Option<FloorGapDiagnostics> {
@@ -2324,12 +2320,16 @@ impl BlockSyncReactor {
     }
 
     fn clamp_served_block_count(&self, start_height: block::Height, count: u32) -> u32 {
-        if start_height > self.state.servable_high {
+        let status = self.local_status();
+        if start_height == block::Height::MIN && status.servable_low > block::Height::MIN {
+            // Genesis is retained separately. Do not cross the pruned gap after it.
+            return count.min(1);
+        }
+        if start_height < status.servable_low || start_height > status.servable_high {
             return 0;
         }
 
-        let available = self
-            .state
+        let available = status
             .servable_high
             .0
             .checked_sub(start_height.0)
@@ -2342,14 +2342,10 @@ impl BlockSyncReactor {
     }
 
     fn local_status(&self) -> BlockSyncStatus {
-        BlockSyncStatus {
-            servable_low: block::Height::MIN,
-            servable_high: self.state.servable_high,
-            tip_hash: self.state.servable_hash,
-            max_blocks_per_response: self.startup.config.advertised_max_blocks_per_response(),
-            max_inflight_requests: self.startup.config.advertised_max_inflight_requests(),
-            max_response_bytes: self.startup.config.advertised_max_response_bytes(),
-        }
+        let status = self.state.local_status(&self.startup.config);
+        self.body_retention
+            .as_ref()
+            .map_or(status, |retention| retention.apply(status))
     }
 
     /// Hand a data-plane action to the action driver without letting a slow or

--- a/crates/zakura-network/src/zakura/block_sync/state.rs
+++ b/crates/zakura-network/src/zakura/block_sync/state.rs
@@ -37,6 +37,7 @@ pub(super) struct NeededBlocksQueryFailure {
 /// Startup inputs for the dependency-neutral block-sync reactor.
 #[derive(Clone, Debug)]
 pub struct BlockSyncStartup {
+    pub(super) body_retention: Option<BodyRetention>,
     /// Cached state frontiers at startup.
     pub frontiers: BlockSyncFrontiers,
     /// Durable best header tip at startup.
@@ -58,6 +59,8 @@ pub struct BlockSyncStartup {
 
 impl BlockSyncStartup {
     /// Build block-sync startup config from durable/frontier facts.
+    ///
+    /// This assumes archive storage unless [`Self::with_retention`] is supplied.
     pub fn new(
         frontiers: BlockSyncFrontiers,
         best_header_tip: (block::Height, block::Hash),
@@ -65,6 +68,7 @@ impl BlockSyncStartup {
         config: ZakuraBlockSyncConfig,
     ) -> Self {
         Self {
+            body_retention: None,
             frontiers,
             best_header_tip,
             header_tip: Some(header_tip),
@@ -77,6 +81,8 @@ impl BlockSyncStartup {
     }
 
     /// Build production block sync from the sole committed frontier publisher.
+    ///
+    /// Pruned storage must also supply [`Self::with_retention`].
     pub fn new_with_committed_views(
         frontiers: BlockSyncFrontiers,
         best_header_tip: (block::Height, block::Hash),
@@ -84,6 +90,7 @@ impl BlockSyncStartup {
         config: ZakuraBlockSyncConfig,
     ) -> Self {
         Self {
+            body_retention: None,
             frontiers,
             best_header_tip,
             header_tip: None,
@@ -95,8 +102,26 @@ impl BlockSyncStartup {
         }
     }
 
+    /// Attach the storage-owned retained-body floor and the network's genesis hash.
+    ///
+    /// The floor must be initialized from disk and updated after pruning commits,
+    /// before publishing the corresponding verified tip. Genesis remains servable
+    /// separately when checkpoint retention is ahead of that tip.
+    pub fn with_retention(
+        mut self,
+        retained_height: watch::Receiver<block::Height>,
+        genesis_hash: block::Hash,
+    ) -> Self {
+        self.body_retention = Some(BodyRetention {
+            retained_height,
+            genesis_hash,
+        });
+        self
+    }
+
     pub(super) fn inert(config: ZakuraBlockSyncConfig) -> Self {
         Self {
+            body_retention: None,
             frontiers: BlockSyncFrontiers {
                 finalized_height: block::Height::MIN,
                 verified_block_tip: block::Height::MIN,
@@ -110,6 +135,26 @@ impl BlockSyncStartup {
             state_queries_enabled: false,
             trace: ZakuraTrace::noop(),
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct BodyRetention {
+    pub(super) retained_height: watch::Receiver<block::Height>,
+    pub(super) genesis_hash: block::Hash,
+}
+
+impl BodyRetention {
+    pub(super) fn apply(&self, mut status: BlockSyncStatus) -> BlockSyncStatus {
+        let retained_height = *self.retained_height.borrow();
+        if retained_height > status.servable_high {
+            status.servable_low = block::Height::MIN;
+            status.servable_high = block::Height::MIN;
+            status.tip_hash = self.genesis_hash;
+        } else {
+            status.servable_low = retained_height;
+        }
+        status
     }
 }
 
@@ -247,12 +292,13 @@ impl BlockSyncHandle {
             .park_session_for_test(peer, conn_id, std::time::Instant::now() + cooldown);
     }
 
-    /// Subscribe to local block-sync status advertisements.
+    /// Subscribe to the reactor's current local serving status.
+    /// Peer delivery is tracked separately and can lag while outbound queues are full.
     pub fn subscribe_status(&self) -> watch::Receiver<BlockSyncStatus> {
         self.status.clone()
     }
 
-    /// Return the currently cached local status advertisement.
+    /// Return the reactor's current local serving status, independent of peer delivery.
     pub fn local_status(&self) -> BlockSyncStatus {
         *self.status.borrow()
     }
@@ -290,9 +336,6 @@ pub(super) struct BlockSyncState {
     pub(super) work_queue: Arc<WorkQueue>,
     pub(super) budget: ByteBudget,
     pub(super) needed_heights: Vec<block::Height>,
-    pub(super) status_refresh: RateMeter,
-    pub(super) pending_status_refresh: bool,
-    pub(super) last_advertised_status: BlockSyncStatus,
     /// Throughput of bodies received off the wire (the download rate). Shared
     /// with the per-peer routines (they `record` on receipt); the reactor samples
     /// it each trace tick. Compared against the Sequencer task's committed
@@ -302,15 +345,6 @@ pub(super) struct BlockSyncState {
 
 impl BlockSyncState {
     pub(super) fn new(startup: &BlockSyncStartup) -> Self {
-        let last_advertised_status = BlockSyncStatus {
-            servable_low: block::Height::MIN,
-            servable_high: startup.frontiers.verified_block_tip,
-            tip_hash: startup.frontiers.verified_block_hash,
-            max_blocks_per_response: startup.config.advertised_max_blocks_per_response(),
-            max_inflight_requests: startup.config.advertised_max_inflight_requests(),
-            max_response_bytes: startup.config.advertised_max_response_bytes(),
-        };
-
         Self {
             finalized_height: startup.frontiers.finalized_height,
             verified_block_hash: startup.frontiers.verified_block_hash,
@@ -323,12 +357,20 @@ impl BlockSyncState {
             work_queue: Arc::new(WorkQueue::new(startup.frontiers.verified_block_tip)),
             budget: ByteBudget::new(startup.config.max_inflight_block_bytes),
             needed_heights: Vec::new(),
-            status_refresh: RateMeter::new(startup.config.status_refresh_interval),
-            pending_status_refresh: false,
-            last_advertised_status,
             received_throughput: Arc::new(std::sync::Mutex::new(ThroughputMeter::new(
                 Instant::now(),
             ))),
+        }
+    }
+
+    pub(super) fn local_status(&self, config: &ZakuraBlockSyncConfig) -> BlockSyncStatus {
+        BlockSyncStatus {
+            servable_low: block::Height::MIN,
+            servable_high: self.servable_high,
+            tip_hash: self.servable_hash,
+            max_blocks_per_response: config.advertised_max_blocks_per_response(),
+            max_inflight_requests: config.advertised_max_inflight_requests(),
+            max_response_bytes: config.advertised_max_response_bytes(),
         }
     }
 
@@ -803,12 +845,7 @@ impl DownloadWindow {
 pub(super) struct PeerBlockState {
     pub(super) session: BlockSyncPeerSession,
     pub(super) direction: ServicePeerDirection,
-    /// Per-peer rate meter for the reactor's `Status` *advertisement* refresh
-    /// (serving-tip change broadcast + retry to peers that have not acknowledged
-    /// our Status). The inbound-status *reply* half lives on the routine's
-    /// `status_reply_meter`; this half stays reactor-side because the reactor owns
-    /// serving-tip advertisement.
-    pub(super) refresh_meter: RateMeter,
+    pub(super) status_delivery: super::status::StatusDelivery,
     pub(super) served_blocks_inflight: u32,
     pub(super) served_block_requests: VecDeque<(block::Height, Instant)>,
 }
@@ -818,7 +855,10 @@ impl PeerBlockState {
         Self {
             direction: session.direction(),
             session,
-            refresh_meter: RateMeter::new(config.status_refresh_interval),
+            status_delivery: super::status::StatusDelivery::new(
+                config.status_refresh_interval,
+                Instant::now(),
+            ),
             served_blocks_inflight: 0,
             served_block_requests: VecDeque::new(),
         }

--- a/crates/zakura-network/src/zakura/block_sync/status.rs
+++ b/crates/zakura-network/src/zakura/block_sync/status.rs
@@ -1,0 +1,181 @@
+//! Per-peer delivery of the latest local serving range.
+
+use super::{state::RateMeter, BlockSyncStatus, Duration, Instant};
+
+/// Bound prompt range corrections independently of ordinary tip-growth updates.
+pub(super) const RANGE_CORRECTION_INTERVAL: Duration = Duration::from_secs(1);
+const QUEUE_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A queued frame is the delivery boundary of the ordered, reliable stream.
+/// Failed attempts retain the difference from the latest local status. There is
+/// no cached retry payload to become stale while the outbound queue is full.
+#[derive(Debug)]
+pub(super) struct StatusDelivery {
+    last_queued: Option<BlockSyncStatus>,
+    growth: RateMeter,
+    contraction: RateMeter,
+    handshake_at: Instant,
+    queue_retry_at: Option<Instant>,
+    queue_retry_interval: Duration,
+}
+
+impl StatusDelivery {
+    pub(super) fn new(interval: Duration, now: Instant) -> Self {
+        let interval = interval.max(Duration::from_millis(1));
+        Self {
+            last_queued: None,
+            growth: RateMeter {
+                next_allowed: now,
+                interval,
+            },
+            contraction: RateMeter {
+                next_allowed: now,
+                interval: interval.min(RANGE_CORRECTION_INTERVAL),
+            },
+            handshake_at: now,
+            queue_retry_at: None,
+            queue_retry_interval: interval.min(QUEUE_RETRY_INTERVAL),
+        }
+    }
+
+    /// The next send is due only while a range change or handshake remains pending.
+    pub(super) fn next_deadline(
+        &self,
+        latest: BlockSyncStatus,
+        received_status: bool,
+    ) -> Option<Instant> {
+        let deadline = match self.last_queued {
+            None => self.handshake_at,
+            Some(previous) if previous != latest => {
+                if contracts(previous, latest) {
+                    self.contraction.next_allowed
+                } else {
+                    self.growth.next_allowed
+                }
+            }
+            Some(_) if !received_status => self.handshake_at,
+            Some(_) => return None,
+        };
+        Some(
+            self.queue_retry_at
+                .map_or(deadline, |retry| deadline.max(retry)),
+        )
+    }
+
+    /// Advance only the allowance for the change that actually entered the stream.
+    pub(super) fn queued(&mut self, status: BlockSyncStatus, now: Instant) {
+        if let Some(previous) = self.last_queued.filter(|previous| *previous != status) {
+            if contracts(previous, status) {
+                self.contraction.mark_taken(now);
+            } else {
+                self.growth.mark_taken(now);
+            }
+        }
+        self.last_queued = Some(status);
+        self.handshake_at = now + self.growth.interval;
+        self.queue_retry_at = None;
+    }
+
+    /// Back off failed queue attempts without spending the range-change allowance.
+    pub(super) fn queue_full(&mut self, now: Instant) {
+        self.queue_retry_at = Some(now + self.queue_retry_interval);
+    }
+}
+
+fn contracts(previous: BlockSyncStatus, latest: BlockSyncStatus) -> bool {
+    latest.servable_low > previous.servable_low || latest.servable_high < previous.servable_high
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zakura::block_sync::{block, MAX_BS_RESPONSE_BYTES};
+
+    fn status(low: u32, high: u32) -> BlockSyncStatus {
+        BlockSyncStatus {
+            servable_low: block::Height(low),
+            servable_high: block::Height(high),
+            tip_hash: block::Hash([0; 32]),
+            max_blocks_per_response: 1,
+            max_inflight_requests: 1,
+            max_response_bytes: MAX_BS_RESPONSE_BYTES,
+        }
+    }
+
+    #[test]
+    fn pruning_corrects_growth_advertisements_without_an_unbounded_bypass() {
+        let now = Instant::now();
+        let mut delivery = StatusDelivery::new(Duration::from_secs(30), now);
+        delivery.queued(status(1_000, 6_000), now);
+        let growth_at = now + Duration::from_millis(500);
+        delivery.queued(status(1_000, 6_001), growth_at);
+        let prune_at = growth_at + Duration::from_millis(1);
+        let first_prune = status(1_001, 6_001);
+        assert!(delivery.next_deadline(first_prune, true).unwrap() <= prune_at);
+        delivery.queued(first_prune, prune_at);
+
+        // Further pruning coalesces into the latest range for this same deadline.
+        for low in 1_002..2_000 {
+            assert_eq!(
+                delivery.next_deadline(status(low, 6_002), true),
+                Some(prune_at + RANGE_CORRECTION_INTERVAL)
+            );
+        }
+        delivery.queued(status(1_999, 6_002), prune_at + RANGE_CORRECTION_INTERVAL);
+        assert_eq!(delivery.next_deadline(status(1_999, 6_002), true), None);
+    }
+
+    #[test]
+    fn queue_pressure_retries_the_latest_range_at_its_own_deadline() {
+        let now = Instant::now();
+        let mut delivery = StatusDelivery::new(Duration::from_secs(30), now);
+        let initial = status(1_000, 6_000);
+        delivery.queued(initial, now);
+        let full_at = now + Duration::from_millis(500);
+        delivery.queue_full(full_at);
+        let latest = status(1_002, 6_002);
+        let deadline = full_at + QUEUE_RETRY_INTERVAL;
+        assert_eq!(delivery.next_deadline(latest, true), Some(deadline));
+        assert_eq!(delivery.last_queued, Some(initial));
+
+        delivery.queue_full(deadline);
+        assert_eq!(
+            delivery.next_deadline(latest, true),
+            Some(deadline + QUEUE_RETRY_INTERVAL)
+        );
+        delivery.queued(latest, deadline + QUEUE_RETRY_INTERVAL);
+        assert_eq!(delivery.next_deadline(latest, true), None);
+    }
+
+    #[test]
+    fn unchanged_status_retries_only_until_the_peer_supplies_its_status() {
+        let now = Instant::now();
+        let interval = Duration::from_secs(30);
+        let mut delivery = StatusDelivery::new(interval, now);
+        let latest = status(1_000, 6_000);
+        assert_eq!(delivery.next_deadline(latest, false), Some(now));
+        delivery.queued(latest, now);
+        assert_eq!(delivery.next_deadline(latest, false), Some(now + interval));
+        assert_eq!(delivery.next_deadline(latest, true), None);
+    }
+
+    #[test]
+    fn returning_to_the_queued_range_cancels_a_failed_correction() {
+        let now = Instant::now();
+        let mut delivery = StatusDelivery::new(Duration::from_secs(30), now);
+        let initial = status(1_000, 6_000);
+        delivery.queued(initial, now);
+        delivery.queue_full(now);
+        assert!(delivery.next_deadline(status(1_001, 6_001), true).is_some());
+        assert_eq!(delivery.next_deadline(initial, true), None);
+    }
+
+    #[test]
+    fn genesis_only_corrections_use_the_prompt_deadline() {
+        let now = Instant::now();
+        let mut delivery = StatusDelivery::new(Duration::from_secs(30), now);
+        delivery.queued(status(1_000, 6_000), now);
+        delivery.queued(status(1_000, 6_001), now);
+        assert_eq!(delivery.next_deadline(status(0, 0), true), Some(now));
+    }
+}

--- a/crates/zakura-network/src/zakura/block_sync/status.rs
+++ b/crates/zakura-network/src/zakura/block_sync/status.rs
@@ -46,13 +46,8 @@ impl StatusDelivery {
     ) -> Option<Instant> {
         let deadline = match self.last_queued {
             None => self.handshake_at,
-            Some(previous) if previous != latest => {
-                if contracts(previous, latest) {
-                    self.contraction.next_allowed
-                } else {
-                    self.growth.next_allowed
-                }
-            }
+            Some(previous) if contracts(previous, latest) => self.contraction.next_allowed,
+            Some(previous) if previous != latest => self.growth.next_allowed,
             Some(_) if !received_status => self.handshake_at,
             Some(_) => return None,
         };

--- a/crates/zakura-network/src/zakura/block_sync/tests.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests.rs
@@ -1,3 +1,5 @@
+mod retention;
+
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     future,

--- a/crates/zakura-network/src/zakura/block_sync/tests/retention.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests/retention.rs
@@ -1,0 +1,483 @@
+use super::*;
+
+struct RetentionHarness {
+    retained: Option<watch::Sender<block::Height>>,
+    handle: BlockSyncHandle,
+    actions: mpsc::Receiver<BlockSyncAction>,
+    service: BlockSyncService,
+    task: JoinHandle<()>,
+}
+
+impl RetentionHarness {
+    fn new(retained: u32) -> Self {
+        Self::with_refresh_interval(retained, Duration::from_millis(10))
+    }
+
+    fn with_refresh_interval(retained: u32, status_refresh_interval: Duration) -> Self {
+        let blocks = mainnet_blocks_1_to_3();
+        let config = ZakuraBlockSyncConfig {
+            status_refresh_interval,
+            ..ZakuraBlockSyncConfig::default()
+        };
+        let mut startup = BlockSyncStartup::inert(config.clone());
+        startup.frontiers = BlockSyncFrontiers {
+            finalized_height: block::Height(3),
+            verified_block_tip: block::Height(3),
+            verified_block_hash: blocks[2].hash(),
+        };
+        startup.best_header_tip = (block::Height(3), blocks[2].hash());
+        let (retained, receiver) = watch::channel(block::Height(retained));
+        let (handle, actions, task) = spawn_block_sync_reactor(startup.with_retention(
+            receiver,
+            zakura_chain::parameters::Network::Mainnet.genesis_hash(),
+        ));
+        let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+        Self {
+            retained: Some(retained),
+            handle,
+            actions,
+            service,
+            task,
+        }
+    }
+
+    async fn connect(&self, id: u8) -> (ZakuraPeerId, FramedSend, FramedRecv, BlockSyncStatus) {
+        let peer = peer(id);
+        let (inbound, receiver) = framed_channel(16);
+        let (sender, mut outbound) = framed_channel(16);
+        self.service.add_peer(Peer::new_with_direction(
+            peer.clone(),
+            None,
+            ZAKURA_CAP_BLOCK_SYNC,
+            ServicePeerDirection::Outbound,
+            HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (receiver, sender))]),
+            CancellationToken::new(),
+        ));
+        let advertised = wait_for_outbound_status(&mut outbound).await;
+        inbound
+            .send(
+                BlockSyncMessage::Status(BlockSyncStatus {
+                    servable_low: block::Height(0),
+                    servable_high: block::Height(0),
+                    tip_hash: zakura_chain::parameters::Network::Mainnet.genesis_hash(),
+                    max_blocks_per_response: 1,
+                    max_inflight_requests: 1,
+                    max_response_bytes: MAX_BS_RESPONSE_BYTES,
+                })
+                .encode_frame()
+                .expect("status encodes"),
+            )
+            .await
+            .expect("status queues");
+        (peer, inbound, outbound, advertised)
+    }
+
+    fn assert_no_storage_query(&mut self) {
+        while let Ok(action) = self.actions.try_recv() {
+            assert!(
+                !matches!(action, BlockSyncAction::QueryBlocksByHeightRange { .. }),
+                "a pruned range must not query storage"
+            );
+        }
+    }
+}
+
+impl Drop for RetentionHarness {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn request(inbound: &FramedSend, start: u32) {
+    inbound
+        .send(
+            BlockSyncMessage::GetBlocks {
+                start_height: block::Height(start),
+                count: 1,
+            }
+            .encode_frame()
+            .expect("request encodes"),
+        )
+        .await
+        .expect("request queues");
+}
+
+async fn status_with_low(outbound: &mut FramedRecv, low: u32) -> BlockSyncStatus {
+    time::timeout(Duration::from_secs(5), async {
+        loop {
+            let status = wait_for_outbound_status(outbound).await;
+            if status.servable_low == block::Height(low) {
+                return status;
+            }
+        }
+    })
+    .await
+    .expect("the retained range is advertised")
+}
+
+#[tokio::test]
+async fn retention_initial_status_preserves_archive_and_pruned_ranges() {
+    let blocks = mainnet_blocks_1_to_3();
+    for (retained, low, high, hash) in [
+        (0, 0, 3, blocks[2].hash()),
+        (2, 2, 3, blocks[2].hash()),
+        (
+            4,
+            0,
+            0,
+            zakura_chain::parameters::Network::Mainnet.genesis_hash(),
+        ),
+    ] {
+        let harness = RetentionHarness::new(retained);
+        let (_, _inbound, _outbound, advertised) = harness.connect(0xe1).await;
+        assert_eq!(advertised.servable_low, block::Height(low));
+        assert_eq!(advertised.servable_high, block::Height(high));
+        assert_eq!(advertised.tip_hash, hash);
+        assert_eq!(harness.handle.local_status(), advertised);
+    }
+}
+
+#[tokio::test]
+async fn retention_rejects_pruned_reads_and_still_serves_retained_blocks() {
+    let blocks = mainnet_blocks_1_to_3();
+    let mut harness = RetentionHarness::new(2);
+    let (peer, inbound, mut outbound, _) = harness.connect(0xe2).await;
+    request(&inbound, 1).await;
+    assert_eq!(
+        wait_for_outbound_range_unavailable(&mut outbound).await,
+        (block::Height(1), 1)
+    );
+    harness.assert_no_storage_query();
+
+    let genesis = mainnet_block(&zakura_test::vectors::BLOCK_MAINNET_GENESIS_BYTES);
+    for (height, body) in [(2, blocks[1].clone()), (0, genesis)] {
+        request(&inbound, height).await;
+        match next_action(&mut harness.actions).await {
+            BlockSyncAction::QueryBlocksByHeightRange { start, count, .. } => {
+                assert_eq!((start, count), (block::Height(height), 1));
+            }
+            other => panic!("expected a retained storage query, got {other:?}"),
+        }
+        harness
+            .handle
+            .send(BlockSyncEvent::BlockRangeResponseReady {
+                peer: peer.clone(),
+                start_height: block::Height(height),
+                requested_count: 1,
+                blocks: vec![(
+                    block::Height(height),
+                    body.clone(),
+                    usize::try_from(block_size(&body)).expect("fixture size fits usize"),
+                )],
+            })
+            .await
+            .expect("storage result queues");
+        assert_eq!(
+            wait_for_outbound_block(&mut outbound).await.hash(),
+            body.hash()
+        );
+        assert_eq!(
+            wait_for_outbound_blocks_done(&mut outbound).await,
+            (block::Height(height), 1)
+        );
+    }
+}
+
+#[tokio::test]
+async fn retention_refreshes_without_tip_growth_and_survives_publisher_shutdown() {
+    let mut harness = RetentionHarness::new(2);
+    let (_, inbound, mut outbound, _) = harness.connect(0xe3).await;
+    harness
+        .retained
+        .as_ref()
+        .expect("publisher exists")
+        .send(block::Height(3))
+        .expect("reactor subscribes");
+    let advertised = status_with_low(&mut outbound, 3).await;
+    assert_eq!(advertised.servable_high, block::Height(3));
+    assert_eq!(harness.handle.local_status(), advertised);
+    request(&inbound, 2).await;
+    assert_eq!(
+        wait_for_outbound_range_unavailable(&mut outbound).await,
+        (block::Height(2), 1)
+    );
+    harness.assert_no_storage_query();
+
+    drop(harness.retained.take());
+    let (_, _inbound, _outbound, advertised_after_close) = harness.connect(0xe4).await;
+    assert_eq!(advertised_after_close, advertised);
+}
+
+#[tokio::test]
+async fn retention_refreshes_at_meter_deadline_between_periodic_ticks() {
+    let interval = Duration::from_secs(1);
+    let harness = RetentionHarness::with_refresh_interval(1, interval);
+    let (_, _inbound, mut outbound, _) = harness.connect(0xea).await;
+    wait_for_outbound_status(&mut outbound).await;
+
+    // Offset the first change from reactor startup. Its meter reopens halfway
+    // between periodic ticks, so polling alone would miss the deadline.
+    time::sleep(interval / 2).await;
+    let retained = harness.retained.as_ref().expect("publisher exists");
+    retained.send(block::Height(2)).expect("reactor subscribes");
+    status_with_low(&mut outbound, 2).await;
+
+    retained.send(block::Height(3)).expect("reactor subscribes");
+    assert!(
+        time::timeout(interval * 3 / 4, outbound.recv())
+            .await
+            .is_err(),
+        "the pending retention change must respect the refresh window"
+    );
+    let advertised = time::timeout(interval / 2, status_with_low(&mut outbound, 3))
+        .await
+        .expect("the pending change must advertise at the meter deadline, before the next tick");
+    assert_eq!(advertised.servable_high, block::Height(3));
+    assert_eq!(harness.handle.local_status(), advertised);
+}
+
+#[tokio::test]
+async fn retention_retries_latest_status_only_for_peer_with_full_outbound_queue() {
+    let harness = RetentionHarness::new(1);
+    let (inbound, receiver) = framed_channel(16);
+    let (sender, mut outbound) = framed_channel(1);
+    harness.service.add_peer(Peer::new_with_direction(
+        peer(0xe8),
+        None,
+        ZAKURA_CAP_BLOCK_SYNC,
+        ServicePeerDirection::Outbound,
+        HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (receiver, sender.clone()))]),
+        CancellationToken::new(),
+    ));
+    let initial_status = wait_for_outbound_status(&mut outbound).await;
+    send_inbound(&inbound, BlockSyncMessage::Status(status())).await;
+    wait_for_outbound_status(&mut outbound).await;
+
+    let (_, _healthy_inbound, mut healthy_outbound, _) = harness.connect(0xe9).await;
+    wait_for_outbound_status(&mut healthy_outbound).await;
+
+    sender
+        .try_send(
+            BlockSyncMessage::Status(initial_status)
+                .encode_frame()
+                .expect("filler status encodes"),
+        )
+        .expect("the established peer's outbound queue fills");
+    for low in [2, 3] {
+        harness
+            .retained
+            .as_ref()
+            .expect("publisher exists")
+            .send(block::Height(low))
+            .expect("reactor subscribes");
+        let advertised = status_with_low(&mut healthy_outbound, low).await;
+        assert_eq!(advertised.servable_high, block::Height(3));
+        assert_eq!(harness.handle.local_status(), advertised);
+    }
+
+    assert_eq!(
+        wait_for_outbound_status(&mut outbound).await,
+        initial_status
+    );
+    let retried = wait_for_outbound_status(&mut outbound).await;
+    assert_eq!(retried.servable_low, block::Height(3));
+    assert_eq!(retried.servable_high, block::Height(3));
+    for outbound in [&mut outbound, &mut healthy_outbound] {
+        assert!(
+            time::timeout(Duration::from_millis(50), outbound.recv())
+                .await
+                .is_err(),
+            "successfully queued updates must not keep retrying"
+        );
+    }
+}
+
+#[tokio::test]
+async fn retention_corrects_a_debounced_tip_and_retries_the_latest_range_after_queue_pressure() {
+    let harness = RetentionHarness::with_refresh_interval(1, Duration::from_secs(30));
+    let (inbound, receiver) = framed_channel(16);
+    let (sender, mut outbound) = framed_channel(1);
+    harness.service.add_peer(Peer::new_with_direction(
+        peer(0xeb),
+        None,
+        ZAKURA_CAP_BLOCK_SYNC,
+        ServicePeerDirection::Outbound,
+        HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (receiver, sender.clone()))]),
+        CancellationToken::new(),
+    ));
+    let initial = wait_for_outbound_status(&mut outbound).await;
+    send_inbound(&inbound, BlockSyncMessage::Status(status())).await;
+    wait_for_outbound_status(&mut outbound).await;
+    let (_, _healthy_inbound, mut healthy_outbound, _) = harness.connect(0xec).await;
+    wait_for_outbound_status(&mut healthy_outbound).await;
+
+    harness
+        .handle
+        .send(BlockSyncEvent::StateFrontiersChanged(BlockSyncFrontiers {
+            finalized_height: block::Height(3),
+            verified_block_tip: block::Height(4),
+            verified_block_hash: block::Hash([4; 32]),
+        }))
+        .await
+        .expect("tip growth queues");
+    assert_eq!(
+        wait_for_outbound_status(&mut outbound).await.servable_high,
+        block::Height(4)
+    );
+    wait_for_outbound_status(&mut healthy_outbound).await;
+    sender
+        .try_send(
+            BlockSyncMessage::Status(initial)
+                .encode_frame()
+                .expect("filler encodes"),
+        )
+        .expect("one peer's queue fills");
+
+    let retained = harness.retained.as_ref().expect("publisher exists");
+    retained.send(block::Height(2)).expect("reactor subscribes");
+    time::timeout(
+        Duration::from_millis(500),
+        status_with_low(&mut healthy_outbound, 2),
+    )
+    .await
+    .expect("pruning must not wait for the consumed 30-second growth allowance");
+
+    retained.send(block::Height(3)).expect("reactor subscribes");
+    await_until("latest local floor", Duration::from_secs(1), || {
+        harness.handle.local_status().servable_low == block::Height(3)
+    })
+    .await
+    .expect("local status tracks the current range even while a peer's queue is full");
+    assert_eq!(wait_for_outbound_status(&mut outbound).await, initial);
+    let latest = time::timeout(
+        Duration::from_millis(500),
+        status_with_low(&mut outbound, 3),
+    )
+    .await
+    .expect("the drained queue retries the latest range without another prune or tip event");
+    assert_eq!(latest.servable_high, block::Height(4));
+    assert!(time::timeout(Duration::from_millis(150), outbound.recv())
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn retention_above_tip_serves_only_genesis_until_retained_tip_arrives() {
+    let mut harness = RetentionHarness::new(4);
+    let (_, inbound, mut outbound, advertised) = harness.connect(0xe5).await;
+    assert_eq!(
+        (advertised.servable_low, advertised.servable_high),
+        (block::Height(0), block::Height(0))
+    );
+    request(&inbound, 1).await;
+    assert_eq!(
+        wait_for_outbound_range_unavailable(&mut outbound).await,
+        (block::Height(1), 1)
+    );
+    harness.assert_no_storage_query();
+
+    request(&inbound, 0).await;
+    match next_action(&mut harness.actions).await {
+        BlockSyncAction::QueryBlocksByHeightRange { start, count, .. } => {
+            assert_eq!((start, count), (block::Height(0), 1));
+        }
+        other => panic!("expected a genesis query, got {other:?}"),
+    }
+    harness
+        .handle
+        .send(BlockSyncEvent::ChainTipGrow(BlockSyncFrontiers {
+            finalized_height: block::Height(4),
+            verified_block_tip: block::Height(4),
+            verified_block_hash: block::Hash([4; 32]),
+        }))
+        .await
+        .expect("tip update queues");
+    let advertised = status_with_low(&mut outbound, 4).await;
+    assert_eq!(advertised.servable_high, block::Height(4));
+    assert_eq!(advertised.tip_hash, block::Hash([4; 32]));
+}
+
+#[tokio::test]
+async fn retention_advertisement_keeps_pruned_heights_out_of_download_requests() {
+    let serving = RetentionHarness::new(2);
+    let blocks = mainnet_blocks_1_to_3();
+    let config = immediate_body_download_config();
+    let (_tip, tip_rx) = watch::channel((block::Height(3), blocks[2].hash()));
+    let startup = BlockSyncStartup::new(
+        BlockSyncFrontiers {
+            finalized_height: block::Height(0),
+            verified_block_tip: block::Height(0),
+            verified_block_hash: block::Hash([0; 32]),
+        },
+        (block::Height(3), blocks[2].hash()),
+        tip_rx,
+        config.clone(),
+    );
+    let (handle, mut actions, task) = spawn_block_sync_reactor(startup);
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let (_, _inbound, mut outbound) = connect_peer_with_status_message(
+        &service,
+        &mut actions,
+        0xe6,
+        serving.handle.local_status(),
+    )
+    .await;
+    handle
+        .send(BlockSyncEvent::NeededBlocks(vec![
+            block_meta(&blocks[0]),
+            block_meta(&blocks[1]),
+        ]))
+        .await
+        .expect("needed blocks queue");
+    assert_eq!(
+        wait_for_outbound_getblocks(&mut outbound).await,
+        (block::Height(2), 1)
+    );
+    assert!(
+        handle
+            .routine_wiring
+            .as_ref()
+            .expect("download wiring exists")
+            .work
+            .pending_contains(block::Height(1)),
+        "the peer's pruning must not discard our need to download older blocks from another peer"
+    );
+    task.abort();
+}
+
+#[tokio::test]
+async fn retention_deferred_status_applies_after_peer_goes_quiet() {
+    let config = ZakuraBlockSyncConfig::default();
+    let (handle, mut actions, task) =
+        spawn_block_sync_reactor(BlockSyncStartup::inert(config.clone()));
+    let service = BlockSyncService::new_with_handle_for_test(config, handle.clone());
+    let mut advertised = BlockSyncStatus {
+        servable_low: block::Height(1),
+        servable_high: block::Height(3),
+        ..status()
+    };
+    let (peer, inbound, mut outbound) =
+        connect_peer_with_status_message(&service, &mut actions, 0xe7, advertised).await;
+    wait_for_outbound_status(&mut outbound).await;
+    let registry = &handle
+        .routine_wiring
+        .as_ref()
+        .expect("download wiring exists")
+        .registry;
+
+    for low in [2, 3] {
+        advertised.servable_low = block::Height(low);
+        send_inbound(&inbound, BlockSyncMessage::Status(advertised)).await;
+        await_until(
+            "updated peer retention floor",
+            Duration::from_secs(5),
+            || {
+                registry.candidate_snapshot()
+                    == vec![(peer.clone(), true, block::Height(low), block::Height(3))]
+            },
+        )
+        .await
+        .expect("the update applies without another incoming frame");
+    }
+    task.abort();
+}

--- a/crates/zakura-network/src/zakura/block_sync/tests/retention.rs
+++ b/crates/zakura-network/src/zakura/block_sync/tests/retention.rs
@@ -138,6 +138,47 @@ async fn retention_initial_status_preserves_archive_and_pruned_ranges() {
 }
 
 #[tokio::test]
+async fn retention_retries_initial_status_after_connecting_with_a_full_queue() {
+    let harness = RetentionHarness::with_refresh_interval(2, Duration::from_secs(30));
+    let (_inbound, receiver) = framed_channel(16);
+    let (sender, mut outbound) = framed_channel(1);
+    let filler = status();
+    sender
+        .try_send(
+            BlockSyncMessage::Status(filler)
+                .encode_frame()
+                .expect("filler status encodes"),
+        )
+        .expect("the outbound queue fills before connecting");
+    let mut peers = harness.handle.subscribe_peer_snapshot();
+    harness.service.add_peer(Peer::new_with_direction(
+        peer(0xed),
+        None,
+        ZAKURA_CAP_BLOCK_SYNC,
+        ServicePeerDirection::Outbound,
+        HashMap::from([(ZAKURA_STREAM_BLOCK_SYNC, (receiver, sender))]),
+        CancellationToken::new(),
+    ));
+    time::timeout(Duration::from_secs(5), async {
+        while peers.borrow_and_update().outbound_peers == 0 {
+            peers.changed().await.expect("reactor stays alive");
+        }
+    })
+    .await
+    .expect("the reactor attempts its initial status while the queue is full");
+
+    assert_eq!(wait_for_outbound_status(&mut outbound).await, filler);
+    let advertised = time::timeout(
+        Duration::from_millis(500),
+        wait_for_outbound_status(&mut outbound),
+    )
+    .await
+    .expect("the initial status retries promptly without a peer status or tip change");
+    assert_eq!(advertised.servable_low, block::Height(2));
+    assert_eq!(advertised.servable_high, block::Height(3));
+}
+
+#[tokio::test]
 async fn retention_rejects_pruned_reads_and_still_serves_retained_blocks() {
     let blocks = mainnet_blocks_1_to_3();
     let mut harness = RetentionHarness::new(2);

--- a/crates/zakura-network/src/zakura/handler.rs
+++ b/crates/zakura-network/src/zakura/handler.rs
@@ -588,6 +588,8 @@ pub struct ZakuraHeaderSyncDriverStartup {
     pub committed_snapshots: watch::Receiver<Option<zakura_header_chain::EngineSnapshot>>,
     /// Atomic committed snapshots and body-work epochs.
     pub committed_views: watch::Receiver<Option<zakura_header_chain::CommittedHeaderChainView>>,
+    /// Durable retained-body floor, published before each corresponding committed view.
+    pub retained_block_height: watch::Receiver<block::Height>,
     /// Coordinator-owned capability and ordered-service demand epochs.
     pub service_demand: watch::Receiver<zakura_node_services::sync_lifecycle::SyncServiceDemand>,
     /// VCT metadata repair needs published by the finalized writer.
@@ -3714,7 +3716,10 @@ async fn spawn_zakura_endpoint_inner(
             );
             startup.shutdown = header_sync_shutdown.clone();
             startup.trace = trace.clone();
-            let (handle, actions, task) = spawn_block_sync_reactor(startup);
+            let (handle, actions, task) = spawn_block_sync_reactor(startup.with_retention(
+                driver_startup.retained_block_height.clone(),
+                config.network.genesis_hash(),
+            ));
             (Some(handle), Some(actions), Some(task))
         } else {
             (None, None, None)

--- a/crates/zakura-rpc/Cargo.toml
+++ b/crates/zakura-rpc/Cargo.toml
@@ -117,7 +117,7 @@ zakura-node-services = { path = "../zakura-node-services", version = "3.2.4", fe
     "rpc-client",
 ] }
 zakura-script = { path = "../zakura-script", version = "3.2.3" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
+zakura-state = { path = "../zakura-state", version = "8.1.0" }
 rustls = { version = "0.23.40", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 # Only used to read the validity dates of the configured RPC TLS certificates.
@@ -145,7 +145,7 @@ zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features =
 zakura-network = { path = "../zakura-network", version = "8.0.0", features = [
     "proptest-impl",
 ] }
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = [
+zakura-state = { path = "../zakura-state", version = "8.1.0", features = [
     "proptest-impl",
 ] }
 

--- a/crates/zakura-state/Cargo.toml
+++ b/crates/zakura-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zakura-state"
-version = "8.0.0"
+version = "8.1.0"
 authors.workspace = true
 description = "State contextual verification and storage code for the Zakura node. Internal crate, published to support cargo install zakura"
 license.workspace = true

--- a/crates/zakura-state/src/service.rs
+++ b/crates/zakura-state/src/service.rs
@@ -1621,6 +1621,17 @@ impl ReadStateService {
         artifact_checkpoint.is_some()
     }
 
+    /// Subscribe to the lowest height at and above which block bodies are retained.
+    ///
+    /// The initial value reflects persisted pruning. Later values follow successful
+    /// writes, before their callers publish the corresponding verified tip. Archive
+    /// state publishes zero. Genesis is always retained separately, and checkpoint
+    /// retention can put this floor above the current verified tip.
+    /// Read-only secondary databases refresh it when they catch up with the primary.
+    pub fn subscribe_retained_block_height(&self) -> tokio::sync::watch::Receiver<block::Height> {
+        self.db.subscribe_retained_block_height()
+    }
+
     /// Subscribe to VCT supplied-root repair needs discovered by the finalized writer.
     pub fn subscribe_vct_root_repairs(&self) -> tokio::sync::watch::Receiver<VctRootRepairStatus> {
         self.vct_root_repair_receiver.clone()

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -27,7 +27,9 @@ use rlimit::increase_nofile_limit;
 
 use rocksdb::{ColumnFamilyDescriptor, ErrorKind, Options, ReadOptions};
 use semver::Version;
-use zakura_chain::{parameters::Network, primitives::byte_array::increment_big_endian};
+use zakura_chain::{
+    block::Height, parameters::Network, primitives::byte_array::increment_big_endian,
+};
 
 use crate::{
     database_format_version_on_disk,
@@ -138,6 +140,9 @@ pub struct DiskDb {
     //
     /// Database startup and each metrics export update this cached disk size.
     cached_size: Arc<AtomicU64>,
+
+    /// Durable body floor, published before a successful write returns to its caller.
+    retained_block_height: tokio::sync::watch::Sender<Height>,
 
     /// The shared inner RocksDB database.
     ///
@@ -834,7 +839,9 @@ impl DiskDb {
 
     /// When called with a secondary DB instance, tries to catch up with the primary DB instance
     pub fn try_catch_up_with_primary(&self) -> Result<(), rocksdb::Error> {
-        self.db.try_catch_up_with_primary()
+        self.db.try_catch_up_with_primary()?;
+        self.publish_retained_block_height();
+        Ok(())
     }
 
     /// Compact the given key range in `cf`, including `from` and excluding
@@ -1213,8 +1220,10 @@ impl DiskDb {
                     _secondary_dir: secondary_dir,
                     finished_format_upgrades: Arc::new(AtomicBool::new(false)),
                     cached_size: Arc::new(AtomicU64::new(0)),
+                    retained_block_height: tokio::sync::watch::channel(Height::MIN).0,
                 };
 
+                db.publish_retained_block_height();
                 db.assert_default_cf_is_empty();
                 db.refresh_cached_size();
 
@@ -1395,7 +1404,33 @@ impl DiskDb {
 
     /// Writes `batch` to the database.
     pub(crate) fn write(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
-        self.db.write(batch.batch)
+        self.db.write(batch.batch)?;
+        // Header/full-state callers publish their new tip after this returns.
+        // Publishing the floor first prevents a new tip using the previous floor.
+        self.publish_retained_block_height();
+        Ok(())
+    }
+
+    pub(super) fn lowest_retained_height(&self) -> Option<Height> {
+        let metadata = self.cf_handle(super::PRUNING_METADATA)?;
+        self.zs_get(&metadata, &())
+    }
+
+    pub(super) fn subscribe_retained_block_height(&self) -> tokio::sync::watch::Receiver<Height> {
+        self.retained_block_height.subscribe()
+    }
+
+    fn publish_retained_block_height(&self) {
+        // Read under the publication lock so concurrent writers cannot publish
+        // an older observation after a newer one.
+        self.retained_block_height.send_if_modified(|current| {
+            let retained = self.lowest_retained_height().unwrap_or(Height::MIN);
+            if *current == retained {
+                return false;
+            }
+            *current = retained;
+            true
+        });
     }
 
     /// Flushes pending writes to SST files.

--- a/crates/zakura-state/src/service/finalized_state/disk_db.rs
+++ b/crates/zakura-state/src/service/finalized_state/disk_db.rs
@@ -1402,7 +1402,8 @@ impl DiskDb {
     // Write methods
     // Low-level write methods are located in the WriteDisk trait
 
-    /// Writes `batch` to the database.
+    /// Writes `batch` to the database and publishes its retained-body floor.
+    /// Body pruning must use this path so the floor is visible before callers publish a new tip.
     pub(crate) fn write(&self, batch: DiskWriteBatch) -> Result<(), rocksdb::Error> {
         self.db.write(batch.batch)?;
         // Header/full-state callers publish their new tip after this returns.
@@ -1422,7 +1423,8 @@ impl DiskDb {
 
     fn publish_retained_block_height(&self) {
         // Read under the publication lock so concurrent writers cannot publish
-        // an older observation after a newer one.
+        // an older observation after a newer one. Offline pruning can also lower
+        // a stale marker when older bodies still exist.
         self.retained_block_height.send_if_modified(|current| {
             let retained = self.lowest_retained_height().unwrap_or(Height::MIN);
             if *current == retained {

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block.rs
@@ -779,8 +779,12 @@ impl ZakuraDb {
     /// Returns `None` if the database has never pruned any data (it is
     /// effectively an archive database).
     pub fn lowest_retained_height(&self) -> Option<Height> {
-        let pruning_metadata = self.db.cf_handle(PRUNING_METADATA)?;
-        self.db.zs_get(&pruning_metadata, &())
+        self.db.lowest_retained_height()
+    }
+
+    /// Subscribe to the durable body floor before commit callers publish their new tip.
+    pub(crate) fn subscribe_retained_block_height(&self) -> tokio::sync::watch::Receiver<Height> {
+        self.db.subscribe_retained_block_height()
     }
 
     /// Returns `true` if the database has pruned historical data, and therefore

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -1132,7 +1132,7 @@ fn prepare_prune_batch_deletes_history_and_keeps_consensus_state() {
             .is_some(),
         "genesis transaction retained"
     );
-    for height in 4..=TEST_BLOCKS {
+    for height in std::iter::once(0).chain(4..=TEST_BLOCKS) {
         let block = state
             .db
             .block(Height(height).into())

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/block/tests/prune.rs
@@ -336,6 +336,8 @@ fn checkpoint_retention_hands_off_to_online_pruning_at_start() {
     let max_checkpoint_height = Height(tx_retention + checkpoint_lowest_retained.0 - 1);
     let mut state =
         new_unvalidated_state_with_checkpoint_retention(&config, &network, max_checkpoint_height);
+    let mut retained_height = state.db.subscribe_retained_block_height();
+    assert_eq!(*retained_height.borrow_and_update(), Height::MIN);
     let blocks = network.blockchain_map();
 
     for height in 0..=max_checkpoint_height.0 {
@@ -346,7 +348,23 @@ fn checkpoint_retention_hands_off_to_online_pruning_at_start() {
             .expect("test data deserializes");
 
         state
-            .commit_finalized_direct(block.into(), None, None, "checkpoint handoff tests")
+            .commit_finalized_direct_with(
+                block.into(),
+                None,
+                None,
+                "checkpoint handoff tests",
+                |db, batch, _proof| {
+                    db.header_chain_disk_db()
+                        .write(batch)
+                        .expect("checkpoint batch writes");
+                    assert_eq!(
+                        *retained_height.borrow(),
+                        db.lowest_retained_height().unwrap_or(Height::MIN),
+                        "the floor must be visible before this callback can publish the new tip"
+                    );
+                    Ok(())
+                },
+            )
             .expect("test block is valid");
     }
 
@@ -354,6 +372,14 @@ fn checkpoint_retention_hands_off_to_online_pruning_at_start() {
         state.db.lowest_retained_height(),
         Some(checkpoint_lowest_retained),
         "checkpoint skipping advances the marker to the retention start"
+    );
+
+    assert!(retained_height
+        .has_changed()
+        .expect("state owns the publisher"));
+    assert_eq!(
+        *retained_height.borrow_and_update(),
+        checkpoint_lowest_retained
     );
 
     for height in 1..checkpoint_lowest_retained.0 {
@@ -391,6 +417,10 @@ fn checkpoint_retention_hands_off_to_online_pruning_at_start() {
         Some(online_prune_until),
         "online pruning resumes exactly at the checkpoint retention start"
     );
+    assert!(retained_height
+        .has_changed()
+        .expect("state owns the publisher"));
+    assert_eq!(*retained_height.borrow_and_update(), online_prune_until);
     assert!(
         state
             .db
@@ -701,6 +731,8 @@ fn archive_to_pruned_checkpoint_sync_drains_archive_raw_transactions_before_skip
         &network,
         max_checkpoint_height,
     );
+    let mut retained_height = pruned_state.db.subscribe_retained_block_height();
+    assert_eq!(*retained_height.borrow_and_update(), Height::MIN);
 
     let block: Arc<Block> = blocks
         .get(&TEST_BLOCKS)
@@ -716,6 +748,13 @@ fn archive_to_pruned_checkpoint_sync_drains_archive_raw_transactions_before_skip
         pruned_state.db.lowest_retained_height(),
         Some(checkpoint_lowest_retained),
         "archive backlog is pruned up to the checkpoint retention start"
+    );
+    assert!(retained_height
+        .has_changed()
+        .expect("state owns the publisher"));
+    assert_eq!(
+        *retained_height.borrow_and_update(),
+        checkpoint_lowest_retained
     );
 
     for height in 1..checkpoint_lowest_retained.0 {
@@ -853,6 +892,10 @@ fn archive_mode_keeps_checkpoint_raw_transactions_before_checkpoint_retention_st
         state.db.lowest_retained_height(),
         None,
         "archive mode does not write a pruning marker"
+    );
+    assert_eq!(
+        *state.db.subscribe_retained_block_height().borrow(),
+        Height::MIN
     );
 }
 
@@ -1202,6 +1245,10 @@ fn reopened_pruned_database_reports_pruned_before_committing_a_block() {
     // without waiting for a block commit to prune anything.
     let reopened = FinalizedState::new(&config, &network).expect("reopening the database succeeds");
 
+    assert_eq!(
+        *reopened.db.subscribe_retained_block_height().borrow(),
+        Height(4)
+    );
     assert!(reopened.db.is_pruned());
     assert!(reopened.db.prunes_historical_data());
     assert_eq!(
@@ -1209,6 +1256,37 @@ fn reopened_pruned_database_reports_pruned_before_committing_a_block() {
         Some(Height(4)),
         "the prune height tracks the marker once bodies have been deleted"
     );
+}
+
+#[test]
+fn secondary_retention_watch_follows_its_database_view() {
+    let _init_guard = zakura_test::init();
+    let network = Mainnet;
+    let dir = tempfile::tempdir().expect("temp dir is created");
+    let config = Config {
+        cache_dir: dir.path().to_path_buf(),
+        ephemeral: false,
+        ..pruned_config()
+    };
+    let primary = new_state_with_blocks(&config, &network);
+    let (read_state, secondary, _non_finalized) =
+        crate::init_read_only(config, &network).expect("secondary opens alongside the primary");
+    let mut retained_height = read_state.subscribe_retained_block_height();
+    assert_eq!(*retained_height.borrow_and_update(), Height::MIN);
+
+    let mut batch = DiskWriteBatch::new();
+    batch.prepare_prune_batch(&primary.db, Height(1), Height(4));
+    primary.db.write_batch(batch).expect("prune batch writes");
+    assert_eq!(*retained_height.borrow(), Height::MIN);
+
+    secondary
+        .try_catch_up_with_primary()
+        .expect("secondary catches up with the prune");
+    assert_eq!(secondary.lowest_retained_height(), Some(Height(4)));
+    assert!(retained_height
+        .has_changed()
+        .expect("secondary owns the publisher"));
+    assert_eq!(*retained_height.borrow_and_update(), Height(4));
 }
 
 #[test]

--- a/crates/zakura-state/src/service/finalized_state/zakura_db/prune.rs
+++ b/crates/zakura-state/src/service/finalized_state/zakura_db/prune.rs
@@ -475,6 +475,7 @@ mod tests {
     fn pruning_summary_uses_raw_transactions_to_correct_marker() {
         let _init_guard = zakura_test::init();
         let state = new_state_with_blocks();
+        let mut retained = state.db.subscribe_retained_block_height();
 
         // Simulate a marker that is ahead of the requested retention boundary,
         // while the corresponding raw transaction data is still present.
@@ -482,6 +483,7 @@ mod tests {
         batch.prepare_pruning_marker_batch(&state.db, block::Height(5));
         state.db.write_batch(batch).expect("marker writes");
         assert_eq!(state.db.lowest_retained_height(), Some(block::Height(5)));
+        assert_eq!(*retained.borrow_and_update(), block::Height(5));
         assert!(
             state.db.transaction(coinbase_tx_hash(4)).is_some(),
             "height 4 raw transaction data is still present despite the marker"
@@ -502,6 +504,25 @@ mod tests {
         assert_eq!(
             summary.compacted_height_range,
             Some((block::Height(1), block::Height(4)))
+        );
+
+        let corrected = summary
+            .new_lowest_retained_height
+            .expect("the plan corrects the marker to the retained range");
+        let mut batch = DiskWriteBatch::new();
+        batch.prepare_prune_batch(&state.db, block::Height(1), corrected);
+        state
+            .db
+            .write_batch(batch)
+            .expect("corrected pruning batch writes");
+        assert_eq!(state.db.lowest_retained_height(), Some(corrected));
+        assert!(retained
+            .has_changed()
+            .expect("database keeps the watch open"));
+        assert_eq!(
+            *retained.borrow(),
+            corrected,
+            "the watch must also publish legitimate decreases of the persisted floor"
         );
     }
 

--- a/crates/zakura-utils/Cargo.toml
+++ b/crates/zakura-utils/Cargo.toml
@@ -81,7 +81,7 @@ zakura-chain = { path = "../zakura-chain", version = "7.0.0", optional = true }
 itertools = { workspace = true, optional = true }
 
 # This crate is needed for the zakura-checkpoints offline export mode
-zakura-state = { path = "../zakura-state", version = "8.0.0", optional = true }
+zakura-state = { path = "../zakura-state", version = "8.1.0", optional = true }
 
 # This crate is needed for the zakura-checkpoints binary
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"], optional = true }

--- a/crates/zakurad/Cargo.toml
+++ b/crates/zakurad/Cargo.toml
@@ -180,7 +180,7 @@ zakura-jsonl-trace = { path = "../zakura-jsonl-trace", version = "1.2.0" }
 zakura-network = { path = "../zakura-network", version = "8.0.0" }
 zakura-node-services = { path = "../zakura-node-services", version = "3.2.4", features = ["rpc-client"] }
 zakura-rpc = { path = "../zakura-rpc", version = "10.0.1-rc1" }
-zakura-state = { path = "../zakura-state", version = "8.0.0" }
+zakura-state = { path = "../zakura-state", version = "8.1.0" }
 # zakura-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -314,7 +314,7 @@ zakura-chain = { path = "../zakura-chain", version = "7.0.0", features = ["propt
 zakura-consensus = { path = "../zakura-consensus", version = "8.0.0", features = ["proptest-impl"] }
 zakura-header-chain = { path = "../zakura-header-chain", version = "2.1.0", features = ["test-support"] }
 zakura-network = { path = "../zakura-network", version = "8.0.0", features = ["proptest-impl", "zakura-testkit"] }
-zakura-state = { path = "../zakura-state", version = "8.0.0", features = ["proptest-impl"] }
+zakura-state = { path = "../zakura-state", version = "8.1.0", features = ["proptest-impl"] }
 zakura-rpc = { path = "../zakura-rpc", version = "10.0.1-rc1", features = ["proptest-impl"] }
 
 zakura-test = { path = "../zakura-test", version = "2.1.0" }

--- a/crates/zakurad/src/commands/start/zakura/header_sync_driver.rs
+++ b/crates/zakurad/src/commands/start/zakura/header_sync_driver.rs
@@ -110,6 +110,7 @@ where
         verified_block_tip_hash: verified_block_tip.1,
         committed_snapshots,
         committed_views,
+        retained_block_height: read_state.subscribe_retained_block_height(),
         service_demand: coordinator.subscribe_service_demand(),
         vct_root_repairs: Some(vct_root_repairs),
         header_chain_port: Arc::new(HeaderChainServicePort::new(

--- a/docs/changelog/unreleased/966.md
+++ b/docs/changelog/unreleased/966.md
@@ -1,0 +1,5 @@
+## Fixed
+
+- Fixed pruned nodes advertising block bodies they no longer retain to native
+  block-sync peers, including after restarts and further pruning
+  ([#966](https://github.com/zakura-core/zakura/pull/966)).


### PR DESCRIPTION
## Motivation

Pruned nodes advertise block bodies they have deleted. Peers request those blocks, get `RangeUnavailable`, and mark an otherwise useful server as less reliable.

## Solution

Advertise the retained, verified range from startup and as pruning advances. Storage publishes the pruning boundary before the new tip. Each peer tracks its last queued status, with prompt pruning corrections and retries for full queues. Receivers keep the latest deferred range instead of dropping it. Archive nodes and separately retained genesis remain supported. Availability is still advisory: requests already in flight can overlap later pruning.

## Testing

After syncing with main, 366 block-sync and pruning tests passed, covering publication order, restart and secondary reads, initial and established full queues, marker corrections, and genesis reads. Clippy, formatting, Markdown lint, and changelog checks passed. Earlier [PR](https://github.com/zakura-core/zakura/actions/runs/34626250212) and [base](https://github.com/zakura-core/zakura/actions/runs/34626268029) Mainnet sync runs matched their seeds and reproduced a separate checkpoint-handoff pause, which this PR does not address.

Codex assisted with the implementation, tests, and description.
