### PR TITLE
fix(test): authenticate generate RPC acceptance test

### DIFF
--- a/crates/zakurad/tests/acceptance.rs
+++ b/crates/zakurad/tests/acceptance.rs
@@ -139,7 +139,10 @@ mod common;
 use std::{
     cmp::Ordering,
     collections::HashSet,
-    env, fs, panic,
+    env, fs,
+    net::SocketAddr,
+    panic,
+    path::Path,
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
@@ -168,7 +171,7 @@ use zakura_chain::{
 use zakura_node_services::rpc_client::RpcRequestClient;
 use zakura_rpc::{
     client::{
-        BlockTemplateResponse, DefaultRoots, GetBlockTemplateParameters,
+        BlockTemplateResponse, DefaultRoots, GetBlockHashResponse, GetBlockTemplateParameters,
         GetBlockTemplateRequestMode, GetBlockTemplateResponse, SubmitBlockErrorResponse,
         SubmitBlockResponse, TransactionTemplate,
     },
@@ -4439,6 +4442,41 @@ async fn wake_debug_mempool(rpc_client: &RpcRequestClient) -> Result<()> {
     Ok(())
 }
 
+/// Generates blocks through a cookie-authenticated test RPC listener.
+async fn generate_with_cookie(
+    rpc_address: SocketAddr,
+    cookie_path: &Path,
+    num_blocks: u32,
+) -> Result<Vec<GetBlockHashResponse>> {
+    let cookie = fs::read_to_string(cookie_path)
+        .wrap_err_with(|| format!("failed to read RPC cookie at {}", cookie_path.display()))?;
+    let (username, password) = cookie
+        .trim()
+        .split_once(':')
+        .ok_or_else(|| eyre!("RPC cookie does not contain basic-auth credentials"))?;
+    let response = reqwest::Client::builder()
+        .timeout(EXTENDED_LAUNCH_DELAY)
+        .build()?
+        .post(format!("http://{rpc_address}"))
+        .basic_auth(username, Some(password))
+        .header("Content-Type", "application/json")
+        .body(format!(
+            r#"{{"jsonrpc":"2.0","method":"generate","params":[{num_blocks}],"id":123}}"#
+        ))
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    let mut response: serde_json::Map<String, Value> = serde_json::from_str(&response)?;
+    if let Some(error) = response.remove("error").filter(|error| !error.is_null()) {
+        return Err(eyre!("generate RPC failed: {error}"));
+    }
+
+    serde_json::from_value(response.remove("result").unwrap_or(Value::Null))
+        .wrap_err("generate RPC response did not contain block hashes")
+}
+
 /// Check that Zebra will disconnect from misbehaving peers.
 ///
 /// In order to simulate a misbehaviour peer we start two zakurad instances:
@@ -4500,6 +4538,17 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     let rpc_listen_addr = config.rpc.listen_addr.unwrap();
     let rpc_client_1 = RpcRequestClient::new_with_timeout(rpc_listen_addr, EXTENDED_LAUNCH_DELAY);
     let node_1_listen_addr = config.network.listen_addr;
+    let admin_rpc_listen_addr = loop {
+        let address = format!("127.0.0.1:{}", random_known_port()).parse()?;
+        if address != rpc_listen_addr && address != node_1_listen_addr {
+            break address;
+        }
+    };
+    let rpc_cookie_dir = tempfile::tempdir()?;
+    config.rpc.admin_listen_addr = Some(admin_rpc_listen_addr);
+    config.rpc.cookie_dir = rpc_cookie_dir.path().to_path_buf();
+    config.rpc.cookie_file_name = "admin.cookie".to_string();
+    let rpc_cookie_path = config.rpc.cookie_dir.join(&config.rpc.cookie_file_name);
 
     tracing::info!(
         ?rpc_listen_addr,
@@ -4546,6 +4595,7 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     config.network.initial_testnet_peers = [node_1_listen_addr.to_string()].into();
     config.network.listen_addr = "127.0.0.1:0".parse()?;
     config.rpc.listen_addr = Some(format!("127.0.0.1:{}", random_known_port()).parse()?);
+    config.rpc.admin_listen_addr = None;
     config.network.crawl_new_peer_interval = Duration::from_secs(5);
     config.network.cache_dir = false.into();
     config.state.ephemeral = true;
@@ -4600,7 +4650,7 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
         // two remaining hashes to select a prospective tip.
         tracing::info!("committed genesis block, mining blocks with invalid PoW");
         tokio::time::sleep(Duration::from_secs(2)).await;
-        rpc_client_1.generate(3).await?;
+        generate_with_cookie(admin_rpc_listen_addr, &rpc_cookie_path, 3).await?;
 
         tokio::time::timeout(test_type.zakurad_timeout(), async {
             loop {

--- a/docs/changelog/unreleased/969.md
+++ b/docs/changelog/unreleased/969.md
@@ -1,0 +1,4 @@
+<!-- changelog: none -->
+
+This PR only changes an acceptance test and has no operator- or
+crate-consumer-visible effect.


### PR DESCRIPTION
## Motivation

Every full-coverage unit-test run on `main` fails in
`disconnects_from_misbehaving_peers`. The test starts an unauthenticated custom
Testnet node and calls the test-only `generate` RPC. Since #876, that listener
uses the restricted RPC surface, so `generate` is absent and the call returns
`MethodNotFound`.

PR checks did not catch the regression because this acceptance test is ignored;
full-coverage `main` runs execute it with `--run-ignored=all`.

## Solution

Give the PoW-disabled test node a loopback, cookie-authenticated admin RPC
listener. Call `generate` through that full RPC surface while keeping the
primary listener unauthenticated and restricted.

The second node does not inherit the admin listener configuration. Production
RPC access policy is unchanged.

## Testing

- `cargo test -p zakura --test acceptance disconnects_from_misbehaving_peers
  --features default-release-binaries -- --ignored --nocapture`
- `cargo clippy -p zakura --test acceptance --features
  default-release-binaries --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/changelog.py check`

## Changelog

Added `docs/changelog/unreleased/969.md` with an internal-only marker because
this change only repairs a test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to acceptance test wiring and changelog metadata; production RPC policy is unchanged.
> 
> **Overview**
> Repairs the ignored **`disconnects_from_misbehaving_peers`** acceptance test, which broke after restricted public RPC stopped exposing the test-only **`generate`** method.
> 
> The PoW-disabled node now gets a loopback **admin RPC** listener with a temp **cookie** file; a new **`generate_with_cookie`** helper POSTs an authenticated JSON-RPC **`generate`** call via `reqwest` instead of using **`RpcRequestClient`** on the primary listener. The PoW-enabled peer node explicitly clears **`admin_listen_addr`** so it does not inherit that setup.
> 
> Adds an unreleased changelog entry marked internal-only (test-only change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01405eab465cfe2d489bc235b79b6ff052cad692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->